### PR TITLE
refactor: switching from usage to help documentation by default

### DIFF
--- a/help/usage.txt
+++ b/help/usage.txt
@@ -1,3 +1,0 @@
-Usage: snyk <command>
-
-See "snyk --help" for more.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -87,7 +87,7 @@ export function args(processargv) {
     command = 'help';
 
     if (!argv._.length) {
-      argv._.unshift(argv.help || 'usage');
+      argv._.unshift(argv.help || 'help');
     }
   }
 

--- a/src/cli/commands/help.js
+++ b/src/cli/commands/help.js
@@ -5,7 +5,7 @@ var path = require('path');
 
 function help(item) {
   if (!item || item === true || typeof item !== 'string') {
-    item = 'usage';
+    item = 'help';
   }
 
   // cleanse the filename to only contain letters


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
The current `snyk` cli shows a `usage.txt` help file when no command is given. That `usage.txt` file points to executing `snyk --help` to get more information in the usage. This PR simplifies that and directly shows `help`

#### Where should the reviewer start?
Run `snyk` and see if the `help.txt` is displayed by default

#### How should this be manually tested?
Executing `snyk`, `snyk --help` should both display `help.txt`

#### Any background context you want to provide?
It's just an improvement, making it a little bit more user friendly.

#### What are the relevant tickets?
None. Encountered this on first usage, and wanted to fix it directly. Let me know if you need a github issue.

#### Screenshots
Not needed.

#### Additional questions
None