### PR TITLE
refactor: harmonize eslint and tslint rules re arrow functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,8 @@
     "es6": true
   },
   "rules": {
+    "arrow-parens": 2,
+    "arrow-spacing": 2,
     "array-bracket-spacing": [2, "never"],
     "block-scoped-var": 2,
     "brace-style": 2,
@@ -28,6 +30,7 @@
     "max-len": [1, 120],
     "max-statements": [1, 100],
     "new-cap": 0,
+    "no-confusing-arrow": 2,
     "no-const-assign": "error",
     "no-caller": 2,
     "no-else-return": 2,
@@ -38,6 +41,7 @@
     "no-unused-vars": 1,
     "no-use-before-define": [2, "nofunc"],
     "object-curly-spacing": [2, "never"],
+    "prefer-arrow-callback": 2,
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
     "keyword-spacing": [2, {"before": true, "after": true}],

--- a/src/cli/commands/config.js
+++ b/src/cli/commands/config.js
@@ -4,12 +4,12 @@ module.exports = function config(method) {
   var args = [].slice.call(arguments, 1);
   var key = args[0];
 
-  return new Promise(function (resolve) {
+  return new Promise((resolve) => {
     var res = '';
     if (method === 'set') {
-      args.map(function (item) {
+      args.map((item) => {
         return item.split('=');
-      }).forEach(function (pair) {
+      }).forEach((pair) => {
         res += pair[0] + ' updated\n';
         snyk.config.set.apply(snyk.config, pair);
 
@@ -40,12 +40,12 @@ module.exports = function config(method) {
       snyk.api = null;
       res = 'config cleared';
     } else if (!method) {
-      res = Object.keys(snyk.config.all).sort(function (a, b) {
-        return a.toLowerCase() < b.toLowerCase();
-      }).reduce(function (acc, curr) {
-        acc += curr + ': ' + snyk.config.all[curr] + '\n';
-        return acc;
-      }, '').trim();
+      res = Object.keys(snyk.config.all)
+        .sort((a, b) => (a.toLowerCase() < b.toLowerCase()))
+        .reduce((acc, curr) => {
+          acc += curr + ': ' + snyk.config.all[curr] + '\n';
+          return acc;
+        }, '').trim();
     } else {
       throw new Error('Unknown config command "' + method + '"');
     }

--- a/src/cli/commands/modules.js
+++ b/src/cli/commands/modules.js
@@ -4,7 +4,7 @@ module.exports = function (path, options) {
   if (!options) {
     options = {};
   }
-  return snyk.modules(path || process.cwd()).then(function (modules) {
+  return snyk.modules(path || process.cwd()).then((modules) => {
 
     var parent = '';
     if (modules.parent) {
@@ -15,8 +15,8 @@ module.exports = function (path, options) {
       return JSON.stringify(modules, '', 2);
     }
 
-    return parent + Object.keys(modules.dependencies).map(function (key) {
-      return modules.dependencies[key].full;
-    }).join('\n');
+    return parent + Object.keys(modules.dependencies)
+      .map((key) => modules.dependencies[key].full)
+      .join('\n');
   });
 };

--- a/src/cli/commands/policy.js
+++ b/src/cli/commands/policy.js
@@ -6,7 +6,7 @@ var display = require('../../lib/display-policy');
 function displayPolicy(path) {
   return policy.load(path || process.cwd())
     .then(display)
-    .catch(function (e) {
+    .catch((e) => {
       if (e.code === 'ENOENT') {
         e.code = 'MISSING_DOTFILE';
       }

--- a/src/cli/commands/protect/index.js
+++ b/src/cli/commands/protect/index.js
@@ -45,13 +45,13 @@ function protectFunc(options = {}) {
   }
 
   return snyk.policy.load(options['policy-path'])
-    .catch(function (error) {
+    .catch((error) => {
       if (error.code === 'ENOENT') {
         error.code = 'MISSING_DOTFILE';
       }
 
       throw error;
-    }).then(function (policy) {
+    }).then((policy) => {
       if (policy.patch) {
         return patch(policy, options);
       }
@@ -60,17 +60,17 @@ function protectFunc(options = {}) {
 }
 
 function patch(policy, options) {
-  return snyk.test(process.cwd(), options).then(function (res) {
+  return snyk.test(process.cwd(), options).then((res) => {
     if (!res.vulnerabilities) {
       var e = new Error('Code is already patched');
       e.code = 'ALREADY_PATCHED';
       throw e;
     }
     return protect.patch(res.vulnerabilities, !options['dry-run']);
-  }).then(function () {
+  }).then(() => {
     analytics.add('success', true);
     return 'Successfully applied Snyk patches';
-  }).catch(function (e) {
+  }).catch((e) => {
     if (e.code === 'ALREADY_PATCHED') {
       analytics.add('success', true);
       return e.message + ', nothing to do';

--- a/src/cli/commands/protect/prompts.js
+++ b/src/cli/commands/protect/prompts.js
@@ -139,18 +139,18 @@ function sortPatchPrompts(a, b) {
 function stripInvalidPatches(vulns) {
   // strip the irrelevant patches from the vulns at the same time, collect
   // the unique package vulns
-  return vulns.map(function (vuln) {
+  return vulns.map((vuln) => {
     // strip verbose meta
     delete vuln.description;
     delete vuln.credit;
 
     if (vuln.patches) {
-      vuln.patches = vuln.patches.filter(function (patch) {
+      vuln.patches = vuln.patches.filter((patch) => {
         return semver.satisfies(vuln.version, patch.version);
       });
 
       // sort by patchModification, then pick the latest one
-      vuln.patches = vuln.patches.sort(function (a, b) {
+      vuln.patches = vuln.patches.sort((a, b) => {
         return b.modificationTime < a.modificationTime ? -1 : 1;
       }).slice(0, 1);
 
@@ -177,7 +177,7 @@ function getPatchPrompts(vulns, policy, options) {
     return [];
   }
 
-  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter(function (vuln) {
+  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter((vuln) => {
     // if there's any upgrade available, then remove it
     return (canBeUpgraded(vuln) || vuln.type === 'license') ? false : true;
   });
@@ -190,7 +190,7 @@ function getPatchPrompts(vulns, policy, options) {
   // note that I use slice first becuase the `res` array will change length
   // and `reduce` _really_ doesn't like when you change the array under
   // it's feet
-  res.slice(0).reduce(function (acc, curr, i, all) {
+  res.slice(0).reduce((acc, curr, i, all) => {
     // var upgrades = curr.upgradePath[1];
     // otherwise it's a patch and that's hidden for now
     if (curr.patches && curr.patches.length) {
@@ -202,7 +202,7 @@ function getPatchPrompts(vulns, policy, options) {
         last = curr.id;
       } else {
         // try to find the right vuln id based on the publication times
-        last = (all.filter(function (vuln) {
+        last = (all.filter((vuln) => {
           var patch = vuln.patches[0];
 
           // don't select the one we're looking at
@@ -277,7 +277,7 @@ function getPatchPrompts(vulns, policy, options) {
       };
 
       // add the from path to our group upgrades if we don't have it already
-      var have = !!acc[last].grouped.upgrades.filter(function (upgrade) {
+      var have = !!acc[last].grouped.upgrades.filter((upgrade) => {
         return upgrade.from.join(' ') === curr.from.join(' ');
       }).length;
 
@@ -302,7 +302,7 @@ function getPatchPrompts(vulns, policy, options) {
   // FIXME this should not just strip those that have an upgrade path, but
   // take into account the previous answers, and if the package has been
   // upgraded, it should be left *out* of our list.
-  res = res.filter(function (curr) {
+  res = res.filter((curr) => {
     // if (curr.upgradePath[1]) {
     //   return false;
     // }
@@ -327,7 +327,7 @@ function getIgnorePrompts(vulns, policy, options) {
     return [];
   }
 
-  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter(function (vuln) {
+  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter((vuln) => {
     // remove all patches and updates
 
     // if there's any upgrade available
@@ -354,7 +354,7 @@ function getUpdatePrompts(vulns, policy, options) {
     return [];
   }
 
-  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter(function (vuln) {
+  var res = stripInvalidPatches(_.cloneDeep(vulns)).filter((vuln) => {
     // only keep upgradeable
     return canBeUpgraded(vuln);
   });
@@ -367,7 +367,7 @@ function getUpdatePrompts(vulns, policy, options) {
   // note that I use slice first becuase the `res` array will change length
   // and `reduce` _really_ doesn't like when you change the array under
   // it's feet
-  res.slice(0).reduce(function (acc, curr, i) {
+  res.slice(0).reduce((acc, curr, i) => {
     var from = curr.from[1];
 
     if (!acc[from]) {
@@ -421,7 +421,7 @@ function getUpdatePrompts(vulns, policy, options) {
   }, {});
 
   // now strip anything that doesn't have an upgrade path
-  res = res.filter(function (curr) {
+  res = res.filter((curr) => {
     return !!curr.upgradePath[1];
   });
 
@@ -443,7 +443,7 @@ function canBeUpgraded(vuln) {
     return false;
   }
 
-  return vuln.upgradePath.some(function (pkg, i) {
+  return vuln.upgradePath.some((pkg, i) => {
     // if the upgade path is to upgrade the module to the same range the
     // user already asked for, then it means we need to just blow that
     // module away and re-install
@@ -501,7 +501,7 @@ function generatePrompt(vulns, policy, prefix, options) {
     name: null, // updated below to the name of the package to update
   };
 
-  var prompts = vulns.map(function (vuln, i) {
+  var prompts = vulns.map((vuln, i) => {
     var id = vuln.id || ('node-' + vuln.name + '@' + vuln.below);
 
     id += '-' + prefix + i;
@@ -576,7 +576,7 @@ function generatePrompt(vulns, policy, prefix, options) {
         // of the vuln
         if (vuln.grouped && !vuln.grouped.main) {
           // find how they answered on the top level question
-          var groupAnswer = Object.keys(answers).map(function (key) {
+          var groupAnswer = Object.keys(answers).map((key) => {
             if (answers[key].meta) {
               // this meta.groupId only appears on a "review" choice, and thus
               // this map will pick out those vulns that are specifically
@@ -604,7 +604,7 @@ function generatePrompt(vulns, policy, prefix, options) {
 
           // if we've upgraded, then stop asking
           var updatedTo = null;
-          res = groupAnswer.filter(function (answer) {
+          res = groupAnswer.filter((answer) => {
             if (answer.choice === 'update') {
               updatedTo = answer;
               return true;
@@ -772,14 +772,14 @@ function generatePrompt(vulns, policy, prefix, options) {
     // choice and whether it was supposed to be a default. If the user is
     // updating their policy options, then we select the choice they had
     // before, otherwise we select the default
-    res.default = (choices.map(function (choice, i) {
+    res.default = (choices.map((choice, i) => {
       return {i: i, default: choice.default};
-    }).filter(function (choice) {
+    }).filter((choice) => {
       return choice.default;
     }).shift() || {i: 0}).i;
 
     // kludge to make sure that we get the vuln in the user selection
-    res.choices = choices.map(function (choice) {
+    res.choices = choices.map((choice) => {
       var value = choice.value;
       // this allows us to pass more data into the inquirer results
       if (vuln.grouped && !vuln.grouped.main) {
@@ -804,7 +804,7 @@ function generatePrompt(vulns, policy, prefix, options) {
   // zip together every prompt and a prompt asking "why", note that the `when`
   // callback controls whether not to prompt the user with this question,
   // in this case, we always show if the user choses to ignore.
-  prompts = prompts.reduce(function (acc, curr) {
+  prompts = prompts.reduce((acc, curr) => {
     acc.push(curr);
     var rule = snykPolicy.getByVuln(policy, curr.choices[0].value.vuln);
     var defaultAnswer = 'None given';
@@ -866,7 +866,7 @@ function nextSteps(pkg, prevAnswers) {
 
   // if `snyk protect` doesn't already appear, then check if we need to add it
   if (i === -1) {
-    skipProtect = Object.keys(prevAnswers).every(function (key) {
+    skipProtect = Object.keys(prevAnswers).every((key) => {
       return prevAnswers[key].choice !== 'patch';
     });
   } else {

--- a/src/cli/commands/protect/tasks.js
+++ b/src/cli/commands/protect/tasks.js
@@ -11,7 +11,7 @@ function answersToTasks(answers) {
     skip: [],
   };
 
-  Object.keys(answers).forEach(function (key) {
+  Object.keys(answers).forEach((key) => {
     // if we're looking at a reason, skip it
     if (key.indexOf('-reason') !== -1) {
       return;
@@ -39,7 +39,7 @@ function answersToTasks(answers) {
 
       var additional = vuln.grouped.upgrades.slice(1);
 
-      additional.forEach(function (upgrade) {
+      additional.forEach((upgrade) => {
         var copy = _.cloneDeep(vuln);
         copy.from = upgrade.from;
         copy.__filename = upgrade.filename;
@@ -53,7 +53,7 @@ function answersToTasks(answers) {
       answer.meta.reason = answers[key + '-reason'];
       if (answer.meta.vulnsInGroup) {
         // also ignore any in the group
-        answer.meta.vulnsInGroup.forEach(function (vuln) {
+        answer.meta.vulnsInGroup.forEach((vuln) => {
           tasks[task].push({
             meta: answer.meta,
             vuln: vuln,

--- a/src/cli/commands/protect/wizard.js
+++ b/src/cli/commands/protect/wizard.js
@@ -102,7 +102,7 @@ function processWizardFlow(options) {
             debug('ignore disabled');
           }
           const intro = __dirname + '/../../../../help/wizard-intro.txt';
-          return fs.readFile(intro, 'utf8').then(function (str) {
+          return fs.readFile(intro, 'utf8').then((str) => {
             if (!isCI()) {
               console.log(str);
             }
@@ -112,7 +112,7 @@ function processWizardFlow(options) {
                 if (options.newPolicy) {
                   return resolve(); // don't prompt to start over
                 }
-                inquirer.prompt(allPrompts.startOver()).then(function (answers) {
+                inquirer.prompt(allPrompts.startOver()).then((answers) => {
                   analytics.add('start-over', answers['misc-start-over']);
                   if (answers['misc-start-over']) {
                     options['ignore-policy'] = true;
@@ -151,7 +151,7 @@ function processWizardFlow(options) {
 
                 return snyk.policy.loadFromText(res.policy)
                   .then((combinedPolicy) => {
-                    return tryRequire(packageFile).then(function (pkg) {
+                    return tryRequire(packageFile).then((pkg) => {
                       options.packageLeading = pkg.prefix;
                       options.packageTrailing = pkg.suffix;
                       return interactive(res, pkg, combinedPolicy, options)
@@ -174,20 +174,20 @@ function interactive(test, pkg, policy, options) {
     pkg = {};
   }
 
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     debug('starting questions');
     var prompts = allPrompts.getUpdatePrompts(vulns, policy, options);
     resolve(inquire(prompts, {}));
-  }).then(function (answers) {
+  })).then((answers) => {
     var prompts = allPrompts.getPatchPrompts(vulns, policy, options);
     return inquire(prompts, answers);
-  }).then(function (answers) {
+  }).then((answers) => {
     var prompts = allPrompts.getIgnorePrompts(vulns, policy, options);
     return inquire(prompts, answers);
-  }).then(function (answers) {
+  }).then((answers) => {
     var prompts = allPrompts.nextSteps(pkg, test.ok ? false : answers);
     return inquire(prompts, answers);
-  }).then(function (answers) {
+  }).then((answers) => {
     if (pkg.shrinkwrap) {
       answers['misc-build-shrinkwrap'] = true;
     }
@@ -200,13 +200,13 @@ function inquire(prompts, answers) {
     return Promise.resolve(answers);
   }
   // inquirer will handle dots in name as path in hash (CSUP-272)
-  prompts.forEach(function (prompt) {
+  prompts.forEach((prompt) => {
     prompt.name = prompt.name.replace(/\./g, '--DOT--');
   });
-  return new Promise(function (resolve) {
-    inquirer.prompt(prompts).then(function (theseAnswers) {
+  return new Promise(((resolve) => {
+    inquirer.prompt(prompts).then((theseAnswers) => {
       _.extend(answers, theseAnswers);
-      Object.keys(answers).forEach(function (answerName) {
+      Object.keys(answers).forEach((answerName) => {
         if (answerName.indexOf('--DOT--') > -1) {
           var newName = answerName.replace(/--DOT--/g, '.');
           answers[newName] = answers[answerName];
@@ -215,7 +215,7 @@ function inquire(prompts, answers) {
       });
       resolve(answers);
     });
-  });
+  }));
 }
 
 function getNewScriptContent(scriptContent, cmd) {
@@ -283,7 +283,7 @@ function processAnswers(answers, policy, options) {
 
   var pkg = {};
 
-  analytics.add('answers', Object.keys(answers).map(function (key) {
+  analytics.add('answers', Object.keys(answers).map((key) => {
     // if we're looking at a reason, skip it
     if (key.indexOf('-reason') !== -1) {
       return;
@@ -316,7 +316,7 @@ function processAnswers(answers, policy, options) {
   var snykVersion = '*';
 
   var res = protect.generatePolicy(policy, tasks, live, options.packageManager)
-    .then(function (policy) {
+    .then((policy) => {
       if (!live) {
       // if this was a dry run, we'll throw an error to bail out of the
       // promise chain, then in the catch, check the error.code and if
@@ -327,16 +327,16 @@ function processAnswers(answers, policy, options) {
         throw e;
       }
 
-      return policy.save(cwd, spinner).then(function () {
+      return policy.save(cwd, spinner).then(() => {
       // don't do this during testing
         if (isCI() || process.env.TAP) {
           return Promise.resolve();
         }
 
-        return new Promise(function (resolve) {
+        return new Promise(((resolve) => {
           exec('git add .snyk', {
             cwd: cwd,
-          }, function (error, stdout, stderr) {
+          }, (error, stdout, stderr) => {
             if (error) {
               debug('error adding .snyk to git', error);
             }
@@ -348,20 +348,20 @@ function processAnswers(answers, policy, options) {
             // resolve either way
             resolve();
           });
-        });
+        }));
       });
     })
-    .then(function () {
+    .then(() => {
     // re-read the package.json - because the generatePolicy can apply
     // an `npm install` which will change the deps
       return fs.readFile(packageFile, 'utf8')
         .then(JSON.parse)
-        .then(function (updatedPkg) {
+        .then((updatedPkg) => {
           pkg = updatedPkg;
         });
     })
     .then(getVersion)
-    .then(function (v) {
+    .then((v) => {
       debug('snyk version: %s', v);
       // little hack to circumvent local testing where the version will
       // be the git branch + commit
@@ -372,7 +372,7 @@ function processAnswers(answers, policy, options) {
       }
       snykVersion = v;
     })
-    .then(function () {
+    .then(() => {
       analytics.add('add-snyk-test', answers['misc-add-test']);
       if (!answers['misc-add-test']) {
         return;
@@ -395,10 +395,10 @@ function processAnswers(answers, policy, options) {
         pkg.scripts.test = cmd;
       }
     })
-    .then(function () {
+    .then(() => {
       return npm.getVersion();
     })
-    .then(function (npmVersion) {
+    .then((npmVersion) => {
       analytics.add('add-snyk-protect', answers['misc-add-protect']);
       if (!answers['misc-add-protect']) {
         return;
@@ -414,7 +414,7 @@ function processAnswers(answers, policy, options) {
 
       pkg.snyk = true;
     })
-    .then(function () {
+    .then(() => {
       let lbl = 'Updating package.json...';
       const addSnykToDependencies = answers['misc-add-test'] || answers['misc-add-protect'];
       let updateSnykFunc = () => protect.install(packageManager, ['snyk'], live);
@@ -472,13 +472,13 @@ function processAnswers(answers, policy, options) {
           })
           // clear spinner in case of success or failure
           .then(spinner.clear(lbl))
-          .catch(function (error) {
+          .catch((error) => {
             spinner.clear(lbl)();
             throw error;
           });
       }
     })
-    .then(function () {
+    .then(() => {
       if (answers['misc-build-shrinkwrap'] && tasks.update.length) {
         debug('updating shrinkwrap');
 
@@ -487,13 +487,13 @@ function processAnswers(answers, policy, options) {
           .then(npm.bind(null, 'shrinkwrap', null, live, cwd, null))
           // clear spinner in case of success or failure
           .then(spinner.clear(lbl))
-          .catch(function (error) {
+          .catch((error) => {
             spinner.clear(lbl)();
             throw error;
           });
       }
     })
-    .then(function () {
+    .then(() => {
       if (answers['misc-test-no-monitor']) { // allows us to automate tests
         return {
           id: 'test',

--- a/src/cli/commands/scenario.js
+++ b/src/cli/commands/scenario.js
@@ -17,14 +17,14 @@ function scenario(casefile, options) {
   auth.isAuthed = function () {
     return Promise.resolve(true);
   };
-  return loadScenario(casefile).then(function (data) {
+  return loadScenario(casefile).then((data) => {
     snyk.test = scenarioTest(data);
     options['dry-run'] = true;
     console.log(data.title || 'Unknown case');
     debug(JSON.stringify(data, '', 2));
     // process.exit(1);
     return wizard(options);
-  }).then(function (res) {
+  }).then((res) => {
     snyk.test = cache.test;
     auth.isAuthed = cache.isAuthed;
     return res;
@@ -41,12 +41,12 @@ function loadScenario(casefile) {
 
 function scenarioTest(data) {
   return function () {
-    return new Promise(function (resolve) {
+    return new Promise(((resolve) => {
       resolve({
         ok: false,
         vulnerabilities: data.vulnerabilities.slice(0),
       });
-    });
+    }));
   };
 }
 
@@ -98,7 +98,7 @@ function parseScenario(source) {
       if ((m = uses.exec(line)) !== null) {
         if (m[1] === 'App') {
           debug('App uses...', line);
-          m.slice(2).filter(Boolean).map(function (module) {
+          m.slice(2).filter(Boolean).map((module) => {
             var p = module.split('-');
             p[1] = cleanVersion(p[1]);
             pkg.dependencies[p[0]] = {
@@ -122,7 +122,7 @@ function parseScenario(source) {
         }
         debug('packages', packages, full);
 
-        m.slice(2).filter(Boolean).map(function (module) {
+        m.slice(2).filter(Boolean).map((module) => {
           var p = module.split('-');
           p[1] = cleanVersion(p[1]);
           debug('package module: %s', module, p.join('@'));
@@ -146,7 +146,7 @@ function parseScenario(source) {
       debug('vulns found? ', vulns);
       if ((m = patches.exec(line)) !== null) {
         for (k = 0; k < vulns.length; k++) {
-          vulnerabilities.forEach(function (vuln) {
+          vulnerabilities.forEach((vuln) => {
             if (vuln.id === vulns[k]) {
               if (!vuln.patches) {
                 vuln.patches = [];
@@ -192,7 +192,7 @@ function parseScenario(source) {
           var v = m[k];
 
           // first check if the vuln exists
-          var match = vulnerabilities.filter(function (vuln) {
+          var match = vulnerabilities.filter((vuln) => {
             return vuln.id === v;
           }); // jshint ignore:line
 
@@ -241,7 +241,7 @@ function parseScenario(source) {
     cleanDepTree(deps, pkg, packages);
   }
 
-  vulnerabilities = vulnerabilities.filter(function (vuln) {
+  vulnerabilities = vulnerabilities.filter((vuln) => {
     debug('checking new vuln: %s', vuln.id);
     var p;
     var i;
@@ -319,7 +319,7 @@ function parseScenario(source) {
 }
 
 function cleanDepTree(deps, pkg, packages) {
-  deps.forEach(function (curr) {
+  deps.forEach((curr) => {
     var full = pkg.dependencies[curr].full;
     debug('push on %s with %s', pkg.dependencies[curr].path, pkg.full);
     pkg.dependencies[curr].path = pkg.path.concat(pkg.dependencies[curr].path);
@@ -377,7 +377,7 @@ function matchDep(module, deps) {
 function patchDate(s) {
   s = (s || '').toLowerCase();
   var d = ['jan', 'feb', 'mar', 'apr', 'may', 'jun', 'jul', 'aug', 'sep',
-    'oct', 'nov', 'dec'].map(function (d, i) {
+    'oct', 'nov', 'dec'].map((d, i) => {
     return s.indexOf(d) === 0 ? i : false;
   }).filter(Boolean);
   var date = new Date();

--- a/src/cli/commands/unpublished/index.js
+++ b/src/cli/commands/unpublished/index.js
@@ -18,9 +18,9 @@ module.exports = function (cwd) {
 
   spinner.sticky();
 
-  return spinner(head).then(function () {
-    return resolve(cwd, {dev: true, disk: true}).then(function (res) {
-      prune(res, function (p) {
+  return spinner(head).then(() => {
+    return resolve(cwd, {dev: true, disk: true}).then((res) => {
+      prune(res, (p) => {
         return packages.indexOf(p.name) === -1;
       });
 
@@ -30,12 +30,12 @@ module.exports = function (cwd) {
       }
 
       // now check the specific version
-      return walk(res, function (p) {
+      return walk(res, (p) => {
         if (packages.indexOf(p.name) !== -1) {
           p.warning = '! package has been unpublished';
         }
-      }).then(function () {
-        return tree(res, function (leaf) {
+      }).then(() => {
+        return tree(res, (leaf) => {
           let label = leaf.full;
 
           if (leaf.warning) {
@@ -50,7 +50,7 @@ module.exports = function (cwd) {
   })
     // clear spinner in case of success or failure
     .then(spinner.clear(head))
-    .catch(function (error) {
+    .catch((error) => {
       spinner.clear(head)();
       throw error;
     });

--- a/src/cli/commands/unpublished/prune.js
+++ b/src/cli/commands/unpublished/prune.js
@@ -9,7 +9,7 @@ function prune(pkg, shouldPrune) {
   const deps = Object.keys(pkg.dependencies || {});
 
   if (deps.length) {
-    remove = deps.filter(function (name) {
+    remove = deps.filter((name) => {
       if (prune(pkg.dependencies[name], shouldPrune)) {
         delete pkg.dependencies[name];
         return false;

--- a/src/cli/commands/unpublished/walk.js
+++ b/src/cli/commands/unpublished/walk.js
@@ -1,7 +1,7 @@
 module.exports = walk;
 
 function walk(deps, filter) {
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     if (!deps) {
 
       return resolve([]);
@@ -11,10 +11,10 @@ function walk(deps, filter) {
       deps = deps.dependencies;
     }
 
-    const promises = Object.keys(deps).map(function (name) {
-      return new Promise(function (resolve) {
+    const promises = Object.keys(deps).map((name) => {
+      return new Promise(((resolve) => {
         return resolve(filter(deps[name], name, deps));
-      }).then(function (res) {
+      })).then((res) => {
         if (!res && deps[name] && deps[name].dep) {
           return walk(deps[name].dependencies, filter);
         }
@@ -22,5 +22,5 @@ function walk(deps, filter) {
     });
 
     resolve(Promise.all(promises));
-  });
+  }));
 }

--- a/src/lib/alerts.js
+++ b/src/lib/alerts.js
@@ -6,7 +6,7 @@ function registerAlerts(alerts) {
   if (!alerts) {
     return;
   }
-  alerts.forEach(function (alert) {
+  alerts.forEach((alert) => {
     if (!hasAlert(alert.name)) {
       registeredAlerts.push(alert);
     }
@@ -27,7 +27,7 @@ function hasAlert(name) {
 function displayAlerts() {
   var res = '';
   var sep = '\n';
-  registeredAlerts.forEach(function (alert) {
+  registeredAlerts.forEach((alert) => {
     res += sep;
     if (alert.type === 'warning') {
       res += chalk.bold.red(alert.msg);

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -44,7 +44,7 @@ function postAnalytics(data) {
   }
 
   // get snyk version
-  return version().then(function (version) {
+  return version().then((version) => {
     data.version = version;
     data.os = osName(os.platform(), os.release());
     data.nodeVersion = process.version;
@@ -72,7 +72,7 @@ function postAnalytics(data) {
       method: 'post',
       headers: headers,
     });
-  }).catch(function (error) {
+  }).catch((error) => {
     debug('analytics', error); // this swallows the analytics error
   });
 }

--- a/src/lib/authorization.js
+++ b/src/lib/authorization.js
@@ -4,7 +4,7 @@ var config = require('./config');
 
 function actionAllowed(action, options) {
   const org = options.org || config.org || null;
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     request({
       method: 'GET',
       url: config.API + '/authorization/' + action,
@@ -13,7 +13,7 @@ function actionAllowed(action, options) {
         authorization: 'token ' + snyk.api,
       },
       qs: org && {org},
-    }, function (error, res, body) {
+    }, (error, res, body) => {
       if (error) {
         return reject(error);
       }
@@ -22,7 +22,7 @@ function actionAllowed(action, options) {
       }
       resolve(body.result);
     });
-  });
+  }));
 }
 
 module.exports = {

--- a/src/lib/display-policy.js
+++ b/src/lib/display-policy.js
@@ -5,7 +5,7 @@ var demunge = require('snyk-policy').demunge;
 var config = require('./config');
 
 function display(policy) {
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     var p = demunge(policy, config.ROOT);
 
     var res = chalk.bold('Current Snyk policy, read from ' + policy.__filename +
@@ -20,7 +20,7 @@ function display(policy) {
     res += p.ignore.map(displayRule('Ignore')).join('\n');
 
     resolve(res);
-  });
+  }));
 }
 
 function displayRule(title) {
@@ -28,7 +28,7 @@ function displayRule(title) {
     i += 1;
     return chalk.bold('\n#' + i + ' ' + title + ' ' + rule.url) +
       ' in the following paths:\n' +
-      (rule.paths.map(function (p) {
+      (rule.paths.map((p) => {
         return p.path +
                (p.reason ? '\nReason: ' + p.reason +
                '\nExpires: ' + p.expires.toUTCString() + '\n': '')  + '\n';

--- a/src/lib/exec.js
+++ b/src/lib/exec.js
@@ -3,14 +3,14 @@ var exec = require('child_process').exec;
 module.exports = command;
 
 function command(cmd, root) {
-  return new Promise(function (resolve, reject) {
-    exec(cmd, {cwd: root}, function (err, stdout, stderr) {
+  return new Promise(((resolve, reject) => {
+    exec(cmd, {cwd: root}, (err, stdout, stderr) => {
       var error = stderr.trim();
       if (error) {
         return reject(new Error(error + ' / ' + cmd));
       }
       resolve(stdout.split('\n').join(''));
     });
-  });
+  }));
 }
 

--- a/src/lib/hook.js
+++ b/src/lib/hook.js
@@ -35,7 +35,7 @@ function registerExtension(ext) {
 
 
 function hookExtensions(_exts) {
-  forEach(oldHandlers, function (old, ext) {
+  forEach(oldHandlers, (old, ext) => {
     if (old === undefined) {
       delete require.extensions[ext];
     } else {
@@ -45,7 +45,7 @@ function hookExtensions(_exts) {
 
   oldHandlers = {};
 
-  forEach(_exts, function (ext) {
+  forEach(_exts, (ext) => {
     oldHandlers[ext] = require.extensions[ext];
     registerExtension(ext);
   });

--- a/src/lib/isolate.js
+++ b/src/lib/isolate.js
@@ -14,19 +14,19 @@ function isolate(options) {
   }
 
   if (Array.isArray(options.isolate)) {
-    potentialBlacklist = options.isolate.map(function (pkg) {
+    potentialBlacklist = options.isolate.map((pkg) => {
       var i = pkg.lastIndexOf('@');
       return {
         name: pkg.slice(0, i),
         version: pkg.slice(i + 1),
       };
-    }).reduce(function (acc, curr) {
+    }).reduce((acc, curr) => {
       acc[curr.name] = curr;
       return acc;
     }, {});
   }
 
-  snyk.bus.on('after:module', function (module) {
+  snyk.bus.on('after:module', (module) => {
     instrumentProps(module.id, module.id, module.exports);
   });
 }
@@ -51,7 +51,7 @@ function instrumentProps(id, key, obj) {
   }
 
   if (type === 'object' || type === 'function') {
-    Object.keys(original).forEach(function (key) {
+    Object.keys(original).forEach((key) => {
       var prop = original[key];
       if (key === '__snyked') {
         return;

--- a/src/lib/npm.js
+++ b/src/lib/npm.js
@@ -21,7 +21,7 @@ function npm(method, packages, live, cwd, flags) {
 
   method += ' ' + flags.join(' ');
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     var cmd = 'npm ' + method + ' ' + packages.join(' ');
     if (!cwd) {
       cwd = process.cwd();
@@ -35,7 +35,7 @@ function npm(method, packages, live, cwd, flags) {
 
     exec(cmd, {
       cwd: cwd,
-    }, function (error, stdout, stderr) {
+    }, (error, stdout, stderr) => {
       if (error) {
         return reject(error);
       }
@@ -51,18 +51,18 @@ function npm(method, packages, live, cwd, flags) {
 
       resolve();
     });
-  });
+  }));
 }
 
 npm.getVersion = function () {
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     exec('npm --version', {
       cwd: process.cwd(),
-    }, function (error, stdout) {
+    }, (error, stdout) => {
       if (error) {
         return reject(error);
       }
       return resolve(stdout);
     });
-  });
+  }));
 };

--- a/src/lib/plugins/rubygems/gemfile-lock-to-dependencies.js
+++ b/src/lib/plugins/rubygems/gemfile-lock-to-dependencies.js
@@ -30,7 +30,7 @@ const gemfileReducer = (lockFile, allDeps, ancestors) => (deps, dep) => {
       allDeps.set(dep, deps[dep]);
       deps[dep].dependencies = Object
         .keys(gemspec)
-        .filter(k => k !== 'version')
+        .filter((k) => k !== 'version')
         .reduce(gemfileReducer(lockFile, allDeps, ancestors.concat([dep])), {});
     }
   }
@@ -44,6 +44,6 @@ function gemfileLockToDependencies(fileContents) {
     .keys(lockFile.dependencies || {})
     // this is required to sanitise git deps with no exact version
     // listed as `rspec!`
-    .map(dep => dep.match(/[^!]+/)[0])
+    .map((dep) => dep.match(/[^!]+/)[0])
     .reduce(gemfileReducer(lockFile, new Map(), []), {});
 }

--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -11,7 +11,7 @@ var errorAnalytics = require('../analytics').single;
 function applyPatch(patchFileName, vuln, live, patchUrl) {
   var cwd = vuln.source;
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     if (!cwd) {
       cwd = process.cwd();
     }
@@ -29,19 +29,19 @@ function applyPatch(patchFileName, vuln, live, patchUrl) {
 
     var patchContent = fs.readFileSync(path.resolve(relative, patchFileName), 'utf8');
 
-    jsDiff(patchContent, relative, live).then(function () {
+    jsDiff(patchContent, relative, live).then(() => {
       debug('patch succeed');
       resolve();
-    }).catch(function (error) {
+    }).catch((error) => {
       debug('patch command failed', relative, error);
       patchError(error, relative, vuln, patchUrl).catch(reject);
     });
-  });
+  }));
 }
 
 function jsDiff(patchContent, relative, live) {
   var patchedFiles = {};
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     diff.applyPatches(patchContent, {
       loadFile: function (index, callback) {
         try {
@@ -113,7 +113,7 @@ function jsDiff(patchContent, relative, live) {
         }
       },
     });
-  });
+  }));
 }
 
 // diff data compares the same file with a dummy path (a/path/to/real.file vs b/path/to/real.file)
@@ -128,12 +128,12 @@ function patchError(error, dir, vuln, patchUrl) {
     return Promise.reject(error);
   }
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     var id = vuln.id;
 
     exec('npm -v', {
       env: process.env,
-    }, function (npmVError, versions) { // stderr is ignored
+    }, (npmVError, versions) => { // stderr is ignored
       var npmVersion = versions && versions.split('\n').shift();
       var referenceId = uuid();
 
@@ -171,5 +171,5 @@ function patchError(error, dir, vuln, patchUrl) {
 
       reject(error);
     });
-  });
+  }));
 }

--- a/src/lib/protect/dedupe-patches.js
+++ b/src/lib/protect/dedupe-patches.js
@@ -6,7 +6,7 @@ var patchesForPackage = require('./patches-for-package');
 function dedupe(source) {
   var removed = [];
 
-  var names = source.reduce(function (acc, vuln) {
+  var names = source.reduce((acc, vuln) => {
     if (Array.isArray(vuln.patches)) {
       // strip down to the only paches that can be applied
       vuln.patches = patchesForPackage(vuln);
@@ -32,7 +32,7 @@ function dedupe(source) {
   }, {});
 
   // turn back into an array
-  var packages = Object.keys(names).map(function (key) {
+  var packages = Object.keys(names).map((key) => {
     return names[key];
   });
 

--- a/src/lib/protect/get-vuln-source.js
+++ b/src/lib/protect/get-vuln-source.js
@@ -7,7 +7,7 @@ var statSync = require('fs').statSync;
 var moduleToObject = require('snyk-module');
 
 function getVulnSource(vuln, live) {
-  var from = vuln.from.slice(1).map(function (pkg) {
+  var from = vuln.from.slice(1).map((pkg) => {
     return moduleToObject(pkg).name;
   });
 

--- a/src/lib/protect/ignore.js
+++ b/src/lib/protect/ignore.js
@@ -5,9 +5,9 @@ var stripVersions = require('./strip-versions');
 var oneDay = 1000 * 60 * 60 * 24;
 
 function ignore(data) {
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     var config = {};
-    config.ignore = data.map(function (res) {
+    config.ignore = data.map((res) => {
       var vuln = res.vuln;
       var days = res.meta.days || 30;
       var ignoreRule = {};
@@ -17,7 +17,7 @@ function ignore(data) {
       };
       ignoreRule.vulnId = vuln.id;
       return ignoreRule;
-    }).reduce(function (acc, curr) {
+    }).reduce((acc, curr) => {
       if (!acc[curr.vulnId]) {
         acc[curr.vulnId] = [];
       }
@@ -33,5 +33,5 @@ function ignore(data) {
     debug('ignore config', config);
 
     resolve(config);
-  });
+  }));
 }

--- a/src/lib/protect/index.js
+++ b/src/lib/protect/index.js
@@ -12,13 +12,13 @@ var debug = require('debug')('snyk');
 var _ = require('lodash');
 
 function generatePolicy(policy, tasks, live, packageManager) {
-  var promises = ['ignore', 'update', 'patch'].filter(function (task) {
+  var promises = ['ignore', 'update', 'patch'].filter((task) => {
     return tasks[task].length;
-  }).map(function (task) {
+  }).map((task) => {
     return protect[task](tasks[task], live, packageManager);
   });
 
-  return Promise.all(promises).then(function (res) {
+  return Promise.all(promises).then((res) => {
     // we're squashing the arrays of arrays into a flat structure
     // with only non-false values
     var results = _.flattenDeep(res).filter(Boolean);

--- a/src/lib/protect/patches-for-package.js
+++ b/src/lib/protect/patches-for-package.js
@@ -3,7 +3,7 @@ module.exports = patchesForPackage;
 var semver = require('semver');
 
 function patchesForPackage(vuln) {
-  return vuln.patches.filter(function (patch) {
+  return vuln.patches.filter((patch) => {
     if (semver.satisfies(vuln.version, patch.version)) {
       return (patch.urls || []).length ? patch : false;
     }

--- a/src/lib/protect/strip-versions.js
+++ b/src/lib/protect/strip-versions.js
@@ -3,7 +3,7 @@ module.exports = stripVersions;
 var moduleToObject = require('snyk-module');
 
 function stripVersions(packages) {
-  return packages.map(function (pkg) {
+  return packages.map((pkg) => {
     return moduleToObject(pkg).name;
   });
 }

--- a/src/lib/protect/update.js
+++ b/src/lib/protect/update.js
@@ -18,9 +18,9 @@ function update(packages, live, pkgManager) {
   var lbl = 'Applying updates using ' + pkgManager + '...';
   var error = false;
 
-  return spinner(lbl).then(function () {
+  return spinner(lbl).then(() => {
     var upgrade = packages
-      .map(function (vuln) {
+      .map((vuln) => {
         var remediation = vuln.upgradePath && vuln.upgradePath[1];
         if (!remediation) {
         // this vuln holds an unreachable upgrade path - send this to analytics
@@ -35,7 +35,7 @@ function update(packages, live, pkgManager) {
         };
       })
       .filter(Boolean)
-      .reduce(function (ups, vuln) {
+      .reduce((ups, vuln) => {
         if (!ups[vuln.type]) {
           ups[vuln.type] = [];
         }
@@ -60,7 +60,7 @@ function update(packages, live, pkgManager) {
     }
 
     var promise = Promise.resolve()
-      .then(function () {
+      .then(() => {
       // create list of unique package names _without versions_ for uninstall
       // skip extraneous packages, if any
         var prodToUninstall = (upgrade.prod && upgrade.prod.map(stripVersion)) ||
@@ -74,23 +74,23 @@ function update(packages, live, pkgManager) {
           return  uninstall(pkgManager, toUninstall, live);
         }
       })
-      .then(function () {
+      .then(() => {
         var prodUpdate = (upgrade.prod ?
           install(pkgManager, findUpgrades(upgrade.prod), live) :
           Promise.resolve(true))
-          .catch(function (e) {
+          .catch((e) => {
             error = e;
             return false;
           });
         var devUpdate = (upgrade.dev ?
           installDev(pkgManager, findUpgrades(upgrade.dev), live) :
           Promise.resolve(true))
-          .catch(function (e) {
+          .catch((e) => {
             error = e;
             return false;
           });
         return Promise.all([prodUpdate, devUpdate])
-          .then(function (results) {
+          .then((results) => {
             return results[0] && results[1];
           });
       });
@@ -98,11 +98,11 @@ function update(packages, live, pkgManager) {
   })
     // clear spinner in case of success or failure
     .then(spinner.clear(lbl))
-    .catch(function (error) {
+    .catch((error) => {
       spinner.clear(lbl)();
       throw error;
     })
-    .then(function (res) {
+    .then((res) => {
       if (error) {
         console.error(chalk.red(errors.message(error)));
         debug(error.stack);
@@ -132,8 +132,8 @@ function uninstall(pkgManager, toUninstall, live) {
 function findUpgrades(packages) {
   return packages
     .map(moduleToObject)
-    .reduce(function (acc, curr) {
-      var have = acc.filter(function (pkg) {
+    .reduce((acc, curr) => {
+      var have = acc.filter((pkg) => {
         return pkg.name === curr.name;
       }).pop();
 
@@ -147,7 +147,7 @@ function findUpgrades(packages) {
 
       return acc;
     }, [])
-    .map(function (pkg) {
+    .map((pkg) => {
       return pkg.name + '@' + pkg.version;
     });
 }

--- a/src/lib/protect/write-patch-flag.js
+++ b/src/lib/protect/write-patch-flag.js
@@ -18,7 +18,7 @@ function writePatchFlag(now, vuln) {
   if (vuln.grouped && vuln.grouped.includes) {
     debug('found addition vulns to write flag files for');
     var writePromises = [fs.writeFile(flag, now.toJSON(), 'utf8')];
-    vuln.grouped.includes.forEach(function () {
+    vuln.grouped.includes.forEach(() => {
       var fileSafeId = vuln.id.replace(/:/g, '-');
       var flag = path.resolve(vuln.source, '.snyk-' + fileSafeId + '.flag');
       debug('Writing flag for grouped vulns', flag);
@@ -29,7 +29,7 @@ function writePatchFlag(now, vuln) {
     debug('Writing flag for single vuln', flag);
     promise = fs.writeFile(flag, now.toJSON(), 'utf8');
   }
-  return promise.then(function () {
+  return promise.then(() => {
     return vuln;
   });
 }

--- a/src/lib/request/index.js
+++ b/src/lib/request/index.js
@@ -3,7 +3,7 @@ var alerts = require('../alerts');
 
 module.exports = function (payload, callback) {
   return request(payload)
-    .then(function (result) {
+    .then((result) => {
       if (result.body.alerts) {
         alerts.registerAlerts(result.body.alerts);
       }
@@ -13,7 +13,7 @@ module.exports = function (payload, callback) {
       }
       return result;
     })
-    .catch(function (error) {
+    .catch((error) => {
       if (callback) {
         return callback(error);
       }

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -16,7 +16,7 @@ function test(root, options, callback) {
 
   var promise = executeTest(root, options);
   if (callback) {
-    promise.then(function (res) {
+    promise.then((res) => {
       callback(null, res);
     }).catch(callback);
   }
@@ -28,7 +28,7 @@ function executeTest(root, options) {
     var packageManager = detect.detectPackageManager(root, options);
     options.packageManager = packageManager;
     return run(root, options)
-      .then(function (results) {
+      .then((results) => {
         for (const res of results) {
           if (!res.packageManager) {
             res.packageManager = packageManager;

--- a/src/lib/spinner.js
+++ b/src/lib/spinner.js
@@ -17,7 +17,7 @@ function createSpinner(label) {
   }
 
   // helper...
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     debug('spinner: %s', label);
     spinners[label].push(spinner({
       // string: '◐◓◑◒',
@@ -27,7 +27,7 @@ function createSpinner(label) {
     }));
 
     resolve();
-  });
+  }));
 }
 
 createSpinner.sticky = function (s) {
@@ -53,7 +53,7 @@ createSpinner.clear = function (label) {
 };
 
 createSpinner.clearAll = function () {
-  Object.keys(spinners).map(function (lbl) {
+  Object.keys(spinners).map((lbl) => {
     createSpinner.clear(lbl)();
   });
 };
@@ -86,7 +86,7 @@ function spinner(opt) {
 
   var delay = typeof opt.delay === 'number' ? opt.delay : 2;
 
-  var interval = setInterval(function () {
+  var interval = setInterval(() => {
     if (--delay >= 0) {
       return;
     }
@@ -104,7 +104,7 @@ function spinner(opt) {
   var cleanup = typeof opt.cleanup === 'boolean' ? opt.cleanup : true;
   if (cleanup && !handleExit) {
     handleExit = true;
-    process.on('exit', function () {
+    process.on('exit', () => {
       if (wrote) {
         str.write(CLEAR);
       }

--- a/src/lib/sub-process.js
+++ b/src/lib/sub-process.js
@@ -6,23 +6,23 @@ module.exports.execute = function (command, args, options) {
     spawnOptions.cwd = options.cwd;
   }
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     var stdout = '';
     var stderr = '';
 
     var proc = childProcess.spawn(command, args, spawnOptions);
-    proc.stdout.on('data', function (data) {
+    proc.stdout.on('data', (data) => {
       stdout = stdout + data;
     });
-    proc.stderr.on('data', function (data) {
+    proc.stderr.on('data', (data) => {
       stderr = stderr + data;
     });
 
-    proc.on('close', function (code) {
+    proc.on('close', (code) => {
       if (code !== 0) {
         return reject(stdout || stderr);
       }
       resolve(stdout || stderr);
     });
-  });
+  }));
 };

--- a/src/lib/version.js
+++ b/src/lib/version.js
@@ -3,7 +3,7 @@ var command = require('./exec');
 var root = path.resolve(__dirname, '../..');
 
 module.exports = function () {
-  return new Promise(function (resolve) {
+  return new Promise(((resolve) => {
     var filename = path.resolve(root, 'package.json');
     var version = require(filename).version;
 
@@ -19,10 +19,10 @@ module.exports = function () {
       dirty(),
     ];
 
-    resolve(Promise.all(promises).catch(function () {
+    resolve(Promise.all(promises).catch(() => {
       // handle any point where the git based lookup fails
       return ['unknown', '', '0'];
-    }).then(function (res) {
+    }).then((res) => {
       var branch = res[0];
       var commit = res[1];
       var dirtyCount = parseInt(res[2], 10);
@@ -33,7 +33,7 @@ module.exports = function () {
 
       return curr;
     }));
-  });
+  }));
 };
 
 function commit() {

--- a/src/lib/yarn.js
+++ b/src/lib/yarn.js
@@ -15,7 +15,7 @@ function yarn(method, packages, live, cwd, flags) {
 
   method += ' ' + flags.join(' ');
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(((resolve, reject) => {
     var cmd = 'yarn ' + method + ' ' + packages.join(' ');
     if (!cwd) {
       cwd = process.cwd();
@@ -29,7 +29,7 @@ function yarn(method, packages, live, cwd, flags) {
 
     exec(cmd, {
       cwd: cwd,
-    }, function (error, stdout, stderr) {
+    }, (error, stdout, stderr) => {
       if (error) {
         return reject(error);
       }
@@ -45,5 +45,5 @@ function yarn(method, packages, live, cwd, flags) {
 
       resolve();
     });
-  });
+  }));
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Updates eslint rules to match tslint ones regarding the use of arrow functions.
Arrow functions can be safely used in Node 6: https://node.green/#ES2015-functions-arrow-functions

The offending occurences were fixed with `eslint --fix`

This will make converting the code to .ts much easier.

Next step: no-vars and prefer-const.
