### PR TITLE
exit code 1 on monitor failure, better monitor output readability

### DIFF
--- a/cli/commands/monitor.js
+++ b/cli/commands/monitor.js
@@ -14,6 +14,8 @@ var detect = require('../../lib/detect');
 var plugins = require('../../lib/plugins');
 var ModuleInfo = require('../../lib/module-info');
 
+var SEPARATOR = '\n-------------------------------------------------------\n';
+
 function monitor() {
   var args = [].slice.call(arguments, 0);
   var options = {};
@@ -150,11 +152,14 @@ function monitor() {
             if (res.ok) {
               return res.data;
             }
-            if (res.data && res.data.cliMessage) {
-              return chalk.bold.red(res.data.cliMessage);
-            }
-            return '\nFor path `' + res.path + '`, ' + res.data.message;
-          }).join('\n');
+
+            var errorMessage = (res.data && res.data.cliMessage) ?
+              chalk.bold.red(res.data.cliMessage) :
+              (res.data ? res.data.message : 'Unknown error occurred.');
+
+            return chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') +
+              errorMessage;
+          }).join('\n' + SEPARATOR);
 
           if (results.every(function (res) {
             return res.ok;
@@ -169,14 +174,13 @@ function monitor() {
 
 function formatMonitorOutput(packageManager, res, manageUrl, isJson) {
   var issues = res.licensesPolicy ? 'issues' : 'vulnerabilities';
-  var strOutput = (packageManager === 'yarn' ?
-    'A yarn.lock file was detected - continuing as a Yarn project.\n\n' : '') +
-    '\n\nProject path: ' + res.path +
-    '\nCaptured a snapshot of this project\'s dependencies.\n' +
-    'Explore this snapshot at ' + res.uri + '\n\n' +
+  var strOutput = chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') +
+    (packageManager === 'yarn' ?
+      'A yarn.lock file was detected - continuing as a Yarn project.\n' : '') +
+      'Explore this snapshot at ' + res.uri + '\n\n' +
     (res.isMonitored ?
-      'Notifications about newly disclosed ' + issues + ' related\n' +
-      'to these dependencies will be emailed to you.' :
+      'Notifications about newly disclosed ' + issues + ' related ' +
+      'to these dependencies will be emailed to you.\n' :
       chalk.bold.red('Project is inactive, so notifications are turned ' +
         'off.\nActivate this project here: ' + manageUrl + '\n\n')) +
     (res.trialStarted ?

--- a/lib/spinner.js
+++ b/lib/spinner.js
@@ -37,7 +37,8 @@ createSpinner.sticky = function (s) {
 createSpinner.clear = function (label) {
   return function (res) {
     if (spinners[label] === undefined) {
-      throw new Error('unknown spinner label: ' + label);
+      // clearing a non-existend spinner is ok by default
+      return res;
     }
 
     debug('clearing %s (%s)', label, spinners[label].length);

--- a/test/acceptance/cli.acceptance.test.js
+++ b/test/acceptance/cli.acceptance.test.js
@@ -1345,10 +1345,20 @@ test('`monitor non-existing --json`', function (t) {
   .catch(function (error) {
     var errObj = JSON.parse(error.message);
     t.notOk(errObj.ok, 'ok object should be false');
-    t.match(errObj.error,
-      'snyk monitor should be pointed at an existing project',
-      'show err message');
+    t.match(errObj.error, 'is not a valid path', 'show err message');
     t.match(errObj.path, 'non-existing', 'should show specified path');
+    t.pass('throws error');
+  });
+});
+
+test('`monitor non-existing`', function (t) {
+  chdirWorkspaces();
+  return cli.monitor('non-existing', {json: false})
+  .then(function () {
+    t.fail('should have failed');
+  })
+  .catch(function (error) {
+    t.match(error.message, 'is not a valid path', 'show err message');
     t.pass('throws error');
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When `snyk monitor` fails, exit with `RC 1` by throwing an error. Prior to this change, `snyk monitor` failures used to have `RC 0`.