### PR TITLE
feat: plugin returns multiple trees

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -54,6 +54,8 @@ Options:
   --gradle-sub-project=<string>
                        For Gradle "multi project" configurations,
                        test a specific sub-project.
+  --all-sub-projects   For "multi project" configurations, test all
+                       sub-projects.
   -q, --quiet ........ Silence all output.
   -h, --help ......... This help information.
   -v, --version ...... The CLI version.

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.22.1",
     "snyk-go-plugin": "1.6.1",
-    "snyk-gradle-plugin": "2.4.3",
+    "snyk-gradle-plugin": "2.5.0",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",

--- a/src/cli/commands/monitor.js
+++ b/src/cli/commands/monitor.js
@@ -35,6 +35,13 @@ function monitor() {
     snyk.id = options.id;
   }
 
+
+  // This is a temporary check for gradual rollout of subprojects scanning
+  // TODO: delete once supported for monitor
+  if (options['all-sub-projects']) {
+    throw new Error('`--all-sub-projects` is currently not supported for `snyk monitor`');
+  }
+
   return apiTokenExists('snyk monitor')
     .then(function () {
       return args.reduce(function (acc, path) {

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -80,14 +80,20 @@ async function test(...args) {
     }
 
     // Not all test results are arrays in order to be backwards compatible
-    // with sctripts that use a callback with test. Coerce results/errors to be arrays
+    // with scripts that use a callback with test. Coerce results/errors to be arrays
     // and add the result options to each to be displayed
-    if (!Array.isArray(res)) {
-      res = [res];
-    }
-    for (const r of res) {
-      results.push(_.assign(r, {path}));
-      resultOptions.push(testOpts);
+    const resArray: any[] = Array.isArray(res) ? res : [res];
+
+    for (let i = 0; i < resArray.length; i++) {
+      results.push(_.assign(resArray[i], {path}));
+      // currently testOpts are identical for each test result returned even if it's for multiple projects.
+      // we want to return the project names, so will need to be crafty in a way that makes sense.
+      if (!testOpts.subProjectNames) {
+        resultOptions.push(testOpts);
+      } else {
+        resultOptions.push(_.assign(_.cloneDeep(testOpts),
+          {subProjectName: testOpts.subProjectNames[i]}));
+      }
     }
   }
 
@@ -519,6 +525,9 @@ function metaForDisplay(res, options) {
   ];
   if (options.file) {
     meta.push(chalk.bold(rightPadWithSpaces('Target file: ', padToLength)) + options.file);
+  }
+  if (options.subProjectName) {
+    meta.push(chalk.bold(rightPadWithSpaces('Sub project: ', padToLength)) + options.subProjectName);
   }
   if (options.docker) {
     meta.push(chalk.bold(rightPadWithSpaces('Docker image: ', padToLength)) + options.path);

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -50,7 +50,6 @@ async function test(...args) {
     // these options later.
     const testOpts = _.cloneDeep(options);
     testOpts.path = path;
-    resultOptions.push(testOpts);
 
     let res;
 
@@ -81,7 +80,13 @@ async function test(...args) {
     }
 
     // add the tested path to the result of the test (or error)
-    results.push(_.assign(res, {path}));
+    if (!Array.isArray(res)) {
+      res = [res];
+    }
+    for (const r of res) {
+      results.push(_.assign(r, {path}));
+      resultOptions.push(testOpts); // doesnt this put testOps in there too many times? line:53
+    }
   }
 
   // resultOptions is now an array of 1 or more options used for

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -79,13 +79,15 @@ async function test(...args) {
       }
     }
 
-    // add the tested path to the result of the test (or error)
+    // Not all test results are arrays in order to be backwards compatible
+    // with sctripts that use a callback with test. Coerce results/errors to be arrays
+    // and add the result options to each to be displayed
     if (!Array.isArray(res)) {
       res = [res];
     }
     for (const r of res) {
       results.push(_.assign(r, {path}));
-      resultOptions.push(testOpts); // doesnt this put testOps in there too many times? line:53
+      resultOptions.push(testOpts);
     }
   }
 

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -56,3 +56,18 @@ export function loadPlugin(packageManager: string, options: types.Options = {}):
     }
   }
 }
+
+export function getPluginOptions(packageManager: string, options: types.Options): types.Options {
+  const pluginOptions: types.Options = {};
+  switch (packageManager) {
+    case 'gradle': {
+      if (options['all-sub-projects']) {
+        pluginOptions.multiDepRoots = true;
+      }
+      return pluginOptions;
+    }
+    default: {
+      return pluginOptions;
+    }
+  }
+}

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -11,6 +11,7 @@ export interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
   strictOutOfSync?: boolean | 'true' | 'false';
