### PR TITLE
Remove unnecessary space before comma in the summary output text

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -206,9 +206,9 @@ function displayResult(res, options) {
   // OK  => no vulns found, return
   if (res.ok && res.vulnerabilities.length === 0) {
     const vulnPathsText = options.showVulnPaths ?
-      ', no vulnerable paths found.' :
-      ', none were found.';
-    const summaryOKText = chalk.green(`✓ ${testedInfoText} ${vulnPathsText}`);
+      'no vulnerable paths found.' :
+      'none were found.';
+    const summaryOKText = chalk.green(`✓ ${testedInfoText}, ${vulnPathsText}`);
     const nextStepsText =
       '\n\nNext steps:' +
       '\n- Run `snyk monitor` to be notified ' +


### PR DESCRIPTION
#### Context
@robcresswell asked me to find a bug in CLI, and this is what I've come up with 😂 

#### What does this PR do?
It removes unnecessary space in the happy case where `snyk test` finds 0 vulnerabilities.

#### Before
<img width="828" alt="screenshot 2019-03-07 at 12 49 54" src="https://user-images.githubusercontent.com/112600/53958276-7c0f4580-40d8-11e9-96d3-e516c61663fb.png">

#### After
<img width="813" alt="screenshot 2019-03-07 at 12 49 35" src="https://user-images.githubusercontent.com/112600/53958280-803b6300-40d8-11e9-985b-43e56cd83893.png">
