### PR TITLE
fix(docs): add missing composer.lock file

### DIFF
--- a/help/file.txt
+++ b/help/file.txt
@@ -21,6 +21,7 @@ looking for files in following order:
   vendor/vendor.json
   obj/project.assets.json
   packages.config
+  composer.lock
 
 If more than one file exists it will use the first order-wise. If you wish to specify manually, you can
   point the --file parameter to force using what you specify, for example:


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Updates the Snyk CLI help for `snyk help file` to also include `composer.lock` as a supported ecosystem
