### PR TITLE
feat: Update unsupported runtimes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
     "max-len": [1, 120],
     "max-statements": [1, 100],
     "new-cap": 0,
+    "no-const-assign": "error",
     "no-caller": 2,
     "no-else-return": 2,
     "no-extend-native": 2,

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "10"
   - "8"
   - "6"
-  - "4"
 cache:
   directories:
     - node_modules

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "snyk": "dist/cli/index.js"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "build": "tsc",

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,8 +1,8 @@
-import {gte} from 'semver';
+import { gte } from 'semver';
 
-const MIN_RUNTIME = '4.0.0';
+const MIN_RUNTIME = '6.5.0';
 
-export const supportedRange = '>= 4';
+export const supportedRange = `>= ${MIN_RUNTIME}`;
 
 export function isSupported(runtimeVersion) {
   return gte(runtimeVersion, MIN_RUNTIME);

--- a/src/lib/snyk-test/npm/index.js
+++ b/src/lib/snyk-test/npm/index.js
@@ -21,7 +21,7 @@ module.exports = test;
 const config = require('../../config');
 
 function test(root, options) {
-  const modules = null;
+  let modules = null;
   const packageManager = detect.detectPackageManager(root, options);
   const payload = {
     // options.vulnEndpoint is only used for file system tests
@@ -32,7 +32,7 @@ function test(root, options) {
       authorization: 'token ' + snyk.api,
     },
   };
-  const hasDevDependencies = false;
+  let hasDevDependencies = false;
 
   // if the file exists, let's read the package files and post
   // the dependency tree to the server.

--- a/test/runtime.test.js
+++ b/test/runtime.test.js
@@ -4,9 +4,11 @@ var runtime = require('../src/cli/runtime');
 test('nodejs runtime versions support ', function (t) {
   t.ok(runtime.isSupported(process.versions.node),
     'Current runtime is supported');
-  t.ok(runtime.isSupported('4.0.0'), '4.0.0 is supported');
+  t.ok(runtime.isSupported('6.16.0'), '6.16.0 is supported');
   t.ok(runtime.isSupported('11.0.0-pre'), 'pre-release is supported');
   t.notOk(runtime.isSupported('0.10.48'), '0.10 is not supported');
   t.notOk(runtime.isSupported('0.12.18'), '0.12 is not supported');
+  t.notOk(runtime.isSupported('4.0.0'), '4.0.0 is not supported');
+  t.notOk(runtime.isSupported('6.4.0'), '6.4.0 is not supported');
   t.end();
 });

--- a/test/wizard-package-changes.test.js
+++ b/test/wizard-package-changes.test.js
@@ -2,8 +2,8 @@ const tap = require('tap');
 const test = require('tap').test;
 const sinon = require('sinon').createSandbox();
 const proxyquire = require('proxyquire');
-const policySpy = sinon.spy();
-const writeSpy = sinon.spy();
+let policySpy = sinon.spy();
+let writeSpy = sinon.spy();
 const detect = require('../src/lib/detect');
 
 sinon.stub(detect, 'detectPackageManager')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "outDir": "./dist",
         "pretty": true,
-        "target": "es5",
+        "target": "es2015",
         "lib": [
           "es2017"
         ],


### PR DESCRIPTION
This PR raises our minimum support Node version to 6. See https://snyk.io/blog/snyk-cli-drops-support-for-node-js-4-argon/ for more detail