### PR TITLE
fix: Parse bool or string out of sync option

### DIFF
--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -22,7 +22,7 @@ interface Options {
   docker?: boolean;
   traverseNodeModules?: boolean;
   dev?: boolean;
-  strictOutOfSync?: boolean;
+  strictOutOfSync?: boolean | 'true' | 'false';
 }
 
 interface Plugin {

--- a/src/lib/plugins/npm/index.ts
+++ b/src/lib/plugins/npm/index.ts
@@ -7,7 +7,7 @@ import * as snyk from '../../';
 interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
-  strictOutOfSync?: boolean;
+  strictOutOfSync?: boolean | 'true' | 'false';
 }
 
 interface InspectResult {
@@ -67,7 +67,7 @@ async function generateDependenciesFromLockfile(root: string, targetFile: string
   ]);
 
   const defaultManifestFileName = path.relative(root, manifestFileFullPath);
-  const strictOutOfSync = _.get(options, 'strictOutOfSync', true);
+  const strictOutOfSync = _.get(options, 'strictOutOfSync') !== 'false';
 
   return await buildDepTree(
     manifestFile,

--- a/src/lib/plugins/yarn/index.ts
+++ b/src/lib/plugins/yarn/index.ts
@@ -10,7 +10,7 @@ const debug = Debug('snyk');
 interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
-  strictOutOfSync?: boolean;
+  strictOutOfSync?: boolean | 'true' | 'false';
 }
 
 interface InspectResult {
@@ -85,7 +85,7 @@ async function generateDependenciesFromLockfile(root, options, targetFile): Prom
   ]);
 
   const defaultManifestFileName = path.relative(root, manifestFileFullPath);
-  const strictOutOfSync = _.get(options, 'strictOutOfSync', true);
+  const strictOutOfSync = _.get(options, 'strictOutOfSync') !== 'false';
 
   return buildDepTree(
     manifestFile,

--- a/src/lib/snyk-test/npm/index.js
+++ b/src/lib/snyk-test/npm/index.js
@@ -149,8 +149,10 @@ function generateDependenciesFromLockfile(root, options, targetFile) {
   debug(resolveModuleSpinnerLabel);
   return spinner(resolveModuleSpinnerLabel)
     .then(() => {
-      const strictOutOfSync = _.get(options, 'strictOutOfSync', true);
-      return lockFileParser.buildDepTree(manifestFile, lockFile, options.dev, lockFileType, strictOutOfSync);
+      const strictOutOfSync = _.get(options, 'strictOutOfSync') !== 'false';
+
+      return lockFileParser
+        .buildDepTree(manifestFile, lockFile, options.dev, lockFileType, strictOutOfSync);
     })
     // clear spinner in case of success or failure
     .then(spinner.clear(resolveModuleSpinnerLabel))

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -867,7 +867,7 @@ if (getRuntimeVersion() > 4) {
 
   test('`test yarn-out-of-sync --strictOutOfSync=false` passes', async (t) => {
     chdirWorkspaces();
-    await cli.test('yarn-out-of-sync', { dev: true, strictOutOfSync: false});
+    await cli.test('yarn-out-of-sync', { dev: true, strictOutOfSync: 'false'});
     const req = server.popRequest();
     const pkg = req.body;
     t.equal(req.method, 'POST', 'makes POST request');
@@ -881,7 +881,7 @@ if (getRuntimeVersion() > 4) {
 
 test('`test npm-out-of-sync --strictOutOfSync=false` passes', async (t) => {
   chdirWorkspaces();
-  await cli.test('npm-out-of-sync', { dev: true, strictOutOfSync: false});
+  await cli.test('npm-out-of-sync', { dev: true, strictOutOfSync: 'false' });
   const req = server.popRequest();
   const pkg = req.body;
   t.equal(req.method, 'POST', 'makes POST request');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- The value provided to the cli can be a string or a bool, handle both

#### How should this be manually tested?

See the commands below

#### What are the relevant tickets?

##### Strict = true
```snyk-dev test --strictOutOfSync=true
An unknown error occurred. Please include the trace below when reporting to Snyk:

Error:
Testing /Users/lili/www/-CSUP...

Dependency @/ops-admin was not found in yarn.lock. Your package.json and yarn.lock are probably out of sync. Please run "yarn install" and try again.
    at /Users/lili/www/snyk/snyk/src/cli/commands/test.ts:141:19
    at step (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:32:23)
    at Object.throw (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:13:53)
    at rejected (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:5:65)
    at <anonymous>
    at runMicrotasksCallback (internal/process/next_tick.js:122:5)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)

```
##### Strict = false

```snyk-dev test --strictOutOfSync=false

Testing /Users/lili/www/-CSUP...

Organisation:      lili2311
Package manager:   yarn
Target file:       yarn.lock
Open source:       no
Project path:      /Users/lili/www/-CSUP
Licenses:          enabled

✓ Tested 2 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.

```
##### Default is strict

```snyk-dev test
An unknown error occurred. Please include the trace below when reporting to Snyk:

Error:
Testing /Users/lili/www/-CSUP...

Dependency @/ops-admin was not found in yarn.lock. Your package.json and yarn.lock are probably out of sync. Please run "yarn install" and try again.
    at /Users/lili/www/snyk/snyk/src/cli/commands/test.ts:141:19
    at step (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:32:23)
    at Object.throw (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:13:53)
    at rejected (/Users/lili/www/snyk/snyk/dist/cli/commands/test.js:5:65)
    at <anonymous>
    at runMicrotasksCallback (internal/process/next_tick.js:122:5)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickCallback (internal/process/next_tick.js:181:9)
```