### PR TITLE
fix: better wording for the "revisit policy" prompt.

### DIFF
--- a/src/cli/commands/protect/prompts.js
+++ b/src/cli/commands/protect/prompts.js
@@ -838,8 +838,7 @@ function generatePrompt(vulns, policy, prefix, options) {
 function startOver() {
   return {
     name: 'misc-start-over',
-    message: 'Do you want to revisit your existing policy [y] or only update ' +
-      'it [N]?',
+    message: 'Existing .snyk policy found. Ignore it and start from scratch [y] or update it [N]?',
     type: 'confirm',
     default: false,
   };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The current message is confusing; changed it to a more straightforward one.

