### PR TITLE
fix: better error message when scanning Python projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "snyk-nuget-plugin": "1.10.0",
     "snyk-php-plugin": "1.5.3",
     "snyk-policy": "1.13.5",
-    "snyk-python-plugin": "1.10.1",
+    "snyk-python-plugin": "1.10.2",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.0.3",
     "snyk-sbt-plugin": "2.2.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Better error message (names of missing packages) when scanning Python projects.
