### PR TITLE
fix: Use unreleased 'pkg' to fix release process

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,7 @@
     "@semantic-release/npm",
     {
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
+      "cmd": "npm i -g github:zeit/pkg#b19d97a && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
     }
   ],
   "publish": [


### PR DESCRIPTION
The CLI build process is currently broken due to an interaction between pkg's "globby" dependency and "dir-glob".

See more at https://github.com/zeit/pkg/issues/603 and https://github.com/kevva/dir-glob/pull/8