### PR TITLE
fix: display monitor error code in the error message

### DIFF
--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -97,7 +97,8 @@ export function monitor(root, meta, info: SingleDepRootResult): Promise<any> {
           if (res.statusCode === 200 || res.statusCode === 201) {
             resolve(body);
           } else {
-            const e = new MonitorError('unexpected error: ' + body.message);
+            const e = new MonitorError('Server returned unexpected error for the monitor request. ' +
+              `Status code: ${res.statusCode}, response: ${res.body.userMessage || res.body.message}`);
             e.code = res.statusCode;
             e.userMessage = body && body.userMessage;
             if (!e.userMessage && res.statusCode === 504) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Improves the error message to make debugging easier.

The existing error just produces `unexpected error: undefined` in the stack trace, which is not helpful.