### PR TITLE
fix: oracle linux version detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "1.24.1",
+    "snyk-docker-plugin": "1.24.2",
     "snyk-go-plugin": "1.7.2",
     "snyk-gradle-plugin": "2.10.4",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
A bug in the oracle linux version detection meant that we were incorrectly remediation oraclelinux-based images. See https://github.com/snyk/snyk-docker-plugin/commit/ed780b61650fd71e5ba59bf13b289b7b0ef67ecd for more detail