### PR TITLE
Adding support for builds on node v6 and v7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ notifications:
   email: false
 matrix:
   include:
+    - node_js: "7"
+    - node_js: "6"
     - node_js: "5"
     - node_js: "4"
     - node_js: "0.10"


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by @remy (Snyk internal team)

#### What does this PR do?
Adds Node v6 and v7 to the build matrix (we might want to add v7 to the allowed_failures matrix if the build constantly fails there, need to test after travis runs)

#### Where should the reviewer start?
Review travis build log

#### How should this be manually tested?
Review travis build log

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions

