### PR TITLE
fix: bump needle to ^2.2.4 to fix bug with node 8.12.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "8.11.4"
+  - "8"
   - "6"
   - "4"
 cache:
@@ -25,7 +25,7 @@ script:
 jobs:
   include:
     - stage: Release
-      node_js: "8.11.4"
+      node_js: "8"
       script:
       - test "${TRAVIS_PULL_REQUEST}" != "false" || (npm i -g semantic-release @semantic-release/exec && semantic-release)
 branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,9 +2052,9 @@
       "optional": true
     },
     "needle": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.3.tgz",
-      "integrity": "sha512-GPL22d/U9cai87FcCPO6e+MT3vyHS2j+zwotakDc7kE2DtUAqFKMXLJCTtRp+5S75vXIwQPvIxkvlctxf9q4gQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
+      "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
       "requires": {
         "debug": "^2.1.2",
         "iconv-lite": "^0.4.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "hasbin": "^1.2.3",
     "inquirer": "^3.0.0",
     "lodash": "^4.17.5",
-    "needle": "^2.0.1",
+    "needle": "^2.2.4",
     "opn": "^5.2.0",
     "os-name": "^2.0.1",
     "proxy-agent": "^2.0.0",


### PR DESCRIPTION
this includes a fix @darscan reported in https://github.com/tomas/needle/issues/261

updating `.travis.yaml` to use up-to-date `node 8` in tests again
