### PR TITLE
fix: switch to openjdk

### DIFF
--- a/docker/Dockerfile.gradle-2.8
+++ b/docker/Dockerfile.gradle-2.8
@@ -1,35 +1,31 @@
-FROM node:8-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
-# Install Java 8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-
-# Accept license non-iteractive
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
+RUN mkdir /home/node
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
 
 #Install gradle
+RUN apt-get update
+RUN apt-get install -y curl
 RUN curl -L https://services.gradle.org/distributions/gradle-2.8-bin.zip -o gradle-2.8-bin.zip && \
   apt-get install -y unzip && \
   unzip gradle-2.8-bin.zip -d /home/node/
+
+#Install node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
 
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
     apt-get update && \
     apt-get install -y jq
 
-ENV GRADLE_HOME=/home/node/gradle-2.8
-ENV PATH=$PATH:$GRADLE_HOME/bin
-
-RUN chmod -R a+wrx /home/node
-WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
+ENV GRADLE_HOME=/home/node/gradle-2.8
+ENV PATH=$PATH:$GRADLE_HOME/bin
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project

--- a/docker/Dockerfile.gradle-4.4
+++ b/docker/Dockerfile.gradle-4.4
@@ -1,35 +1,31 @@
-FROM node:8-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
-# Install Java 8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-
-# Accept license non-iteractive
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
+RUN mkdir /home/node
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
 
 #Install gradle
+RUN apt-get update
+RUN apt-get install -y curl
 RUN curl -L https://services.gradle.org/distributions/gradle-4.4-bin.zip -o gradle-4.4-bin.zip && \
   apt-get install -y unzip && \
   unzip gradle-4.4-bin.zip -d /home/node/
+
+#Install node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
 
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
     apt-get update && \
     apt-get install -y jq
 
-ENV GRADLE_HOME=/home/node/gradle-4.4
-ENV PATH=$PATH:$GRADLE_HOME/bin
-
-RUN chmod -R a+wrx /home/node
-WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
+ENV GRADLE_HOME=/home/node/gradle-4.4
+ENV PATH=$PATH:$GRADLE_HOME/bin
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project

--- a/docker/Dockerfile.maven-3.5.4
+++ b/docker/Dockerfile.maven-3.5.4
@@ -1,30 +1,26 @@
-FROM node:8-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
-# Install Java 8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-
-# Accept license non-iteractive
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
-
 #Install maven
-RUN wget https://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
+RUN apt-get update
+RUN apt-get install -y curl
+RUN curl -L -o apache-maven-3.5.4-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.5.4/binaries/apache-maven-3.5.4-bin.tar.gz
 RUN tar -xvzf apache-maven-3.5.4-bin.tar.gz
 RUN rm -f apache-maven-3.5.4-bin.tar.gz
+
+#Install node
+RUN mkdir /home/node
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
 
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
     apt-get update && \
     apt-get install -y jq
 
-RUN chmod -R a+wrx /home/node
-WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
 ENV PATH /apache-maven-3.5.4/bin:$PATH
@@ -40,4 +36,3 @@ ENTRYPOINT ["./docker-entrypoint.sh"]
 # Default command is `snyk test`
 # Override with `docker run ... snyk/snyk-cli <command> <args>`
 CMD ["test"]
-

--- a/docker/Dockerfile.sbt-0.13.16
+++ b/docker/Dockerfile.sbt-0.13.16
@@ -1,19 +1,14 @@
-FROM node:8-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
-# Install Java 8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-
-# Accept license non-iteractive
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
+RUN mkdir /home/node
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
 
 #Install sbt
+RUN apt-get update
+RUN apt-get install -y curl
 RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get install -y apt-transport-https && \
     curl -L -o sbt.deb https://dl.bintray.com/sbt/debian/sbt-0.13.16.deb && \
@@ -28,13 +23,15 @@ RUN echo "docker-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers  && \
     echo "net.virtualvoid.sbt.graph.DependencyGraphSettings.graphSettings" >> /home/node/.sbt/0.13/user.sbt && \
     echo "-sbt-version  0.13.16" >> /etc/sbt/sbtopts
 
+#Install node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
     apt-get update && \
     apt-get install -y jq
 
-RUN chmod -R a+wrx /home/node
-WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
 

--- a/docker/Dockerfile.sbt-1.0.4
+++ b/docker/Dockerfile.sbt-1.0.4
@@ -1,19 +1,14 @@
-FROM node:8-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
-# Install Java 8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee /etc/apt/sources.list.d/webupd8team-java.list
-RUN echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" | tee -a /etc/apt/sources.list.d/webupd8team-java.list
-
-# Accept license non-iteractive
-RUN echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-RUN apt-key adv --no-tty --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886
-RUN apt-get update
-RUN mkdir -p /usr/share/man/man1
-RUN apt-get install -y oracle-java8-installer oracle-java8-set-default
+RUN mkdir /home/node
+RUN chmod -R a+wrx /home/node
+WORKDIR /home/node
 
 #Install sbt
+RUN apt-get update
+RUN apt-get install -y curl
 RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
     apt-get install -y apt-transport-https && \
     curl -L -o sbt.deb https://dl.bintray.com/sbt/debian/sbt-1.0.4.deb && \
@@ -27,13 +22,15 @@ RUN echo "docker-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers  && \
     echo "addCommandAlias(\"dependency-tree\", \"dependencyTree\")" >> /root/.sbt/1.0/user.sbt && \
     echo "addCommandAlias(\"dependency-tree\", \"dependencyTree\")" >> /home/node/.sbt/1.0/user.sbt
 
+#Install node
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt-get install -y nodejs
+
 # Install snyk cli
 RUN npm install --global snyk snyk-to-html && \
     apt-get update && \
     apt-get install -y jq
 
-RUN chmod -R a+wrx /home/node
-WORKDIR /home/node
 ENV HOME /home/node
 ENV M2 /home/node/.m2
 


### PR DESCRIPTION
Because of the license change, Oracle JDK is not available anymore. In order to keep maven docker image working, another version of JDK has to be used.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team
