### PR TITLE
fix: scan all Gradle subprojects when computing config attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
     "snyk-go-plugin": "1.10.2",
-    "snyk-gradle-plugin": "2.12.4",
+    "snyk-gradle-plugin": "2.12.5",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.0",
     "snyk-nodejs-lockfile-parser": "1.13.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes a customer issue where dependency variants could not be resolved because our constructed configuration did not scan all of the subprojects to select unambiguous attributes.
(see https://github.com/snyk/snyk-gradle-plugin/pull/81)
