### PR TITLE
feat: move fixed in calculation for os packages to phoenix

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -337,7 +337,7 @@ function formatIssues(vuln, options) {
     remediationInfo: vuln.metadata.type !== 'license'
       ? createRemediationText(vuln, packageManager)
       : '',
-    fixedIn: options.docker ? createFixedInText(vuln, version) : '',
+    fixedIn: options.docker ? createFixedInText(vuln) : '',
     dockerfilePackage: options.docker ? dockerfileInstructionText(vuln) : '',
   };
 
@@ -367,26 +367,10 @@ function dockerfileInstructionText(vuln) {
   return '';
 }
 
-function createFixedInText(vuln, pkgVersion) {
-  let fixedVersion = '';
-  if (vuln.nearestFixedInVersion) {
-    fixedVersion = vuln.nearestFixedInVersion;
-  // pkgVersion is undefined for OS packages vuln
-  // TODO move this logic to vuln
-  } else if (!pkgVersion) {
-    const versionRangeList = vuln.list[0].semver.vulnerable;
-    let fixedVersionCandidate = '';
-    const lesserThan = /^<\S+$/;
-
-    if (versionRangeList && versionRangeList.length) {
-      // OS packages vulns versionRangeList includes a single upper bound version
-      fixedVersionCandidate = versionRangeList[0];
-      // trim relational operator `<` from first version in list
-      fixedVersion = lesserThan.test(fixedVersionCandidate) ?
-        fixedVersionCandidate.substr(1) : '';
-    }
-  }
-  return fixedVersion ? chalk.bold('\n  Fixed in: ' + fixedVersion) : '';
+function createFixedInText(vuln: any): string {
+  return vuln.nearestFixedInVersion ?
+    chalk.bold('\n  Fixed in: ' + vuln.nearestFixedInVersion )
+    : '';
 }
 
 function createRemediationText(vuln, packageManager) {

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -146,6 +146,7 @@ function convertTestDepGraphResultToLegacy(
           isPatchable: pkgIssue.fixInfo.isPatchable,
           name: pkgInfo.pkg.name,
           version: pkgInfo.pkg.version as string,
+          nearestFixedInVersion: pkgIssue.fixInfo.nearestFixedInVersion,
         });
 
         vulns.push(annotatedIssue);


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

The calculation is now done only once on our backend services
and our UI(cli & registry) are getting it as a vulnerability attribute.


