### PR TITLE
fix: correct scanning when targeting Gradle subprojects

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "snyk-config": "2.2.1",
     "snyk-docker-plugin": "1.22.0",
     "snyk-go-plugin": "1.6.1",
-    "snyk-gradle-plugin": "2.3.0",
+    "snyk-gradle-plugin": "2.3.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes issue when target file for scanning is a Gradle subproject.

#### How should this be manually tested?

As per https://github.com/snyk/snyk-gradle-plugin/issues/33, scan subproject/build.gradle

#### What are the relevant tickets?

https://github.com/snyk/snyk-gradle-plugin/issues/33
