### PR TITLE
chore: ignore root package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ local.log
 tmp
 .DS_Store
 package-lock.json
-!**/package-lock.json
+!/test/fixtures/**/package-lock.json


### PR DESCRIPTION
A change to the gitignore started picking up the package-lock.json again; this patch re-ignores it