### PR TITLE
fix: Raise get-uri version

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "configstore": "^3.1.2",
     "debug": "^3.1.0",
     "diff": "^4.0.1",
-    "get-uri": "2.0.2",
+    "get-uri": "2.0.3",
     "inquirer": "^3.0.0",
     "lodash": "^4.17.11",
     "needle": "^2.2.4",


### PR DESCRIPTION
This prevents a vulnerable version of extend (<3.0.2) being pulled in during
deduping.

See https://snyk.io/vuln/npm:extend:20180424