### PR TITLE
fix: clear spinner labels on errors

### DIFF
--- a/cli/commands/auth.js
+++ b/cli/commands/auth.js
@@ -55,8 +55,14 @@ function githubAuth(via) {
     }, 2000);
     // start checking the token immediately in case they've already
     // opened the url manually
-    return testAuthComplete(token).then(spinner.clear(lbl));
-  });
+    return testAuthComplete(token);
+  })
+    // clear spinnger in case of success or failure
+    .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    });
 }
 
 function testAuthComplete(token) {

--- a/cli/commands/monitor.js
+++ b/cli/commands/monitor.js
@@ -69,7 +69,12 @@ function monitor() {
               .then(function () {
                 return moduleInfo.inspect(path, targetFile, options);
               })
+              // clear spinner in case of success or failure
               .then(spinner.clear(analyzingDepsSpinnerLabel))
+              .catch(function (error) {
+                spinner.clear(analyzingDepsSpinnerLabel)();
+                throw error;
+              })
               .then(function (info) {
                 return spinner(postingMonitorSpinnerLabel)
                   .then(function () {
@@ -90,7 +95,12 @@ function monitor() {
                 };
                 return snyk.monitor(path, meta, info);
               })
+              // clear spinner in case of success or failure
               .then(spinner.clear(postingMonitorSpinnerLabel))
+              .catch(function (error) {
+                spinner.clear(postingMonitorSpinnerLabel)();
+                throw error;
+              })
               .then(function (res) {
                 res.path = path;
                 var endpoint = url.parse(config.API);

--- a/cli/commands/protect/wizard.js
+++ b/cli/commands/protect/wizard.js
@@ -469,7 +469,12 @@ function processAnswers(answers, policy, options) {
                           options.packageTrailing;
         return spinner(lbl)
           .then(fs.writeFile(packageFile, packageString))
-          .then(spinner.clear(lbl));
+          // clear spinner in case of success or failure
+          .then(spinner.clear(lbl))
+          .catch(function (error) {
+            spinner.clear(lbl)();
+            throw error;
+          });
       }
     })
     .then(function () {
@@ -479,7 +484,12 @@ function processAnswers(answers, policy, options) {
         var lbl = 'Updating npm-shrinkwrap.json...';
         return spinner(lbl)
           .then(npm.bind(null, 'shrinkwrap', null, live, cwd, null))
-          .then(spinner.clear(lbl));
+          // clear spinner in case of success or failure
+          .then(spinner.clear(lbl))
+          .catch(function (error) {
+            spinner.clear(lbl)();
+            throw error;
+          });
       }
     })
     .then(function () {
@@ -501,7 +511,12 @@ function processAnswers(answers, policy, options) {
       return info.inspect(cwd, targetFile, options)
         .then(spinner(lbl))
         .then(snyk.monitor.bind(null, cwd, meta))
-        .then(spinner.clear(lbl));
+        // clear spinner in case of success or failure
+        .then(spinner.clear(lbl))
+        .catch(function (error) {
+          spinner.clear(lbl)();
+          throw error;
+        });
     })
     .then(function (monitorRes) {
       var endpoint = url.parse(config.API);

--- a/cli/commands/unpublished/index.js
+++ b/cli/commands/unpublished/index.js
@@ -51,5 +51,11 @@ module.exports = function (cwd) {
         'shed-packages/\n');
       });
     });
-  }).then(spinner.clear(lbl));
+  })
+    // clear spinner in case of success or failure
+    .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    });
 };

--- a/lib/protect/patch.js
+++ b/lib/protect/patch.js
@@ -164,16 +164,23 @@ function patch(vulns, live, cwd) {
     });
 
     return promise;
-  }).then(spinner.clear(lbl)).then(function (res) {
-    if (errorList.length) {
-      errorList.forEach(function (error) {
-        console.log(chalk.red(errors.message(error)));
-      });
-      throw new Error('Please email support@snyk.io if this problem persists.');
-    }
+  })
+    // clear spinner in case of success or failure
+    .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    })
+    .then(function (res) {
+      if (errorList.length) {
+        errorList.forEach(function (error) {
+          console.log(chalk.red(errors.message(error)));
+        });
+        throw new Error('Please email support@snyk.io if this problem persists.');
+      }
 
-    return res;
-  });
+      return res;
+    });
 }
 
 function patchRule(vuln) {

--- a/lib/protect/update.js
+++ b/lib/protect/update.js
@@ -92,7 +92,12 @@ function update(packages, live, pkgManager) {
       });
     return promise;
   })
+    // clear spinner in case of success or failure
     .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    })
     .then(function (res) {
       if (error) {
         console.error(chalk.red(errors.message(error)));

--- a/lib/snyk-test/npm/index.js
+++ b/lib/snyk-test/npm/index.js
@@ -141,9 +141,12 @@ function generateDependenciesFromLockfile(root, options) {
     .then(function () {
       return lockFileParser.buildDepTree(manifestFile, lockFile, options.dev);
     })
-    .then(
-      spinner.clear(resolveModuleSpinnerLabel)
-    );
+    // clear spinner in case of success or failure
+    .then(spinner.clear(resolveModuleSpinnerLabel))
+    .catch(function (error) {
+      spinner.clear(resolveModuleSpinnerLabel)();
+      throw error;
+    });
 }
 
 function getDependenciesFromNodeModules(root, options) {
@@ -163,7 +166,13 @@ function getDependenciesFromNodeModules(root, options) {
         .then(function () {
           return snyk.modules(
             root, Object.assign({}, options, {noFromArrays: true}));
-        }).then(spinner.clear(resolveModuleSpinnerLabel));
+        })
+        // clear spinner in case of success or failure
+        .then(spinner.clear(resolveModuleSpinnerLabel))
+        .catch(function (error) {
+          spinner.clear(resolveModuleSpinnerLabel)();
+          throw error;
+        });
     });
 }
 
@@ -263,7 +272,13 @@ function queryForVulns(data, modules, hasDevDependencies, root, options) {
 
         return res;
       });
-    }).then(spinner.clear(lbl));
+    })
+    // clear spinner in case of success or failure
+    .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    });
 }
 
 function pluckPolicies(pkg) {

--- a/lib/snyk-test/run-test.js
+++ b/lib/snyk-test/run-test.js
@@ -93,7 +93,13 @@ function runTest(packageManager, root, options) {
 
             return res;
           });
-      }).then(spinner.clear(lbl));
+      })
+      // clear spinner in case of success or failure
+      .then(spinner.clear(lbl))
+      .catch(function (error) {
+        spinner.clear(lbl)();
+        throw error;
+      });
   });
 }
 
@@ -123,7 +129,12 @@ function assembleLocalPayload(root, options, policyLocations) {
     .then(function () {
       return moduleInfo.inspect(root, options.file, options);
     })
+    // clear spinner in case of success or failure
     .then(spinner.clear(lbl))
+    .catch(function (error) {
+      spinner.clear(lbl)();
+      throw error;
+    })
     .then(function (info) {
       var pkg = info.package;
       if (_.get(info, 'plugin.packageManager')) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

In error flows, spinner labels are not cleared, causing a failed invocation of the CLI to have excess output at the last line like this:
```
...
<Some error message explaining the failure>
...
<Stack trace>
...

\ Analyzing maven dependencies for pom.xml
```

This change clears all running spinners in case an error is being thrown.