### PR TITLE
fix: when running in a docker container, save monitor command output in a file

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -4,6 +4,7 @@ set -v
 set -x
 
 OUTPUT_FILE=snyk-result.json
+MONITOR_OUTPUT_FILE=snyk-monitor-result.json
 ERROR_FILE=snyk-error.log
 HTML_FILE=snyk_report.html
 SNYK_COMMAND="$1"
@@ -103,8 +104,8 @@ fi
 runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 
 if [ -n "$MONITOR" ]; then
-  runCmdAsDockerUser "PATH=${PATH} snyk monitor --json ${SNYK_PARAMS} \
-  ${ADDITIONAL_ENV} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>\"${ERROR_FILE}\""
+  runCmdAsDockerUser "PATH=$PATH snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} > ${MONITOR_OUTPUT_FILE} 2>$ERROR_FILE"
+  runCmdAsDockerUser "cat ${MONITOR_OUTPUT_FILE} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>>\"${ERROR_FILE}\""
 fi
 
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Currently, only the regular result is output
However, the monitor result has some useful info such as the scan URL

This merges #381 as an internal contribution to overcome CI.