### PR TITLE
fix: add alpine platform to standalone binary release assets

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,8 +2,19 @@
   "prepare": [
     "@semantic-release/npm",
     {
+      "//": "build alpine binary inside an alpine container, or else the binary is broken",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . && shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256"
+      "cmd": "docker run --rm -ti -v `pwd`:/snyk node:alpine sh /snyk/scripts/alpine-build.sh"
+    },
+    {
+      "//": "build the regular macos, linux and windows binaries",
+      "path": "@semantic-release/exec",
+      "cmd": "npm i -g pkg && pkg ."
+    },
+    {
+      "//": "shasum all binaries",
+      "path": "@semantic-release/exec",
+      "cmd": "shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256 && shasum -a 256 snyk-alpine > snyk-alpine.sha256"
     }
   ],
   "publish": [
@@ -40,6 +51,16 @@
           "path": "./snyk-win.exe.sha256",
           "name": "snyk-win.exe.sha256",
           "label": "snyk-win.exe.sha256"
+        },
+        {
+          "path": "./snyk-alpine",
+          "name": "snyk-alpine",
+          "label": "snyk-alpine"
+        },
+        {
+          "path": "./snyk-alpine.sha256",
+          "name": "snyk-alpine.sha256",
+          "label": "snyk-alpine.sha256"
         }
       ]
     }

--- a/scripts/alpine-build.sh
+++ b/scripts/alpine-build.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "Building an alpine standalone binary..."
+cd snyk
+# install pkg globally so that the local deps do not get polluted with it
+# prevents non-deterministic tests, as they depend on the deps being used
+npm i -g pkg
+pkg . -t alpine -o snyk-alpine
+echo "Done building an alpine standalone binary!"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Finding a way to build a good standalone alpine image using `pkg`.

Naive `pkg . -t alpine` generates a broken binary (segfault on a plain alpine image). Generating one inside an alpine container works.