### PR TITLE
feat: Convert patch to `.ts` & split option types by command

### DIFF
--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -8,7 +8,7 @@ import {isCI} from '../../lib/is-ci';
 import {apiTokenExists} from '../../lib/api-token';
 import {SEVERITIES, WIZARD_SUPPORTED_PMS} from '../../lib/snyk-test/common';
 import * as Debug from 'debug';
-import {TestOptions} from '../../lib/types';
+import {Options} from '../../lib/types';
 import {isLocalFolder} from '../../lib/detect';
 import { MethodArgs } from '../args';
 
@@ -24,10 +24,10 @@ interface OptionsAtDisplayStage {
 async function test(...args: MethodArgs): Promise<string> {
   const resultOptions = [] as any[];
   let results = [] as any[];
-  let options = {} as any as TestOptions;
+  let options = {} as any as Options;
 
   if (typeof args[args.length - 1] === 'object') {
-    options = args.pop() as any as TestOptions;
+    options = args.pop() as any as Options;
   }
 
   // populate with default path (cwd) if no path given
@@ -215,7 +215,7 @@ function summariseErrorResults(errorResults) {
   return '';
 }
 
-function displayResult(res, options: TestOptions & OptionsAtDisplayStage) {
+function displayResult(res, options: Options & OptionsAtDisplayStage) {
   const meta = metaForDisplay(res, options) + '\n\n';
   const dockerAdvice = dockerRemediationForDisplay(res);
   const packageManager = options.packageManager;
@@ -333,7 +333,7 @@ function displayResult(res, options: TestOptions & OptionsAtDisplayStage) {
 function formatDockerBinariesIssues(
     dockerBinariesSortedGroupedVulns,
     binariesVulns,
-    options: TestOptions & OptionsAtDisplayStage) {
+    options: Options & OptionsAtDisplayStage) {
   const binariesIssuesOutput = [] as string[];
   for (const pkgInfo of _.values(binariesVulns.affectedPkgs)) {
     binariesIssuesOutput.push(createDockerBinaryHeading(pkgInfo));
@@ -355,7 +355,7 @@ function createDockerBinaryHeading(pkgInfo) {
       ` for ${binaryName}@${binaryVersion} ------------`, '\n') : '';
 }
 
-function formatIssues(vuln, options: TestOptions & OptionsAtDisplayStage) {
+function formatIssues(vuln, options: Options & OptionsAtDisplayStage) {
   const vulnID = vuln.list[0].id;
   const packageManager = options.packageManager;
   const uniquePackages = _.uniq(

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -2,3 +2,4 @@ export {MissingApiTokenError} from './missing-api-token';
 export {FileFlagBadInputError} from './file-flag-bad-input';
 export {MissingTargetFileError} from './missing-targetfile-error';
 export {NoSupportedManifestsFoundError} from './no-supported-manifests-found';
+export {CustomError} from './custom-error';

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -1,8 +1,8 @@
-import { DepDict, TestOptions, MonitorOptions, DepTree } from './types';
+import { DepDict, Options, MonitorOptions, DepTree } from './types';
 
 // This option is still experimental and might be deprecated.
 // It might be a better idea to convert it to a command (i.e. do not perform test/monitor).
-export function maybePrintDeps(options: TestOptions | MonitorOptions, rootPackage: DepTree) {
+export function maybePrintDeps(options: Options | MonitorOptions, rootPackage: DepTree) {
   if (options['print-deps']) {
     if (options.json) {
       // Will produce 2 JSON outputs, one for the deps, one for the vuln scan.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,3 @@
-import * as depGraphLib from '@snyk/dep-graph';
 import { SupportedPackageManagers } from './package-managers';
 
 // TODO(kyegupov): use a shared repository snyk-cli-interface
@@ -6,7 +5,7 @@ import { SupportedPackageManagers } from './package-managers';
 export interface PluginMetadata {
   name: string;
   packageFormatVersion?: string;
-  packageManager: string;
+  packageManager: SupportedPackageManagers;
   imageLayers?: any;
   targetFile?: string; // this is wrong (because Shaun said it)
   runtime?: any;
@@ -57,12 +56,21 @@ export class MonitorError extends Error {
 }
 
 export interface TestOptions {
+  traverseNodeModules: boolean;
+  interactive: boolean;
+}
+export interface ProtectOptions {
+  loose: boolean;
+}
+export interface Options {
   org: string;
   path: string;
   docker?: boolean;
   file?: string;
   policy?: string;
   json?: boolean;
+  vulnEndpoint?: string;
+  projectName?: string;
   'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
   'project-name'?: string;
   'show-vulnerable-paths'?: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
         "pretty": true,
         "target": "es2015",
         "lib": [
-          "es2015"
+            "es2015",
+            "es2016.array.include",
         ],
         "module": "commonjs",
         "allowJs": true,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- Convert patch from `.js` to `.ts`
- Split Options type into base (cli commands), test options & patch options
- Rename TestOptions to Options (not all of them were test specific, most were base CLI options that are exposed to the user)