### PR TITLE
feat: pruning of big-trees if a flag is specified

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -45,10 +45,18 @@ Options:
   --dry-run .......... Don't apply updates or patches during protect.
   --severity-threshold=<low|medium|high>
                        Only report vulnerabilities of provided level or higher.
-  --print-deps ....... (experimental) Print the dependency tree.
   -q, --quiet ........ Silence all output.
   -h, --help ......... This help information.
   -v, --version ...... The CLI version.
+
+Experimental options:
+  --print-deps ....... (test and monitor commands only)
+                       Print the dependency tree before sending it for analysis.
+  --prune-repeated-subdependencies
+                       (monitor command only)
+                       Prune dependency trees, removing duplicate sub-dependencies.
+                       Will still find all vulnerabilities, but potentially not all
+                       of the vulnerable paths.
 
 Gradle options:
   --gradle-sub-project=<string>

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/dep-graph": "1.4.1",
+    "@snyk/dep-graph": "1.8.1",
     "@snyk/gemfile": "1.2.0",
     "@types/agent-base": "^4.2.0",
     "abbrev": "^1.1.1",

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -14,7 +14,14 @@ import * as spinner from '../../lib/spinner';
 import * as detect from '../../lib/detect';
 import * as plugins from '../../lib/plugins';
 import {ModuleInfo} from '../../lib/module-info'; // TODO(kyegupov): fix import
-import { SingleDepRootResult, MultiDepRootsResult, isMultiResult, MonitorOptions } from '../../lib/types';
+import {
+  SingleDepRootResult,
+  MultiDepRootsResult,
+  isMultiResult,
+  MonitorOptions,
+  MonitorMeta,
+  MonitorResult,
+} from '../../lib/types';
 import { MethodArgs, ArgsOptions } from '../args';
 import { maybePrintDeps } from '../../lib/print-deps';
 import * as analytics from '../../lib/analytics';
@@ -117,12 +124,13 @@ async function monitor(...args0: MethodArgs): Promise<any> {
       if (inspectResult.plugin.packageManager) {
         packageManager = inspectResult.plugin.packageManager;
       }
-      const meta = {
+      const meta: MonitorMeta = {
         'method': 'cli',
         'packageManager': packageManager,
         'policy-path': options['policy-path'],
         'project-name': options['project-name'] || config.PROJECT_NAME,
         'isDocker': !!options.docker,
+        'prune': !!options['prune-repeated-subdependencies'],
       };
 
       // We send results from "all-sub-projects" scanning as different Monitor objects
@@ -228,7 +236,12 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 }
 
 function formatMonitorOutput(
-    packageManager, res, manageUrl, options, subProjectName?: string, advertiseSubprojectsCount?: number|null,
+    packageManager,
+    res: MonitorResult,
+    manageUrl,
+    options,
+    subProjectName?: string,
+    advertiseSubprojectsCount?: number|null,
   ) {
   const issues = res.licensesPolicy ? 'issues' : 'vulnerabilities';
   const humanReadableName = subProjectName ? `${res.path} (${subProjectName})` : res.path;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -27,6 +27,14 @@ export interface DepTree {
   docker?: any;
   files?: any;
   targetFile?: string;
+
+  labels?: {
+    [key: string]: string;
+
+    // Known keys:
+    // pruned: identical subtree already presents in the parent node.
+    //         See --prune-repeated-subdependencies flag.
+  };
 }
 
 export interface DepRoot {
@@ -87,4 +95,26 @@ export interface MonitorOptions {
   'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
   'project-name'?: string;
   'print-deps'?: boolean;
+
+  // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
+  'prune-repeated-subdependencies'?: boolean;
+}
+
+export interface MonitorMeta {
+  'method': 'cli';
+  'packageManager': SupportedPackageManagers;
+  'policy-path': string;
+  'project-name': string;
+  'isDocker': boolean;
+  'prune': boolean;
+}
+
+export interface MonitorResult {
+  org?: string;
+  id: string;
+  path: string;
+  licensesPolicy: any;
+  uri: string;
+  isMonitored: boolean;
+  trialStarted: boolean;
 }

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -2209,6 +2209,19 @@ test('`monitor npm-package`', async (t) => {
   t.notOk(pkg.from, 'no "from" array on root');
   t.notOk(pkg.dependencies.debug.from,
     'no "from" array on dep');
+  t.notOk(req.body.meta.prePruneDepCount, "doesn't send meta.prePruneDepCount");
+});
+
+test('`monitor npm-package-pruneable --prune-repeated-subdependencies`', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-package-pruneable', {'prune-repeated-subdependencies': true});
+  const req = server.popRequest();
+  t.equal(req.method, 'PUT', 'makes PUT request');
+  t.match(req.url, '/monitor/npm', 'puts at correct url');
+  t.ok(req.body.meta.prePruneDepCount, 'sends meta.prePruneDepCount');
+  const adc = req.body.package.dependencies.a.dependencies.d.dependencies.c;
+  t.ok(adc.labels.pruned, 'a.d.c is pruned');
+  t.notOk(adc.dependencies, 'a.d.c has no dependencies');
 });
 
 test('`monitor yarn-package`', async (t) => {

--- a/test/acceptance/workspaces/npm-package-pruneable/package-lock.json
+++ b/test/acceptance/workspaces/npm-package-pruneable/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "npm-package",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "a": {
+      "version": "1.0.0",
+      "requires": {
+        "b": "1.0.0",
+        "d": "1.0.0"
+      }
+    },
+    "b": {
+      "version": "1.0.0",
+      "requires": {
+        "c": "1.0.0"
+      }
+    },
+    "d": {
+      "version": "1.0.0",
+      "requires": {
+        "c": "1.0.0"
+      }
+    },
+    "c": {
+      "version": "1.0.0",
+      "requires": {
+        "v": "5.0.0"
+      }
+    },
+    "v": {
+      "version": "5.0.0"
+    }
+  }
+}

--- a/test/acceptance/workspaces/npm-package-pruneable/package.json
+++ b/test/acceptance/workspaces/npm-package-pruneable/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "npm-package",
+  "version": "1.0.0",
+  "description": "Simple NPM package",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "snyk",
+  "license": "ISC",
+  "dependencies": {
+    "a": "1.0.0"
+  }
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds an experimental flag to prune large dependency trees for `snyk monitor` (preserves vulns, can lose some vuln paths).
This is backed up by the new logic in dep-graph: https://github.com/snyk/dep-graph/pull/27
Should be matched by changes in the Registry UI (PR TBD).

Out of scope: snyk test (already converted to DepGraph, will not reap any benefits), snyk wizard / protect (degraded remediation advice; needs more research).

Drive-by: some Typescript definitions.

#### Where should the reviewer start?
See dep-graph first.
**if the build is breaking maybe it's because new dep-graph version hasn't been released yet?**

#### How should this be manually tested?
Get a big-tree project (e.g. a npm one requiring jest) and try `snyk monitor`. Compare to `snyk test`.

#### Any background context you want to provide?
Temporary stop-gap until we convert monitor to graphs.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-696
https://github.com/snyk/snyk/issues/156
https://github.com/snyk/snyk/issues/445
https://github.com/snyk/snyk/issues/156
https://github.com/snyk/snyk/issues/403