### PR TITLE
fix: do not traverse node_modules on wizard monitor for yarn

### DIFF
--- a/src/cli/commands/protect/wizard.js
+++ b/src/cli/commands/protect/wizard.js
@@ -282,8 +282,9 @@ function processAnswers(answers, policy, options) {
   // on disk without traversing node_modules
   // currently the npm@2 nd npm@3 plugin resolve-deps can do this
   // but not the latest node-lockfile-parser
-  // HACK: if yarn set traverseNodeModules option to
+  // HACK: for yarn set traverseNodeModules option to true
   // bypass lockfile test for wizard
+  // it is set back to false just before the monitor test
   if (targetFile.endsWith('yarn.lock')) {
     options.traverseNodeModules = true;
   }
@@ -506,6 +507,17 @@ function processAnswers(answers, policy, options) {
       var plugin = plugins.loadPlugin(packageManager);
       var info = moduleInfo(plugin, options.policy);
 
+      if (targetFile.endsWith('yarn.lock')) {
+        // TODO: fix this by providing better patch support for yarn
+        // yarn hoists packages up a tree so we can't assume their location
+        // on disk without traversing node_modules
+        // currently the npm@2 nd npm@3 plugin resolve-deps can do this
+        // but not the latest node-lockfile-parser
+        // HACK: for yarn set traverseNodeModules option to true
+        // bypass lockfile test for wizard, but set this back
+        // before we monitor
+        options.traverseNodeModules = false;
+      }
       return info.inspect(cwd, targetFile, options)
         .then(spinner(lbl))
         .then(snyk.monitor.bind(null, cwd, meta))


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixing a bug where if a yarn project is fixed with wizard we traversed the node modules via a specially set flag but then did not set this back just before monitoring.

While traversing node_modules for yarn is a must for now for patching (old style node_module traversal populates where each package lives on disk which is used during patch time) this fall back is not needed for yarn projects node > 6 when we run a test just before monitoring the project & sending the snapshot to snyk web.

#### Where should the reviewer start?
To replicate:
- clone https://github.com/lili2311/npm-lockfiles
- run `snyk wizard` in the `yarn-lockfiles` folder and see the error appear: not a node project (this is an error encountered because we are sending yarn.lock as a filename to the `resolve-deps` lib instead pf `package.json`)
