### PR TITLE
saving snyk as a devdependency

### DIFF
--- a/cli/commands/protect/wizard.js
+++ b/cli/commands/protect/wizard.js
@@ -356,7 +356,7 @@ function processAnswers(answers, policy, options) {
           undefsafe(pkg, 'optionalDependencies.snyk')) {
         installPromise = Promise.resolve(); // do nothing
       } else {
-        installPromise = npm.bind(null, 'install', 'snyk', live, cwd);
+        installPromise = npm.bind(null, 'install', 'snyk', live, cwd, {dev: true});
       }
 
       // finally, add snyk as a dependency because they'll need it

--- a/lib/npm.js
+++ b/lib/npm.js
@@ -3,7 +3,8 @@ module.exports = npm;
 var debug = require('debug')('snyk');
 var exec = require('child_process').exec;
 
-function npm(method, packages, live, cwd) {
+function npm(method, packages, live, cwd, options) {
+  options = options || {};
   if (!packages) {
     packages = [];
   }
@@ -15,7 +16,7 @@ function npm(method, packages, live, cwd) {
   // only if we have packages, then always save, otherwise the command might
   // be something like `npm shrinkwrap'
   if (packages.length) {
-    method = '--save ' + method;
+    method = [options.dev ? '--save-dev' : '--save', method].join(' ');
   }
 
   return new Promise(function (resolve, reject) {


### PR DESCRIPTION
wizard saves `snyk` in `devDependencies` instead of `dependencies`