### PR TITLE
fix: move to the new version of nodejs-lockfile-parser 

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "snyk-gradle-plugin": "2.1.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.0",
-    "snyk-nodejs-lockfile-parser": "1.8.0",
+    "snyk-nodejs-lockfile-parser": "1.9.0",
     "snyk-nuget-plugin": "1.6.5",
     "snyk-php-plugin": "1.5.1",
     "snyk-policy": "1.13.1",

--- a/src/lib/plugins/npm/index.js
+++ b/src/lib/plugins/npm/index.js
@@ -60,8 +60,9 @@ async function generateDependenciesFromLockfile(root, options, targetFile) {
 
   const manifestFile = await fs.readFile(manifestFileFullPath, 'utf-8');
   const lockFile = await fs.readFile(lockFileFullPath, 'utf-8');
+  const defaultManifestFileName = path.relative(root, manifestFileFullPath);
 
-  return lockFileParser
-    .buildDepTree(manifestFile, lockFile, options.dev, lockFileParser.LockfileType.npm);
+  return lockFileParser.buildDepTree(manifestFile, lockFile, options.dev,
+    lockFileParser.LockfileType.npm, true, defaultManifestFileName);
 }
 

--- a/src/lib/plugins/yarn/index.js
+++ b/src/lib/plugins/yarn/index.js
@@ -74,9 +74,10 @@ async function generateDependenciesFromLockfile(root, options, targetFile) {
 
   const manifestFile = await fs.readFile(manifestFileFullPath, 'utf-8');
   const lockFile = await fs.readFile(lockFileFullPath, 'utf-8');
+  const defaultManifestFileName = path.relative(root, manifestFileFullPath);
 
-  return lockFileParser
-    .buildDepTree(manifestFile, lockFile, options.dev, lockFileParser.LockfileType.yarn);
+  return lockFileParser.buildDepTree(manifestFile, lockFile, options.dev,
+    lockFileParser.LockfileType.yarn, true, defaultManifestFileName);
 }
 
 function getRuntimeVersion() {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Projects with no name property in package.json will now be named by their relative path

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/SC-6758
Also related to snyk/nodejs-lockfile-parser#29 and
snyk/npm-deps#53