### PR TITLE
feat: allow passing color for docker cli response

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -579,15 +579,25 @@ function dockerRemediationForDisplay(res) {
 
   if (advice) {
     for (const item of advice) {
-      out.push(item.bold ? chalk.bold(item.message) : item.message);
+      out.push(getTerminalStringFormatter(item)(item.message));
     }
   } else if (message) {
     out.push(message);
   } else {
     return '';
   }
-
   return `\n\n${out.join('\n')}`;
+}
+
+function getTerminalStringFormatter({ color, bold }) {
+  let formatter = chalk;
+  if (color && formatter[color]) {
+    formatter = formatter[color];
+  }
+  if (bold) {
+    formatter = formatter.bold;
+  }
+  return formatter;
 }
 
 function validateSeverityThreshold(severityThreshold) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds the option to set the color of the docker remediation advice message.

#### Where should the reviewer start?
src/cli/commands/test.ts

#### How should this be manually tested?
run test --docker goof (even better to add --file=Dockerfile)

#### Any background context you want to provide?
Recently we added a new alert as part of the docker remediation advice which provides information about whether or not the os distribution version is supported by Snyk. In order to make it more visible, I added to the code an option to choose a different color from the default. 

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/DC-79

#### Screenshots
![image](https://user-images.githubusercontent.com/17844958/57696264-07690200-7659-11e9-9c97-09f1774235ea.png)

#### Additional questions
