### PR TITLE
feat: vulns exit code 1, errors 2

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -153,7 +153,8 @@ async function test(...args): Promise<string> {
       summariseErrorResults(errorResults) + '\n';
   }
 
-  const notSuccess = vulnerableResults.length > 0 || errorResults.length > 0;
+  const notSuccess = errorResults.length > 0;
+  const foundVulnerabilities = vulnerableResults.length > 0;
 
   if (notSuccess) {
     response += chalk.bold.red(summaryMessage);
@@ -162,9 +163,15 @@ async function test(...args): Promise<string> {
     // translation
     // HACK as there can be different errors, and we pass only the
     // first one
-    error.code = (vulnerableResults[0] || errorResults[0]).code;
-    error.userMessage = (vulnerableResults[0] || errorResults[0]).userMessage;
+    error.code = errorResults[0].code;
+    error.userMessage = errorResults[0].userMessage;
     throw error;
+  }
+
+  if (foundVulnerabilities) {
+    response += chalk.bold.red(summaryMessage);
+    console.error(response);
+    process.exit(1);
   }
 
   response += chalk.bold.green(summaryMessage);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -38,12 +38,9 @@ async function runCommand(args) {
 
 async function handleError(args, error) {
   spinner.clearAll();
-  let command = 'bad-command';
+  const command = 'bad-command';
 
-  if (error.code === 'VULNS') {
-    // this isn't a bad command, so we won't record it as such
-    command = args.command;
-  } else if (!error.stack) { // log errors that are not error objects
+  if (!error.stack) { // log errors that are not error objects
     analytics.add('error', JSON.stringify(error));
     analytics.add('command', args.command);
   } else {
@@ -55,6 +52,10 @@ async function handleError(args, error) {
     if (error.message && error.message.vulnerabilities) {
       delete error.message.vulnerabilities;
     }
+    if (error.vulnerabilities) {
+      delete error.message.vulnerabilities;
+    }
+
     analytics.add('error-message', error.message);
     analytics.add('error', error.stack);
     analytics.add('error-code', error.code);
@@ -117,7 +118,7 @@ async function main() {
   let failed = false;
 
   try {
-    if (args.options.file && args.options.file.match(/\.sln$/)) {
+    if (args.options && args.options.file && args.options.file.match(/\.sln$/)) {
       sln.updateArgs(args);
     }
     checkPaths(args);
@@ -132,7 +133,7 @@ async function main() {
   }
 
   if (!process.env.TAP && failed) {
-    process.exit(1);
+    process.exit(2);
   }
 
   return res;
@@ -140,7 +141,7 @@ async function main() {
 
 const cli = main().catch((e) => {
   console.log('super fail', e.stack);
-  process.exit(1);
+  process.exit(2);
 });
 
 if (module.parent) {

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -71,10 +71,6 @@ module.exports = function error(command) {
 module.exports.message = function(error) {
   let message = error; // defaults to a string (which is super unlikely)
   if (error instanceof Error) {
-    if (error.code === 'VULNS') {
-      return error.message;
-    }
-
     // try to lookup the error string based either on the error code OR
     // the actual error.message (which can be "Unauthorized" for instance),
     // otherwise send the error message back

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -6,7 +6,6 @@ const {SEVERITIES} = require('../snyk-test/common');
 const errors = {
   connect: 'Check your network connection, failed to connect to Snyk API',
   endpoint: 'The Snyk API is not available on ' + config.API,
-  auth: 'Unauthorized: please ensure you are logged in using `snyk auth`',
   dotfile: 'Try running `snyk wizard` to define a Snyk protect policy',
   oldsnyk: 'You have an alpha format Snyk policy file in this directory. ' +
     'Please remove it, and re-create using `snyk wizard`',
@@ -46,7 +45,6 @@ const codes = {
   404: errors.notfound,
   411: errors.endpoint, // try to post to a weird endpoint
   403: errors.endpoint,
-  401: errors.auth,
   400: errors.invalidSeverityThreshold,
   Unauthorized: errors.auth,
   MISSING_DOTFILE: errors.dotfile,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Add error code 2 for all failure states apart from *vulns found*, give's user a chance to act on this and retry if needed
- Stop treating *vulns* as an error that is treated as a `bad-command`, stop further processing and display vuln results.


#### Where should the reviewer start?
Start in command/test

#### How should this be manually tested?
Run snyk locally and try a few failed commands vs normal test runs

#### Any background context you want to provide?

We send all the vuln found commands back and pollute our analytics, it is hard to differentiate between actual failures in this way


![MultipleTestsExistCodes2](https://user-images.githubusercontent.com/2911613/58165143-0cdcd280-7c7f-11e9-9414-a975ff54f34a.gif)
