### PR TITLE
chore: convert the monitor command to Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "uuid": "^3.3.2"
   },
   "devDependencies": {
+    "@types/chalk": "^2.2.0",
     "@types/diff": "^3.5.2",
     "@types/lodash": "^4.14.123",
     "@types/needle": "^2.0.4",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Converts Monitor command to Typescript. This is going to be helpful in the light of support for scanning multiple sub-projects, refactoring of the plugin APIs and pinning down the type definitions for plugins and monitors.

The diff is minimal: no conversion to async/await, no thorough types, many modules still use "default exports".

#### How should this be manually tested?

The usual; nothing in the CLI should break.
