### PR TITLE
fix(protect): only patch when version on disk satisfies vuln

### DIFF
--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -6,7 +6,7 @@ const exec = require('child_process').exec;
 const path = require('path');
 const fs = require('fs');
 const uuid = require('uuid/v4');
-const semver = require("semver");
+const semver = require('semver');
 const errorAnalytics = require('../analytics').single;
 
 function applyPatch(patchFileName, vuln, live, patchUrl) {
@@ -33,18 +33,18 @@ function applyPatch(patchFileName, vuln, live, patchUrl) {
 
     const vulnerableVersions = vuln.semver.vulnerable;
     let foundVersionMatchToPatch = false;
-    vulnerableVersions.forEach(versionRange => {
+    vulnerableVersions.forEach((versionRange) => {
       debug(`comparing versions: ${versionOfPackageToPatch} - ${versionRange}`);
       if (semver.satisfies(versionOfPackageToPatch, versionRange)) {
         foundVersionMatchToPatch = true;
       }
     });
-    
+
     if (!foundVersionMatchToPatch) {
       debug('could not find package on disk that satisfies the vuln to patch, nothing to do');
       return resolve();
     }
-    
+
     const patchContent = fs.readFileSync(path.resolve(relative, patchFileName), 'utf8');
 
     jsDiff(patchContent, relative, live).then(() => {

--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -29,16 +29,13 @@ function applyPatch(patchFileName, vuln, live, patchUrl) {
       debug('Failed loading package.json of package about to be patched', err);
     }
 
+    let foundVersionMatchToPatch;
     const versionOfPackageToPatch = pkg.version;
-
-    const vulnerableVersions = vuln.semver.vulnerable;
-    let foundVersionMatchToPatch = false;
-    vulnerableVersions.forEach((versionRange) => {
-      debug(`comparing versions: ${versionOfPackageToPatch} - ${versionRange}`);
-      if (semver.satisfies(versionOfPackageToPatch, versionRange)) {
-        foundVersionMatchToPatch = true;
-      }
-    });
+    const patchableVersionsRange = vuln.patches.version;
+    if (semver.satisfies(versionOfPackageToPatch, patchableVersionsRange)) {
+      debug(`found patchable version range ${patchableVersionsRange}`);
+      foundVersionMatchToPatch = true;
+    }
 
     if (!foundVersionMatchToPatch) {
       debug('could not find package on disk that satisfies the vuln to patch, nothing to do');

--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -20,25 +20,25 @@ function applyPatch(patchFileName, vuln, live, patchUrl) {
     const relative = path.relative(process.cwd(), cwd);
     debug('DRY RUN: relative: %s', relative);
 
-    let pkg;
+    let pkg = {};
+    const packageJsonPath = path.resolve(relative, 'package.json');
     try {
-      const packageJson = fs.readFileSync(path.resolve(relative, 'package.json'));
+      const packageJson = fs.readFileSync(packageJsonPath);
       pkg = JSON.parse(packageJson);
       debug('package at patch target location: %s@%s', pkg.name, pkg.version);
     } catch (err) {
-      debug('Failed loading package.json of package about to be patched', err);
+      debug('Failed loading package.json at %s. Skipping patch!', packageJsonPath, err);
+      return resolve();
     }
 
-    let foundVersionMatchToPatch;
     const versionOfPackageToPatch = pkg.version;
     const patchableVersionsRange = vuln.patches.version;
     if (semver.satisfies(versionOfPackageToPatch, patchableVersionsRange)) {
-      debug(`found patchable version range ${patchableVersionsRange}`);
-      foundVersionMatchToPatch = true;
-    }
-
-    if (!foundVersionMatchToPatch) {
-      debug('could not find package on disk that satisfies the vuln to patch, nothing to do');
+      debug('Patch version range %s matches package version %s',
+        patchableVersionsRange, versionOfPackageToPatch);
+    } else {
+      debug('Patch version range %s does not match package version %s. Skipping patch!',
+        patchableVersionsRange, versionOfPackageToPatch);
       return resolve();
     }
 

--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -33,7 +33,7 @@ function applyPatch(patchFileName, vuln, live, patchUrl) {
       }
 
       const versionOfPackageToPatch = pkg.version;
-      const patchableVersionsRange = vuln.patches.version;
+      const patchableVersionsRange = semver.coerce(vuln.patches.version);
       if (semver.satisfies(versionOfPackageToPatch, patchableVersionsRange)) {
         debug('Patch version range %s matches package version %s',
           patchableVersionsRange, versionOfPackageToPatch);

--- a/test/fixtures/lodash@4.17.11-vuln.json
+++ b/test/fixtures/lodash@4.17.11-vuln.json
@@ -1,0 +1,118 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-06-19T12:04:21.040000Z",
+      "credit": [
+        "Snyk Security Team"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n\n[lodash](https://www.npmjs.com/package/lodash) is a modern JavaScript utility library delivering modularity, performance, & extras.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe function `defaultsDeep` could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nconst mergeFn = require('lodash').defaultsDeep;\r\nconst payload = '{\"constructor\": {\"prototype\": {\"a0\": true}}}'\r\n\r\nfunction check() {\r\n    mergeFn({}, JSON.parse(payload));\r\n    if (({})[`a0`] === true) {\r\n        console.log(`Vulnerable to Prototype Pollution via ${payload}`);\r\n    }\r\n  }\r\n\r\ncheck();\r\n```\r\n\r\nFor more information, check out our [blog post](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `lodash` to version 4.17.12 or higher.\n\n\n## References\n\n- [Github Issue](https://github.com/lodash/lodash/issues/4348)\n\n- [GitHub PR](https://github.com/lodash/lodash/pull/4336)\n\n- [Snyk Blog](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)\n",
+      "disclosureTime": "2019-06-19T11:45:02Z",
+      "fixedIn": [
+        "4.17.12"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-LODASH-450202",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-10744"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-07-10T08:12:59.719272Z",
+      "moduleName": "lodash",
+      "packageManager": "npm",
+      "packageName": "lodash",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-LODASH-450202:0",
+          "modificationTime": "2019-07-03T13:52:26.362878Z",
+          "urls": [
+            "https://snyk-rules-pre-repository.s3.amazonaws.com/snapshots/master/patches/npm/lodash/20190702/lodash_20190702_0_0_1f8ea07746963a535385a5befc19fa687a627d2b.patch"
+          ],
+          "version": "=4.17.11"
+        }
+      ],
+      "publicationTime": "2019-07-02T11:45:01Z",
+      "references": [
+        {
+          "title": "Github Issue",
+          "url": "https://github.com/lodash/lodash/issues/4348"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/lodash/lodash/pull/4336"
+        },
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<4.17.12"
+        ]
+      },
+      "severity": "high",
+      "title": "Prototype Pollution",
+      "from": [
+        "test@1.0.0",
+        "lodash@4.17.11"
+      ],
+      "upgradePath": [
+        false,
+        "lodash@4.17.12"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "lodash",
+      "version": "4.17.11"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "adrukh",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.5\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {
+      "MS-RL": "medium",
+      "EPL-1.0": "medium",
+      "GPL-2.0": "high",
+      "GPL-3.0": "high",
+      "MPL-1.1": "medium",
+      "MPL-2.0": "medium",
+      "Unknown": "medium",
+      "AGPL-1.0": "high",
+      "AGPL-3.0": "high",
+      "CDDL-1.0": "medium",
+      "LGPL-2.0": "medium",
+      "LGPL-2.1": "medium",
+      "LGPL-3.0": "medium",
+      "CPOL-1.02": "high",
+      "LGPL-2.1+": "medium",
+      "LGPL-3.0+": "medium",
+      "SimPL-2.0": "high",
+      "Unlicense": "medium",
+      "Artistic-1.0": "medium",
+      "Artistic-2.0": "medium"
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": null,
+  "summary": "1 vulnerable dependency path",
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 1,
+  "path": "/Users/anton/code/snyk/test"
+}

--- a/test/protect-patch-skip.test.js
+++ b/test/protect-patch-skip.test.js
@@ -1,0 +1,57 @@
+'use strict';
+const debug = require('debug')('snyk');
+const protect = require('../src/lib/protect');
+const path = require('path');
+const test = require('tape');
+const vulns = require('./fixtures/lodash@4.17.11-vuln.json').vulnerabilities;
+const exec = require('child_process').exec;
+
+test('patch is correctly applied', (t) => {
+  const name = 'lodash';
+  const version = '4.17.13';
+
+  const dir = path.resolve(__dirname, 'fixtures/protect');
+  npm('install', name + '@' + version, dir).then(() => {
+    debug('installing to %s', dir);
+    return protect.patch(vulns, true, dir).then(() => {
+      t.pass('patch resolved');
+    });
+  })
+  .catch((error) => {
+    console.log(error.stack);
+    t.fail(error);
+  })
+  .then(() => {
+    return npm('uninstall', name, dir).then(() => {
+      t.pass('packages cleaned up');
+      t.end();
+    });
+  })
+  .catch((error) => {
+    console.log(error.stack);
+    t.fail(error);
+  });
+});
+
+function npm(method, packages, dir) {
+  if (!Array.isArray(packages)) {
+    packages = [packages];
+  }
+  return new Promise(function (resolve, reject) {
+    const cmd = 'npm ' + method + ' ' + packages.join(' ');
+    debug(cmd);
+    exec(cmd, {
+      cwd: dir,
+    }, function (error, stdout, stderr) {
+      if (error) {
+        return reject(error);
+      }
+
+      if (stderr) {
+        return reject(new Error(stderr.trim()));
+      }
+
+      resolve(stdout.trim());
+    });
+  });
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Updates the logic for checking whether to apply patch A on dep B to fix vuln C.

Prior to this change, our logic would sometime lead to a misdetection of the following kind:
Patch A is applicable to `pkg@1.0.0`
Dep B is located in node_modules as `pkg@2.0.0`
Vuln C was detected on `pkg@1.0.0`, which was then resolved on the disk as dep B.

This would cause a clash and fail when applying the patch due to version incompatibility.

The fix is a stop-gap measure that validates the version of the dep located in node_modules prior to applying a patch.

