### PR TITLE
Add dangerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ script:
   - npm test
 jobs:
   include:
+    - stage: test
+      script: npx danger ci --failOnErrors
+      name: "Danger Zone"
     - stage: Release
       if: branch = master AND type != pull_request
       node_js: "8"

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,0 +1,28 @@
+const {danger, warn, fail, message} = require('danger');
+
+if (danger.github && danger.github.pr) {
+  const commitizenRegex = /^(feat|fix|chore|test|docs|perf|refactor|revert)(\(.*\))?:(.+)$/;
+  const ghCommits = danger.github.commits;
+  let willTriggerRelease = false;
+  for (const {commit} of ghCommits) {
+    const {message, url} = commit;
+    const firstLine = message.split('\n')[0];
+
+    if (message.startsWith('feat') || message.startsWith('fix')) {
+      willTriggerRelease = true;
+    }
+
+    const regexMatch = commitizenRegex.exec(firstLine);
+    if (!regexMatch) {
+      fail(`Commit ["${firstLine}"](${url}) is not a valid commitizen message. See [Contributing page](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md#commit-types) with required commit message format.`);
+    }
+
+    if (firstLine.length >= 72) {
+      warn(`Your commit message ["${firstLine}"](${url}) is too long. Keep first line of your commit under 72 characters.`);
+    }
+  }
+
+  if (!willTriggerRelease) {
+    message('This PR will not trigger a new version. It doesn\'t include any commit message with `feat` or `fix`.');
+  }
+}


### PR DESCRIPTION
PoC: Use danger.system checks for PRs

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Add dangerfile to check commit messages.

Commit messages will be corrected before merging, they now serve as an illustration of the output.