### PR TITLE
chore: refactor auth to async await

### DIFF
--- a/src/cli/commands/auth/is-authed.ts
+++ b/src/cli/commands/auth/is-authed.ts
@@ -2,33 +2,30 @@ import * as snyk from '../../../lib';
 import * as config from '../../../lib/config';
 import * as request from '../../../lib/request';
 
-export function isAuthed() {
+export async function isAuthed() {
   const token = snyk.config.get('api');
-  return verifyAPI(token).then((res: any) => {
-    return res.body.ok;
-  });
+  const res = await verifyAPI(token);
+  return res.body.ok;
 }
 
-export function verifyAPI(api) {
+export async function verifyAPI(apiToken) {
   const payload = {
     body: {
-      api,
+      api: apiToken,
     },
     method: 'POST',
     url: config.API + '/verify/token',
     json: true,
   };
 
-  return new Promise((resolve, reject) => {
-    request(payload, (error, res, body) => {
-      if (error) {
-        return reject(error);
-      }
+  const verifyTokenRes = await request(payload);
+  const {error, res, body} = verifyTokenRes;
+  if (error) {
+    throw error;
+  }
 
-      resolve({
-        res,
-        body,
-      });
-    });
-  });
+  return {
+    res,
+    body,
+  };
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Refactor auth handling to use `async/await` instead of promises
- Slightly refactor to simplify + for readability

#### Where should the reviewer start?
`auth/index.ts`

#### How should this be manually tested?
- Build with `npm run build` & then test out using `snyk auth`
