### PR TITLE
fix: Improve dockerfile instruction parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "1.25.0",
+    "snyk-docker-plugin": "1.25.1",
     "snyk-go-plugin": "1.9.0",
     "snyk-gradle-plugin": "2.12.0",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
Raises the version of `snyk-docker-plugin` to more accurately parse `Dockerfile` instructions in some edge cases