### PR TITLE
fix: Move exclude-base... option to docker plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "recursive-readdir": "^2.2.2",
     "semver": "^5.6.0",
     "snyk-config": "2.2.1",
-    "snyk-docker-plugin": "1.22.0",
+    "snyk-docker-plugin": "1.22.1",
     "snyk-go-plugin": "1.6.1",
     "snyk-gradle-plugin": "2.4.2",
     "snyk-module": "1.9.1",

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -67,10 +67,6 @@ async function runTest(packageManager: string, root: string, options): Promise<o
       });
     }
 
-    if (options.docker && options.file && options['exclude-base-image-vulns']) {
-      res.vulnerabilities = res.vulnerabilities.filter((vuln) => (vuln.dockerfileInstruction));
-    }
-
     res.uniqueCount = countUniqueVulns(res.vulnerabilities);
 
     return res;

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -1594,26 +1594,6 @@ test('`test foo:latest --docker --file=Dockerfile remediation advice`', async (t
   }
 });
 
-test('`test foo:latest --docker --file=Dockerfile --exclude-base-image-vulns`', async (t) => {
-  stubDockerPluginResponse('./fixtures/docker/plugin-multiple-deps', t);
-  const vulns = require('./fixtures/docker/find-result-remediation.json');
-  server.setNextResponse(vulns);
-
-  try {
-    await cli.test('foo:latest', {
-      docker: true,
-      org: 'explicit-org',
-      file: 'Dockerfile',
-      'exclude-base-image-vulns': true,
-    });
-    t.fail('should have found vuln');
-
-  } catch (err) {
-    t.notMatch(err.message, /introduced by your base image/i, 'should exclude base image vulns');
-    t.match(err.message, /introduced in your dockerfile/i, 'should include vulns introduced by dockerfile');
-  }
-});
-
 test('`test foo:latest --docker` doesnt collect policy from cwd', async (t) => {
   chdirWorkspaces('npm-package-policy');
   const spyPlugin = stubDockerPluginResponse({


### PR DESCRIPTION
In order to resolve some bugs and improve the code, move exclude-base-image-vulns option logic out of this repo and into the docker plugin:
* Remove logic for excluding base image vulns from this repo - now handled in docker plugin.
* Bump docker plugin version to include support for this option.

More info on the docker plugin implementation and effects can be found in original [PR](https://github.com/snyk/snyk-docker-plugin/pull/74).