+  multiDepRoots?: boolean;
 }
 
 export interface Plugin {

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -48,7 +48,7 @@ function executeTest(root, options) {
 function run(root, options) {
   var packageManager = options.packageManager;
   if (['npm', 'yarn'].indexOf(packageManager) >= 0) {
-    return require('./npm')(root, options);
+    return require('./npm')(root, options).then((res) => [res]);
   }
   if (!options.docker && [
     'rubygems',

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -27,11 +27,18 @@ function executeTest(root, options) {
     var packageManager = detect.detectPackageManager(root, options);
     options.packageManager = packageManager;
     return run(root, options)
-      .then(function (res) {
-        if (!res.packageManager) {
-          res.packageManager = packageManager;
+      .then(function (results) {
+        for (const res of results) {
+          if (!res.packageManager) {
+            res.packageManager = packageManager;
+          }
         }
-        return res;
+        if (results.length === 1) {
+          // Return only one result if only one found as this is the default usecase
+          return results[0];
+        }
+        // For gradle and yarnWorkspaces we may be returning more than one result
+        return results;
       });
   } catch (error) {
     return Promise.reject(chalk.red.bold(error));

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -22,59 +22,6 @@ const debug = require('debug')('snyk');
 
 export = runTest;
 
-async function runTest(packageManager: string, root: string, options): Promise<object> {
-  const policyLocations = [options['policy-path'] || root];
-  // TODO: why hasDevDependencies is always false?
-  const hasDevDependencies = false;
-
-  const spinnerLbl = 'Querying vulnerabilities database...';
-  try {
-    const payload = await assemblePayload(root, options, policyLocations);
-    const filesystemPolicy = payload.body && !!payload.body.policy;
-    const depGraph = payload.body && payload.body.depGraph;
-
-    let dockerfilePackages;
-    if (payload.body && payload.body.docker && payload.body.docker.dockerfilePackages) {
-      dockerfilePackages = payload.body.docker.dockerfilePackages;
-    }
-
-    await spinner(spinnerLbl);
-    let res = await sendPayload(payload, hasDevDependencies);
-    if (depGraph) {
-      res = convertTestDepGraphResultToLegacy(
-        res,
-        depGraph,
-        packageManager,
-        options.severityThreshold);
-    }
-
-    analytics.add('vulns-pre-policy', res.vulnerabilities.length);
-    res.filesystemPolicy = filesystemPolicy;
-    if (!options['ignore-policy']) {
-      const policy = await snyk.policy.loadFromText(res.policy);
-      res = policy.filter(res, root);
-    }
-    analytics.add('vulns', res.vulnerabilities.length);
-
-    if (res.docker && dockerfilePackages) {
-      res.vulnerabilities = res.vulnerabilities.map((vuln) => {
-        const dockerfilePackage = dockerfilePackages[vuln.name.split('/')[0]];
-        if (dockerfilePackage) {
-          vuln.dockerfileInstruction = dockerfilePackage.instruction;
-        }
-        vuln.dockerBaseImage = res.docker.baseImage;
-        return vuln;
-      });
-    }
-
-    res.uniqueCount = countUniqueVulns(res.vulnerabilities);
-
-    return res;
-  } finally {
-    spinner.clear(spinnerLbl)();
-  }
-}
-
 interface Payload {
   method: string;
   url: string;
@@ -93,7 +40,101 @@ interface Payload {
   qs?: object | null;
 }
 
-function sendPayload(payload, hasDevDependencies): Promise<any> {
+interface PluginMetadata {
+  name: string;
+  packageFormatVersion?: string;
+  packageManager: string;
+  imageLayers?: any;
+  targetFile?: string; // this is wrong (because Shaun said it)
+}
+
+interface DepDict {
+  [name: string]: DepTree;
+}
+
+interface DepTree {
+  name: string;
+  version: string;
+  dependencies?: DepDict;
+  packageFormatVersion?: string;
+  docker?: any;
+  files?: any;
+  targetFile?: string;
+}
+
+interface DepRoot {
+  depTree: DepTree; // to be soon replaced with depGraph
+  targetFile?: string;
+}
+
+interface Package {
+  plugin: PluginMetadata;
+  depRoots: DepRoot[]; // currently only returned by gradle
+  package?: DepTree;
+}
+
+async function runTest(packageManager: string, root: string, options): Promise<object[]> {
+  const policyLocations = [options['policy-path'] || root];
+  // TODO: why hasDevDependencies is always false?
+  const hasDevDependencies = false;
+
+  const results: object[] = [];
+  const spinnerLbl = 'Querying vulnerabilities database...';
+  try {
+    const payloads = await assemblePayload(root, options, policyLocations);
+    for (const payload of payloads) {
+      const filesystemPolicy = payload.body && !!payload.body.policy;
+      const depGraph = payload.body && payload.body.depGraph;
+
+      let dockerfilePackages;
+      if (payload.body && payload.body.docker && payload.body.docker.dockerfilePackages) {
+        dockerfilePackages = payload.body.docker.dockerfilePackages;
+      }
+
+      await spinner(spinnerLbl);
+      let res = await sendPayload(payload, hasDevDependencies);
+      if (depGraph) {
+        res = convertTestDepGraphResultToLegacy(
+          res,
+          depGraph,
+          packageManager,
+          options.severityThreshold);
+      }
+
+      analytics.add('vulns-pre-policy', res.vulnerabilities.length);
+      res.filesystemPolicy = filesystemPolicy;
+      if (!options['ignore-policy']) {
+        const policy = await snyk.policy.loadFromText(res.policy);
+        res = policy.filter(res, root);
+      }
+      analytics.add('vulns', res.vulnerabilities.length);
+
+      if (res.docker && dockerfilePackages) {
+        res.vulnerabilities = res.vulnerabilities.map((vuln) => {
+          const dockerfilePackage = dockerfilePackages[vuln.name.split('/')[0]];
+          if (dockerfilePackage) {
+            vuln.dockerfileInstruction = dockerfilePackage.instruction;
+          }
+          vuln.dockerBaseImage = res.docker.baseImage;
+          return vuln;
+        });
+      }
+
+      if (options.docker && options.file && options['exclude-base-image-vulns']) {
+        res.vulnerabilities = res.vulnerabilities.filter((vuln) => (vuln.dockerfileInstruction));
+      }
+
+      res.uniqueCount = countUniqueVulns(res.vulnerabilities);
+
+      results.push(res);
+    }
+    return results;
+  } finally {
+    spinner.clear(spinnerLbl)();
+  }
+}
+
+function sendPayload(payload: Payload, hasDevDependencies: boolean): Promise<any> {
   const filesystemPolicy = payload.body && !!payload.body.policy;
   return new Promise((resolve, reject) => {
     request(payload, (error, res, body) => {
@@ -130,7 +171,7 @@ function sendPayload(payload, hasDevDependencies): Promise<any> {
   });
 }
 
-function assemblePayload(root: string, options, policyLocations: string[]): Promise<Payload> {
+function assemblePayload(root: string, options, policyLocations: string[]): Promise<Payload[]> {
   let isLocal;
   if (options.docker) {
     isLocal = true;
@@ -147,87 +188,108 @@ function assemblePayload(root: string, options, policyLocations: string[]): Prom
   return assembleRemotePayload(root, options);
 }
 
-async function assembleLocalPayload(root, options, policyLocations): Promise<Payload> {
+async function getDepsFromPlugin(root, options): Promise<Package> {
   options.file = options.file || detect.detectPackageFile(root);
   const plugin = plugins.loadPlugin(options.packageManager, options);
   const moduleInfo = ModuleInfo(plugin, options.policy);
+  const inspectRes: Package = await moduleInfo.inspect(root, options.file, options);
+
+  if (!inspectRes.depRoots) {
+    if (!inspectRes.package) {
+      // something went wrong if both are not present...
+      throw Error('Error getting deps from plugin');
+    }
+    if (!inspectRes.package.targetFile && inspectRes.plugin) {
+      inspectRes.package.targetFile = inspectRes.plugin.targetFile;
+    }
+    inspectRes.depRoots = [{depTree: inspectRes.package}];
+  }
+  return inspectRes;
+}
+
+async function assembleLocalPayload(root, options, policyLocations): Promise<Payload[]> {
   const analysisType = options.docker ? 'docker' : options.packageManager;
   const spinnerLbl = 'Analyzing ' + analysisType + ' dependencies for ' +
     pathUtil.relative('.', pathUtil.join(root, options.file || ''));
 
   try {
+    const payloads: Payload[] = [];
+
     await spinner(spinnerLbl);
-    const inspectRes = await moduleInfo.inspect(root, options.file, options);
+    const deps = await getDepsFromPlugin(root, options);
 
-    const pkg = inspectRes.package;
-    if (_.get(inspectRes, 'plugin.packageManager')) {
-      options.packageManager = inspectRes.plugin.packageManager;
-    }
+    for (const depRoot of deps.depRoots) {
+      const pkg = depRoot.depTree;
+      if (deps.plugin && deps.plugin.packageManager) {
+        options.packageManager = deps.plugin.packageManager;
+      }
 
-    const baseImageFromDockerfile = _.get(pkg, 'docker.baseImage');
-    if (!baseImageFromDockerfile && options['base-image']) {
-      pkg.docker = pkg.docker || {};
-      pkg.docker.baseImage = options['base-image'];
-    }
+      const baseImageFromDockerfile = _.get(pkg, 'docker.baseImage');
+      if (!baseImageFromDockerfile && options['base-image']) {
+        pkg.docker = pkg.docker || {};
+        pkg.docker.baseImage = options['base-image'];
+      }
 
-    if (baseImageFromDockerfile && inspectRes.plugin.imageLayers) {
-      analytics.add('BaseImage', baseImageFromDockerfile);
-      analytics.add('imageLayers', inspectRes.plugin.imageLayers);
-    }
+      if (baseImageFromDockerfile && deps.plugin && deps.plugin.imageLayers) {
+        analytics.add('BaseImage', baseImageFromDockerfile);
+        analytics.add('imageLayers', deps.plugin.imageLayers);
+      }
 
-    if (_.get(pkg, 'files.gemfileLock.contents')) {
-      const gemfileLockBase64 = pkg.files.gemfileLock.contents;
-      const gemfileLockContents = Buffer.from(gemfileLockBase64, 'base64').toString();
-      pkg.dependencies = gemfileLockToDependencies(gemfileLockContents);
-    }
+      if (_.get(pkg, 'files.gemfileLock.contents')) {
+        const gemfileLockBase64 = pkg.files.gemfileLock.contents;
+        const gemfileLockContents = Buffer.from(gemfileLockBase64, 'base64').toString();
+        pkg.dependencies = gemfileLockToDependencies(gemfileLockContents);
+      }
 
-    const depGraph = await depGraphLib.legacy.depTreeToGraph(
-      pkg, options.packageManager);
+      const depGraph = await depGraphLib.legacy.depTreeToGraph(
+        pkg, options.packageManager);
 
-    analytics.add('policies', policyLocations.length);
-    analytics.add('packageManager', options.packageManager);
-    analytics.add('packageName', pkg.name);
-    analytics.add('packageVersion', pkg.version);
-    analytics.add('package', pkg.name + '@' + pkg.version);
+      analytics.add('policies', policyLocations.length);
+      analytics.add('packageManager', options.packageManager);
+      analytics.add('packageName', pkg.name);
+      analytics.add('packageVersion', pkg.version);
+      analytics.add('package', pkg.name + '@' + pkg.version);
 
-    let policy;
-    if (policyLocations.length > 0) {
-      try {
-        policy = await snyk.policy.load(policyLocations, options);
-      } catch (err) {
-        // note: inline catch, to handle error from .load
-        //   if the .snyk file wasn't found, it is fine
-        if (err.code !== 'ENOENT') {
-          throw err;
+      let policy;
+      if (policyLocations.length > 0) {
+        try {
+          policy = await snyk.policy.load(policyLocations, options);
+        } catch (err) {
+          // note: inline catch, to handle error from .load
+          //   if the .snyk file wasn't found, it is fine
+          if (err.code !== 'ENOENT') {
+            throw err;
+          }
         }
       }
+
+      const payload: Payload = {
+        method: 'POST',
+        url: config.API + '/test-dep-graph',
+        json: true,
+        headers: {
+          'x-is-ci': isCI,
+          'authorization': 'token ' + (snyk as any).api,
+        },
+        qs: common.assembleQueryString(options),
+        body: {
+          depGraph,
+          targetFile: pkg.targetFile || options.file,
+          projectNameOverride: options.projectName,
+          policy: policy && policy.toString(),
+          docker: pkg.docker,
+        },
+      };
+
+      payloads.push(payload);
     }
-
-    const payload: Payload = {
-      method: 'POST',
-      url: config.API + '/test-dep-graph',
-      json: true,
-      headers: {
-        'x-is-ci': isCI,
-        'authorization': 'token ' + (snyk as any).api,
-      },
-      qs: common.assembleQueryString(options),
-      body: {
-        depGraph,
-        targetFile: pkg.targetFile || options.file,
-        projectNameOverride: options.projectName,
-        policy: policy && policy.toString(),
-        docker: pkg.docker,
-      },
-    };
-
-    return payload;
+    return payloads;
   } finally {
     spinner.clear(spinnerLbl)();
   }
 }
 
-async function assembleRemotePayload(root, options): Promise<Payload> {
+async function assembleRemotePayload(root, options): Promise<Payload[]> {
   const pkg = moduleToObject(root);
   debug('testing remote: %s', pkg.name + '@' + pkg.version);
   analytics.add('packageName', pkg.name);
@@ -245,7 +307,7 @@ async function assembleRemotePayload(root, options): Promise<Payload> {
     },
   };
   payload.qs = common.assembleQueryString(options);
-  return payload;
+  return [payload];
 }
 
 function countUniqueVulns(vulns: AnnotatedIssue[]): number {

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -125,7 +125,6 @@ async function runTest(packageManager: string, root: string, options): Promise<o
       }
 
       res.uniqueCount = countUniqueVulns(res.vulnerabilities);
-
       results.push(res);
     }
     return results;
@@ -210,6 +209,8 @@ async function getDepsFromPlugin(root, options): Promise<MultiRootsPackage> {
       inspectRes.package.targetFile = inspectRes.plugin.targetFile;
     }
     inspectRes.depRoots = [{depTree: inspectRes.package}];
+  } else {
+    options.subProjectNames = inspectRes.depRoots.map((depRoot) => depRoot.depTree.name);
   }
 
   return {
@@ -289,6 +290,7 @@ async function assembleLocalPayload(root, options, policyLocations): Promise<Pay
           projectNameOverride: options.projectName,
           policy: policy && policy.toString(),
           docker: pkg.docker,
+
         },
       };
 

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -551,7 +551,7 @@ test('`test gradle-app` returns correct meta', async (t) => {
     'local policy not displayed');
 });
 
-test('`test gradle-app --all-sub-projects` returns sends `multiDepRoots` argument to plugin', async (t) => {
+test('`test gradle-app --all-sub-projects` sends `multiDepRoots` argument to plugin', async (t) => {
   chdirWorkspaces();
   const plugin = {
     async inspect() {
@@ -601,13 +601,13 @@ test('`test gradle-app --all-sub-projects` returns correct multi tree meta', asy
         depRoots: [
           {
             depTree: {
-              name: 'tree1',
+              name: 'tree0',
               version: '1.0.0',
               dependencies: {dep1: {name: 'dep1', version: '1'}},
             },
           }, {
             depTree: {
-              name: 'tree2',
+              name: 'tree1',
               version: '2.0.0',
               dependencies: {dep1: {name: 'dep2', version: '2'}},
             },
@@ -627,15 +627,17 @@ test('`test gradle-app --all-sub-projects` returns correct multi tree meta', asy
   const tests = res.split('Testing gradle-app...').filter((s) => !!s.trim());
   t.equals(tests.length, 2, 'two projects tested independently');
   t.match(res, /Tested 2 projects/, 'number projects tested displayed properly');
-  for (const tst of tests) {
-    const meta = tst.slice(tst.indexOf('Organisation:')).split('\n');
+  for (let i = 0; i < tests.length; i++) {
+    const meta = tests[i].slice(tests[i].indexOf('Organisation:')).split('\n');
     t.match(meta[0], /Organisation:\s+test-org/, 'organisation displayed');
     t.match(meta[1], /Package manager:\s+gradle/,
       'package manager displayed');
     t.match(meta[2], /Target file:\s+build.gradle/, 'target file displayed');
-    t.match(meta[3], /Open source:\s+no/, 'open source displayed');
-    t.match(meta[4], /Project path:\s+gradle-app/, 'path displayed');
-    t.notMatch(meta[5], /Local Snyk policy:\s+found/,
+    t.match(meta[3], /Sub project:\s+tree/, 'subproject displayed');
+    t.includes(meta[3], `tree${i}`, 'subproject displayed');
+    t.match(meta[4], /Open source:\s+no/, 'open source displayed');
+    t.match(meta[5], /Project path:\s+gradle-app/, 'path displayed');
+    t.notMatch(meta[6], /Local Snyk policy:\s+found/,
       'local policy not displayed');
   }
 });


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This is done in preparation for getting multiple trees from gradle plugin.
Currently gradle plugin will return multiple test results iff the `--all-subprojects` flag is passed.

We don't support multiple trees for monitor as of yet, because it breaks our upstream handling of projects. so we fail if the argument `--scan-all-subprojects` is passed.