### PR TITLE
spike: test command paket support

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -23,6 +23,7 @@ const DETECTABLE_FILES = [
   'project.assets.json',
   'packages.config',
   'composer.lock',
+  'paket.dependencies',
 ];
 
 // when file is specified with --file, we look it up here
@@ -44,6 +45,7 @@ const DETECTABLE_PACKAGE_MANAGERS = {
   'packages.config': 'nuget',
   'project.json': 'nuget',
   'composer.lock': 'composer',
+  'paket.dependencies': 'paket',
 };
 
 export function isPathToPackageFile(path) {

--- a/src/lib/plugins/index.js
+++ b/src/lib/plugins/index.js
@@ -38,6 +38,9 @@ function loadPlugin(packageManager, options) {
     case 'composer': {
       return require('snyk-php-plugin');
     }
+    case 'paket': {
+      return require('./paket');
+    }
     default: {
       throw new Error('Unsupported package manager: ' + packageManager);
     }

--- a/src/lib/plugins/paket/index.ts
+++ b/src/lib/plugins/paket/index.ts
@@ -1,0 +1,55 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {parse} from 'snyk-paket-parser';
+
+export async function inspect(root: string, targetFile: string, options: any) {
+  const manifestFileFullPath = path.resolve(root, targetFile);
+
+  if (!fs.existsSync(manifestFileFullPath)) {
+    throw new Error('Manifest ' + targetFile + ' not found at location: ' +
+      manifestFileFullPath);
+  }
+
+  const fullPath = path.parse(manifestFileFullPath);
+  const lockFileFullPath = path.resolve(fullPath.dir, 'paket.lock');
+
+  if (!fs.existsSync(lockFileFullPath)) {
+    throw new Error('Lockfile paket.lock not found at location: ' +
+      lockFileFullPath + '. Please run `paket install` and re-run your snyk command.');
+  }
+
+  return {
+    plugin: {
+      name: 'paket',
+      packageManager: 'nuget',
+    },
+    package: {
+      dependencies: buildTree(fs.readFileSync(manifestFileFullPath, 'utf8')),
+      hasDevDependencies: false,
+      name: manifestFileFullPath,
+      version: '',
+    },
+  };
+}
+
+// TODO: use function from snyk-paket-parser to build the tree
+function buildTree(data) {
+  const parsed = parse(data);
+  const dependencies = {} as any;
+
+  for (const group of parsed) {
+    for (const dep of group.dependencies) {
+      if (dep.source === 'nuget') {
+        const nugetDep = dep as any;
+
+        dependencies[nugetDep.name] = {
+          name: nugetDep.name,
+          version: nugetDep.versionRange,
+          dependencies: {},
+        };
+      }
+    }
+  }
+
+  return dependencies;
+}

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -53,6 +53,7 @@ function run(root, options) {
     'govendor',
     'nuget',
     'composer',
+    'paket',
   ].indexOf(packageManager) === -1) {
     throw new Error('Unsupported package manager: ' + packageManager);
   }


### PR DESCRIPTION
#### What does this PR do?

Added `paket` support to `snyk test` command.

It is not production-ready:

- **only root level dependencies**
- **relevant tasks still in progress**

#### How to test locally

- Clone and checkout https://github.com/snyk/snyk-paket-parser/pull/20
- `npm link` in `snyk-paket-parser`
- `npm link snyk-paket-parser` in `snyk`
- Run test command on paket project.

#### Tested manifest file

```
framework: net451
source https://api.nuget.org/v3/index.json

nuget System.Net.Http 4.3.0
nuget FAKE
```

#### CLI output

```
snyk-dev test /Users/kirill/Work/paket-test

Testing /Users/kirill/Work/paket-test...

✗ Medium severity vulnerability found in System.Net.Http
  Description: Authentication Bypass
  Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60048
  Introduced through: System.Net.Http@4.3.0
  From: System.Net.Http@4.3.0

✗ High severity vulnerability found in System.Net.Http
  Description: Denial of Service (DoS)
  Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60045
  Introduced through: System.Net.Http@4.3.0
  From: System.Net.Http@4.3.0

✗ High severity vulnerability found in System.Net.Http
  Description: Improper Certificate Validation
  Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60046
  Introduced through: System.Net.Http@4.3.0
  From: System.Net.Http@4.3.0

✗ High severity vulnerability found in System.Net.Http
  Description: Privilege Escalation
  Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60047
  Introduced through: System.Net.Http@4.3.0
  From: System.Net.Http@4.3.0

✗ High severity vulnerability found in System.Net.Http
  Description: Information Disclosure
  Info: https://snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-72439
  Introduced through: System.Net.Http@4.3.0
  From: System.Net.Http@4.3.0




Organisation:      kirill
Package manager:   nuget
Target file:       paket.dependencies
Open source:       no
Project path:      /Users/kirill/Work/paket-test

Tested 2 dependencies for known vulnerabilities, found 5 vulnerabilities, 5 vulnerable paths.


Process finished with exit code 1

```
