### PR TITLE
chore: replace undefsafe with lodash.get

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "source-map-support": "^0.5.9",
     "tempfile": "^2.0.0",
     "then-fs": "^2.0.0",
-    "undefsafe": "^2.0.0",
     "update-notifier": "^2.5.0",
     "uuid": "^3.2.1"
   },

--- a/src/cli/commands/protect/prompts.js
+++ b/src/cli/commands/protect/prompts.js
@@ -13,7 +13,6 @@ var fmt = require('util').format;
 var debug = require('debug')('snyk');
 var protect = require('../../../lib/protect');
 var moduleToObject = require('snyk-module');
-var undefsafe = require('undefsafe');
 var config = require('../../../lib/config');
 var snykPolicy = require('snyk-policy');
 var chalk = require('chalk');
@@ -851,7 +850,7 @@ function nextSteps(pkg, prevAnswers) {
   var prompts = [];
   var i;
 
-  i = (undefsafe(pkg, 'scripts.test') || '').indexOf('snyk test');
+  i = _.get(pkg, 'scripts.test', '').indexOf('snyk test');
   if (i === -1) {
     prompts.push({
       name: 'misc-add-test',
@@ -868,7 +867,7 @@ function nextSteps(pkg, prevAnswers) {
     return prompts;
   }
 
-  i = (undefsafe(pkg, 'scripts.prepublish') || '').indexOf('snyk-pro');
+  i = _.get(pkg, 'scripts.prepublish', '').indexOf('snyk-pro');
 
   // if `snyk protect` doesn't already appear, then check if we need to add it
   if (i === -1) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- Replace [undefsafe](https://www.npmjs.com/package/undefsafe) with `lodash.get` which is essentially the same thing.
- Throw away `undefsafe` dependency.