### PR TITLE
fix: remove incorrect Gradle logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.0",
     "snyk-go-plugin": "1.7.2",
-    "snyk-gradle-plugin": "2.11.1",
+    "snyk-gradle-plugin": "2.11.2",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Removes a debug logging statement accidentally added to `snyk-gradle-plugin` that would pollute the output.
