### PR TITLE
fix: do not scan all Gradle subprojects unless requested

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.24.1",
     "snyk-go-plugin": "1.7.2",
-    "snyk-gradle-plugin": "2.10.2",
+    "snyk-gradle-plugin": "2.10.4",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
We used to scan all gradle subprojects always, and maybe return the result for one (because we thought we will switch to --all-sub-projects as a default soon).

However, there's value in scanning one project only, if requested to do so: it's faster, and won't fail on every subproject if we have trouble scanning only one.

The plugin version bump includes the fix, and a fix for the fix :)

