### PR TITLE
chore: Revert "fix: add alpine platform to standalone binary release assets"

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,15 +3,7 @@
     "@semantic-release/npm",
     {
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg"
-    },
-    {
-      "path": "@semantic-release/exec",
-      "cmd": "pkg . --targets node10-linux-x64,node10-macos-x64,node10-win-x64,node10-alpine-x64"
-    },
-    {
-      "path": "@semantic-release/exec",
-      "cmd": "shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256 && shasum -a 256 snyk-alpine > snyk-alpine.sha256"
+      "cmd": "npm i -g pkg && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
     }
   ],
   "publish": [
@@ -48,16 +40,6 @@
           "path": "./snyk-win.exe.sha256",
           "name": "snyk-win.exe.sha256",
           "label": "snyk-win.exe.sha256"
-        },
-        {
-          "path": "./snyk-alpine",
-          "name": "snyk-alpine",
-          "label": "snyk-alpine"
-        },
-        {
-          "path": "./snyk-alpine.sha256",
-          "name": "snyk-alpine.sha256",
-          "label": "snyk-alpine.sha256"
         }
       ]
     }


### PR DESCRIPTION
The naive approach didn't work - apparently `pkg` won't generate a `musl`-based binary when running in a `glibc` env. Needs something deeper, maybe a second publish job that would run in an alpine container?