### PR TITLE
feat: Include devDependencies in default test from Wizard

### DIFF
--- a/cli/commands/protect/wizard.js
+++ b/cli/commands/protect/wizard.js
@@ -270,7 +270,7 @@ function processAnswers(answers, policy, options) {
     }
 
     var test = pkg.scripts.test;
-    var cmd = 'snyk test';
+    var cmd = 'snyk test --dev';
     if (test && test !== 'echo "Error: no test specified" && exit 1') {
       // only add the test if it's not already in the test
       if (test.indexOf(cmd) === -1) {

--- a/test/fixtures/pkg-mean-io/package.json
+++ b/test/fixtures/pkg-mean-io/package.json
@@ -15,7 +15,7 @@
     "start": "node server",
     "mocha": "node tools/test/run-mocha.js",
     "karma": "node node_modules/karma/bin/karma start karma.conf.js",
-    "test": "snyk test && gulp test",
+    "test": "snyk test --dev && gulp test",
     "test-e2e": "gulp e2e.test",
     "postinstall": "node tools/scripts/postinstall.js",
     "snyk-protect": "snyk protect",

--- a/test/wizard-process-answers.test.js
+++ b/test/wizard-process-answers.test.js
@@ -133,7 +133,7 @@ test('wizard replaces npm\s default scripts.test', function (t) {
   }).then(function () {
     t.equal(writeSpy.callCount, 1, 'package was written to');
     var pkg = JSON.parse(writeSpy.args[0][1]);
-    t.equal(pkg.scripts.test, 'snyk test', 'default npm exit 1 was replaced');
+    t.equal(pkg.scripts.test, 'snyk test --dev', 'default npm exit 1 was replaced');
   }).catch(t.threw).then(function () {
     process.chdir(old);
     t.end();
@@ -153,7 +153,7 @@ test('wizard replaces prepends to scripts.test', function (t) {
   }).then(function () {
     t.equal(writeSpy.callCount, 1, 'package was written to');
     var pkg = JSON.parse(writeSpy.args[0][1]);
-    t.equal(pkg.scripts.test, 'snyk test && ' + prevPkg.scripts.test, 'prepended to test script');
+    t.equal(pkg.scripts.test, 'snyk test --dev && ' + prevPkg.scripts.test, 'prepended to test script');
   }).catch(t.threw).then(function () {
     process.chdir(old);
     t.end();


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)
#### What does this PR do?

(This was previously raised as PR [#14](https://github.com/Snyk/snyk/pull/14) but I... errr... broke it 😊)

Adds --dev to the default `snyk test` script generated by the Wizard.
#### Where should the reviewer start?
#### How should this be manually tested?
- Create a new package (e.g. `npm init`)
- Run `snyk wizard` and allow it to update the test script
- Review `package.json`
#### Any background context you want to provide?

By default `npm install` will include devDependencies unless `--production` or the relevant environment variable is set.

Therefore it would be sensible to reflect this in the implementation of `snyk` to ensure consistency.
#### What are the relevant tickets?
#### Screenshots
#### Additional questions
- Test `wizard detects existing snyk in scripts.test` now fails because of the way it has been implemented.  I haven't changed this as I'm unsure if you'd prefer to mock the entire thing.
