### PR TITLE
feat: remove misleading docker layers vulns count breakdown

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -225,6 +225,10 @@ function displayResult(res, options) {
     );
   }
 
+  if (options.docker && options.file && options['exclude-base-image-vulns'] && res.vulnerabilities) {
+    res.uniqueCount = countExcludeBaseImageVulns(options, res);
+  }
+
   // NOT OK => We found some vulns, let's format the vulns info
   const vulnCount = res.vulnerabilities && res.vulnerabilities.length;
   const singleVulnText = res.licensesPolicy ? 'issue' : 'vulnerability';
@@ -248,8 +252,6 @@ function displayResult(res, options) {
     vulnCountText += '.';
   }
   let summary = testedInfoText + ', ' + chalk.red.bold(vulnCountText);
-
-  summary += getDockerLayersVulnCount(options, res);
 
   if (WIZARD_SUPPORTED_PMS.indexOf(packageManager) > -1) {
     summary += chalk.bold.green('\n\nRun `snyk wizard` to address these issues.');
@@ -637,10 +639,7 @@ function metadataForVuln(vuln) {
   };
 }
 
-function getDockerLayersVulnCount(options, res): string {
-  if (!options.docker || !options.file || !res.vulnerabilities) {
-    return '';
-  }
+function countExcludeBaseImageVulns(options, res): number {
   const nonBaseImageVulns = res.vulnerabilities.filter((vuln) => (vuln.dockerfileInstruction));
   if (options['exclude-base-image-vulns']) {
     res.vulnerabilities = nonBaseImageVulns;
@@ -654,8 +653,5 @@ function getDockerLayersVulnCount(options, res): string {
     }
     return acc;
   }, 0);
-  const layersVulnsCount = '\nVulnerabilities introduced by your base image: ' +
-    chalk.bold.red(`${res.uniqueCount - userUniqueCount}.`) +
-    '\nVulnerabilities introduced by other layers: ' + chalk.bold.red(`${userUniqueCount}.`);
-  return layersVulnsCount;
+  return userUniqueCount;
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Removes misleading docker layers vulns count breakdown. After introducing a breakdown of the total amount of vulns to base image vulns and other layers vulns, we've realized the number might be misleading since base image vulns and other layers vulns may overlap which means they won't add up to the total amount vulns and the breakdown will be misleading as seen in the screenshot below.


#### Screenshots
Here we can see the total number of vulns is 166, user layers vulns amount is 94 and base image vulns is 126. (the line `Vulnerabilities introduced by your base image: 72.` is a mistake since it ignores the real count of base image vulns and base on `total amount of vulns - other layers vulns`).
![image](https://user-images.githubusercontent.com/42895464/52728217-864d9080-2fbf-11e9-906e-4f616b1c6dc2.png)

This PR will propose this output when using the flags `--file` and `--exclude-base-image-vulns`:
![image](https://user-images.githubusercontent.com/42895464/52728576-36bb9480-2fc0-11e9-91c3-541c222d7bc3.png)

and this output without using the flag `--exclude-base-image-vulns`:
![image](https://user-images.githubusercontent.com/42895464/52728694-6cf91400-2fc0-11e9-8fc6-0020f940154f.png)

