### PR TITLE
chore: Use new node js parser that drops node 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "snyk-gradle-plugin": "2.4.3",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
-    "snyk-nodejs-lockfile-parser": "1.11.0",
+    "snyk-nodejs-lockfile-parser": "1.12.0",
     "snyk-nuget-plugin": "1.9.0",
     "snyk-php-plugin": "1.5.2",
     "snyk-policy": "1.13.4",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Bump to latest parser version that drops node 4