### PR TITLE
fix: correct remediation (after switching to dep-graph)

### DIFF
--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -124,7 +124,7 @@ function trimUpToFirstSlash(fileName) {
 
 function patchError(error, dir, vuln, patchUrl) {
   if (error && error.code === 'ENOENT') {
-    error.message = 'Failed to patch: the target could not be found.';
+    error.message = 'Failed to patch: the target could not be found (' + error.message + ').';
     return Promise.reject(error);
   }
 

--- a/src/lib/snyk-test/nodejs/index.ts
+++ b/src/lib/snyk-test/nodejs/index.ts
@@ -86,7 +86,6 @@ async function runTest(packageManager: string, root: string, options): Promise<o
       }
     }
 
-
     analytics.add('vulns-pre-policy', res.vulnerabilities.length);
 
     res.filesystemPolicy = !!payloadPolicy;

--- a/src/lib/snyk-test/nodejs/index.ts
+++ b/src/lib/snyk-test/nodejs/index.ts
@@ -60,6 +60,33 @@ async function runTest(packageManager: string, root: string, options): Promise<o
         options.severityThreshold);
     }
 
+    // For Node.js: inject additional information (for remediation etc.) into the response.
+    if (payload.modules) {
+      res.dependencyCount = payload.modules.numDependencies;
+      if (res.vulnerabilities) {
+        res.vulnerabilities.forEach((vuln) => {
+          if (payload.modules && payload.modules.pluck) {
+            const plucked = payload.modules.pluck(vuln.from, vuln.name, vuln.version);
+            vuln.__filename = plucked.__filename;
+            vuln.shrinkwrap = plucked.shrinkwrap;
+            vuln.bundled = plucked.bundled;
+
+            // this is an edgecase when we're testing the directly vuln pkg
+            if (vuln.from.length === 1) {
+              return;
+            }
+
+            const parentPkg = moduleToObject(vuln.from[1]);
+            const parent = payload.modules.pluck(vuln.from.slice(0, 2),
+              parentPkg.name,
+              parentPkg.version);
+            vuln.parentDepType = parent.depType;
+          }
+        });
+      }
+    }
+
+
     analytics.add('vulns-pre-policy', res.vulnerabilities.length);
 
     res.filesystemPolicy = !!payloadPolicy;
@@ -234,32 +261,6 @@ async function sendPayload(payload: Payload): Promise<any> {
       }
 
       body.filesystemPolicy = filesystemPolicy;
-
-      // This branch is valid for node modules flow only
-      if (payload.modules) {
-        body.dependencyCount = payload.modules.numDependencies;
-        if (body.vulnerabilities) {
-          body.vulnerabilities.forEach((vuln) => {
-            if (payload.modules && payload.modules.pluck) {
-              const plucked = payload.modules.pluck(vuln.from, vuln.name, vuln.version);
-              vuln.__filename = plucked.__filename;
-              vuln.shrinkwrap = plucked.shrinkwrap;
-              vuln.bundled = plucked.bundled;
-
-              // this is an edgecase when we're testing the directly vuln pkg
-              if (vuln.from.length === 1) {
-                return;
-              }
-
-              const parentPkg = moduleToObject(vuln.from[1]);
-              const parent = payload.modules.pluck(vuln.from.slice(0, 2),
-                parentPkg.name,
-                parentPkg.version);
-              vuln.parentDepType = parent.depType;
-            }
-          });
-        }
-      }
 
       resolve(body);
     });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a remediation bug introduced by the recent switch to depGraph. (https://github.com/snyk/snyk/commit/a085a05845430254a47b6eddb5066be1e107f3c6)

Injection of remediation-related information into snyk-test response should happen _after_ conversion to the legacy response format.

Additionally: more useful error message when failing to apply a patch.

