### PR TITLE
fix: bump python-plugin to not depend on `pip` being available

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "snyk-nuget-plugin": "1.6.5",
     "snyk-php-plugin": "1.5.1",
     "snyk-policy": "1.13.1",
-    "snyk-python-plugin": "1.9.0",
+    "snyk-python-plugin": "1.9.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.0.2",
     "snyk-sbt-plugin": "2.0.1",


### PR DESCRIPTION
`snyk-python-plugin` PR: https://github.com/snyk/snyk-python-plugin/pull/50
