### PR TITLE
feat: bump snyk-docker-plugin to include openjdk analyser fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.5.0",
     "snyk-config": "2.2.0",
-    "snyk-docker-plugin": "1.21.2",
+    "snyk-docker-plugin": "1.21.3",
     "snyk-go-plugin": "1.6.1",
     "snyk-gradle-plugin": "2.1.3",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
commit 7f41eac1e3a introduced a change to snyk-docker-plugin
where the subprocess module would return both stdout and stderr.

unfortunately, due to backward compatibility considerations,
java's "-version" command outputs strictly to stderr; naively,
we were looking for stdout.

(https://stackoverflow.com/questions/17968856/redirect-to-stdout-in-bash)

the fix in snyk-docker-plugin propagates both stdout and stderr
for further parsing.

- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team