### PR TITLE
Make human-readable error message if --file value wasn't passed correctly

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,7 +15,7 @@ import errors = require('../lib/errors/legacy-errors');
 import ansiEscapes = require('ansi-escapes');
 import {isPathToPackageFile} from '../lib/detect';
 import {updateCheck} from '../lib/updater';
-import { MissingTargetFileError } from '../lib/errors/missing-targetfile-error';
+import { MissingTargetFileError, FileFlagBadInputError } from '../lib/errors';
 
 const debug = Debug('snyk');
 const EXIT_CODES = {
@@ -134,9 +134,12 @@ async function main() {
   let failed = false;
   let exitCode = EXIT_CODES.ERROR;
   try {
-    if (args.options.file && (args.options.file as string).match(/\.sln$/)) {
+    if (args.options.file && typeof args.options.file === 'string' && (args.options.file as string).match(/\.sln$/)) {
       sln.updateArgs(args);
+    } else if (typeof args.options.file === 'boolean') {
+      throw new FileFlagBadInputError();
     }
+
     checkPaths(args);
     res = await runCommand(args);
   } catch (error) {

--- a/src/lib/errors/file-flag-bad-input.ts
+++ b/src/lib/errors/file-flag-bad-input.ts
@@ -1,0 +1,12 @@
+import {CustomError} from './custom-error';
+
+export class FileFlagBadInputError extends CustomError {
+    private static ERROR_CODE: number = 422;
+    private static ERROR_MESSAGE: string = 'Empty --file argument. Did you mean --file=path/to/file ?';
+
+    constructor() {
+        super(FileFlagBadInputError.ERROR_MESSAGE);
+        this.code = FileFlagBadInputError.ERROR_CODE;
+        this.userMessage = FileFlagBadInputError.ERROR_MESSAGE;
+    }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,2 +1,3 @@
-export {NoSupportedManifestsFoundError} from './no-supported-manifests-found';
+export {FileFlagBadInputError} from './file-flag-bad-input';
 export {MissingTargetFileError} from './missing-targetfile-error';
+export {NoSupportedManifestsFoundError} from './no-supported-manifests-found';

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -1,0 +1,10 @@
+import {test} from 'tap';
+import {exec} from 'child_process';
+
+test('snyk test command should fail when --file is not specified correctly', (t) => {
+    t.plan(1);
+
+    exec('node ./dist/cli/index.js test --file package-lock.json', (_, stdout) => {
+        t.equal(stdout.trim(), 'Empty --file argument. Did you mean --file=path/to/file ?', 'correct error output');
+    });
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Gives nice, human-readable error message, if --file value was passed with space, but now as expected (--file=[filename])

#### How should this be manually tested?
From root folder of this project run command:
`node ./dist/cli/index.js test --file package.json`

#### What are the relevant tickets?
[BST-606](https://snyksec.atlassian.net/browse/BST-606)