### PR TITLE
test: remove a fixture change done in PR #340

### DIFF
--- a/test/fixtures/protect-via-snyk/package.json
+++ b/test/fixtures/protect-via-snyk/package.json
@@ -5,7 +5,6 @@
   "main": "index.js",
   "dependencies": {
     "semver": "^2.3.2",
-    "get-uri": "2.0.2",
     "snyk": "*"
   },
   "scripts": {


### PR DESCRIPTION
This change was needed in #340 because one strange test tested via installing an already released snyk version ... now the fixed version is already released, so can restore the fixture ...
