### PR TITLE
fix: patch filename compat with windows

### DIFF
--- a/lib/protect/write-patch-flag.js
+++ b/lib/protect/write-patch-flag.js
@@ -13,13 +13,16 @@ function writePatchFlag(now, vuln) {
 
   debug('writing flag for %s', vuln.id);
   var promise;
-  var flag = path.resolve(vuln.source, '.snyk-' + vuln.id + '.flag');
+  // the colon doesn't like Windows, ref: https://git.io/vw2iO
+  var fileSafeId = vuln.id.replace(/:/g, '-');
+  var flag = path.resolve(vuln.source, '.snyk-' + fileSafeId + '.flag');
   if (vuln.grouped && vuln.grouped.includes) {
     debug('found addition vulns to write flag files for');
     var writePromises = [fs.writeFile(flag, now.toJSON(), 'utf8')];
     debug(flag);
     vuln.grouped.includes.forEach(function (id) {
-      var flag = path.resolve(vuln.source, '.snyk-' + id + '.flag');
+      var fileSafeId = vuln.id.replace(/:/g, '-');
+      var flag = path.resolve(vuln.source, '.snyk-' + fileSafeId + '.flag');
       debug(flag);
       writePromises.push(fs.writeFile(flag, now.toJSON(), 'utf8'));
     });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [x] Reviewed by @remy (Snyk internal team)

#### What does this PR do?
Changes the filename of `.flag` files (added after patches are successfully applied) by omitting colons—this allows those files to be created on Windows (which does not allow colons in filenames) and fixes https://github.com/Snyk/snyk/issues/22.

#### Where should the reviewer start?
lib/protect/patch.js

#### How should this be manually tested?
@harriha provided an example flow that demonstrates the problem this PR attempts to fix in [this comment](https://github.com/Snyk/snyk/issues/22#issuecomment-227677472).

#### Any background context you want to provide?
Here is the [output of a build](https://ci.appveyor.com/project/smockle/www-smockle-com/build/1.0.845#L408) where snyk fails to create a `.flag` file. Here is the [output of a build](https://ci.appveyor.com/project/smockle/www-smockle-com/build/1.0.848#L407) where a modified snyk (with this PR merged) successfully creates a `.flag` file.

#### What are the relevant tickets?
https://github.com/Snyk/snyk/issues/22

#### Screenshots


#### Additional questions

Fixes #22

TL,DR; use dash instead of colons.