### PR TITLE
feat: add monitor errors

### DIFF
--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -14,10 +14,11 @@ import * as spinner from '../../lib/spinner';
 import * as detect from '../../lib/detect';
 import * as plugins from '../../lib/plugins';
 import {ModuleInfo} from '../../lib/module-info'; // TODO(kyegupov): fix import
-import { SingleDepRootResult, MultiDepRootsResult, isMultiResult, MonitorError, MonitorOptions } from '../../lib/types';
+import { SingleDepRootResult, MultiDepRootsResult, isMultiResult, MonitorOptions } from '../../lib/types';
 import { MethodArgs, ArgsOptions } from '../args';
 import { maybePrintDeps } from '../../lib/print-deps';
 import * as analytics from '../../lib/analytics';
+import {MonitorError} from '../../lib/errors';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 

--- a/src/lib/errors/connection-timeout-error.ts
+++ b/src/lib/errors/connection-timeout-error.ts
@@ -1,0 +1,12 @@
+import {CustomError} from './custom-error';
+
+export class ConnectionTimeoutError extends CustomError {
+    private static ERROR_MESSAGE: string =
+        'Connection timeout.';
+
+    constructor() {
+        super(ConnectionTimeoutError.ERROR_MESSAGE);
+        this.code = 504;
+        this.userMessage = ConnectionTimeoutError.ERROR_MESSAGE;
+    }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -3,3 +3,5 @@ export {FileFlagBadInputError} from './file-flag-bad-input';
 export {MissingTargetFileError} from './missing-targetfile-error';
 export {NoSupportedManifestsFoundError} from './no-supported-manifests-found';
 export {CustomError} from './custom-error';
+export {MonitorError} from './monitor-error';
+export {ConnectionTimeoutError} from './connection-timeout-error';

--- a/src/lib/errors/monitor-error.ts
+++ b/src/lib/errors/monitor-error.ts
@@ -5,9 +5,11 @@ export class MonitorError extends CustomError {
         'Server returned unexpected error for the monitor request. ';
 
     constructor(errorCode, message) {
-        super(MonitorError.ERROR_MESSAGE +
-          `Status code: ${errorCode}, response: ${message}`);
-        this.code = errorCode;
-        this.userMessage = message;
+      const errorMessage = message ? `, response: ${message}` : '';
+      const code = errorCode || 500;
+      super(MonitorError.ERROR_MESSAGE +
+          `Status code: ${code}${errorMessage}`);
+      this.code = errorCode;
+      this.userMessage = message;
     }
 }

--- a/src/lib/errors/monitor-error.ts
+++ b/src/lib/errors/monitor-error.ts
@@ -1,0 +1,13 @@
+import {CustomError} from './custom-error';
+
+export class MonitorError extends CustomError {
+    private static ERROR_MESSAGE: string =
+        'Server returned unexpected error for the monitor request. ';
+
+    constructor(errorCode, message) {
+        super(MonitorError.ERROR_MESSAGE +
+          `Status code: ${errorCode}, response: ${message}`);
+        this.code = errorCode;
+        this.userMessage = message;
+    }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,11 +50,6 @@ export function isMultiResult(pet: SingleDepRootResult | MultiDepRootsResult): p
   return !!(pet as MultiDepRootsResult).depRoots;
 }
 
-export class MonitorError extends Error {
-  public code?: number;
-  public userMessage?: string;
-}
-
 export interface TestOptions {
   traverseNodeModules: boolean;
   interactive: boolean;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add custom Monitor & Timeout Error with error code + message

#### Any background context you want to provide?
Improving cli error handling + analytics
Fixing errors like this: 
`Server returned unexpected error for the monitor request. Status code: 502, response: undefined` 
=>  `Server returned unexpected error for the monitor request. Status code: 502`