### PR TITLE
fix: explicitly include files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,16 @@
   "name": "snyk",
   "description": "snyk library and cli utility",
   "main": "lib/index.js",
+  "files": [
+    "cli",
+    "help",
+    "lib",
+    "config.default.json",
+    "SECURITY.md",
+    "README.md",
+    "Contributor-Agreement.md",
+    ".snyk"
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- explicitly include files in npm package (pass list) instead of ignoring files with .npmignore (block list)
- https://docs.npmjs.com/files/package.json#files

#### How should this be manually tested?

- checkout branch
- navigate elsewhere
- `npm pack path/to/branch`
- unpack resultant tarball
- `npm install package` (tarball will unpack into a folder named `package`)
- ensure `cli` works: `path/to/unpacked-package/node_modules/snyk/cli/index.js <command>`

#### Any background context you want to provide?

- we had inadvertently started bundling package binaries into the npm package