### PR TITLE
feat: bump docker plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.5.0",
     "snyk-config": "2.2.0",
-    "snyk-docker-plugin": "1.18.1",
+    "snyk-docker-plugin": "1.19.0",
     "snyk-go-plugin": "1.6.1",
     "snyk-gradle-plugin": "2.1.3",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
bumps docker plugin to `1.19.0` recognize `openjdk-jre` origin of installation.
