### PR TITLE
fix: isDocker is a boolean flag in analytics

### DIFF
--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -114,7 +114,7 @@ export async function monitor(
 
   const packageManager = meta.packageManager;
   analytics.add('packageManager', packageManager);
-  analytics.add('isDocker', meta.isDocker);
+  analytics.add('isDocker', !!meta.isDocker);
 
   const target = await projectMetadata.getInfo(pkg);
   const targetFileRelativePath = targetFile ? path.relative(root, targetFile) : '';

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -74,7 +74,7 @@ async function runTest(packageManager: SupportedPackageManagers,
 
       await spinner(spinnerLbl);
       analytics.add('depGraph', !!depGraph);
-      analytics.add('isDocker', (payload.body && payload.body.docker) || false);
+      analytics.add('isDocker', !!(payload.body && payload.body.docker));
       // Type assertion might be a lie, but we are correcting that below
       let res = await sendTestPayload(payload) as LegacyVulnApiResult;
       if (depGraph) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Analytics would pick up an non-boolean value for the `isDocker` key sometimes. Fixed.