### PR TITLE
feat: Rename cliMessage to userMessage for consistency

### DIFF
--- a/src/cli/commands/monitor.js
+++ b/src/cli/commands/monitor.js
@@ -153,8 +153,8 @@ function monitor() {
               return res.data;
             }
 
-            var errorMessage = (res.data && res.data.cliMessage) ?
-              chalk.bold.red(res.data.cliMessage) :
+            var errorMessage = (res.data && res.data.userMessage) ?
+              chalk.bold.red(res.data.userMessage) :
               (res.data ? res.data.message : 'Unknown error occurred.');
 
             return chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') +

--- a/src/cli/commands/test.js
+++ b/src/cli/commands/test.js
@@ -156,7 +156,7 @@ function test() {
         // HACK as there can be different errors, and we pass only the
         // first one
         error.code = (vulnerableResults[0] || errorResults[0]).code;
-        error.cliMessage = (vulnerableResults[0] || errorResults[0]).cliMessage;
+        error.userMessage = (vulnerableResults[0] || errorResults[0]).userMessage;
         throw error;
       }
 

--- a/src/lib/error.js
+++ b/src/lib/error.js
@@ -81,7 +81,7 @@ module.exports.message = function (error) {
     // try to lookup the error string based either on the error code OR
     // the actual error.message (which can be "Unauthorized" for instance),
     // otherwise send the error message back
-    message = error.cliMessage ||
+    message = error.userMessage ||
       codes[error.code || error.message] ||
       errors[error.code || error.message];
     if (message) {

--- a/src/lib/monitor.js
+++ b/src/lib/monitor.js
@@ -74,7 +74,7 @@ function monitor(root, meta, info) {
           } else {
             var e = new Error('unexpected error: ' + body.message);
             e.code = res.statusCode;
-            e.cliMessage = body && body.cliMessage;
+            e.userMessage = body && body.userMessage;
             reject(e);
           }
         });

--- a/src/lib/snyk-test/npm/index.js
+++ b/src/lib/snyk-test/npm/index.js
@@ -219,7 +219,7 @@ function queryForVulns(data, modules, hasDevDependencies, root, options) {
               body.error :
               res.statusCode);
 
-            err.cliMessage = body && body.cliMessage;
+            err.userMessage = body && body.userMessage;
             // this is the case where a local module has been tested, but
             // doesn't have any production deps, but we've noted that they
             // have dep deps, so we'll error with a more useful message

--- a/src/lib/snyk-test/run-test.js
+++ b/src/lib/snyk-test/run-test.js
@@ -42,7 +42,7 @@ function runTest(packageManager, root, options) {
                 body.error :
                 res.statusCode);
 
-              err.cliMessage = body && body.cliMessage;
+              err.userMessage = body && body.userMessage;
               // this is the case where a local module has been tested, but
               // doesn't have any production deps, but we've noted that they
               // have dep deps, so we'll error with a more useful message

--- a/test/acceptance/cli.acceptance.test.js
+++ b/test/acceptance/cli.acceptance.test.js
@@ -69,23 +69,23 @@ test('test cli with multiple params: good and bad', function (t) {
   });
 });
 
-test('cliMessage correctly bubbles with npm', function (t) {
+test('userMessage correctly bubbles with npm', function (t) {
   chdirWorkspaces();
   return cli.test('npm-package', {org: 'missing-org'})
     .then(function () {
       t.fail('expect to error');
     }).catch(function (error) {
-      t.equal(error.cliMessage, 'cli error message', 'got correct error message');
+      t.equal(error.userMessage, 'cli error message', 'got correct error message');
     });
 });
 
-test('cliMessage correctly bubbles with everything other than npm', function (t) {
+test('userMessage correctly bubbles with everything other than npm', function (t) {
   chdirWorkspaces();
   return cli.test('ruby-app', { org: 'missing-org' })
     .then(function () {
       t.fail('expect to error');
     }).catch(function (error) {
-      t.equal(error.cliMessage, 'cli error message', 'got correct error message');
+      t.equal(error.userMessage, 'cli error message', 'got correct error message');
     });
 });
 

--- a/test/acceptance/fake-server.js
+++ b/test/acceptance/fake-server.js
@@ -66,7 +66,7 @@ module.exports = function (root, apikey) {
       res.status(404);
       res.send({
         code: 404,
-        cliMessage: 'cli error message',
+        userMessage: 'cli error message',
       });
       return next();
     }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Rename cliMessage to userMessage as it is to be re-used throughout other services and needs to be more generic/consistent

#### Where should the reviewer start?
https://github.com/snyk/registry/pull/5937