### PR TITLE
fix: docker image fails with spaces in project folder names

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -41,9 +41,11 @@ exitWithMsg () {
 }
 
 ##
-## Start of backward compatability code
-## Should be phased out when we phase out the current version of the jenkins plugin
-## These parameters should only be used with the Jenkins plugin! Please see README.md for more info
+## Start of backward compatability code.
+## Should be phased out when we phase out the current version of the jenkins
+## plugin.
+## These parameters should only be used with the Jenkins plugin! Please see
+## README.md for more info.
 ##
 
 TEST_SETTINGS="";
@@ -77,9 +79,11 @@ if [ -n "${ENV_FLAGS}" ]; then
   ADDITIONAL_ENV="-- ${ENV_FLAGS}"
 fi
 
-cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" || exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
+cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" || \
+exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
 
-runCmdAsDockerUser "PATH=${PATH} snyk ${SNYK_COMMAND} ${SNYK_PARAMS} ${ADDITIONAL_ENV} > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
+runCmdAsDockerUser "PATH=${PATH} snyk ${SNYK_COMMAND} ${SNYK_PARAMS} \
+${ADDITIONAL_ENV} > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
 
 RC=$?
 
@@ -88,21 +92,30 @@ if [ "$RC" -ne "0" ] && [ "$RC" -ne "1" ]; then
 fi
 
 #
-# Commented out the condition because we want to always generate the html file until we phase out the old version of the Jenkins plugin
+# Commented out the condition because we want to always generate the html
+# file until we phase out the old version of the Jenkins plugin.
 # TODO: Re-add this option to documentation once back
 #
-# - `GENERATE_REPORT` - [OPTIONAL] if set, this will generate the HTML report with a summary of the vulnerabilities detected by snyk.
+# - `GENERATE_REPORT` - [OPTIONAL] if set, this will generate the HTML report
+# with a summary of the vulnerabilities detected by snyk.
 #
 # if [ -n $GENERATE_REPORT ]; then
 runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 
 if [ -n "$MONITOR" ]; then
-  runCmdAsDockerUser "PATH=${PATH} snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>\"${ERROR_FILE}\""
+  runCmdAsDockerUser "PATH=${PATH} snyk monitor --json ${SNYK_PARAMS} \
+  ${ADDITIONAL_ENV} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>\"${ERROR_FILE}\""
 fi
 
 
