### PR TITLE
fix: temporarily remove new Gradle configuration options from help

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -55,15 +55,6 @@ Gradle options:
                        test a specific sub-project.
   --all-sub-projects   For "multi project" configurations, test all
                        sub-projects.
-  --configuration-matching=<string>
-                       Resolve dependencies using only configuration(s) that
-                       match the provided Java regular expression, e.g.
-                       '^releaseRuntimeClasspath$'.
-  --configuration-attributes=<string>
-                       Select certain values of configuration attributes to
-                       resolve the dependencies. E.g.:
-                       'buildtype:release,usage:java-runtime'
-  More information: https://snyk.io/docs/cli-advanced-gradle-testing/
 
 .Net (Nuget) options:
   --assets-project-name


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Updates the help to match the rollback in https://github.com/snyk/snyk/pull/563