### PR TITLE
Fix failing docker image builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ docker run -it
   snyk/snyk-cli:rubygems test --org=my-org-name
 ```
 
-### Maven 3.5.2
+### Maven 3.5.4
 
 We will need to mount the project root folder when running the image so that Snyk can access the code within the container and mount the local .m2 and .ivy2 folders. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Maven:
 
@@ -108,7 +108,7 @@ docker run -it
     -v "<PROJECT_DIRECTORY>:/project"
     -v "/home/user/.m2:/home/node/.m2"
     -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:mvn-3.5.2 test --org=my-org-name
+  snyk/snyk-cli:mvn-3.5.4 test --org=my-org-name
 ```
 
 ### SBT 0.13.16 / SBT 1.0.4

--- a/docker/Dockerfile.gradle-2.8
+++ b/docker/Dockerfile.gradle-2.8
@@ -10,6 +10,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 #Install gradle

--- a/docker/Dockerfile.gradle-4.4
+++ b/docker/Dockerfile.gradle-4.4
@@ -10,6 +10,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 #Install gradle

--- a/docker/Dockerfile.maven-3.5.4
+++ b/docker/Dockerfile.maven-3.5.4
@@ -10,12 +10,13 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 #Install maven
-RUN wget http://www-eu.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.tar.gz
-RUN tar -xvzf apache-maven-3.5.2-bin.tar.gz
-RUN rm -f apache-maven-3.5.2-bin.tar.gz
+RUN wget http://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+RUN tar -xvzf apache-maven-3.5.4-bin.tar.gz
+RUN rm -f apache-maven-3.5.4-bin.tar.gz
 
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
@@ -26,7 +27,7 @@ RUN chmod -R a+wrx /home/node
 WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
-ENV PATH /apache-maven-3.5.2/bin:$PATH
+ENV PATH /apache-maven-3.5.4/bin:$PATH
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project

--- a/docker/Dockerfile.sbt-0.13.16
+++ b/docker/Dockerfile.sbt-0.13.16
@@ -10,6 +10,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 #Install sbt

--- a/docker/Dockerfile.sbt-1.0.4
+++ b/docker/Dockerfile.sbt-1.0.4
@@ -10,6 +10,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
+RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
 
 #Install sbt


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows CONTRIBUTING rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
All java docker images are currently failing their builds. This PR fixes this.
* Upgrade to Maven 3.5.4. 3.5.2 is not published anymore. http://www-eu.apache.org/dist/maven/maven-3/
* Add `RUN mkdir -p /usr/share/man/man1` as suggested in https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=863199 to fix the `oracle-java8-installer` failing installation.