### PR TITLE
fix: missing config command in help.txt

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -22,6 +22,8 @@ Commands:
   ignore ............. Modifies the .snyk policy to ignore stated issues.
                        For more information run `snyk help ignore`.
   help [topic] ....... Display detailed help about commands and options.
+  config ............. Manage Snyk's configuration, note that this configuration is stored
+                       on your machine and applies to all Snyk CLI calls.
 
 Options:
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add `config` to help text command