### PR TITLE
fix: ensure patch utility is gnu version

### DIFF
--- a/src/lib/protect/ensure-patch.js
+++ b/src/lib/protect/ensure-patch.js
@@ -3,27 +3,38 @@ module.exports = ensurePatchExists;
 var hasbin = require('hasbin');
 var analytics = require('../analytics');
 var chalk = require('chalk');
+var exec = require('child_process').exec;
+var err = new Error(
+  'Snyk couldn\'t patch the specified ' +
+  'vulnerabilities because GNU\'s patch is not ' +
+  'available. Please install \'patch\' ' +
+  'and try again. \n For more information ' +
+  'please see our support page: '
+  + chalk.underline(
+    'https://support.snyk.io' +
+    '/snyk-cli/snyk-protect-requires-the-patch-binary.'
+  ));
 
 function ensurePatchExists() {
   return new Promise(function (resolve, reject) {
     return hasbin('patch', function (exists) {
+      // Output error if patch binary is not installed
       if (!exists) {
-        var err =
-        new Error(
-          'Snyk couldn\'t patch the specified ' +
-          'vulnerabilities because GNU\'s patch is not ' +
-          'available. Please install \'patch\' ' +
-          'and try again. \n For more information ' +
-          'please see our support page: '
-          + chalk.underline(
-            'https://support.snyk.io' +
-            '/snyk-cli/snyk-protect-requires-the-patch-binary.'
-          ));
         analytics.add('patch-binary-missing', {
           message: err.message,
         });
         return reject(err);
       }
+      // Output error if patch binary is not GNU version
+      exec('patch --version', function (error, stdout) { // stderr is ignored
+        var out = stdout.trim();
+        if (out.indexOf('GNU') === -1) {
+          analytics.add('patch-binary-missing', {
+            message: err.message,
+          });
+          return reject(err);
+        }
+      });
       return resolve();
     });
   });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This pull adds a check to test whether `patch` binary is GNU version and outputs an error message if it's not.

#### How should this be manually tested?
1. Use alpine as CI build environment
2. Install a patch-able node package (e.g. [renovate](https://www.npmjs.com/package/renovate)).
3. `snyk protect`
4. There should be [error message](https://support.snyk.io/snyk-cli/snyk-protect-requires-the-patch-binary) `Snyk couldn't patch the specified vulnerabilities because GNU's patch is not available. Please install 'patch' and try again.`.
5. Repeat 1-4 again, but this time with GNU patch installed `apk add patch`.

#### Current behavior
- Alpine 3.8: https://gitlab.com/curben/snyk-test/-/jobs/114648947

#### With this pull
- Alpine 3.8:
  - [Without GNU patch](https://gitlab.com/curben/snyk-test/-/jobs/114669522)
  - [With GNU patch](https://gitlab.com/curben/snyk-test/-/jobs/114670161)

- TrueOS 18.03 (FreeBSD 12):
  - Without GNU patch
![](https://i.postimg.cc/WpYQN6FT/bsd-no-gnu.png)

  - With GNU patch
![](https://i.postimg.cc/qMtWzhyn/bsd-with-gnu.png)


#### Any background context you want to provide?
Alpine and *BSD ships with BusyBox and BSD versions of `patch` respectively, which don't support the arguments (i.e. `--backup` in BusyBox and `--verbose` in BSD) used by Synk.

This pull helps those OS users to locate the issue, even without `--debug`.

#### What are the relevant tickets?
Closes #108 @welwood08 

#### Additional questions
1. This [comment](https://github.com/snyk/snyk/issues/48#issuecomment-270350881) mention Snyk ships with `patch` binary. Please clarify.
2. `hasbin()` can be replaced by `if(error)` in `exec()`. Shall I remove it?
3. Is test case required? not sure what the following line does currently,
https://github.com/snyk/snyk/blob/c98b8b39779410f70027eab31a97dd910994f332/test/patch-ensure-patch.js#L33
