### PR TITLE
fix: remove auto authentication on all commands other than auth

### DIFF
--- a/src/lib/errors/misconfigured-auth-in-ci-error.ts
+++ b/src/lib/errors/misconfigured-auth-in-ci-error.ts
@@ -1,8 +1,8 @@
 import {CustomError} from './custom-error';
 
 export function MisconfiguredAuthInCI() {
-  const errorMsg = 'Web auth cannot be used whilst inside CI. You must include ' +
-  'your API token as an environment value: `API=12345678`';
+  const errorMsg = 'Snyk is missing auth token in order to run inside CI. You must include ' +
+  'your API token as an environment value: `SNYK_TOKEN=12345678`';
 
   const error = new CustomError(errorMsg);
   error.code = 401;


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
`Wizard` and `Ignore` commands have been doing automated authentication in case of no authentication, this behaviour is different to what test or monitor do - which is to bail out if there is no auth. This PR aims to regulate auth behaviour across all the commands. 

In addition, wording for the CI auth error is changed to 

#### Where should the reviewer start?


#### How should this be manually tested?
run 
`snyk test`
`snyk protect`
`snyk monitor`
`snyk ignore`
`snyk wizard`
See that we require authentication.

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
