### PR TITLE
fix: remove old auth from ignore

### DIFF
--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -1,70 +1,49 @@
 module.exports = ignore;
 
 import * as policy from 'snyk-policy';
-import chalk from 'chalk';
-import * as authorization from '../../lib/authorization';
-import * as auth from './auth/is-authed';
 import {apiTokenExists} from '../../lib/api-token';
-import {isCI} from '../../lib/is-ci';
 
 import * as Debug from 'debug';
 const debug = Debug('snyk');
 
-import {MisconfiguredAuthInCI} from '../../lib/errors/misconfigured-auth-in-ci-error';
-
 function ignore(options) {
   debug('snyk ignore called with options: %O', options);
 
-  return auth.isAuthed().then((authed) => {
-    if (!authed) {
-      if (isCI()) {
-        throw MisconfiguredAuthInCI();
+  apiTokenExists();
+
+  if (!options.id) {
+    throw Error('idRequired');
+  }
+  options.expiry = new Date(options.expiry);
+  if (options.expiry.getTime() !== options.expiry.getTime()) {
+    debug('No/invalid expiry given, using the default 30 days');
+    options.expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
+  }
+  if (!options.reason) {
+    options.reason = 'None Given';
+  }
+
+  debug(
+    'changing policy: ignore "%s", for all paths, reason: "%s", until: %o',
+    options.id, options.reason, options.expiry,
+  );
+  return policy.load(options['policy-path'])
+    .catch((error) => {
+      if (error.code === 'ENOENT') {    // file does not exist - create it
+        return policy.create();
       }
-    }
-    apiTokenExists();
-  }).then(() => {
-    return authorization.actionAllowed('cliIgnore', options);
-  }).then((cliIgnoreAuthorization) => {
-    if (!cliIgnoreAuthorization.allowed) {
-      debug('snyk ignore called when disallowed');
-      console.log(chalk.bold.red(cliIgnoreAuthorization.reason));
-      return;
-    }
-
-    if (!options.id) {
-      throw Error('idRequired');
-    }
-    options.expiry = new Date(options.expiry);
-    if (options.expiry.getTime() !== options.expiry.getTime()) {
-      debug('No/invalid expiry given, using the default 30 days');
-      options.expiry = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000);
-    }
-    if (!options.reason) {
-      options.reason = 'None Given';
-    }
-
-    debug(
-      'changing policy: ignore "%s", for all paths, reason: "%s", until: %o',
-      options.id, options.reason, options.expiry,
-    );
-    return policy.load(options['policy-path'])
-      .catch((error) => {
-        if (error.code === 'ENOENT') {    // file does not exist - create it
-          return policy.create();
-        }
-        throw Error('policyFile');
-      })
-      .then(function ignoreIssue(pol) {
-        pol.ignore[options.id] = [
-          {
-            '*':
-              {
-                reason: options.reason,
-                expires: options.expiry,
-              },
-          },
-        ];
-        policy.save(pol, options['policy-path']);
-      });
-  });
+      throw Error('policyFile');
+    })
+    .then(function ignoreIssue(pol) {
+      pol.ignore[options.id] = [
+        {
+          '*':
+            {
+              reason: options.reason,
+              expires: options.expiry,
+            },
+        },
+      ];
+      policy.save(pol, options['policy-path']);
+    });
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Test and Monitor are no longer using `is-authed` and `authorization` . Removing them and only authing with `apiTokenExists`

#### How should this be manually tested?
run ignore without and with auth. 

#### Any background context you want to provide?
https://github.com/snyk/snyk/issues/556


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
