### PR TITLE
feat: send analytics for docker and depgraph

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -71,6 +71,8 @@ async function runTest(packageManager: SupportedPackageManagers,
       }
 
       await spinner(spinnerLbl);
+      analytics.add('depGraph', depGraph);
+      analytics.add('isDocker', payload.body && payload.body.docker);
       // Type assertion might be a lie, but we are correcting that below
       let res = await sendPayload(payload, hasDevDependencies) as LegacyVulnApiResult;
       if (depGraph) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Add more analytics to better monitor failures of:
- docker based projects vs not
- when test is using a `depGraph` vs not
