### PR TITLE
Upgrade Python3 to 3.7 instead of 3.5

### DIFF
--- a/docker/Dockerfile.python-2
+++ b/docker/Dockerfile.python-2
@@ -6,7 +6,7 @@ RUN mkdir /home/node
 WORKDIR /home/node
 
 # Install Python utilities, node, Snyk CLI
-RUN pip3 install pip pipenv virtualenv -U && \
+RUN pip install pip pipenv virtualenv -U && \
     apt-get update && \
     apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \

--- a/docker/Dockerfile.python-2
+++ b/docker/Dockerfile.python-2
@@ -1,18 +1,22 @@
-FROM node:8-slim
+FROM python:2.7-slim
 
 MAINTAINER Snyk Ltd
 
+RUN mkdir /home/node
 WORKDIR /home/node
-ENV HOME /home/node
 
-# Install python, virtualenv, cli
-RUN apt-get update && \
-    apt-get install -y python python-dev python-pip libssl-dev jq && \
-    pip install pip virtualenv -U && \
+# Install Python utilities, node, Snyk CLI
+RUN pip3 install pip pipenv virtualenv -U && \
+    apt-get update && \
+    apt-get install -y curl && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs jq && \
     npm install --global snyk snyk-to-html && \
     apt-get autoremove -y && \
     apt-get clean && \
     chmod -R a+wrx /home/node
+
+ENV HOME /home/node
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project

--- a/docker/Dockerfile.python-3
+++ b/docker/Dockerfile.python-3
@@ -6,7 +6,7 @@ RUN mkdir /home/node
 WORKDIR /home/node
 
 # Install Python utilities, node, Snyk CLI
-RUN pip3 install pip pipenv virtualenv -U && \
+RUN pip install pip pipenv virtualenv -U && \
     apt-get update && \
     apt-get install -y curl && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \

--- a/docker/Dockerfile.python-3
+++ b/docker/Dockerfile.python-3
@@ -1,20 +1,22 @@
-FROM node:8-slim
+FROM python:3.7-slim
 
 MAINTAINER Snyk Ltd
 
+RUN mkdir /home/node
 WORKDIR /home/node
-ENV HOME /home/node
 
-# Install python, virtualenv and cli
-RUN apt-get update && \
-    apt-get install -y python3 python3-dev python3-pip libssl-dev jq && \
-    pip3 install pip pipenv virtualenv -U && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
-    ln -s /usr/bin/pip3 /usr/bin/pip && \
+# Install Python utilities, node, Snyk CLI
+RUN pip3 install pip pipenv virtualenv -U && \
+    apt-get update && \
+    apt-get install -y curl && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get install -y nodejs jq && \
     npm install --global snyk snyk-to-html && \
     apt-get autoremove -y && \
     apt-get clean && \
     chmod -R a+wrx /home/node
+
+ENV HOME /home/node
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project


### PR DESCRIPTION
Some packages require higher versions to be installed

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Some packages need features from newer python versions so Python should be kept up-to-date. The current Python docker image has Python 3.5.3 which is pretty old.

Here is an example error from incompatible packages:
`ERROR: dacite requires Python '>=3.6' but the running Python is 3.5.3`

The Python 2 image was also migrated to use the same format (`FROM python`) to facilitate changes to both images
