### PR TITLE
fix: Undefined base image

### DIFF
--- a/src/cli/commands/test.js
+++ b/src/cli/commands/test.js
@@ -358,9 +358,7 @@ function formatIssues(vuln, options) {
       ? createRemediationText(vuln, packageManager)
       : '',
     fixedIn: options.docker ? createFixedInText(vulnerableRange, version) : '',
-    dockerfilePackage: options.docker && vuln.dockerfileInstruction
-      ? `\n  Introduced in your Dockerfile by '${ vuln.dockerfileInstruction }'`
-      : `\n  Introduced by your base image (${ vuln.dockerBaseImage })`,
+    dockerfilePackage: options.docker ? dockerfileInstructionText(vuln) : '',
   };
 
   return (
@@ -375,6 +373,18 @@ function formatIssues(vuln, options) {
     vulnOutput.fixedIn +
     vulnOutput.extraInfo
   );
+}
+
+function dockerfileInstructionText(vuln) {
+  if (vuln.dockerfileInstruction) {
+    return `\n  Introduced in your Dockerfile by '${ vuln.dockerfileInstruction }'`;
+  }
+
+  if (vuln.dockerBaseImage) {
+    return `\n  Introduced by your base image (${ vuln.dockerBaseImage })`;
+  }
+
+  return '';
 }
 
 function createFixedInText(versionRangeList, pkgVersion) {


### PR DESCRIPTION
This patch updates the conditions in which docker file instructions are
shown in remediation advice; currently they are shown even the file is
not used, resulting in some strange "undefined" messages.