### PR TITLE
fix: newline formatting for the suggestion to use --all-sub-projects

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -221,8 +221,8 @@ function displayResult(res, options: TestOptions) {
 
   if (options.advertiseSubprojectsCount) {
     multiProjAdvice = chalk.bold.white(
-      `This project has multiple sub-projects (${options.advertiseSubprojectsCount}), ` +
-      'use --all-sub-projects flag to scan all sub-projects.\n\n');
+      `\n\nThis project has multiple sub-projects (${options.advertiseSubprojectsCount}), ` +
+      'use --all-sub-projects flag to scan all sub-projects.');
   }
 
   // OK  => no vulns found, return


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes the ugliness (see the screenshot).

![image](https://user-images.githubusercontent.com/502156/57015168-3ae46f00-6c0b-11e9-997a-61c3cd1f827a.png)
