### PR TITLE
fix: Parse ARGs in Dockerfile FROM instructions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.5.0",
     "snyk-config": "2.2.0",
-    "snyk-docker-plugin": "1.12.2",
+    "snyk-docker-plugin": "1.12.3",
     "snyk-go-plugin": "1.6.0",
     "snyk-gradle-plugin": "2.1.1",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
This patch raises the snyk-docker-plugin version, fixing an issue where
we failed to parse ARGs used in a Dockerfile FROM instruction


- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team