### PR TITLE
feat: Gradle Android config selection, verified Gradle 2.x support

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -55,6 +55,15 @@ Gradle options:
                        test a specific sub-project.
   --all-sub-projects   For "multi project" configurations, test all
                        sub-projects.
+  --configuration-matching=<string>
+                       Resolve dependencies using only configuration(s) that
+                       match the provided Java regular expression, e.g.
+                       '^releaseRuntimeClasspath$'.
+  --configuration-attributes=<string>
+                       Select certain values of configuration attributes to
+                       resolve the dependencies. E.g.:
+                       'buildtype:release,usage:java-runtime'
+  More information: https://snyk.io/docs/cli-advanced-gradle-testing/
 
 .Net (Nuget) options:
   --assets-project-name

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
     "snyk-go-plugin": "1.9.0",
-    "snyk-gradle-plugin": "2.11.2",
+    "snyk-gradle-plugin": "2.12.4",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -144,9 +144,9 @@ async function monitor(...args0: MethodArgs): Promise<any> {
       } else {
         if (!options['gradle-sub-project']
           && inspectResult.plugin.meta
-          && inspectResult.plugin.meta.allDepRootNames
-          && inspectResult.plugin.meta.allDepRootNames.length > 1) {
-          advertiseSubprojectsCount = inspectResult.plugin.meta.allDepRootNames.length;
+          && inspectResult.plugin.meta.allSubProjectNames
+          && inspectResult.plugin.meta.allSubProjectNames.length > 1) {
+          advertiseSubprojectsCount = inspectResult.plugin.meta.allSubProjectNames.length;
         }
         perDepRootResults = [inspectResult];
       }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -214,9 +214,9 @@ async function getDepsFromPlugin(root, options: TestOptions): Promise<MultiDepRo
     // but don't want to send to Registry in the Payload.
     // TODO(kyegupov): decouple inspect and payload so that we don't need this hack
     if (inspectRes.plugin.meta
-      && inspectRes.plugin.meta.allDepRootNames
-      && inspectRes.plugin.meta.allDepRootNames.length > 1) {
-      options.advertiseSubprojectsCount = inspectRes.plugin.meta.allDepRootNames.length;
+      && inspectRes.plugin.meta.allSubProjectNames
+      && inspectRes.plugin.meta.allSubProjectNames.length > 1) {
+      options.advertiseSubprojectsCount = inspectRes.plugin.meta.allSubProjectNames.length;
     }
     return {
       plugin: inspectRes.plugin,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export interface PluginMetadata {
   runtime?: any;
   dockerImageId: any;
   meta?: {
-    allDepRootNames: string[]; // To warn the user about subprojects not being scanned
+    allSubProjectNames: string[]; // To warn the user about subprojects not being scanned
   };
 }
 

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -2310,7 +2310,7 @@ test('`monitor gradle-app`', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           meta: {
-            allDepRootNames: ['foo', 'bar'],
+            allSubProjectNames: ['foo', 'bar'],
           },
         },
         package: {},


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Restores temporarily downgraded Gradle plugin to add Android config selection support while preserving Gradle 2.x compatibility.

Also, reinstate the advertisement for `--all-sub-projects` flag.