### PR TITLE
feat: use cli-interface package to define the plugin interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
+    "@snyk/cli-interface": "^1.5.0",
     "@snyk/dep-graph": "1.10.0",
     "@snyk/gemfile": "1.2.0",
     "@types/agent-base": "^4.2.0",
@@ -72,7 +73,7 @@
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.25.1",
     "snyk-go-plugin": "1.11.0",
-    "snyk-gradle-plugin": "2.12.5",
+    "snyk-gradle-plugin": "^3.0.1",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.3.1",
     "snyk-nodejs-lockfile-parser": "1.15.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -157,8 +157,9 @@ export function args(rawArgv: string[]): Args {
   // should be added here
   for (const dashedArg of [
     'package-manager',
-    'packages-folder',
+    'packages-folder', // TODO(kyegupov): find out where it is used
     'severity-threshold',
+    'all-sub-projects',
   ]) {
     if (argv[dashedArg]) {
       const camelCased = dashToCamelCase(dashedArg);

--- a/src/lib/module-info/index.ts
+++ b/src/lib/module-info/index.ts
@@ -1,13 +1,17 @@
 import * as _ from 'lodash';
 import * as Debug from 'debug';
+import {
+  Plugin, InspectOptions, isMultiResult, SingleSubprojectPlugin,
+} from '@snyk/cli-interface/dist/legacy/plugin';
+import { ArgsOptions } from '../../cli/args';
 
 const debug = Debug('snyk-module-info');
 
-export function ModuleInfo(plugin, policy) {
+export function ModuleInfo(plugin: Plugin | SingleSubprojectPlugin, policy) {
   return {
-    async inspect(root, targetFile, options) {
+    async inspect(root: string, targetFile: string | undefined, options: ArgsOptions & InspectOptions) {
       const pluginOptions = _.merge({
-        args: options._doubleDashArgs,
+        args: (options as ArgsOptions)._doubleDashArgs,
       }, options);
 
       debug('calling plugin inspect()', {root, targetFile, pluginOptions});
@@ -15,8 +19,13 @@ export function ModuleInfo(plugin, policy) {
       debug('plugin inspect() done');
 
       // attach policy if not provided by plugin
-      if (policy && !info.package.policy) {
+
+      if (policy && !isMultiResult(info) && !(info.package.policy)) {
         info.package.policy = policy.toString();
+      }
+
+      if (policy && isMultiResult(info)) {
+        throw new Error('Applying policy to multiple sub-project scans is not yet supported');
       }
 
       return info;

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -8,10 +8,11 @@ import * as os from 'os';
 import * as _ from 'lodash';
 import {isCI} from './is-ci';
 import * as analytics from './analytics';
-import { SingleDepRootResult, DepTree, MonitorMeta, MonitorResult } from './types';
+import { DepTree, MonitorMeta, MonitorResult } from './types';
 import * as projectMetadata from './project-metadata';
 import * as path from 'path';
 import {MonitorError, ConnectionTimeoutError} from './errors';
+import { SinglePackageResult } from '@snyk/cli-interface/dist/legacy/plugin';
 
 const debug = Debug('snyk');
 
@@ -87,7 +88,7 @@ async function pruneTree(tree: DepTree, packageManagerName: string): Promise<Dep
 export async function monitor(
     root: string,
     meta: MonitorMeta,
-    info: SingleDepRootResult,
+    info: SinglePackageResult,
     targetFile?: string,
     ): Promise<MonitorResult> {
   apiTokenExists();
@@ -194,7 +195,7 @@ export async function monitor(
 export async function monitorGraph(
     root: string,
     meta: MonitorMeta,
-    info: SingleDepRootResult,
+    info: SinglePackageResult,
     targetFile?: string,
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -1,6 +1,6 @@
-export type SupportedPackageManagers = 'rubygems' | 'npm' | 'yarn' |
-'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' | 'gomodules' |
-'nuget' | 'paket' | 'composer';
+import { SupportedPackageManagers } from '@snyk/cli-interface/dist/legacy/common';
+
+export { SupportedPackageManagers };
 
 export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   readonly [packageManager in SupportedPackageManagers]: string;
@@ -18,6 +18,12 @@ export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   nuget: 'NuGet',
   paket: 'Paket',
   composer: 'Composer',
+
+  // Docker
+  rpm: 'rpm (Linux)',
+  deb: 'deb (Linux)',
+  apk: 'apk (Linux)',
+  dockerfile: 'Dockerfile',
 };
 
 export const WIZARD_SUPPORTED_PACKAGE_MANAGERS: SupportedPackageManagers[]

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -10,66 +10,54 @@ import * as phpPlugin from 'snyk-php-plugin';
 import * as nodejsPlugin from './nodejs-plugin';
 import * as types from './types';
 import {SupportedPackageManagers} from '../package-managers';
+import { Plugin, adaptSingleProjectPlugin, SingleSubprojectPlugin } from '@snyk/cli-interface/dist/legacy/plugin';
 
 export function loadPlugin(packageManager: SupportedPackageManagers,
-                           options: types.Options = {}): types.Plugin {
+                           options: types.Options = {}): Plugin {
   if (options.docker) {
     return dockerPlugin;
   }
 
   switch (packageManager) {
     case 'npm': {
-      return nodejsPlugin;
+      return adaptSingleProjectPlugin(nodejsPlugin);
     }
     case 'rubygems': {
-      return rubygemsPlugin;
+      return adaptSingleProjectPlugin(rubygemsPlugin);
     }
     case 'maven': {
-      return mvnPlugin;
+      return adaptSingleProjectPlugin(mvnPlugin);
     }
     case 'gradle': {
-      return gradlePlugin;
+      return gradlePlugin as any as Plugin; // TODO(kyegupov): remove the cast once gradle plugin is updated
     }
     case 'sbt': {
-      return sbtPlugin;
+      return adaptSingleProjectPlugin(sbtPlugin);
     }
     case 'yarn': {
-      return nodejsPlugin;
+      return adaptSingleProjectPlugin(nodejsPlugin); // will become a full Plugin when Yarn Workspaces are supported
     }
     case 'pip': {
-      return pythonPlugin;
+      return adaptSingleProjectPlugin(pythonPlugin);
     }
     case 'golangdep':
     case 'gomodules':
     case 'govendor': {
-      return goPlugin;
+      // this plugin needs an updrade of the types
+      return adaptSingleProjectPlugin(goPlugin as SingleSubprojectPlugin);
     }
     case 'nuget': {
-      return nugetPlugin;
+      return adaptSingleProjectPlugin(nugetPlugin);
     }
     case 'paket': {
-      return nugetPlugin;
+      return adaptSingleProjectPlugin(nugetPlugin);
     }
     case 'composer': {
-      return phpPlugin;
+      // this plugin needs an updrade of the types;
+      return adaptSingleProjectPlugin(phpPlugin as SingleSubprojectPlugin);
     }
     default: {
       throw new Error(`Unsupported package manager: ${packageManager}`);
-    }
-  }
-}
-
-export function getPluginOptions(packageManager: string, options: types.Options): types.Options {
-  const pluginOptions: types.Options = {};
-  switch (packageManager) {
-    case 'gradle': {
-      if (options['all-sub-projects']) {
-        pluginOptions.multiDepRoots = true;
-      }
-      return pluginOptions;
-    }
-    default: {
-      return pluginOptions;
     }
   }
 }

--- a/src/lib/plugins/nodejs-plugin/index.ts
+++ b/src/lib/plugins/nodejs-plugin/index.ts
@@ -2,10 +2,23 @@ import * as modulesParser from './npm-modules-parser';
 import * as lockParser from './npm-lock-parser';
 import * as types from '../types';
 import { MissingTargetFileError } from '../../errors/missing-targetfile-error';
+import {
+  isMultiSubProject, SingleSubprojectInspectOptions, SinglePackageResult,
+} from '@snyk/cli-interface/dist/legacy/plugin';
 
-export async function inspect(root: string, targetFile: string, options: types.Options = {}):
-Promise<types.InspectResult> {
-  if (!targetFile ) {
+export function pluginName(): string {
+  return 'node.js';
+}
+
+export async function inspect(
+    root: string,
+    targetFile: string,
+    options: types.Options & SingleSubprojectInspectOptions = {},
+  ): Promise<SinglePackageResult> {
+  if (isMultiSubProject(options)) {
+    throw new Error('Returning multiple sub-projects is not supported for Node.js');
+  }
+  if (!targetFile) {
     throw MissingTargetFileError(root);
   }
   const isLockFileBased = (targetFile.endsWith('package-lock.json') || targetFile.endsWith('yarn.lock'));

--- a/src/lib/plugins/rubygems/index.ts
+++ b/src/lib/plugins/rubygems/index.ts
@@ -1,17 +1,17 @@
 import {inspectors, Spec} from './inspectors';
-import * as types from '../types';
 import {MissingTargetFileError} from '../../errors/missing-targetfile-error';
+import { SinglePackageResult, SingleSubprojectInspectOptions } from '@snyk/cli-interface/dist/legacy/plugin';
 
-interface RubyGemsInspectResult extends types.InspectResult {
-  package: {
-    name: string;
-    targetFile: string;
-    files: any
-  };
+export function pluginName(): string {
+  return 'rubygems';
 }
 
-export async function inspect(root: string, targetFile: string): Promise<RubyGemsInspectResult> {
-  if (!targetFile ) {
+export async function inspect(
+    root: string,
+    targetFile: string,
+    options?: SingleSubprojectInspectOptions,
+  ): Promise<SinglePackageResult> {
+  if (!targetFile) {
     throw MissingTargetFileError(root);
   }
   const specs = await gatherSpecs(root, targetFile);

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -1,26 +1,16 @@
-export interface InspectResult {
-  plugin: {
-    name: string;
-    runtime?: string;
-  };
-  package?: any;
-  depRoots?: any;
-}
+import {InspectOptions } from '@snyk/cli-interface/dist/legacy/plugin';
 
-export interface Options {
+export type Options = CliInspectOptions & InspectOptions;
+
+interface CliInspectOptions {
   file?: string;
   docker?: boolean;
   traverseNodeModules?: boolean;
   dev?: boolean;
   strictOutOfSync?: boolean | 'true' | 'false';
-  multiDepRoots?: boolean;
   debug?: boolean;
   packageManager?: string;
   composerIsFine?: boolean;
   composerPharIsFine?: boolean;
   systemVersions?: object;
-}
-
-export interface Plugin {
-  inspect: (root: string, targetFile: string, options?: Options) => Promise<InspectResult>;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,5 @@
 import { SupportedPackageManagers } from './package-managers';
+import { DepTree } from '@snyk/cli-interface/dist/legacy/common';
 
 // TODO(kyegupov): use a shared repository snyk-cli-interface
 
@@ -19,43 +20,11 @@ export interface DepDict {
   [name: string]: DepTree;
 }
 
-export interface DepTree {
-  name: string;
-  version: string;
-  dependencies?: DepDict;
-  packageFormatVersion?: string;
-  docker?: any;
-  files?: any;
-  targetFile?: string;
-
-  labels?: {
-    [key: string]: string;
-
-    // Known keys:
-    // pruned: identical subtree already presents in the parent node.
-    //         See --prune-repeated-subdependencies flag.
-  };
-}
+export { DepTree };
 
 export interface DepRoot {
   depTree: DepTree; // to be soon replaced with depGraph
   targetFile?: string;
-}
-
-// Legacy result type. Will be deprecated soon.
-export interface SingleDepRootResult {
-  plugin: PluginMetadata;
-  package: DepTree;
-}
-
-export interface MultiDepRootsResult {
-  plugin: PluginMetadata;
-  depRoots: DepRoot[];
-}
-
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-export function isMultiResult(pet: SingleDepRootResult | MultiDepRootsResult): pet is MultiDepRootsResult {
-  return !!(pet as MultiDepRootsResult).depRoots;
 }
 
 export interface TestOptions {
@@ -79,14 +48,14 @@ export interface Options {
   'ignore-policy'?: boolean;
   'trust-policies'?: boolean; // used in snyk/policy lib
   'policy-path'?: boolean;
-  'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
+  allSubProjects?: boolean; // Converted from dash case in args.ts
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
   showVulnPaths?: boolean;
-  packageManager: SupportedPackageManagers;
+  packageManager: SupportedPackageManagers; // Converted from dash case in args.ts
   advertiseSubprojectsCount?: number;
   subProjectNames?: string[];
-  severityThreshold?: string;
+  severityThreshold?: string; // Converted from dash case in args.ts
   dev?: boolean;
   'print-deps'?: boolean;
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,7 +1,7 @@
-var test = require('tap').test;
-var args = require('../src/cli/args').args;
+import { test } from 'tap';
+import { args } from '../src/cli/args';
 
-test('test command line arguments', function(t) {
+test('test command line arguments', (t) => {
   t.plan(1);
   var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
@@ -15,7 +15,7 @@ test('test command line arguments', function(t) {
   t.end();
 });
 
-test('test command line test --package-manager', function(t) {
+test('test command line test --package-manager', (t) => {
   t.plan(1);
   var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
@@ -27,7 +27,17 @@ test('test command line test --package-manager', function(t) {
   t.end();
 });
 
-test('test command line monitor --package-manager', function(t) {
+test('test command line test --all-sub-projects', async (t) => {
+  var cliArgs = [ 'node',
+    'snyk/dist/index.js',
+    'test',
+    '--all-sub-projects',
+  ];
+  var result = args(cliArgs);
+  t.ok(result.options.allSubProjects);
+});
+
+test('test command line monitor --package-manager', (t) => {
   t.plan(1);
   var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
@@ -39,10 +49,10 @@ test('test command line monitor --package-manager', function(t) {
   t.end();
 });
 
-test('test --insecure', function(t) {
+test('test --insecure', (t) => {
   t.plan(1);
   t.teardown(function () {
-    delete global.ignoreUnknownCA;
+    delete (global as any).ignoreUnknownCA;
   });
   var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
     '/Users/dror/work/snyk/snyk-internal/cli',
@@ -50,6 +60,6 @@ test('test --insecure', function(t) {
     '--insecure',
   ];
   var result = args(cliArgs);
-  t.equal(global.ignoreUnknownCA, true, 'ignoreUnknownCA true');
+  t.equal((global as any).ignoreUnknownCA, true, 'ignoreUnknownCA true');
   t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Enables using the new `cli-interface` repo for plugin type definitions.

The only plugin which is now 100% supported is Gradle (plugin v 3.0.0+), the rest have only partially compatible types.

Also changes names of some options (e.g. multiDepRoot -> allSubProjects).
Option transformation for allSubProjects has moved to args.ts

#### Where should the reviewer start?
Be familiar with https://github.com/snyk/snyk-cli-interface repo.

Note that DepTree has a lot of fields of poorly known origin or purpose. This might affect switching the plugins to DepGraph interface.
