### PR TITLE
fix: update resolve-deps to skip ~ directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "snyk-policy": "1.12.0",
     "snyk-python-plugin": "1.8.2",
     "snyk-resolve": "1.0.1",
-    "snyk-resolve-deps": "4.0.1",
+    "snyk-resolve-deps": "4.0.2",
     "snyk-sbt-plugin": "2.0.0",
     "snyk-tree": "^1.0.0",
     "snyk-try-require": "1.3.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Updates `resolve-deps` package, which transitively fixes issue caused by circular symlink. For more details, see https://github.com/snyk/resolve-deps/pull/44. 
