### PR TITLE
feat: add dockerLayers field to monitor payload

### DIFF
--- a/src/lib/monitor.js
+++ b/src/lib/monitor.js
@@ -48,6 +48,7 @@ function monitor(root, meta, info) {
               pluginRuntime: pluginMeta.runtime,
               dockerImageId: pluginMeta.dockerImageId,
               dockerBaseImage: pkg.docker ? pkg.docker.baseImage : undefined,
+              dockerLayers: pluginMeta.dockerLayers,
               projectName: meta['project-name'],
             },
             policy: policy.toString(),


### PR DESCRIPTION
snyk-docker-plugin generates information regarding
docker layers (id, possible associated command and
packages introduced).

its immediate use would be for displaying docker layers
in vuln snapshots.

- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team