-runCmdAsDockerUser "cat \"${OUTPUT_FILE}\" | jq '.vulnerabilities|= map(. + {severity_numeric: (if(.severity) == \"high\" then 1 else (if(.severity) == \"medium\" then 2 else (if(.severity) == \"low\" then 3 else 4 end) end) end)}) |.vulnerabilities |= sort_by(.severity_numeric) | del(.vulnerabilities[].severity_numeric)' | snyk-to-html | sed 's/<\/head>/  <link rel=\"stylesheet\" href=\"snyk_report.css\"><\/head>/' >> \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
-runCmdAsDockerUser "cat /home/node/snyk_report.css > \"${PROJECT_PATH}/${PROJECT_FOLDER}/snyk_report.css\""
+runCmdAsDockerUser "cat \"${OUTPUT_FILE}\" | \
+jq '.vulnerabilities|= map(. + {severity_numeric: (if(.severity) == \"high\" then 1 else (if(.severity) == \"medium\" then 2 else (if(.severity) == \"low\" then 3 else 4 end) end) end)}) |.vulnerabilities |= sort_by(.severity_numeric) | del(.vulnerabilities[].severity_numeric)' | \
+snyk-to-html | \
+sed 's/<\/head>/  <link rel=\"stylesheet\" href=\"snyk_report.css\"><\/head>/' \
+>> \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
+
+runCmdAsDockerUser "cat /home/node/snyk_report.css > \
+\"${PROJECT_PATH}/${PROJECT_FOLDER}/snyk_report.css\""
 # fi
 #
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -49,7 +49,7 @@ exitWithMsg () {
 TEST_SETTINGS="";
 PROJECT_SUBDIR=""
 
-if [ ! -z "${TARGET_FILE}" ]; then
+if [ -n "${TARGET_FILE}" ]; then
   if [ ! -f "${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}" ]; then
     exitWithMsg "\"${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}\" does not exist" 1
   fi
@@ -59,7 +59,7 @@ if [ ! -z "${TARGET_FILE}" ]; then
   TEST_SETTINGS="--file=${MANIFEST_NAME} "
 fi
 
-if [ ! -z "${ORGANIZATION}" ]; then
+if [ -n "${ORGANIZATION}" ]; then
   TEST_SETTINGS="${TEST_SETTINGS} --org=${ORGANIZATION}"
 fi
 
@@ -73,7 +73,7 @@ if [ -z "${SNYK_TOKEN}" ]; then
   exitWithMsg "Missing \${SNYK_TOKEN}" 1
 fi
 
-if [ ! -z "${ENV_FLAGS}" ]; then
+if [ -n "${ENV_FLAGS}" ]; then
   ADDITIONAL_ENV="-- ${ENV_FLAGS}"
 fi
 
@@ -93,10 +93,10 @@ fi
 #
 # - `GENERATE_REPORT` - [OPTIONAL] if set, this will generate the HTML report with a summary of the vulnerabilities detected by snyk.
 #
-# if [ ! -z $GENERATE_REPORT ]; then
+# if [ -n $GENERATE_REPORT ]; then
 runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 
-if [ ! -z "$MONITOR" ]; then
+if [ -n "$MONITOR" ]; then
   runCmdAsDockerUser "PATH=${PATH} snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>\"${ERROR_FILE}\""
 fi
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -10,17 +10,17 @@ SNYK_COMMAND="$1"
 SNYK_PARAMS="${@:2}"
 ADDITIONAL_ENV=""
 
-if [ -z "$USER_ID" ]; then
+if [ -z "${USER_ID}" ]; then
   USER_ID=$(id -u)
 fi
 
-USER_NAME=$(getent passwd "$USER_ID" | awk -F ':' '{print $1}')
+USER_NAME=$(getent passwd "${USER_ID}" | awk -F ':' '{print $1}')
 
-if [ "$USER_NAME" != "" ] && [ "$USER_NAME" != "root" ]; then
-  usermod -d /home/node "$USER_NAME"
+if [ "${USER_NAME}" != "" ] && [ "${USER_NAME}" != "root" ]; then
+  usermod -d /home/node "${USER_NAME}"
 fi
 
-useradd -o -m -u "$USER_ID" -d /home/node docker-user 2>/dev/null
+useradd -o -m -u "${USER_ID}" -d /home/node docker-user 2>/dev/null
 
 runCmdAsDockerUser () {
   su docker-user -m -c "$1"
@@ -49,9 +49,9 @@ exitWithMsg () {
 TEST_SETTINGS="";
 PROJECT_SUBDIR=""
 
-if [ ! -z "$TARGET_FILE" ]; then
-  if [ ! -f "$PROJECT_PATH/$PROJECT_FOLDER/$TARGET_FILE" ]; then
-    exitWithMsg "$PROJECT_PATH/$PROJECT_FOLDER/$TARGET_FILE does not exist" 1
+if [ ! -z "${TARGET_FILE}" ]; then
+  if [ ! -f "${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}" ]; then
+    exitWithMsg "\"${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}\" does not exist" 1
   fi
 
   PROJECT_SUBDIR=$(dirname "${TARGET_FILE}")
@@ -59,7 +59,7 @@ if [ ! -z "$TARGET_FILE" ]; then
   TEST_SETTINGS="--file=${MANIFEST_NAME} "
 fi
 
-if [ ! -z "$ORGANIZATION" ]; then
+if [ ! -z "${ORGANIZATION}" ]; then
   TEST_SETTINGS="${TEST_SETTINGS} --org=${ORGANIZATION}"
 fi
 
@@ -69,22 +69,22 @@ SNYK_PARAMS="${SNYK_PARAMS} ${TEST_SETTINGS}"
 ## End of backward compatability code
 ##
 
-if [ -z "$SNYK_TOKEN" ]; then
-  exitWithMsg "Missing \$SNYK_TOKEN" 1
+if [ -z "${SNYK_TOKEN}" ]; then
+  exitWithMsg "Missing \${SNYK_TOKEN}" 1
 fi
 
-if [ ! -z "$ENV_FLAGS" ]; then
+if [ ! -z "${ENV_FLAGS}" ]; then
   ADDITIONAL_ENV="-- ${ENV_FLAGS}"
 fi
 
-cd "$PROJECT_PATH/$PROJECT_FOLDER/$PROJECT_SUBDIR" || exitWithMsg "Can't cd to $PROJECT_PATH/$PROJECT_FOLDER/$PROJECT_SUBDIR" 1
+cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" || exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
 
-runCmdAsDockerUser "PATH=$PATH snyk $SNYK_COMMAND $SNYK_PARAMS $ADDITIONAL_ENV > $OUTPUT_FILE 2>$ERROR_FILE"
+runCmdAsDockerUser "PATH=${PATH} snyk ${SNYK_COMMAND} ${SNYK_PARAMS} ${ADDITIONAL_ENV} > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
 
 RC=$?
 
 if [ "$RC" -ne "0" ] && [ "$RC" -ne "1" ]; then
-  exitWithMsg "$OUTPUT_FILE" "$RC"
+  exitWithMsg "${OUTPUT_FILE}" "$RC"
 fi
 
 #
@@ -94,22 +94,22 @@ fi
 # - `GENERATE_REPORT` - [OPTIONAL] if set, this will generate the HTML report with a summary of the vulnerabilities detected by snyk.
 #
 # if [ ! -z $GENERATE_REPORT ]; then
-runCmdAsDockerUser "touch $PROJECT_PATH/$PROJECT_FOLDER/$HTML_FILE"
+runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 
 if [ ! -z "$MONITOR" ]; then
-  runCmdAsDockerUser "PATH=$PATH snyk monitor --json $SNYK_PARAMS -- $ADDITIONAL_ENV | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > $PROJECT_PATH/$PROJECT_FOLDER/$HTML_FILE 2>$ERROR_FILE"
+  runCmdAsDockerUser "PATH=${PATH} snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>\"${ERROR_FILE}\""
 fi
 
 
-runCmdAsDockerUser "cat $OUTPUT_FILE | jq '.vulnerabilities|= map(. + {severity_numeric: (if(.severity) == \"high\" then 1 else (if(.severity) == \"medium\" then 2 else (if(.severity) == \"low\" then 3 else 4 end) end) end)}) |.vulnerabilities |= sort_by(.severity_numeric) | del(.vulnerabilities[].severity_numeric)' | snyk-to-html | sed 's/<\/head>/  <link rel=\"stylesheet\" href=\"snyk_report.css\"><\/head>/' >> $PROJECT_PATH/$PROJECT_FOLDER/$HTML_FILE"
-runCmdAsDockerUser "cat /home/node/snyk_report.css > $PROJECT_PATH/$PROJECT_FOLDER/snyk_report.css"
+runCmdAsDockerUser "cat \"${OUTPUT_FILE}\" | jq '.vulnerabilities|= map(. + {severity_numeric: (if(.severity) == \"high\" then 1 else (if(.severity) == \"medium\" then 2 else (if(.severity) == \"low\" then 3 else 4 end) end) end)}) |.vulnerabilities |= sort_by(.severity_numeric) | del(.vulnerabilities[].severity_numeric)' | snyk-to-html | sed 's/<\/head>/  <link rel=\"stylesheet\" href=\"snyk_report.css\"><\/head>/' >> \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
+runCmdAsDockerUser "cat /home/node/snyk_report.css > \"${PROJECT_PATH}/${PROJECT_FOLDER}/snyk_report.css\""
 # fi
 #
 
 if [ $RC -ne "0" ]; then
-  exitWithMsg "$OUTPUT_FILE" "$RC"
+  exitWithMsg "${OUTPUT_FILE}" "$RC"
 fi
 
-cat "$OUTPUT_FILE"
+cat "${OUTPUT_FILE}"
 
 exit "$RC"

--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -2,5 +2,5 @@
 
 virtualenv -p python snyk
 source snyk/bin/activate
-pip install -U -r $PROJECT_PATH/requirements.txt
+pip install -U -r "${PROJECT_PATH}/requirements.txt"
 bash docker-entrypoint.sh "$@"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes two issues in the docker entrypoint that wraps the CLI and supports a Jenkins context:
* Project paths that include spaces were causing the build report to be lost. Specifically, `${PROJECT_PATH}/${PROJECT_FOLDER}/...` needed to be quoted.
* `snyk monitor` command with standalone double-dash args was having an extra standalone double-dash.
* General sanitisation of `$ARG` to `${ARG}`
* Breaking long lines with `\` for readability