### PR TITLE
fix: bump version for snyk-policy dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "snyk-nodejs-lockfile-parser": "1.10.1",
     "snyk-nuget-plugin": "1.6.5",
     "snyk-php-plugin": "1.5.1",
-    "snyk-policy": "1.13.2",
+    "snyk-policy": "1.13.3",
     "snyk-python-plugin": "1.9.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.0.2",

--- a/test/acceptance/workspaces/npm-package-policy/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
+++ b/test/acceptance/workspaces/npm-package-policy/custom-location/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   'npm:marked:20170907':

--- a/test/acceptance/workspaces/npm-package-with-git-url/.snyk
+++ b/test/acceptance/workspaces/npm-package-with-git-url/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
+++ b/test/acceptance/workspaces/npm-with-dep-missing-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:

--- a/test/acceptance/workspaces/ruby-app-policy/.snyk
+++ b/test/acceptance/workspaces/ruby-app-policy/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-RUBY-LYNX-20160:

--- a/test/fixtures/pkg-SC-1472/.snyk
+++ b/test/fixtures/pkg-SC-1472/.snyk
@@ -1,4 +1,4 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.2
+version: v1.13.3
 ignore: {}
 patch: {}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

bump version for snyk-policy dependency

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-264