### PR TITLE
feat: send the base image when running `snyk monitor`

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,8 +5,8 @@ ignore:
   'npm:mem:20180117':
     - nyc > yargs > os-locale > mem:
         reason: DoS vulnerability is not valid for CLI tool
-        expires: '2018-11-19T10:35:25.346Z'
+        expires: '2018-12-19T10:35:25.346Z'
     - tap > nyc > yargs > os-locale > mem:
         reason: DoS vulnerability is not valid for CLI tool
-        expires: '2018-11-19T10:35:25.346Z'
+        expires: '2018-12-19T10:35:25.346Z'
 patch: {}

--- a/src/cli/commands/monitor.js
+++ b/src/cli/commands/monitor.js
@@ -47,7 +47,7 @@ function monitor() {
 
             var packageManager = detect.detectPackageManager(path, options);
 
-            var targetFile = options.docker
+            var targetFile = options.docker && !options.file // snyk monitor --docker (without --file)
               ? undefined
               : (options.file || detect.detectPackageFile(path));
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Sends the base image to registry when running `snyk monitor --docker`.

