### PR TITLE
fix: create copies of original files prior to patching

### DIFF
--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -72,15 +72,17 @@ function patch(vulns, live) {
                     return reject(error);
                   }
 
-                  resolve(Promise.all(files.filter(function (file) {
+                  var origFiles = files.filter(function (file) {
                     return file.slice(-5) === '.orig';
-                  }).map(function (file) {
-                    return fs.rename(file, path.dirname(file) + '/' +
+                  });
+
+                  for (var file of origFiles) {
+                    fs.renameSync(file, path.dirname(file) + '/' +
                       path.basename(file).slice(0, -5));
-                  })));
+                  }
+
+                  resolve(patch);
                 });
-              }).then(function () {
-                return patch;
               });
             });
           }).then(function (patch) {

--- a/test/protect-apply-same-patch-again.test.js
+++ b/test/protect-apply-same-patch-again.test.js
@@ -32,8 +32,8 @@ const patch = proxyquire('../src/lib/protect/patch', {
 });
 
 test('setup', (t) => {
-  fs.createReadStream(fixturesModuleFolder + '/node-fixture.js')
-  .pipe(fs.createWriteStream(fixturesModuleFolder + '/node.js'));
+  var fixture = fs.readFileSync(fixturesModuleFolder + '/node-fixture.js');
+  fs.writeFileSync(fixturesModuleFolder + '/node.js', fixture);
   t.pass();
   t.end();
 });
@@ -44,13 +44,13 @@ test('Same patch is applied multiple times without issue', (t) => {
     fs.readdir(fixturesBaseFolder, (err, fileNames) => {
       const fixturesBaseFolderFiles = fileNames || [];
 
-      if (err || fixturesBaseFolderFiles.length == 0) {
+      if (err || fixturesBaseFolderFiles.length === 0) {
         console.log(`ERROR: Could not remove the .snyk-***.flag | ${err}`);
         return;
       }
 
       fixturesBaseFolderFiles.forEach((file) => {
-        const flagMatch = file.match(/\.snyk.*\.flag/)
+        const flagMatch = file.match(/\.snyk.*\.flag/);
         if (flagMatch) {
           fs.unlink(fixturesBaseFolder + file);
         }
@@ -60,7 +60,7 @@ test('Same patch is applied multiple times without issue', (t) => {
     fs.readdir(fixturesModuleFolder, (err, fileNames) => {
       const fixturesModuleFolderFiles = fileNames || [];
 
-      if (err || fixturesModuleFolderFiles.length == 0) {
+      if (err || fixturesModuleFolderFiles.length === 0) {
         return;
       }
 
@@ -100,5 +100,5 @@ test('Same patch is applied multiple times without issue', (t) => {
       t.pass();
       t.end();
     })
-    .catch(t.threw);
+    .catch(t.fail);
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a bug where the patched files object was iterated over as an array `for ... of`, instead of an object `for ... in`.

This revealed another issue where the `.orig` copies of patched files were not being created. This is needed as our logic undoes a patch using the `.orig` pre-patched file when the same patch is re-applied twice. This is needed in cases where a protected project is being protected again, for the chance the used patch has been updated in the meantime.

😌 