### PR TITLE
fix: Re-pin get-uri at 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "configstore": "^3.1.2",
     "debug": "^3.1.0",
     "diff": "^4.0.1",
+    "get-uri": "2.0.2",
     "inquirer": "^3.0.0",
     "lodash": "^4.17.5",
     "needle": "^2.2.4",

--- a/test/fixtures/protect-via-snyk/package.json
+++ b/test/fixtures/protect-via-snyk/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "semver": "^2.3.2",
+    "get-uri": "2.0.2",
     "snyk": "*"
   },
   "scripts": {


### PR DESCRIPTION
`get-uri` was removed by https://github.com/snyk/snyk/commit/c3c1a337f33f6986e6ef049eea3ffbaed5a755f4 because it didn't seem to have any direct usage.

However, it was originally added by https://github.com/snyk/snyk/commit/8bfae15559fdc502974853ddebfd66fcb0a11f47 to prevent `get-uri@2.0.3` from breaking Node 4 compatibility.

This patch reintroduces `get-uri` as a top level dependency to prevent npm from installing the higher version (effectively relying on npm's deduping mechanism to restrict the version used). Also changes a test fixture temporarily (see the previous get-uri pin and subsequent revert in https://github.com/snyk/snyk/commit/bbfd7002aed081b4c4018c4f2743a11329c93f9a)