### PR TITLE
fix: Use actual package manager on test runs

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -279,6 +279,7 @@ async function assembleLocalPayloads(root, options): Promise<Payload[]> {
       debug('policies found', policyLocations);
 
       analytics.add('policies', policyLocations.length);
+      analytics.add('packageManager', options.packageManager);
       addPackageAnalytics(pkg);
 
       let policy;
@@ -364,7 +365,6 @@ async function assembleRemotePayloads(root, options): Promise<Payload[]> {
 }
 
 function addPackageAnalytics(module): void {
-  analytics.add('packageManager', 'npm');
   analytics.add('packageName', module.name);
   analytics.add('packageVersion', module.version);
   analytics.add('package', module.name + '@' + module.version);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
During refactor the packageManager was accidentally hardcoded to 'npm', setting this back