### PR TITLE
fix: correct remediation broken after last refactoring

### DIFF
--- a/src/cli/commands/protect/wizard.js
+++ b/src/cli/commands/protect/wizard.js
@@ -125,6 +125,7 @@ function processWizardFlow(options) {
               });
             })
             .then(() => {
+              // We need to have modules information for remediation. See Payload.modules
               options.traverseNodeModules = true;
 
               return snyk.test(cwd, options).then((res) => {

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -29,9 +29,18 @@ interface AnnotatedIssue extends IssueData {
   isUpgradable: boolean;
   isPatchable: boolean;
   nearestFixedInVersion?: string;
+
+  // These fields present for "node_module" based scans to allow remediation
+  bundled?: any;
+  shrinkwrap?: any;
+  __filename?: string;
+  parentDepType: string;
+
+  dockerfileInstruction?: any;
+  dockerBaseImage?: any;
 }
 
-interface LegacyVulnApiResult {
+export interface LegacyVulnApiResult {
   vulnerabilities: AnnotatedIssue[];
   ok: boolean;
   dependencyCount: number;
@@ -42,8 +51,11 @@ interface LegacyVulnApiResult {
   packageManager: string;
   ignoreSettings: object | null;
   summary: string;
-  docker?: object;
+  docker?: {baseImage?: any};
   severityThreshold?: string;
+
+  filesystemPolicy?: boolean;
+  uniqueCount?: any;
 }
 
 interface UpgradePathItem {
@@ -80,6 +92,7 @@ interface TestDepGraphResult {
   };
   docker: {
     binariesVulns?: TestDepGraphResult;
+    baseImage?: any;
   };
 }
 
@@ -96,7 +109,7 @@ interface TestDepGraphMeta {
   org: string;
 }
 
-interface TestDepGraphResponse {
+export interface TestDepGraphResponse {
   result: TestDepGraphResult;
   meta: TestDepGraphMeta;
 }
@@ -145,7 +158,7 @@ function convertTestDepGraphResultToLegacy(
           name: pkgInfo.pkg.name,
           version: pkgInfo.pkg.version as string,
           nearestFixedInVersion: pkgIssue.fixInfo.nearestFixedInVersion,
-        });
+        }) as AnnotatedIssue;  // TODO(kyegupov): get rid of type assertion
 
         vulns.push(annotatedIssue);
       }
@@ -168,7 +181,7 @@ function convertTestDepGraphResultToLegacy(
           name: pkgInfo.pkg.name,
           version: pkgInfo.pkg.version as string,
           nearestFixedInVersion: pkgIssue.fixInfo.nearestFixedInVersion,
-        });
+        }) as any as AnnotatedIssue; // TODO(kyegupov): get rid of forced type assertion
         vulns.push(annotatedIssue);
       }
     }

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -989,6 +989,7 @@ test('`test npm-out-of-sync` out of sync fails', async (t) => {
   }
 });
 
