### PR TITLE
fix: show stacktrace only when in debug mode

### DIFF
--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -2,6 +2,7 @@
 const config = require('../config');
 const chalk = require('chalk');
 const {SEVERITIES} = require('../snyk-test/common');
+const analytics = require('../analytics');
 
 const errors = {
   connect: 'Check your network connection, failed to connect to Snyk API',
@@ -85,8 +86,9 @@ module.exports.message = function(error) {
       message = message.replace(/(%s)/g, error.message).trim();
       message = chalk.bold.red(message);
     } else if (error.code) { // means it's a code error
-      message = 'An unknown error occurred. Please include the trace below ' +
-                'when reporting to Snyk:\n\n' + error.stack;
+      message = 'An unknown error occurred. Please run with `-d` and include full trace ' +
+                'when reporting to Snyk';
+      analytics.add('unknown-error-code', JSON.stringify(error));
     } else { // should be one of ours
       message = error.message;
     }

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -174,6 +174,7 @@ function patch(vulns, live) {
       if (errorList.length) {
         errorList.forEach(function (error) {
           console.log(chalk.red(errors.message(error)));
+          debug(error.stack);
         });
         throw new Error('Please email support@snyk.io if this problem persists.');
       }

--- a/src/lib/protect/update.js
+++ b/src/lib/protect/update.js
@@ -105,6 +105,7 @@ function update(packages, live, pkgManager) {
     .then(function (res) {
       if (error) {
         console.error(chalk.red(errors.message(error)));
+        debug(error.stack);
       }
       return res;
     });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Most stacktraces are only visible in debug mode, but there were a few that fell through the cracks. This PR fixes this.

#### Where should the reviewer start?
`https://github.com/snyk/snyk/blob/master/src/cli/index.ts#L45` will handle most of the errors. But some places were still using the legacy error handling to show errors. Removed the stack from the message, and only logging it in debug mode.

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
