### PR TITLE
fix: do not offer remediation advice when scanning a non-local package

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -110,7 +110,7 @@ function localFileSuppliedButNotFound(root, file) {
     !fs.existsSync(pathLib.resolve(root, file));
 }
 
-function isLocalFolder(root) {
+export function isLocalFolder(root) {
   try {
     return fs.lstatSync(root).isDirectory();
   } catch (e) {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -106,13 +106,15 @@ test('userMessage correctly bubbles with everything other than npm', async (t) =
  */
 
 test('`test semver` sends remote NPM request:', async (t) => {
-  t.plan(3);
   // We care about the request here, not the response
-  await cli.test('semver', {registry: 'npm', org: 'EFF'});
+  let output = await cli.test('semver', {registry: 'npm', org: 'EFF'});
   const req = server.popRequest();
   t.equal(req.method, 'GET', 'makes GET request');
   t.match(req.url, '/vuln/npm/semver', 'gets from correct url');
   t.equal(req.query.org, 'EFF', 'org sent as a query in request');
+  t.match(output, 'Testing semver', 'has "Testing semver" message');
+  t.notMatch(output, 'Remediation', 'shows no remediation advice');
+  t.notMatch(output, 'snyk wizard', 'does not suggest `snyk wizard`');
 });
 
 test('`test sinatra --registry=rubygems` sends remote Rubygems request:', async (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Currently we display remediation advice even when a non-local package is scanned.
We should not, since the user does not own the package and cannot fix it.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-591

![image](https://user-images.githubusercontent.com/502156/56979031-bcd38a00-6b70-11e9-8b0c-0c32f36253cb.png)
