### PR TITLE
fix: preserve all additional deptree fields when pruning

### DIFF
--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -77,18 +77,10 @@ async function pruneTree(tree: DepTree, packageManagerName: string): Promise<Dep
   const graph = await depGraphLib.legacy.depTreeToGraph(tree, packageManagerName);
   const prunedTree: DepTree = await depGraphLib.legacy
     .graphToDepTree(graph, packageManagerName, {deduplicateWithinTopLevelDeps: true}) as DepTree;
-  // Transplant metadata not preserved by the transformation:
-  if (tree.docker) {
-    prunedTree.docker = tree.docker;
-  }
-  if (tree.packageFormatVersion) {
-    prunedTree.packageFormatVersion = tree.packageFormatVersion;
-  }
-  if (tree.targetFile) {
-    prunedTree.targetFile = tree.targetFile;
-  }
+  // Transplant pruned dependencies in the original tree (we want to keep all other fields):
+  tree.dependencies = prunedTree.dependencies;
   debug('finished pruning dep tree');
-  return prunedTree;
+  return tree;
 }
 
 export async function monitor(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Makes sure we preserve all the additional fields of the tree.
