### PR TITLE
fix: Fallback to node_modules for initial wizard  & protect test

### DIFF
--- a/src/cli/commands/test.js
+++ b/src/cli/commands/test.js
@@ -31,7 +31,6 @@ function test() {
 
   // org fallback to config unless specified
   options.org = options.org || config.org;
-
   // making `show-vulnerable-paths` true by default.
   options.showVulnPaths = (options['show-vulnerable-paths'] || '')
     .toLowerCase() !== 'false';

--- a/src/lib/plugins/npm/index.js
+++ b/src/lib/plugins/npm/index.js
@@ -14,8 +14,7 @@ function inspect(root, targetFile, options) {
   const isShrinkwrapPresent = fileSystem.existsSync(
     path.resolve(root, targetFile).dir, 'npm-shrinkwrap.json'
   );
-
-  if (isLockFileBased && !isShrinkwrapPresent) {
+  if (isLockFileBased && !isShrinkwrapPresent && !options.traverseNodeModules) {
     return generateDependenciesFromLockfile(root, options, targetFile)
       .then((modules) => ({
         plugin: {

--- a/src/lib/snyk-test/npm/index.js
+++ b/src/lib/snyk-test/npm/index.js
@@ -58,11 +58,12 @@ function test(root, options) {
 
       return Promise.resolve()
         .then(() => {
-          if (getRuntimeVersion() < 6) {
+          const isLockFilebased = (targetFile.endsWith('package-lock.json')
+          || targetFile.endsWith('yarn.lock'));
+          if (targetFile.endsWith('yarn.lock') && getRuntimeVersion() < 6) {
             options.traverseNodeModules = true;
           }
-          if (targetFile.endsWith('package-lock.json')
-            || targetFile.endsWith('yarn.lock') && !options.traverseNodeModules) {
+          if (isLockFilebased && !options.traverseNodeModules) {
             return generateDependenciesFromLockfile(root, options, targetFile);
           }
           return getDependenciesFromNodeModules(root, options, targetFile)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Always fall back to node_module traversal for the initial wizard test, then test using lockfile parser before monitor for lockfile based projects
