### PR TITLE
feat: remove semver and use nearestFixedInVersion instead

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -32,6 +32,7 @@ interface AnnotatedIssue extends IssueData {
   upgradePath: Array<string | boolean>;
   isUpgradable: boolean;
   isPatchable: boolean;
+  nearestFixedInVersion?: string;
 }
 
 interface LegacyVulnApiResult {
@@ -63,6 +64,7 @@ interface UpgradePath {
 interface FixInfo {
   upgradePaths: UpgradePath[];
   isPatchable: boolean;
+  nearestFixedInVersion?: string;
 }
 
 interface TestDepGraphResult {
@@ -166,6 +168,7 @@ function convertTestDepGraphResultToLegacy(
           isPatchable: false,
           name: pkgInfo.pkg.name,
           version: pkgInfo.pkg.version as string,
+          nearestFixedInVersion: pkgIssue.fixInfo.nearestFixedInVersion,
         });
         vulns.push(annotatedIssue);
       }

--- a/test/acceptance/fixtures/docker/find-result-binaries.json
+++ b/test/acceptance/fixtures/docker/find-result-binaries.json
@@ -245,16 +245,18 @@
                       "issueId": "SNYK-UPSTREAM-BZIP2-106947",
                       "fixInfo": {
                           "upgradePaths": [],
-                          "isPatchable": false
+                          "isPatchable": false,
+                          "nearestFixedInVersion": "5.13.1"
                       }
                   },
-                  "SNYK-LINUX-BZR-133048": {
-                    "issueId": "SNYK-LINUX-BZR-133048",
+                  "SNYK-UPSTREAM-NODE-72328": {
+                    "issueId": "SNYK-UPSTREAM-NODE-72328",
                     "fixInfo": {
-                        "upgradePaths": [],
-                        "isPatchable": false
+                      "upgradePaths": [],
+                      "isPatchable": false,
+                      "nearestFixedInVersion": "5.15.1"
                     }
-                }
+                  }
                 }
               }
             },
@@ -300,14 +302,14 @@
                   ],
                   "semver": {
                     "vulnerable": [
-                      ">=4.0.0 <4.2.3",
-                      ">=5.0.0 <5.13.1"
+                      "[4.0.0, 4.2.3)",
+                      "[5.0.0, 5.13.1)"
                     ]
                   },
                   "severity": "high",
                   "title": "Denial of Service"
                 },
-                "SNYK-LINUX-BZR-133048": {
+                "SNYK-UPSTREAM-NODE-72328": {
                   "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
                   "alternativeIds": [],
                   "creationTime": "2018-09-12T13:04:09.124530Z",
@@ -348,8 +350,8 @@
                   ],
                   "semver": {
                     "vulnerable": [
-                      ">=4.0.0 <4.2.3",
-                      ">=5.0.0 <5.15.1"
+                      "[4.0.0, 4.2.3)",
+                      "[5.0.0, 5.15.1)"
                     ]
                   },
                   "severity": "high",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Removes calculation of `fixedInVersion` for binaries, as the calculation of it has moved
to phoenix.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-53

