### PR TITLE
fix: show friendly message on monitor timeout

### DIFF
--- a/src/lib/monitor.js
+++ b/src/lib/monitor.js
@@ -75,6 +75,9 @@ function monitor(root, meta, info) {
             var e = new Error('unexpected error: ' + body.message);
             e.code = res.statusCode;
             e.userMessage = body && body.userMessage;
+            if (!e.userMessage && res.statusCode === 504) {
+              e.userMessage = 'Connection Timeout';
+            }
             reject(e);
           }
         });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- shows a "Connection Timeout" message when `monitor` times out
- previously this should show `unexpected error: undefined`
