### PR TITLE
fix: handle dependency cycles in Gradle projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.22.1",
     "snyk-go-plugin": "1.6.1",
-    "snyk-gradle-plugin": "2.6.1",
+    "snyk-gradle-plugin": "2.7.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an issue where parsing of the Gradle project with cyclic deps fails with StackOverflowError.

This also picks up changes introduced in gradle plugin version 2.7.0, but they should not affect anything (a new field with trivially generated data was added to the output, this field is unused so far).

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-575

