### PR TITLE
Go Modules support in `snyk test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
-    "snyk-go-plugin": "1.9.0",
+    "snyk-go-plugin": "1.10.0",
     "snyk-gradle-plugin": "2.12.4",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -18,7 +18,6 @@ const DETECTABLE_FILES: string[] = [
   'build.gradle.kts',
   'build.sbt',
   'Pipfile',
-  'requirements.txt',
   'Gopkg.lock',
   'vendor/vendor.json',
   'obj/project.assets.json',
@@ -26,6 +25,9 @@ const DETECTABLE_FILES: string[] = [
   'packages.config',
   'paket.dependencies',
   'composer.lock',
+  // Python has the lowest priority. Python scripts are sometimes included in projects written in
+  // more "heavyweight" languages, so we should prefer those.
+  'requirements.txt',
 ];
 
 // when file is specified with --file, we look it up here
@@ -45,6 +47,7 @@ const DETECTABLE_PACKAGE_MANAGERS: {
   'Pipfile': 'pip',
   'requirements.txt': 'pip',
   'Gopkg.lock': 'golangdep',
+  'go.mod': 'gomod',
   'vendor.json': 'govendor',
   'project.assets.json': 'nuget',
   'packages.config': 'nuget',

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -18,6 +18,7 @@ const DETECTABLE_FILES: string[] = [
   'build.gradle.kts',
   'build.sbt',
   'Pipfile',
+  'requirements.txt',
   'Gopkg.lock',
   'vendor/vendor.json',
   'obj/project.assets.json',
@@ -25,9 +26,6 @@ const DETECTABLE_FILES: string[] = [
   'packages.config',
   'paket.dependencies',
   'composer.lock',
-  // Python has the lowest priority. Python scripts are sometimes included in projects written in
-  // more "heavyweight" languages, so we should prefer those.
-  'requirements.txt',
 ];
 
 // when file is specified with --file, we look it up here

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -54,6 +54,9 @@ export async function monitor(root, meta, info: SingleDepRootResult, targetFile)
   policy = await snyk.policy.load(policyLocations, {loose: true});
 
   const packageManager = meta.packageManager;
+  if (packageManager === 'gomod') {
+    throw new Error('Monitoring go.mod files is not supported yet.');
+  }
   analytics.add('packageManager', packageManager);
 
   const target = await projectMetadata.getInfo(pkg);

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -1,5 +1,5 @@
 export type SupportedPackageManagers = 'rubygems' | 'npm' | 'yarn' |
-'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' |
+'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' | 'gomod' |
 'nuget' | 'paket' | 'composer';
 
 export const SUPPORTED_PACKAGE_MANAGER_NAME: {
@@ -13,6 +13,7 @@ export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   sbt: 'SBT',
   gradle: 'Gradle',
   golangdep: 'dep (Go)',
+  gomod: 'Go Modules',
   govendor: 'govendor',
   nuget: 'NuGet',
   paket: 'Paket',

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -40,6 +40,7 @@ export function loadPlugin(packageManager: SupportedPackageManagers,
       return pythonPlugin;
     }
     case 'golangdep':
+    case 'gomod':
     case 'govendor': {
       return goPlugin;
     }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -132,6 +132,14 @@ async function runTest(packageManager: string, root: string, options): Promise<L
       results.push(res);
     }
     return results;
+  } catch (err) {
+    // handling denial from registry because of the feature flag
+    // currently done for go.mod
+    if (err.code === 403 && err.message.includes('Feature not allowed')) {
+      throw NoSupportedManifestsFoundError([root]);
+    }
+
+    throw err;
   } finally {
     spinner.clear(spinnerLbl)();
   }
@@ -180,6 +188,7 @@ function assemblePayloads(root: string, options): Promise<Payload[]> {
   if (options.docker) {
     isLocal = true;
   } else {
+    // TODO: Refactor this check so we don't require files when tests are using mocks
     isLocal = fs.existsSync(root);
   }
   analytics.add('local', isLocal);

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -1415,7 +1415,7 @@ test('`test golang-mod --file=go.mod`', async (t) => {
     }], 'calls golang plugin');
 });
 
-test('`test golang-app` does not auto-detects golang-mod', async (t) => {
+test('`test golang-app` does not auto-detect golang-mod', async (t) => {
   chdirWorkspaces();
   const plugin = {
     async inspect() {

--- a/test/acceptance/workspaces/golang-mod/go.mod
+++ b/test/acceptance/workspaces/golang-mod/go.mod
@@ -1,0 +1,7 @@
+module app
+
+go 1.12
+
+require (
+	github.com/lib/pq v1.1.1
+)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Enables go.mod files support for test command via `--file=go.mod` flag. Sending organisation has to be enabled on the backend.

Monitor command will go in soon.

#### Where should the reviewer start?
As usual, with the tests.

#### How should this be manually tested?
Running test command on this branch with `--file=go.mod` using entitled organisation.

#### Any background context you want to provide?
This change means that go.mod files is scanned and tree is created always, but backend than denies the request if sending organisation is not entitled.

This is not ideal, but I believe it pays off given the temporary nature of the beta release. Otherwise, we would need to create whole new communication flow for feature flag pre-check.
