### PR TITLE
fix: Add package manager data to scratch images

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "1.24.0",
+    "snyk-docker-plugin": "1.24.1",
     "snyk-go-plugin": "1.7.1",
     "snyk-gradle-plugin": "2.10.0",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
We recently added some extra logic around handling scratch Docker images; unfortunately one of the fields missing from this broke snyk monitor for scratch images only. Bumping the snyk-docker-plugin allows monitor to function correctly.