### PR TITLE
fix: send depgraph as a bool

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -71,8 +71,8 @@ async function runTest(packageManager: SupportedPackageManagers,
       }
 
       await spinner(spinnerLbl);
-      analytics.add('depGraph', depGraph);
-      analytics.add('isDocker', payload.body && payload.body.docker);
+      analytics.add('depGraph', !!depGraph);
+      analytics.add('isDocker', (payload.body && payload.body.docker) || false);
       // Type assertion might be a lie, but we are correcting that below
       let res = await sendPayload(payload, hasDevDependencies) as LegacyVulnApiResult;
       if (depGraph) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix analytics to send `depgraph` meta as a boolean 