### PR TITLE
feat: send docker image layers SHAs

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -172,9 +172,16 @@ async function assembleLocalPayload(root, options, policyLocations): Promise<Pay
     if (_.get(inspectRes, 'plugin.packageManager')) {
       options.packageManager = inspectRes.plugin.packageManager;
     }
-    if (!_.get(pkg, 'docker.baseImage') && options['base-image']) {
+
+    const baseImageFromDockerfile = _.get(pkg, 'docker.baseImage');
+    if (!baseImageFromDockerfile && options['base-image']) {
       pkg.docker = pkg.docker || {};
       pkg.docker.baseImage = options['base-image'];
+    }
+
+    if (baseImageFromDockerfile && inspectRes.plugin.imageLayers) {
+      analytics.add('BaseImage', baseImageFromDockerfile);
+      analytics.add('imageLayers', inspectRes.plugin.imageLayers);
     }
 
     if (_.get(pkg, 'files.gemfileLock.contents')) {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
In order to collect improve our docker image matching, we want to start looking on the layers SHAs.
In his PR we'll send the layers SHAs as part of the analytics.