### PR TITLE
feat: add Dockerfile for scanning Docker repos

### DIFF
--- a/docker/Dockerfile.docker
+++ b/docker/Dockerfile.docker
@@ -1,0 +1,35 @@
+FROM node:8-slim
+
+MAINTAINER Snyk Ltd
+
+# Install snyk cli
+RUN npm install --global snyk snyk-to-html && \
+    apt-get update && \
+    apt-get install -y jq
+
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
+ENV HOME /home/node
+
+# Install docker cli
+RUN apt-get update && \
+    apt-get install -y \
+      apt-transport-https
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+RUN echo "deb https://download.docker.com/linux/debian stretch stable" | tee /etc/apt/sources.list.d/docker.list
+RUN apt-get update && \
+    apt-get install -y docker-ce-cli
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+ADD docker-entrypoint.sh .
+ADD snyk_report.css .
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]
+


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add a Dockerfile for generating a Docker image with the Snyk CLI and the Docker CLI.

This means that a Docker user can scan Docker images using a Docker image!

#### Where should the reviewer start?

Build with

```
docker build -t snyk/snyk-cli:docker -f docker/Dockerfile.docker docker
```

#### How should this be manually tested?

Run using a command such as

```
docker run --rm \
    -e SNYK_TOKEN=$SNYK_TOKEN \
    -v $(pwd):/project \
    -v /var/run/docker.sock:/var/run/docker.sock \
    snyk/snyk-cli:docker \
    test --docker snyk/snyk-cli:docker --file=docker/Dockerfile.docker --json
```

#### Any background context you want to provide?

I want to run Snyk tests on Docker images generated on CI, and it's easier to have Snyk in a container than install it on the CI server.

#### Additional questions

Can this also be added to the build system with the other Docker images?