### PR TITLE
fix: support for Gradle < 4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "snyk-config": "2.2.1",
     "snyk-docker-plugin": "1.22.0",
     "snyk-go-plugin": "1.6.1",
-    "snyk-gradle-plugin": "2.4.1",
+    "snyk-gradle-plugin": "2.4.2",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an issue where scans will fail because `--no-parallel` flag is not supported on Gradle <4.3
Plugin version bump.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/BST-530