### PR TITLE
feat: read targetFramework from assets file

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.11.0",
-    "snyk-nuget-plugin": "1.7.2",
+    "snyk-nuget-plugin": "1.9.0",
     "snyk-php-plugin": "1.5.2",
     "snyk-policy": "1.13.4",
     "snyk-python-plugin": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
bump snyk-nuget-plugin version so CLI can now process nuget projects that have their target frameworks available in the project.assets.json lock file but not in the csproj file. 

#### How should this be manually tested?
Run snyk test on nuget project that doesn't have TF specified in .csproj file. -> should now work.

#### What are the relevant tickets?
https://snyk.slack.com/archives/C85KJCJAJ/p1547042854066600
