### PR TITLE
fix: add proxy support

### DIFF
--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -12,6 +12,13 @@ var querystring = require('querystring');
 var zlib = require('zlib');
 var config = require('../config');
 
+function resolveProxy() {
+  return process.env.https_proxy
+      || process.env.HTTPS_PROXY
+      || process.env.http_proxy
+      || process.env.HTTPS_PROXY;
+}
+
 function makeRequest(payload) {
   return new Promise(function (resolve, reject) {
     var body = payload.body;
@@ -68,6 +75,12 @@ function makeRequest(payload) {
       timeout: payload.timeout,
       follow_max: 5,
     };
+
+    var proxy = resolveProxy();
+    if (proxy) {
+      debug('Using proxy: ', proxy);
+      options.proxy = proxy;
+    }
 
     needle.request(method, url, bodyStream, options, function (err, res, body) {
       debug(err);

--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -16,7 +16,7 @@ function resolveProxy() {
   return process.env.https_proxy
       || process.env.HTTPS_PROXY
       || process.env.http_proxy
-      || process.env.HTTPS_PROXY;
+      || process.env.HTTP_PROXY;
 }
 
 function makeRequest(payload) {

--- a/lib/request/request.js
+++ b/lib/request/request.js
@@ -11,13 +11,7 @@ var format = require('url').format;
 var querystring = require('querystring');
 var zlib = require('zlib');
 var config = require('../config');
-
-function resolveProxy() {
-  return process.env.https_proxy
-      || process.env.HTTPS_PROXY
-      || process.env.http_proxy
-      || process.env.HTTP_PROXY;
-}
+var getProxyForUrl = require('proxy-from-env').getProxyForUrl;
 
 function makeRequest(payload) {
   return new Promise(function (resolve, reject) {
@@ -76,7 +70,7 @@ function makeRequest(payload) {
       follow_max: 5,
     };
 
-    var proxy = resolveProxy();
+    var proxy = getProxyForUrl(url);
     if (proxy) {
       debug('Using proxy: ', proxy);
       options.proxy = proxy;

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "needle": "^2.0.1",
     "open": "^0.0.5",
     "os-name": "^1.0.3",
+    "proxy-from-env": "^1.0.0",
     "semver": "^5.1.0",
     "snyk-config": "1.0.1",
     "snyk-go-plugin": "1.3.8",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Needle doesn't support automatic proxy like request does, snyk moved to
needle on v1.41.0

This change will look for the standard unix environment variables for
proxying.

Note, I couldn't see any support for no_proxy in needle, so the docs
here need an update: https://snyk.io/docs/faqs search proxy.

This has been manually tested:

DEBUG=snyk:req ./node_modules/.bin/snyk protect  --debug
```
...
Successfully applied Snyk patches
...
snyk:req Using proxy:  http://proxyout.companydomain.com:8080 +0ms
```

#### Where should the reviewer start?
?

#### How should this be manually tested?
block internet access, except through a proxy and set the proxy as one of the needed environment variables.

#### Any background context you want to provide?
I had a support chat with Aviat and Ellen and here's the error I gave them:

```
$ ./node_modules/.bin/snyk protect  --debug
  snyk protect { _: [ [Circular] ], debug: true } +0ms
  snyk ~~~~ LIVE RUN ~~~~ +266ms
  snyk checking for cli updates +4ms
{ url: 'https://snyk.io/api/v1/vuln/npm/patches',
  json: true,
  headers: { 'x-is-ci': false, authorization: 'token undefined' } }
  snyk { url: 'https://snyk.io/api/v1/vuln/npm/patches',
  snyk   json: true,
  snyk   headers: { 'x-is-ci': false, authorization: 'token undefined' } } +65ms
  snyk add local true +1ms
  snyk policies found [ '/home/jenkins/slave/workspace/cmc-citizen-frontend_PR-171-AWDTYLFSQAZX3ZN5LUZLPKFADT667EZMLGNTHHXTHDKW6IQORVBQ',
  '/home/jenkins/slave/workspace/cmc-citizen-frontend_PR-171-AWDTYLFSQAZX3ZN5LUZLPKFADT667EZMLGNTHHXTHDKW6IQORVBQ/node_modules/snyk' ] +2s
  snyk add policies 2 +0ms
  snyk add packageManager npm +4ms
  snyk add packageName cmc-citizen-frontend +0ms
  snyk add packageVersion 1.1.0 +0ms
  snyk add package cmc-citizen-frontend@1.1.0 +0ms
  snyk add success false +150msbase...
▽
  snyk add error-message connect ECONNREFUSED 23.37.79.107:443 +0ms
 
▽
  snyk add error Error: connect ECONNREFUSED 23.37.79.107:443
    at Object._errnoException (util.js:1024:11)
    at _exceptionWithHostPort (util.js:1046:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14) +0ms
  snyk add error-code ECONNREFUSED +0ms
  snyk add command protect +0ms
Error: connect ECONNREFUSED 23.37.79.107:443
    at Object._errnoException (util.js:1024:11)
    at _exceptionWithHostPort (util.js:1046:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14)
  snyk { command: 'bad-command',
  snyk   args: [ { debug: true } ],
  snyk   metadata:
  snyk    { local: true,
  snyk      policies: 2,
  snyk      packageManager: 'npm',
  snyk      packageName: 'cmc-citizen-frontend',
  snyk      packageVersion: '1.1.0',
  snyk      package: 'cmc-citizen-frontend@1.1.0',
  snyk      success: false,
  snyk      'error-message': 'connect ECONNREFUSED 23.37.79.107:443',
  snyk      error: 'Error: connect ECONNREFUSED 23.37.79.107:443\n    at Object._errnoException (util.js:1024:11)\n    at _exceptionWithHostPort (util.js:1046:20)\n    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14)',
  snyk      'error-code': 'ECONNREFUSED',
  snyk      command: 'protect' },
  snyk   version: '1.49.2',
  snyk   os: 'Linux 3.10',
  snyk   nodeVersion: 'v8.9.1',
  snyk   id: 'f28b66bd647654aa4de26daf12e60d28f8cdc677',
  snyk   ci: false } +2ms
  snyk Error: connect ECONNREFUSED 23.37.79.107:443
  snyk     at Object._errnoException (util.js:1024:11)
  snyk     at _exceptionWithHostPort (util.js:1046:20)
  snyk     at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1182:14) +8ms
```

#### What are the relevant tickets?
None, feel free to create one if needed

#### Screenshot

#### Additional questions
