### PR TITLE
Fix missing quote in README.md sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Get the badge by copying the relevant snippet below and replacing "name" with th
 HTML:
 
 ```
-<img src="https://snyk.io/package/npm/name/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/package/npm/name style="max-width:100%;">
+<img src="https://snyk.io/package/npm/name/badge.svg" alt="Known Vulnerabilities" data-canonical-src="https://snyk.io/package/npm/name" style="max-width:100%;">
 ```
 
 Markdown:


### PR DESCRIPTION
The closing `"` was missing from the `data-canonical-src` attribute in the HTML badge sample code.

- [ ] Ready for review
- [ ] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fix a typo.

#### Where should the reviewer start?

Github changes window.

#### How should this be manually tested?

It's just a typo.

#### Any background context you want to provide?

No.

#### What are the relevant tickets?

None.

#### Screenshots

Nope.

#### Additional questions

I hereby give permission to use my such great contribution to the project without signing a CLA. Seriously, I hope you'll make an exception in the CLA for small changes like this one...