### PR TITLE
fix: do not fail if csproj not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.13.0",
-    "snyk-nuget-plugin": "1.9.1",
+    "snyk-nuget-plugin": "1.9.2",
     "snyk-php-plugin": "1.5.2",
     "snyk-policy": "1.13.5",
     "snyk-python-plugin": "1.9.2",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Large nuget projects might not have their csproj file next to their obj/project.assets.json file. The paths to each of the files is listed in a properties file that we don't parse yet. Since we don't require the target framework from the csproj, yet, we can stop failing if we can't find the csproj where we expect it. This PR allows such projects to succeed when sending --file=path/to/project.assets.json flag.

#### Where should the reviewer start?
https://github.com/snyk/snyk-nuget-plugin/pull/52