### PR TITLE
fix: use pkg emergency build

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,7 @@
     "@semantic-release/npm",
     {
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
+      "cmd": "npm i -g https://github.com/randallknutson/pkg.git#build && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
     }
   ],
   "publish": [


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
The current release process fails with `TypeError: Expected `cwd` to be of type `string` but received type `undefined`` when running `pkg .`.

The reason is a new version of `globby@8.0.2` has been release to resolve compatibility issue with dir-glob (https://github.com/zeit/pkg/issues/604).

We'll use https://github.com/zeit/pkg/issues/603#issuecomment-452849624 as a fast fix

#### More info
https://github.com/zeit/pkg/issues/609