### PR TITLE
fix travis lint script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
 script: "[[ $BABEL == true ]] && npm run test:babel || npm test"
 before_install:
   - npm i -g npm@^2.0.0
+  - printf '\nshopt -s globstar\n' >> ~/.profile
 before_script:
   - npm prune
   - psql -c 'create database test;' -U postgres

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tap": "npm run tapone test/*.test.js",
     "test": "npm run check-tests && npm run lint && npm run tap && node cli/index.js test -q",
     "test:babel": "babel test/*.test.js -d . && npm test",
-    "lint": "jscs cli/*.js cli/**/*.js lib/*.js -v",
+    "lint": "bash --login -c './node_modules/.bin/jscs cli/**/*.js lib/**/*.js'",
     "check-tests": "! grep 'test\\.only' test/*.test.js -n",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)
#### The ugly bug

Currently the globs used in the npm scripts will not expand properly. Even operating systems with an up-to-date version of Bash (cross out OSX from that) and a configured environment with [globstar](https://www.gnu.org/software/bash/manual/bashref.html#The-Shopt-Builtin-1) will not take advantage because npm scripts open a non-interactive shell.

Running the lint script after the fix:

```
> bash --login -c './node_modules/.bin/jscs cli/**/*.js lib/**/*.js'

Missing comma before closing curly brace at cli/commands/protect/wizard.js :
   369 |    if (answers['misc-test-no-monitor']) { // allows us to automate tests
   370 |      return {
   371 |        id: 'test'
--------------------------^
   372 |      };
   373 |    }
```
#### The ugly fix

Since npm will open a non-interactive shell, a new interactive shell is opened (so that will load `~/.profile` settings) with globstar configured.
As for what I've read on the Travis docs, they don't support environment configuration (`~/.profile`, `~/.bashrc`, etc) on their settings and that's why the changes on `.travis.yml`.
Another good reason for not to merge this is that it will only work on *nix systems.
#### How should this be manually tested?

Executing `npm run lint`.
#### Reasonable solution

Migrate to ESLint since it has proper support for globs. [The two projects merged anyway](http://eslint.org/blog/2016/04/welcoming-jscs-to-eslint).
