### PR TITLE
fix: enable debug output from Gradle plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.0",
     "snyk-go-plugin": "1.7.2",
-    "snyk-gradle-plugin": "2.10.4",
+    "snyk-gradle-plugin": "2.11.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -91,6 +91,8 @@ async function handleError(args, error) {
     analytics.add('command', args.command);
   } else {
     analytics.add('error-message', analyticsError.message);
+    // Note that error.stack would also contain the error message
+    // (see https://nodejs.org/api/errors.html#errors_error_stack)
     analytics.add('error', analyticsError.stack);
     analytics.add('error-code', error.code);
     analytics.add('command', args.command);

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -77,7 +77,6 @@ function postAnalytics(data) {
 }
 
 analytics.add = function (key, value) {
-  debug('analytics adding to metadata: ', key, value);
   if (metadata[key]) {
     if (!Array.isArray(metadata[key])) {
       metadata[key] = [metadata[key]];


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Enables output from the Gradle plugin via the `-d` flag.

Drive-by: reduce debug logging spam related to analytics payloads.

![image](https://user-images.githubusercontent.com/502156/58485530-23da6380-815c-11e9-9700-58fd53cb0fcb.png)
