### PR TITLE
fix: make sure binaries are built on node8

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "build the regular macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg ."
+      "cmd": "npm i -g pkg && pkg . -t node8-linux-x64,node8-macos-x64,node8-win-x64"
     },
     {
       "//": "shasum all binaries",

--- a/.releaserc
+++ b/.releaserc
@@ -2,14 +2,9 @@
   "prepare": [
     "@semantic-release/npm",
     {
-      "//": "build alpine binary inside an alpine container, or else the binary is broken",
+      "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "docker run --rm -i -v `pwd`:/snyk node:alpine sh /snyk/scripts/alpine-build.sh"
-    },
-    {
-      "//": "build the regular macos, linux and windows binaries",
-      "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . -t node8-linux-x64,node8-macos-x64,node8-win-x64"
+      "cmd": "npm i -g pkg && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"
     },
     {
       "//": "shasum all binaries",

--- a/scripts/alpine-build.sh
+++ b/scripts/alpine-build.sh
@@ -5,5 +5,5 @@ cd snyk
 # install pkg globally so that the local deps do not get polluted with it
 # prevents non-deterministic tests, as they depend on the deps being used
 npm i -g pkg
-pkg . -t alpine -o snyk-alpine
+pkg . -t node8-alpine-x64 -o snyk-alpine
 echo "Done building an alpine standalone binary!"

--- a/scripts/alpine-build.sh
+++ b/scripts/alpine-build.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-echo "Building an alpine standalone binary..."
-cd snyk
-# install pkg globally so that the local deps do not get polluted with it
-# prevents non-deterministic tests, as they depend on the deps being used
-npm i -g pkg
-pkg . -t node8-alpine-x64 -o snyk-alpine
-echo "Done building an alpine standalone binary!"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Prior to this change we relied on pkg's default node version, which can change with time. Setting it to the current default to be explicit.

Also, no need for a special way to build the alpine target, reverting the container-building flow.