### PR TITLE
fix: bump snyk-docker-plugin for smaller footprint

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.5.0",
     "snyk-config": "2.2.0",
-    "snyk-docker-plugin": "1.10.3",
+    "snyk-docker-plugin": "1.10.4",
     "snyk-go-plugin": "1.5.2",
     "snyk-gradle-plugin": "1.3.0",
     "snyk-module": "1.8.2",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Bumps `snyk-docker-plugin` to achieve a smaller footprint of the overall published package.
See https://github.com/snyk/snyk-docker-plugin/pull/40