### PR TITLE
fix: improve gzip compression of the payloads to handle some larger ones

### DIFF
--- a/src/lib/request/request.js
+++ b/src/lib/request/request.js
@@ -28,7 +28,7 @@ function makeRequest(payload) {
       }
 
       // always compress going upstream
-      data = zlib.gzipSync(json);
+      data = zlib.gzipSync(json, {level: 9});
 
       snykDebug('sending request to:', payload.url);
       snykDebug('request body size:', json.length);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Improve gzip compression.
On a npm project with Jest this reduces the payload from 1.8MB to 1.5MB, which means it will be accepted by Akamai.
