### PR TITLE
fix: Gradle analysis fixed in standalone Snyk binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "snyk-config": "2.2.1",
     "snyk-docker-plugin": "1.22.1",
     "snyk-go-plugin": "1.6.1",
-    "snyk-gradle-plugin": "2.4.2",
+    "snyk-gradle-plugin": "2.4.3",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

More reliable support for Gradle analysis using standalone Snyk CLI binaries.
Applies especially for Windows (Unix builds should have been fixed in 1.143.2, but that was not properly mentioned in the release notes.)

#### How should this be manually tested?

Build binaries via `pkg` and let 'em loose, under Linux, Mac and Windows.

#### Any background context you want to provide?

Depends on writable tmp filesystem being available, which seems to be usually the case, given data from plugins for different build systems, e.g. Python.