### PR TITLE
Include devDependencies in default 'test'

### DIFF
--- a/cli/commands/protect/wizard.js
+++ b/cli/commands/protect/wizard.js
@@ -300,7 +300,7 @@ function processAnswers(answers, policy, options) {
     }
 
     var test = pkg.scripts.test;
-    var cmd = 'snyk test';
+    var cmd = 'snyk test --dev';
     if (test && test !== 'echo "Error: no test specified" && exit 1') {
       // only add the test if it's not already in the test
       if (test.indexOf(cmd) === -1) {

--- a/test/wizard-process-answers.test.js
+++ b/test/wizard-process-answers.test.js
@@ -117,7 +117,7 @@ test('wizard replaces npm\s default scripts.test', function (t) {
   }).then(function () {
     t.equal(writeSpy.callCount, 1, 'package was written to');
     var pkg = JSON.parse(writeSpy.args[0][1]);
-    t.equal(pkg.scripts.test, 'snyk test', 'default npm exit 1 was replaced');
+    t.equal(pkg.scripts.test, 'snyk test --dev', 'default npm exit 1 was replaced');
   }).catch(t.threw).then(function () {
     process.chdir(old);
     t.end();
@@ -137,7 +137,7 @@ test('wizard replaces prepends to scripts.test', function (t) {
   }).then(function () {
     t.equal(writeSpy.callCount, 1, 'package was written to');
     var pkg = JSON.parse(writeSpy.args[0][1]);
-    t.equal(pkg.scripts.test, 'snyk test && ' + prevPkg.scripts.test, 'prepended to test script');
+    t.equal(pkg.scripts.test, 'snyk test --dev && ' + prevPkg.scripts.test, 'prepended to test script');
   }).catch(t.threw).then(function () {
     process.chdir(old);
     t.end();


### PR DESCRIPTION
By default npm will install dev dependencies unless the `--production` flag is provided or the NODE_ENV environment variable is set to `production`.

This change adds the `--dev` flag to the default test script generated by `snyk wizard` to ensure dev dependencies, if present, are checked for vulnerabilities.