### PR TITLE
fix: highlight the use of machine name for orgs help

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -27,8 +27,8 @@ Options:
 
   --dev .............. Include devDependencies (defaults to production only).
   --file=<File> ...... Sets package file. For more help run `snyk help file`.
-  --org=<org-name> ... Run snyk with a specific organisation. For more help
-                       run `snyk help orgs`.
+  --org=<org-name> ... Specify the org machine-name to run Snyk with a specific
+                       organisation. For more help run `snyk help orgs`.
   --ignore-policy .... Ignores and resets the state of your policy file.
   --trust-policies ... Applies and uses ignore rules from your dependencies's
                        Snyk policies, otherwise ignore policies are only


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Current help advises to use specify the org name but it isn't clear about the fact that you need to specify the "machine name" representation of the org name.

If I have an org called "Liran demo", it has a machine name of "liran-demo-123" associated with it and the latter is the one that should be provided to the CLI.
