### PR TITLE
fix: don't print vulnerable paths count for docker tests

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,8 +5,8 @@ ignore:
   'npm:mem:20180117':
     - nyc > yargs > os-locale > mem:
         reason: DoS vulnerability is not valid for CLI tool
-        expires: '2018-10-19T10:35:25.346Z'
+        expires: '2018-11-19T10:35:25.346Z'
     - tap > nyc > yargs > os-locale > mem:
         reason: DoS vulnerability is not valid for CLI tool
-        expires: '2018-10-19T10:35:25.346Z'
+        expires: '2018-11-19T10:35:25.346Z'
 patch: {}

--- a/src/cli/commands/test.js
+++ b/src/cli/commands/test.js
@@ -242,7 +242,8 @@ function displayResult(res, options) {
   var vulnCountText = 'found ' + res.uniqueCount + ' '
     + (res.uniqueCount === 1 ? singleVulnText : multipleVulnsText);
 
-  if (options.showVulnPaths) {
+  // Docker is currently not supported as num of paths is inaccurate due to trimming of paths to reduce size.
+  if (options.showVulnPaths && !options.docker) {
     vulnCountText += ', ' + vulnCount + ' vulnerable ';
 
     if (vulnCount === 1) {

--- a/test/acceptance/fixtures/docker/vulns.json
+++ b/test/acceptance/fixtures/docker/vulns.json
@@ -1,0 +1,139 @@
+{
+  "ok": false,
+  "vulnerabilities": [
+    {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2018-06-27T16:12:23.571063Z",
+        "credit": [""],
+        "cvssScore": 6.5,
+        "description": "## Overview\nUse-after-free vulnerability in bzip2recover in bzip2 1.0.6 allows remote attackers to cause a denial of service (crash) via a crafted bzip2 file, related to block ends set to before the start of the block.\n\n## References\n- [GENTOO](https://security.gentoo.org/glsa/201708-08)\n- [CONFIRM](https://bugzilla.redhat.com/show_bug.cgi?id=1319648)\n- [SECTRACK](http://www.securitytracker.com/id/1036132)\n- [BID](http://www.securityfocus.com/bid/91297)\n- [CONFIRM](http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2016/06/20/1)\n",
+        "disclosureTime": null,
+        "id": "SNYK-LINUX-BZIP2-106947",
+        "identifiers": {
+            "CVE": ["CVE-2016-3189"],
+            "CWE": []
+        },
+        "internal": {},
+        "language": "linux",
+        "modificationTime": "2018-10-22T04:31:58.564093Z",
+        "packageManager": "linux",
+        "packageName": "bzip2",
+        "patches": [],
+        "publicationTime": "2016-06-30T17:59:00Z",
+        "references": [{
+            "title": "GENTOO",
+            "url": "https://security.gentoo.org/glsa/201708-08"
+        }, {
+            "title": "CONFIRM",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1319648"
+        }, {
+            "title": "SECTRACK",
+            "url": "http://www.securitytracker.com/id/1036132"
+        }, {
+            "title": "BID",
+            "url": "http://www.securityfocus.com/bid/91297"
+        }, {
+            "title": "CONFIRM",
+            "url": "http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html"
+        }, {
+            "title": "MLIST",
+            "url": "http://www.openwall.com/lists/oss-security/2016/06/20/1"
+        }],
+        "semver": {
+            "vulnerableByDistro": {
+                "alpine:3.4": ["<1.0.6-r5"],
+                "alpine:3.5": ["<1.0.6-r5"],
+                "alpine:3.6": ["<1.0.6-r5"],
+                "alpine:3.7": ["<1.0.6-r5"],
+                "alpine:3.8": ["<1.0.6-r5"],
+                "debian:10": ["<1.0.6-8.1"],
+                "debian:8": ["*"],
+                "debian:9": ["<1.0.6-8.1"],
+                "debian:unstable": ["<1.0.6-8.1"],
+                "ubuntu:12.04": ["*"],
+                "ubuntu:14.04": ["*"],
+                "ubuntu:16.04": ["*"],
+                "ubuntu:18.04": ["*"]
+            },
+            "vulnerable": ["*"]
+        },
+        "severity": "low",
+        "title": "Denial of Service (DoS)",
+        "from": ["ubuntu@18.04", "bzip2/libbz2-1.0@1.0.6-8.1"],
+        "upgradePath": [],
+        "version": "1.0.6-8.1",
+        "name": "bzip2/libbz2-1.0",
+        "isUpgradable": false,
+        "isPatchable": false
+    },
+    {
+    	"CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+    	"alternativeIds": [],
+    	"creationTime": "2018-06-27T16:12:23.571063Z",
+    	"credit": [""],
+    	"cvssScore": 6.5,
+    	"description": "## Overview\nUse-after-free vulnerability in bzip2recover in bzip2 1.0.6 allows remote attackers to cause a denial of service (crash) via a crafted bzip2 file, related to block ends set to before the start of the block.\n\n## References\n- [GENTOO](https://security.gentoo.org/glsa/201708-08)\n- [CONFIRM](https://bugzilla.redhat.com/show_bug.cgi?id=1319648)\n- [SECTRACK](http://www.securitytracker.com/id/1036132)\n- [BID](http://www.securityfocus.com/bid/91297)\n- [CONFIRM](http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2016/06/20/1)\n",
+    	"disclosureTime": null,
+    	"id": "SNYK-LINUX-BZIP2-106947",
+    	"identifiers": {
+    		"CVE": ["CVE-2016-3189"],
+    		"CWE": []
+    	},
+    	"internal": {},
+    	"language": "linux",
+    	"modificationTime": "2018-10-22T04:31:58.564093Z",
+    	"packageManager": "linux",
+    	"packageName": "bzip2",
+    	"patches": [],
+    	"publicationTime": "2016-06-30T17:59:00Z",
+    	"references": [{
+    		"title": "GENTOO",
+    		"url": "https://security.gentoo.org/glsa/201708-08"
+    	}, {
+    		"title": "CONFIRM",
+    		"url": "https://bugzilla.redhat.com/show_bug.cgi?id=1319648"
+    	}, {
+    		"title": "SECTRACK",
+    		"url": "http://www.securitytracker.com/id/1036132"
+    	}, {
+    		"title": "BID",
+    		"url": "http://www.securityfocus.com/bid/91297"
+    	}, {
+    		"title": "CONFIRM",
+    		"url": "http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html"
+    	}, {
+    		"title": "MLIST",
+    		"url": "http://www.openwall.com/lists/oss-security/2016/06/20/1"
+    	}],
+    	"semver": {
+    		"vulnerableByDistro": {
+    			"alpine:3.4": ["<1.0.6-r5"],
+    			"alpine:3.5": ["<1.0.6-r5"],
+    			"alpine:3.6": ["<1.0.6-r5"],
+    			"alpine:3.7": ["<1.0.6-r5"],
+    			"alpine:3.8": ["<1.0.6-r5"],
+    			"debian:10": ["<1.0.6-8.1"],
+    			"debian:8": ["*"],
+    			"debian:9": ["<1.0.6-8.1"],
+    			"debian:unstable": ["<1.0.6-8.1"],
+    			"ubuntu:12.04": ["*"],
+    			"ubuntu:14.04": ["*"],
+    			"ubuntu:16.04": ["*"],
+    			"ubuntu:18.04": ["*"]
+    		},
+    		"vulnerable": ["*"]
+    	},
+    	"severity": "low",
+    	"title": "Denial of Service (DoS)",
+    	"from": ["ubuntu@18.04", "apt/libapt-pkg5.0@1.6.3ubuntu0.1", "bzip2/libbz2-1.0@1.0.6-8.1"],
+    	"upgradePath": [],
+    	"version": "1.0.6-8.1",
+    	"name": "bzip2/libbz2-1.0",
+    	"isUpgradable": false,
+    	"isPatchable": false
+    }
+
+
+  ]
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Removes display of number of vulnerable paths for docker, since currently the count is inaccurate for several reasons:
1. the trees are trimmed quite aggressively in snyk-docker-plugin to reduce size.
2. for rpm & apk based images, we don't differentiate between packages installed manually vs. transitives that were installed automatically.


#### What are the relevant tickets?

[Jira ticket SC-6459](https://snyksec.atlassian.net/browse/SC-6459)