### PR TITLE
chore: add exec plugin to enable release process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
     - stage: Release
       node_js: "8"
       script:
-      - test "${TRAVIS_PULL_REQUEST}" != "false" || npx semantic-release
+      - test "${TRAVIS_PULL_REQUEST}" != "false" || (npm i semantic-release @semantic-release/exec && semantic-release)
 branches:
   only:
     - "master"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds the needed `@semantic-release/exec` plugin as a dependency to enable the semantic release process.