### PR TITLE
feat: Split dockerfile / base image vulns

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.5.0",
     "snyk-config": "2.2.0",
-    "snyk-docker-plugin": "1.14.0",
+    "snyk-docker-plugin": "1.17.0",
     "snyk-go-plugin": "1.6.1",
     "snyk-gradle-plugin": "2.1.2",
     "snyk-module": "1.9.1",

--- a/src/cli/commands/test.js
+++ b/src/cli/commands/test.js
@@ -358,7 +358,11 @@ function formatIssues(vuln, options) {
       ? createRemediationText(vuln, packageManager)
       : '',
     fixedIn: options.docker ? createFixedInText(vulnerableRange, version) : '',
+    dockerfilePackage: options.docker && vuln.dockerfileInstruction
+      ? `\n  Introduced in your Dockerfile by '${ vuln.dockerfileInstruction }'`
+      : `\n  Introduced by your base image (${ vuln.dockerBaseImage })`,
   };
+
   return (
     vulnOutput.issueHeading + '\n' +
     vulnOutput.description + '\n' +
@@ -367,6 +371,7 @@ function formatIssues(vuln, options) {
     vulnOutput.fromPaths +
     // Optional - not always there
     vulnOutput.remediationInfo +
+    vulnOutput.dockerfilePackage +
     vulnOutput.fixedIn +
     vulnOutput.extraInfo
   );
@@ -620,6 +625,8 @@ function groupVulnerabilities(vulns) {
       map[curr.id].note = curr.note;
       map[curr.id].severity = curr.severity;
       map[curr.id].isNew = isNewVuln(curr);
+      map[curr.id].dockerfileInstruction = curr.dockerfileInstruction;
+      map[curr.id].dockerBaseImage = curr.dockerBaseImage;
     }
     if (curr.upgradePath) {
       curr.isOutdated = curr.upgradePath[1] === curr.from[1];

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -1572,9 +1572,7 @@ test('`test foo:latest --docker with binaries`', async (t) => {
         },
         package: {
           docker: {
-            binaries: {
-              Analysis: [{name: 'node', version: '5.10.1'}],
-            },
+            binaries: [{name: 'node', version: '5.10.1'}],
           },
         },
       });
@@ -1594,7 +1592,7 @@ test('`test foo:latest --docker with binaries`', async (t) => {
   t.equal(req.method, 'POST', 'makes POST request');
   t.match(req.url, '/test-dep-graph', 'posts to correct url');
   t.equal(req.body.depGraph.pkgManager.name, 'deb');
-  t.match(req.body.docker.binaries, [{name: 'node', version: '5.10.1'}],
+  t.same(req.body.docker.binaries, [{name: 'node', version: '5.10.1'}],
     'posts docker binaries');
   t.same(spyPlugin.getCall(0).args,
     ['foo:latest', null, {


### PR DESCRIPTION
This patch adds an extra line to vulnerabilities found in a Dockerfile, indicating whether they came from the base Docker image (FROM: ) or your Dockerfile. In the latter case, the instruction that installed the vulnerable package is also highlighted.