### PR TITLE
Feat/gradle subproject flag

### DIFF
--- a/src/cli/commands/monitor.js
+++ b/src/cli/commands/monitor.js
@@ -35,6 +35,9 @@ function monitor() {
     snyk.id = options.id;
   }
 
+
+  // This is a temporary check for gradual rollout of subprojects scanning
+  // TODO: delete once supported for monitor
   if (options['scan-all-subprojects']) {
     throw new Error('`--scan-all-subprojects` is currently not supported for `snyk monitor`');
   }

--- a/src/cli/commands/monitor.js
+++ b/src/cli/commands/monitor.js
@@ -35,6 +35,10 @@ function monitor() {
     snyk.id = options.id;
   }
 
+  if (options['scan-all-subprojects']) {
+    throw new Error('`--scan-all-subprojects` is currently not supported for `snyk monitor`');
+  }
+
   return apiTokenExists('snyk monitor')
     .then(function () {
       return args.reduce(function (acc, path) {

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -23,6 +23,7 @@ interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
   strictOutOfSync?: boolean | 'true' | 'false';
+  multiDepRoots?: boolean;
 }
 
 interface Plugin {
@@ -71,6 +72,17 @@ export function loadPlugin(packageManager: string, options: Options = {}): Plugi
     }
     default: {
       throw new Error(`Unsupported package manager: ${packageManager}`);
+    }
+  }
+}
+
+export function getDefaultPluginOptions(packageManager: string): Options {
+  switch (packageManager) {
+    case 'gradle': {
+      return { multiDepRoots: true};
+    }
+    default: {
+      return {};
     }
   }
 }

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -23,6 +23,8 @@ interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
   strictOutOfSync?: boolean | 'true' | 'false';
+  // multiDepRoots tells plugin to return multiple dependency trees
+  // current support: gradle via --scan-all-subprojects options
   multiDepRoots?: boolean;
 }
 

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -161,7 +161,8 @@ async function assembleLocalPayload(root, options, policyLocations): Promise<Pay
 
   try {
     await spinner(spinnerLbl);
-    const inspectRes = await moduleInfo.inspect(root, options.file, options);
+    const defaultPluginOptions = plugins.getDefaultPluginOptions(options.packageManager);
+    const inspectRes = await moduleInfo.inspect(root, options.file, { ...options, ...defaultPluginOptions});
 
     const pkg = inspectRes.package;
     if (_.get(inspectRes, 'plugin.packageManager')) {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -540,6 +540,7 @@ test('`test gradle-app` returns correct meta', async (t) => {
 
   const res = await cli.test('gradle-app');
   const meta = res.slice(res.indexOf('Organisation:')).split('\n');
+  t.true(spyPlugin.args[0][2].multiDepRoots);
   t.match(meta[0], /Organisation:\s+test-org/, 'organisation displayed');
   t.match(meta[1], /Package manager:\s+gradle/,
     'package manager displayed');


### PR DESCRIPTION
**DO NOT MERGE**

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
As a part of upcoming gradle improvements, this PR makes sure there'll be gradual support of scanning all Gradle subprojects by adding this option to `test` command and failing `monitor` command. 

#### Any background context you want to provide?
As this is basically an internal feature flag, not public documentation is available and this code will change soon.

This PR might be completely destroyed as well as merged together with the work around `snyk test` with multiple trees.