### PR TITLE
fix: fix for assumed patch paths

### DIFF
--- a/src/lib/protect/get-vuln-source.js
+++ b/src/lib/protect/get-vuln-source.js
@@ -6,15 +6,13 @@ var path = require('path');
 var statSync = require('fs').statSync;
 var moduleToObject = require('snyk-module');
 
-function getVulnSource(vuln, cwd, live) {
+function getVulnSource(vuln, live) {
   var from = vuln.from.slice(1).map(function (pkg) {
     return moduleToObject(pkg).name;
   });
 
   var viaPath = path.resolve(
-    // cwd is optional and mostly used for testing
-    // according to an old note in the code in patch
-    process.cwd() || cwd,
+    process.cwd(),
     'node_modules',
     from.join('/node_modules/')
   );

--- a/src/lib/protect/get-vuln-source.js
+++ b/src/lib/protect/get-vuln-source.js
@@ -12,7 +12,9 @@ function getVulnSource(vuln, cwd, live) {
   });
 
   var viaPath = path.resolve(
-    cwd || process.cwd(),
+    // cwd is optional and mostly used for testing
+    // according to an old note in the code in patch
+    process.cwd() || cwd,
     'node_modules',
     from.join('/node_modules/')
   );

--- a/src/lib/protect/index.js
+++ b/src/lib/protect/index.js
@@ -1,6 +1,8 @@
 var protect = module.exports = {
   ignore: require('./ignore'),
   update: require('./update').update,
+  install: require('./update').install,
+  installDev: require('./update').installDev,
   patch: require('./patch'),
   patchesForPackage: require('./patches-for-package'),
   generatePolicy: generatePolicy,

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -20,16 +20,13 @@ var analytics = require('../analytics');
 var getPatchFile = require('./fetch-patch');
 var ensurePatchUtilExists = require('./ensure-patch');
 
-// note: cwd is optional and mostly used for testing
-function patch(vulns, live, cwd) {
+function patch(vulns, live) {
   var lbl = 'Applying patches...';
   var errorList = [];
 
   return ensurePatchUtilExists().then(spinner(lbl)).then(function () {
     // the target directory where our module name will live
-    vulns.forEach(function (vuln) {
-      vuln.source = getVulnSource(vuln, cwd, live);
-    });
+    vulns.forEach((vuln) => vuln.source = getVulnSource(vuln, live));
 
     var deduped = dedupe(vulns);
     debug('patching %s vulns after dedupe', deduped.packages.length);

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -47,6 +47,7 @@ function patch(vulns, live, cwd) {
         }
 
         analytics.add('patch', vuln.from.slice(1).join(' > '));
+        debug(`Patching vuln: ${vuln.id} ${vuln.from}`);
 
         // the colon doesn't like Windows, ref: https://git.io/vw2iO
         var fileSafeId = vuln.id.replace(/:/g, '-');

--- a/src/lib/protect/update.js
+++ b/src/lib/protect/update.js
@@ -1,5 +1,6 @@
 module.exports.update = update;
 module.exports.install = install;
+module.exports.installDev = installDev;
 
 var debug = require('debug')('snyk');
 var chalk = require('chalk');

--- a/test/deduped-package-patch.test.js
+++ b/test/deduped-package-patch.test.js
@@ -2,8 +2,9 @@ var test = require('tap').test;
 var protect = require('../src/lib/protect');
 var answers = require('./fixtures/deduped-dep/answers.json');
 
-test('npm deduped packages are found and patched correctly', function (t) {
-  protect.patch(answers, false, __dirname + '/fixtures/deduped-dep/').then(function (res) {
-    t.equal(Object.keys(res.patch).length, 1, 'found and patched 1 file');
-  }).catch(t.threw).then(t.end);
+test('npm deduped packages are found and patched correctly', async (t) => {
+  process.chdir(__dirname + '/fixtures/deduped-dep/');
+  const res = await protect.patch(answers, false);
+  t.equal(Object.keys(res.patch).length, 1, 'found and patched 1 file');
+  process.chdir(__dirname);
 });

--- a/test/wizard-package-changes.test.js
+++ b/test/wizard-package-changes.test.js
@@ -1,10 +1,19 @@
-var tap = require('tap');
-var test = require('tap').test;
-var path = require('path');
-var sinon = require('sinon');
-var proxyquire = require('proxyquire');
-var policySpy = sinon.spy();
-var writeSpy = sinon.spy();
+const tap = require('tap');
+const test = require('tap').test;
+const sinon = require('sinon').createSandbox();
+const proxyquire = require('proxyquire');
+const policySpy = sinon.spy();
+const writeSpy = sinon.spy();
+const detect = require('../src/lib/detect');
+
+sinon.stub(detect, 'detectPackageManager')
+  .returns('npm');
+sinon.stub(detect, 'detectPackageFile')
+  .returns('package.json');
+
+tap.tearDown(() => {
+  sinon.restore();
+});
 
 var mockPackage;
 
@@ -19,6 +28,17 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     readFile: function (filename) {
       return Promise.resolve(JSON.stringify(mockPackage));
     },
+    '../../../lib/npm': {
+      getVersion: function() {
+        return new Promise(function(resolve) {
+          return resolve('5.0.1');
+        });
+      },
+    },
+    '../../../lib/protect': {
+      install: () => new Promise((resolve) => resolve()),
+      installDev: () => new Promise((resolve) => resolve()),
+    },
   },
 });
 
@@ -29,17 +49,16 @@ var save = p => {
 
 var policy = proxyquire('snyk-policy', { save: save });
 var mockPolicy;
-var noop = () => {};
 
 tap.beforeEach(done => {
   // reset the mock package
   mockPackage = {
     name: 'snyk-test',
     dependencies: {
-      foo: '1.1.1'
+      foo: '1.1.1',
     },
     devDependencies: {
-      bar: '2.2.2'
+      bar: '2.2.2',
     },
   };
 
@@ -51,77 +70,85 @@ tap.beforeEach(done => {
   }).then(done);
 });
 
-test('user deps are left alone if they do not test or protect', t => {
-  return wizard.processAnswers({
+test('user deps are left alone if they do not test or protect', async (t) => {
+  process.chdir(__dirname, '/fixtures/protect');
+
+  await wizard.processAnswers({
     'misc-test-no-monitor': true,
-  }, mockPolicy).then(res => {
-    t.equal(writeSpy.called, false, 'the package is not touched');
-  });
+  }, mockPolicy);
+
+  t.equal(writeSpy.called, false, 'the package is not touched');
 });
 
-test('snyk adds to devDeps when test only is selected', async (t) => {
-  const res = await wizard.processAnswers({
+test('snyk adds to devDeps when test only is selected', async (t)  => {
+  process.chdir(__dirname, '/fixtures/protect');
+  await wizard.processAnswers({
     'misc-add-test': true,
     'misc-test-no-monitor': true,
   }, mockPolicy);
 
   var pkg = writeSpy.args[0][0];
-  console.log('PACKAGE', pkg)
-
   t.equal(writeSpy.called, true, 'the package was updated');
   t.equal(pkg.scripts.test.includes('snyk test'), true, 'snyk test found in npm test');
   t.equal(pkg.dependencies.snyk, undefined, 'snyk not in production deps');
   t.notEqual(pkg.devDependencies.snyk, undefined, 'snyk IS in dev deps');
+  process.chdir(__dirname);
 });
 
-test('snyk adds to prod deps when protect only is selected', t => {
-  return wizard.processAnswers({
+test('snyk adds to prod deps when protect only is selected', async (t) => {
+  process.chdir(__dirname, '/fixtures/protect');
+  await wizard.processAnswers({
     'misc-add-protect': true,
     'misc-test-no-monitor': true,
-  }, mockPolicy).then(res => {
-    var pkg = writeSpy.args[0][0];
+  }, mockPolicy);
 
-    t.equal(writeSpy.called, true, 'the package was updated');
-    t.equal(pkg.scripts.test, undefined, 'snyk test not added');
-    t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
-    t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
-    t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
-  });
+  var pkg = writeSpy.args[0][0];
+
+  t.equal(writeSpy.called, true, 'the package was updated');
+  t.equal(pkg.scripts.test, undefined, 'snyk test not added');
+  t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
+  t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
+  t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
+  process.chdir(__dirname);
 });
 
-test('snyk adds to prod deps when both protect AND test are selected', t => {
-  return wizard.processAnswers({
+test('snyk adds to prod deps when both protect AND test are selected',async (t) => {
+  process.chdir(__dirname, '/fixtures/debug-package');
+  await wizard.processAnswers({
     'misc-add-protect': true,
     'misc-add-test': true,
-    'misc-test-no-monitor': true
-  }, mockPolicy).then(res => {
-    var pkg = writeSpy.args[0][0];
+    'misc-test-no-monitor': true,
+  }, mockPolicy);
+  var pkg = writeSpy.args[0][0];
 
-    t.equal(writeSpy.called, true, 'the package was updated');
-    t.equal(pkg.scripts.test.includes('snyk test'), true, 'snyk test is added');
-    t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
-    t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
-    t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
-  });
+  t.equal(writeSpy.called, true, 'the package was updated');
+  t.equal(pkg.scripts.test.includes('snyk test'), true, 'snyk test is added');
+  t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
+  t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
+  t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
+  process.chdir(__dirname);
 });
 
-test('upgrades snyk from devDeps to prod deps if protect is used', t => {
+test('upgrades snyk from devDeps to prod deps if protect is used', async (t) => {
+  process.chdir(__dirname, '/fixtures/debug-package');
+
   mockPackage = {
     name: 'snyk-test',
     devDependencies: {
-      snyk: '*'
+      snyk: '*',
     },
   };
 
   return wizard.processAnswers({
     'misc-add-protect': true,
-    'misc-test-no-monitor': true
-  }, mockPolicy).then(res => {
-    var pkg = writeSpy.args[0][0];
+    'misc-test-no-monitor': true,
+  }, mockPolicy);
 
-    t.equal(writeSpy.called, true, 'the package was updated');
-    t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
-    t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
-    t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
-  });
+  var pkg = writeSpy.args[0][0];
+
+  t.equal(writeSpy.called, true, 'the package was updated');
+  t.equal(pkg.scripts['snyk-protect'].includes('snyk protect'), true, 'snyk protect added');
+  t.notEqual(pkg.dependencies.snyk, undefined, 'snyk is in production deps');
+  t.equal(pkg.devDependencies.snyk, undefined, 'snyk is not in dev deps');
+  process.chdir(__dirname);
 });

--- a/test/wizard-package-changes.test.js
+++ b/test/wizard-package-changes.test.js
@@ -18,8 +18,8 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     },
     readFile: function (filename) {
       return Promise.resolve(JSON.stringify(mockPackage));
-    }
-  }
+    },
+  },
 });
 
 var save = p => {
@@ -53,29 +53,31 @@ tap.beforeEach(done => {
 
 test('user deps are left alone if they do not test or protect', t => {
   return wizard.processAnswers({
-    'misc-test-no-monitor': true
+    'misc-test-no-monitor': true,
   }, mockPolicy).then(res => {
     t.equal(writeSpy.called, false, 'the package is not touched');
   });
 });
 
-test('snyk adds to devDeps when test only is selected', t => {
-  return wizard.processAnswers({
+test('snyk adds to devDeps when test only is selected', async (t) => {
+  const res = await wizard.processAnswers({
     'misc-add-test': true,
-    'misc-test-no-monitor': true
-  }, mockPolicy).then(res => {
-    var pkg = writeSpy.args[0][0];
-    t.equal(writeSpy.called, true, 'the package was updated');
-    t.equal(pkg.scripts.test.includes('snyk test'), true, 'snyk test found in npm test');
-    t.equal(pkg.dependencies.snyk, undefined, 'snyk not in production deps');
-    t.notEqual(pkg.devDependencies.snyk, undefined, 'snyk IS in dev deps');
-  });
+    'misc-test-no-monitor': true,
+  }, mockPolicy);
+
+  var pkg = writeSpy.args[0][0];
+  console.log('PACKAGE', pkg)
+
+  t.equal(writeSpy.called, true, 'the package was updated');
+  t.equal(pkg.scripts.test.includes('snyk test'), true, 'snyk test found in npm test');
+  t.equal(pkg.dependencies.snyk, undefined, 'snyk not in production deps');
+  t.notEqual(pkg.devDependencies.snyk, undefined, 'snyk IS in dev deps');
 });
 
 test('snyk adds to prod deps when protect only is selected', t => {
   return wizard.processAnswers({
     'misc-add-protect': true,
-    'misc-test-no-monitor': true
+    'misc-test-no-monitor': true,
   }, mockPolicy).then(res => {
     var pkg = writeSpy.args[0][0];
 

--- a/test/wizard-prepare.test.js
+++ b/test/wizard-prepare.test.js
@@ -19,6 +19,10 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
       });
     },
   },
+  '../../../lib/protect': {
+    install: () => new Promise((resolve) => resolve()),
+    installDev: () => new Promise((resolve) => resolve()),
+  },
   'then-fs': {
     readFile: function () {
       return Promise.resolve(JSON.stringify(fixture));

--- a/test/wizard-prepublish.test.js
+++ b/test/wizard-prepublish.test.js
@@ -1,8 +1,8 @@
-var test = require('tap').test;
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var spy = sinon.spy();
-var fixture = require(__dirname + '/fixtures/protect-via-snyk/package.json');
+const test = require('tap').test;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const spy = sinon.spy();
+const fixture = require(__dirname + '/fixtures/protect-via-snyk/package.json');
 
 var wizard = proxyquire('../src/cli/commands/protect/wizard', {
   inquirer: {
@@ -10,12 +10,16 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
       cb(q);
     },
   },
-  '../../../src/lib/npm': {
+  '../../../lib/npm': {
     getVersion: function() {
       return new Promise(function(resolve) {
         return resolve('4.9.9');
       });
     },
+  },
+  '../../../lib/protect': {
+    install: () => new Promise((resolve) => resolve()),
+    installDev: () => new Promise((resolve) => resolve()),
   },
   'then-fs': {
     readFile: function () {
@@ -25,8 +29,9 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
       spy(body);
       return Promise.resolve();
     },
-  }
+  },
 });
+
 
 test('prepublish is added and postinstall is removed', function (t) {
   return wizard.processAnswers({
@@ -34,7 +39,7 @@ test('prepublish is added and postinstall is removed', function (t) {
     'misc-test-no-monitor': true,
     'misc-add-protect': true,
   }, {
-    save: () => Promise.resolve()
+    save: () => Promise.resolve(),
   }).then(function () {
     t.equal(spy.callCount, 1, 'write function was only called once');
     var pkg = JSON.parse(spy.args[0][0]);


### PR DESCRIPTION
Also amend how we re-lock the lockfile

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- Fixes a bug where for package-lock.json projects we are relying on the assumed patch paths for patching (since the lockfile is the exact shape of the `node_modules`)
The bug was around us using `cwd` which is mostly used for tests and this was returning path paths like: `/npm/node_modules/path-to-module/` instead of  `/node_modules/path-to-module/`

- Also fixing how we regenerate the lockfile if user selected to add snyk to dependencies. Update is relying on having the vuln from paths present, so skipping straight past all this and directly calling `install` && `installDev` since adding `snyk` is not part of the vuln testing flow 

#### Where should the reviewer start?
https://github.com/snyk/snyk/compare/fix/file-path-fix?expand=1#diff-7d011e4c9a3d66fcafd27dede7916a27R17
#### How should this be manually tested?
Project `goof` can be used after adding a lockfile as an example

