### PR TITLE
chore: convert monitor code to async/await

### DIFF
--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -38,7 +38,7 @@ interface BadResult {
   path: string;
 }
 
-function monitor(...args0: any[]) {
+async function monitor(...args0: any[]) {
   let args = [...args0];
   let options: MonitorOptions = {};
   const results: Array<GoodResult | BadResult> = [];
@@ -63,142 +63,126 @@ function monitor(...args0: any[]) {
     throw new Error('`--all-sub-projects` is currently not supported for `snyk monitor`');
   }
 
-  return apiTokenExists('snyk monitor')
-    .then(() => {
-      return args.reduce((acc, path) => {
-        return acc.then(() => {
-          return fs.exists(path).then((exists) => {
-            if (!exists && !options.docker) {
-              throw new Error(
-                '"' + path + '" is not a valid path for "snyk monitor"');
-            }
+  await apiTokenExists('snyk monitor');
+  // Part 1: every argument is a scan target; run scans sequentially
+  for (const path of args) {
+    try {
+      const exists = await fs.exists(path);
+      if (!exists && !options.docker) {
+        throw new Error(
+          '"' + path + '" is not a valid path for "snyk monitor"');
+      }
 
-            let packageManager = detect.detectPackageManager(path, options);
+      let packageManager = detect.detectPackageManager(path, options);
 
-            const targetFile = options.docker && !options.file // snyk monitor --docker (without --file)
-              ? undefined
-              : (options.file || detect.detectPackageFile(path));
+      const targetFile = options.docker && !options.file // snyk monitor --docker (without --file)
+        ? undefined
+        : (options.file || detect.detectPackageFile(path));
 
-            const plugin = plugins.loadPlugin(packageManager, options);
+      const plugin = plugins.loadPlugin(packageManager, options);
 
-            const moduleInfo = ModuleInfo(plugin, options.policy);
+      const moduleInfo = ModuleInfo(plugin, options.policy);
 
-            const displayPath = pathUtil.relative(
-              '.', pathUtil.join(path, targetFile || ''));
+      const displayPath = pathUtil.relative(
+        '.', pathUtil.join(path, targetFile || ''));
 
-            const analysisType = options.docker ? 'docker' : packageManager;
+      const analysisType = options.docker ? 'docker' : packageManager;
 
-            const analyzingDepsSpinnerLabel =
-          'Analyzing ' + analysisType + ' dependencies for ' + displayPath;
+      const analyzingDepsSpinnerLabel =
+        'Analyzing ' + analysisType + ' dependencies for ' + displayPath;
 
-            const postingMonitorSpinnerLabel =
-          'Posting monitor snapshot for ' + displayPath + ' ...';
+      const postingMonitorSpinnerLabel =
+        'Posting monitor snapshot for ' + displayPath + ' ...';
 
-            return spinner(analyzingDepsSpinnerLabel)
-              .then(() => {
-                return moduleInfo.inspect(path, targetFile, options);
-              })
-            // clear spinner in case of success or failure
-              .then(spinner.clear(analyzingDepsSpinnerLabel))
-              .catch((error) => {
-                spinner.clear(analyzingDepsSpinnerLabel)();
-                throw error;
-              })
-              .then((info) => {
-                return spinner(postingMonitorSpinnerLabel)
-                  .then(() => {
-                    return info;
-                  });
-              })
-              .then((info) => {
-                if (_.get(info, 'plugin.packageManager')) {
-                  packageManager = info.plugin.packageManager;
-                }
-                const meta = {
-                  'method': 'cli',
-                  'packageManager': packageManager,
-                  'policy-path': options['policy-path'],
-                  'project-name':
-                options['project-name'] || config.PROJECT_NAME,
-                  'isDocker': !!options.docker,
-                };
-                return (snyk.monitor as any as (path, meta, info) => Promise<any>)(path, meta, info);
-              })
-            // clear spinner in case of success or failure
-              .then(spinner.clear(postingMonitorSpinnerLabel))
-              .catch((error) => {
-                spinner.clear(postingMonitorSpinnerLabel)();
-                throw error;
-              })
-              .then((res) => {
-                res.path = path;
-                const endpoint = url.parse(config.API);
-                let leader = '';
-                if (res.org) {
-                  leader = '/org/' + res.org;
-                }
-                endpoint.pathname = leader + '/manage';
-                const manageUrl = url.format(endpoint);
+      await spinner(analyzingDepsSpinnerLabel);
 
-                endpoint.pathname = leader + '/monitor/' + res.id;
-                const output = formatMonitorOutput(
-                  packageManager,
-                  res,
-                  manageUrl,
-                  options,
-                );
-                // push a good result
-                results.push({ok: true, data: output, path});
-              });
-          }).catch((err) => {
-          // push this error so the promise chain continues
-            results.push({ok: false, data: err, path});
-          });
-        });
-      }, Promise.resolve())
-        .then(() => {
-          if (options.json) {
-            let dataToSend = results.map((result) => {
-              if (result.ok) {
-                return JSON.parse(result.data);
-              }
-              return {ok: false, error: result.data.message, path: result.path};
-            });
-            // backwards compat - strip array if only one result
-            dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;
-            const json = JSON.stringify(dataToSend, null, 2);
+      let info;
+      try {
+        info = await moduleInfo.inspect(path, targetFile, options);
+        await spinner.clear(analyzingDepsSpinnerLabel)(info);
+      } catch (error) {
+        spinner.clear(analyzingDepsSpinnerLabel)();
+        throw error;
+      }
+      await spinner(postingMonitorSpinnerLabel);
+      if (_.get(info, 'plugin.packageManager')) {
+        packageManager = info.plugin.packageManager;
+      }
+      const meta = {
+        'method': 'cli',
+        'packageManager': packageManager,
+        'policy-path': options['policy-path'],
+        'project-name': options['project-name'] || config.PROJECT_NAME,
+        'isDocker': !!options.docker,
+      };
+      let res;
+      try {
+        res = await (snyk.monitor as any as (path, meta, info) => Promise<any>)(path, meta, info);
+        spinner.clear(postingMonitorSpinnerLabel)(res);
+      } catch (error) {
+        spinner.clear(postingMonitorSpinnerLabel)();
+        throw error;
+      }
+      res.path = path;
+      const endpoint = url.parse(config.API);
+      let leader = '';
+      if (res.org) {
+        leader = '/org/' + res.org;
+      }
+      endpoint.pathname = leader + '/manage';
+      const manageUrl = url.format(endpoint);
 
-            if (results.every((res) => {
-              return res.ok;
-            })) {
-              return json;
-            }
-
-            throw new Error(json);
-          }
-
-          const output = results.map((res) => {
-            if (res.ok) {
-              return res.data;
-            }
-
-            const errorMessage = (res.data && res.data.userMessage) ?
-              chalk.bold.red(res.data.userMessage) :
-              (res.data ? res.data.message : 'Unknown error occurred.');
-
-            return chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') +
-              errorMessage;
-          }).join('\n' + SEPARATOR);
-
-          if (results.every((res) => {
-            return res.ok;
-          })) {
-            return output;
-          }
-
-          throw new Error(output);
-        });
+      endpoint.pathname = leader + '/monitor/' + res.id;
+      const monOutput = formatMonitorOutput(
+        packageManager,
+        res,
+        manageUrl,
+        options,
+      );
+      // push a good result
+      results.push({ok: true, data: monOutput, path});
+    } catch (err) {
+      // push this error, the loop continues
+      results.push({ok: false, data: err, path});
+    }
+  }
+  // Part 2: having collected the results, format them for shipping to the Registry
+  if (options.json) {
+    let dataToSend = results.map((result) => {
+      if (result.ok) {
+        return JSON.parse(result.data);
+      }
+      return {ok: false, error: result.data.message, path: result.path};
     });
+    // backwards compat - strip array if only one result
+    dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;
+    const json = JSON.stringify(dataToSend, null, 2);
+
+    if (results.every((res) => res.ok)) {
+      return json;
+    }
+
+    throw new Error(json);
+  }
+
+  const output = results.map((res) => {
+    if (res.ok) {
+      return res.data;
+    }
+
+    const errorMessage = (res.data && res.data.userMessage) ?
+      chalk.bold.red(res.data.userMessage) :
+      (res.data ? res.data.message : 'Unknown error occurred.');
+
+    return chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') +
+      errorMessage;
+  }).join('\n' + SEPARATOR);
+
+  if (results.every((res) => res.ok)) {
+    return output;
+  }
+
+  throw new Error(output);
 }
 
 function formatMonitorOutput(packageManager, res, manageUrl, options) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

In preparation for the `--all-sub-projects` feature, convert the `monitor` code from a poorly readable promise chain to async/await syntax. 

