### PR TITLE
fix: apt update after adding docker repository

### DIFF
--- a/docker/Dockerfile.docker
+++ b/docker/Dockerfile.docker
@@ -7,7 +7,7 @@ RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get install -y docker-ce jq && \
+    apt-get update && apt-get install -y docker-ce jq && \
     npm install --global snyk snyk-to-html && \
     apt-get autoremove -y && \
     apt-get clean && \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
After making docker images smaller, one necessary `apt-get update` was removed. This PR adds it back.