### PR TITLE
chore: downgrade tsconfig lib to match Node 6+

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "pretty": true,
         "target": "es2015",
         "lib": [
-          "es2017"
+          "es2015"
         ],
         "module": "commonjs",
         "allowJs": true,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Our tsconfig had es2017 library enabled in it.
The library must match the target runtime (https://stackoverflow.com/a/50987516), and Snyk CLI needs to run on Node 6 which only supports (roughly) es2015: https://node.green/

