### PR TITLE
docs: update vuln badge in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ docker run -it
 
 Make users feel more confident in using your website by adding your Snyk badge!
 
-<a href="https://snyk.io/test/npm/snyk"><img src="https://snyk.io/test/npm/snyk/badge.svg" alt="Known Vulnerabilities"/></a>
+<a href="https://snyk.io/test/github/snyk/snyk"><img src="https://snyk.io/test/github/snyk/snyk/badge.svg" alt="Known Vulnerabilities"/></a>
 
 ```
 [![Known Vulnerabilities](https://snyk.io/package/npm/snyk/badge.svg)](https://snyk.io/package/npm/snyk)


### PR DESCRIPTION
Update the example badge to test the GH repo. Testing the npm package ignores the policy for the time being, providing partial results.