+// TODO(kyegupov): drop this check, we're on node > 4
 if (getRuntimeVersion() > 4) {
   // yarn lockfile based testing is only supported for node 4+
   test('`test yarn-out-of-sync` out of sync fails', async (t) => {

--- a/test/acceptance/fixtures/npm-package/test-graph-result.json
+++ b/test/acceptance/fixtures/npm-package/test-graph-result.json
@@ -1,0 +1,172 @@
+{
+  "result": {
+    "affectedPkgs": {
+      "debug@2.2.0": {
+        "pkg": {
+          "name": "debug",
+          "version": "2.2.0"
+        },
+        "issues": {
+          "SNYK-JS-QS-10407": {
+            "issueId": "SNYK-JS-QS-10407",
+            "fixInfo": {
+              "isUpgradable": false,
+              "isPatchable": true,
+              "upgradePaths": [
+                {
+                  "path": [
+                    {
+                      "name": "debug",
+                      "version": "2.2.0"
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "issuesData": {
+      "SNYK-JS-QS-10407": {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [
+          "SNYK-JS-QS-10407"
+        ],
+        "creationTime": "2017-02-14T11:44:54.163000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 7.4,
+        "description": "## Overview\r\n[`qs`](https://www.npmjs.com/package/qs) is a querystring parser that supports nesting and arrays, with a depth limit.\r\n\r\nBy default `qs` protects against attacks that attempt to overwrite an object's existing prototype properties, such as `toString()`, `hasOwnProperty()`,etc.\r\n\r\nFrom [`qs` documentation](https://github.com/ljharb/qs):\r\n> By default parameters that would overwrite properties on the object prototype are ignored, if you wish to keep the data from those fields either use plainObjects as mentioned above, or set allowPrototypes to true which will allow user input to overwrite those properties. WARNING It is generally a bad idea to enable this option as it can cause problems when attempting to use the properties that have been overwritten. Always be careful with this option.\r\n\r\nOverwriting these properties can impact application logic, potentially allowing attackers to work around security controls, modify data, make the application unstable and more.\r\n\r\nIn versions of the package affected by this vulnerability, it is possible to circumvent this protection and overwrite prototype properties and functions by prefixing the name of the parameter with `[` or `]`. e.g. `qs.parse(\"]=toString\")` will return `{toString = true}`, as a result, calling `toString()` on the object will throw an exception.\r\n\r\n**Example:**\r\n```js\r\nqs.parse('toString=foo', { allowPrototypes: false })\r\n// {}\r\n\r\nqs.parse(\"]=toString\", { allowPrototypes: false })\r\n// {toString = true} <== prototype overwritten\r\n```\r\n\r\nFor more information, you can check out our [blog](https://snyk.io/blog/high-severity-vulnerability-qs/).\r\n\r\n## Disclosure Timeline\r\n- February 13th, 2017 - Reported the issue to package owner.\r\n- February 13th, 2017 - Issue acknowledged by package owner.\r\n- February 16th, 2017 - Partial fix released in versions `6.0.3`, `6.1.1`, `6.2.2`, `6.3.1`.\r\n- March 6th, 2017     - Final fix released in versions `6.4.0`,`6.3.2`, `6.2.3`, `6.1.2` and `6.0.4`\r\n\r\n## Remediation\r\nUpgrade `qs` to version `6.4.0` or higher.\r\n**Note:** The fix was backported to the following versions `6.3.2`, `6.2.3`, `6.1.2`, `6.0.4`.\r\n\r\n## References\r\n- [GitHub Commit](https://github.com/ljharb/qs/commit/beade029171b8cef9cee0d03ebe577e2dd84976d)\r\n- [Report of an insufficient fix](https://github.com/ljharb/qs/issues/200)",
+        "disclosureTime": "2017-02-13T00:00:00Z",
+        "functions": [],
+        "id": "npm:qs:20170213",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-QS-10407"
+          ],
+          "CVE": [
+            "CVE-2017-1000048"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "js",
+        "methods": [
+          {
+            "methodId": {
+              "className": "nan",
+              "filePath": "lib/parse.js",
+              "methodName": "parseObject"
+            },
+            "version": [
+              "<6.3.2 >=6.3.0",
+              "<6.2.3 >=6.2.0",
+              "<6.1.2 >=6.1.0",
+              "<6.0.4"
+            ]
+          }
+        ],
+        "modificationTime": "2018-10-10T14:56:55.142935Z",
+        "moduleName": "qs",
+        "packageManager": "npm",
+        "packageName": "qs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:7",
+            "modificationTime": "2018-09-04T11:57:08.692963Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/603_604.patch"
+            ],
+            "version": "=6.0.3"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:6",
+            "modificationTime": "2018-09-04T11:57:08.691571Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/602_604.patch"
+            ],
+            "version": "=6.0.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:5",
+            "modificationTime": "2018-09-04T11:57:08.690235Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/611_612.patch"
+            ],
+            "version": "=6.1.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:4",
+            "modificationTime": "2018-09-04T11:57:08.688957Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/610_612.patch"
+            ],
+            "version": "=6.1.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:3",
+            "modificationTime": "2018-09-04T11:57:08.687714Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/622_623.patch"
+            ],
+            "version": "=6.2.2"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:2",
+            "modificationTime": "2018-09-04T11:57:08.686294Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/621_623.patch"
+            ],
+            "version": "=6.2.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:1",
+            "modificationTime": "2018-09-04T11:57:08.684986Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/631_632.patch"
+            ],
+            "version": "=6.3.1"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:qs:20170213:0",
+            "modificationTime": "2018-09-04T11:57:08.683816Z",
+            "urls": [
+              "https://s3.amazonaws.com/snyk-rules-pre-repository/snapshots/master/patches/npm/qs/20170213/630_632.patch"
+            ],
+            "version": "=6.3.0"
+          }
+        ],
+        "publicationTime": "2017-03-01T10:00:54Z",
+        "semver": {
+          "vulnerable": [
+            "<6.3.2 >=6.3.0 || <6.2.3 >=6.2.0 || <6.1.2 >=6.1.0 || <6.0.4"
+          ]
+        },
+        "severity": "high",
+        "title": "Prototype Override Protection Bypass"
+      }
+    }
+  },
+  "meta": {
+    "isPublic": false,
+    "isLicensesEnabled": false,
+    "licensesPolicy": null,
+    "ignoreSettings": null,
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\nignore: {}\n# patches apply the minimum changes required to fix a vulnerability\npatch:\n  'npm:qs:20170213':\n    - npm-package-with-git-url > qs:\n        patched: '2018-11-04T12:47:13.696Z'\n",
+    "org": "darmalovan",
+    "summary": "1 vulnerable dependency path"
+
+  },
+  "filesystemPolicy": true
+}

--- a/test/acceptance/run-test.test.ts
+++ b/test/acceptance/run-test.test.ts
@@ -1,0 +1,89 @@
+import * as tap from 'tap';
+import {only, test} from 'tap';
+import * as fakeServer from './fake-server';
+import * as cli from '../../src/cli/commands';
+
+const port = process.env.PORT = process.env.SNYK_PORT = '12345';
+process.env.SNYK_API = 'http://localhost:' + port + '/api/v1';
+process.env.SNYK_HOST = 'http://localhost:' + port;
+process.env.LOG_LEVEL = '0';
+const apiKey = '123456789';
+let oldkey;
+let oldendpoint;
+const server: any = fakeServer(process.env.SNYK_API, apiKey);
+
+const before = tap.runOnly ? only : test;
+const after = tap.runOnly ? only : test;
+
+// Import has to happen after setting SNYK_API
+import runTest = require('../../src/lib/snyk-test/run-test');
+
+// @later: remove this config stuff.
+// Was copied straight from ../src/cli-server.js
+before('setup', async (t) => {
+  t.plan(3);
+  let key = await cli.config('get', 'api');
+  oldkey = key;
+  t.pass('existing user config captured');
+
+  key = await cli.config('get', 'endpoint');
+  oldendpoint = key;
+  t.pass('existing user endpoint captured');
+
+  await new Promise((resolve) => {
+    server.listen(port, resolve);
+  });
+  t.pass('started demo server');
+  t.end();
+});
+
+
+test('runTest annotates results with remediation data when using node_modules', async (t) => {
+  const vulns = require('./fixtures/npm-package-with-git-url/test-graph-result.json');
+  server.setNextResponse(vulns);
+
+  let result = await runTest('npm', 'test/acceptance/workspaces/npm-package-with-git-url',
+    {packageManager: 'npm'});
+  t.ok(result[0].vulnerabilities[0].parentDepType, 'has parentDepType');
+});
+
+test('runTest annotates results with remediation data when traverseNodeModules', async (t) => {
+  const vulns = require('./fixtures/npm-package/test-graph-result.json');
+  server.setNextResponse(vulns);
+
+  let result = await runTest('npm', 'test/acceptance/workspaces/npm-package',
+    {packageManager: 'npm', traverseNodeModules: true});
+  t.ok(result[0].vulnerabilities[0].parentDepType, 'has parentDepType');
+});
+
+// @later: try and remove this config stuff
+// Was copied straight from ../src/cli-server.js
+after('teardown', async (t) => {
+  t.plan(4);
+
+  delete process.env.SNYK_API;
+  delete process.env.SNYK_HOST;
+  delete process.env.SNYK_PORT;
+  t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
+
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+  t.pass('server shutdown');
+  let key = 'set';
+  let value = 'api=' + oldkey;
+  if (!oldkey) {
+    key = 'unset';
+    value = 'api';
+  }
+  await cli.config(key, value);
+  t.pass('user config restored');
+  if (oldendpoint) {
+    await cli.config('endpoint', oldendpoint);
+    t.pass('user endpoint restored');
+    t.end();
+  } else {
+    t.pass('no endpoint');
+    t.end();
+  }
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes remediation which got broken in v1.161.2

Remediation relies on annotations added to the test result from the Registry. These annotations are added depending on `payload.modules`, which is a piggybacking field on a request description object. In the latest refactoring, modules were erroneously (and under inverse conditions) assigned to `body.modules`, which broke the refactoring workflow.

Apart from the fix, now there are:
- a test that ensures the annotations are added
- type-checks for Policy, Body and friends

#### Where should the reviewer start?

The fix itself is at the bottom of src/lib/snyk-test/run-test.ts

The rest is just tests and typechecks.

#### How should this be manually tested?

`snyk wizard` now forks on snyk-fixtures/npm-lockfiles/goof-yarn (e.g. not offering to fix `braces` which it shouldn't).

#### Any background context you want to provide?

The bug was introduced in https://github.com/snyk/snyk/commit/73e96aa73d22f477671481eba0893c1ac03e0322