### PR TITLE
fix: gpg complains on non-tty mode in docker building process

### DIFF
--- a/docker/Dockerfile.gradle-2.8
+++ b/docker/Dockerfile.gradle-2.8
@@ -8,7 +8,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 
 # Accept license non-iteractive
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default

--- a/docker/Dockerfile.gradle-4.4
+++ b/docker/Dockerfile.gradle-4.4
@@ -8,7 +8,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 
 # Accept license non-iteractive
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default

--- a/docker/Dockerfile.maven-3.5.4
+++ b/docker/Dockerfile.maven-3.5.4
@@ -8,7 +8,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 
 # Accept license non-iteractive
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default

--- a/docker/Dockerfile.sbt-0.13.16
+++ b/docker/Dockerfile.sbt-0.13.16
@@ -8,7 +8,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 
 # Accept license non-iteractive
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default

--- a/docker/Dockerfile.sbt-1.0.4
+++ b/docker/Dockerfile.sbt-1.0.4
@@ -8,7 +8,7 @@ RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" 
 
 # Accept license non-iteractive
 RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
+RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 RUN apt-get update
 RUN mkdir -p /usr/share/man/man1
 RUN apt-get install -y oracle-java8-installer oracle-java8-set-default


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

A recent change to `gpg` invoked by `apt-key` broke our image building process with this message:
```
Step 6/22 : RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
 ---> Running in 75c61f36c92b
Warning: apt-key output should not be parsed (stdout is not a terminal)
Executing: /tmp/apt-key-gpghome.3O5vEEFljY/gpg.1.sh --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
gpg: key 8F9293A1EEA14886: public key "Totally Legit Signing Key <mallory@example.org>" imported
gpg: cannot open '/dev/tty': No such device or address
The command '/bin/sh -c apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886' returned a non-zero code: 2
```

Solving this with the wisdom of the Internet by using `--no-tty`.