### PR TITLE
fix: name and version in gomodules

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
-    "snyk-go-plugin": "1.10.1",
+    "snyk-go-plugin": "1.10.2",
     "snyk-gradle-plugin": "2.12.4",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Moving version to 0.0.0 from unknown and setting default name to base path of the file by bumping snyk-go-plugin module.
