### PR TITLE
fix: update nuget-plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",
-    "snyk-nuget-plugin": "1.7.1",
+    "snyk-nuget-plugin": "1.7.2",
     "snyk-php-plugin": "1.5.2",
     "snyk-policy": "1.13.3",
     "snyk-python-plugin": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Update nuget-plugin version to fix issue where we set the `--file` flag from a different directory (`--file='./path/to/file.txt`) and the lock file was not found in the directory (`.`)