### PR TITLE
fix: gradle legacy --configuration flag and scanning from child project

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
     "snyk-go-plugin": "1.9.0",
-    "snyk-gradle-plugin": "2.12.0",
+    "snyk-gradle-plugin": "2.12.2",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds bugfixes to the Gradle plugin to restore the functionality of legacy unocumented `-- --configuration=foo` option and enable proper configuration resolution when scanning from a sub-project.
