### PR TITLE
feat: docker exclude base image vulns flag

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -43,6 +43,8 @@ Options:
                        vulnerabilities. Can be used alongside `--file` and a
                        path to the image's Dockerfile for more detailed
                        remediation advice.
+  --exclude-base-image-vulns
+                       Exclude from display Docker base image vulnerabilities.
   --policy-path....... Manually pass a path to a policy file.
   --insecure ......... Ignore unknown certificate authorities.
   --json ............. Return results in JSON format.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Introduces `user layer` flag, when used, only user layer issues will be displayed.
- fixes single/multiple vulnerabilities text for key binaries display.

#### Screenshot
![image](https://user-images.githubusercontent.com/42895464/52652496-dc0a3600-2ef6-11e9-9e83-cae2717c95f5.png)


added `Pro tip` to introduce flag:
![image](https://user-images.githubusercontent.com/42895464/52652556-01973f80-2ef7-11e9-93e4-98204931ec8d.png)


