### PR TITLE
fix: when package-lock.json file is present, snyk wizard included dev…

### DIFF
--- a/src/lib/snyk-test/npm/index.js
+++ b/src/lib/snyk-test/npm/index.js
@@ -186,6 +186,11 @@ function getDependenciesFromNodeModules(root, options, targetFile) {
           if (targetFile.endsWith('yarn.lock')) {
             options.file = options.file.replace('yarn.lock', 'package.json');
           }
+
+          //package-lock.json falls back to package.json (used in wizard code)
+          if (targetFile.endsWith('package-lock.json')) {
+            options.file = options.file.replace('package-lock.json', 'package.json');
+          }
           return snyk.modules(
             root, Object.assign({}, options, {noFromArrays: true}));
         })


### PR DESCRIPTION
…Depepndencies in vulnerability count

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
fix: when package-lock.json file is present, snyk wizard included devDepepndencies in vulnerability count; for the fix, I flip package-lock.json with package.json

#### How should this be manually tested?
1. Manually run "snyk wizard" and "snyk wizard --dev" on a custom branch and goof branch and compared the results to the output of "snyk test" and "snyk test --dev" respectively
2. Run "snyk monitor" and made sure correct vulnerability count was shown

#### Additional questions
It seems from the code we do not flip lock files back. Is it required?