### PR TITLE
fix: bump snyk-python-plugin to 1.8.2 - to handle pip 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "snyk-nuget-plugin": "1.6.5",
     "snyk-php-plugin": "1.5.1",
     "snyk-policy": "1.12.0",
-    "snyk-python-plugin": "1.8.1",
+    "snyk-python-plugin": "1.8.2",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.0.1",
     "snyk-sbt-plugin": "2.0.0",


### PR DESCRIPTION
This updates `snyk-python-plugin` to handle pip 18 (relevant PR: https://github.com/snyk/snyk-python-plugin/pull/47)