### PR TITLE
feat: Release improved project naming for csproj behind a flag

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -39,26 +39,35 @@ Options:
                        to true). Applicable to `snyk test`.
   --project-name=<string>
                        Specify a custom Snyk project name (`snyk monitor` only).
+  --policy-path ...... Manually pass a path to a policy file.
+  --insecure ......... Ignore unknown certificate authorities.
+  --json ............. Return results in JSON format.
+  --dry-run .......... Don't apply updates or patches during protect.
+  --severity-threshold=<low|medium|high>
+                       Only report vulnerabilities of provided level or higher.
+  -q, --quiet ........ Silence all output.
+  -h, --help ......... This help information.
+  -v, --version ...... The CLI version.
+
+Gradle options:
+  --gradle-sub-project=<string>
+                       For Gradle "multi project" configurations,
+                       test a specific sub-project.
+  --all-sub-projects   For "multi project" configurations, test all
+                       sub-projects.
+
+.Net (Nuget) options:
+  --assets-project-name
+                       When monitoring a .NET project using NuGet PackageReference use
+                       the project name in project.assets.json, if found.
+
+Docker options:
   --docker ........... Test or monitor a local docker image for Linux
                        vulnerabilities. Can be used alongside `--file` and a
                        path to the image's Dockerfile for more detailed
                        remediation advice.
   --exclude-base-image-vulns
                        Exclude from display Docker base image vulnerabilities.
-  --policy-path....... Manually pass a path to a policy file.
-  --insecure ......... Ignore unknown certificate authorities.
-  --json ............. Return results in JSON format.
-  --dry-run .......... Don't apply updates or patches during protect.
-  --severity-threshold=<low|medium|high>
-                       Only report vulnerabilities of provided level or higher.
-  --gradle-sub-project=<string>
-                       For Gradle "multi project" configurations,
-                       test a specific sub-project.
-  --all-sub-projects   For "multi project" configurations, test all
-                       sub-projects.
-  -q, --quiet ........ Silence all output.
-  -h, --help ......... This help information.
-  -v, --version ...... The CLI version.
 
 
 Examples:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.0.1",
     "snyk-nodejs-lockfile-parser": "1.13.0",
-    "snyk-nuget-plugin": "1.9.2",
+    "snyk-nuget-plugin": "1.10.0",
     "snyk-php-plugin": "1.5.2",
     "snyk-policy": "1.13.5",
     "snyk-python-plugin": "1.9.2",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bump the nuget plugin to release improved naming behind the flag `--assets-project-name`
```snyk monitor --file=pathtosln --org=snykorg --assets-project-name```
https://github.com/snyk/snyk-nuget-plugin/pull/50