### PR TITLE
feat: removes npm update prompt

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,6 +2,11 @@
   "prepare": [
     "@semantic-release/npm",
     {
+      "//": "adds a file to identify a build as a standalone binary",
+      "path": "@semantic-release/exec",
+      "cmd": "echo '' > dist/STANDALONE"
+    },
+    {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
       "cmd": "npm i -g pkg && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"

--- a/package.json
+++ b/package.json
@@ -136,7 +136,8 @@
     "assets": [
       "config.default.json",
       "test-unpublished.json",
-      "help/**/*.txt"
+      "help/**/*.txt",
+      "dist/STANDALONE"
     ]
   }
 }

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -10,6 +10,13 @@ export function updateCheck() {
     return false;
   }
 
+  const standalonePath = p.join(__dirname, '../', 'STANDALONE');
+  const isStandaloneBuild = fs.existsSync(standalonePath);
+
+  if (isStandaloneBuild) {
+    return false;
+  }
+
   const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
 
   // if there's no version (f.e. during tests) - do not proceed

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -1,19 +1,18 @@
 const tap = require('tap');
 const test = tap.test;
 const updateCheck = require('../src/lib/updater').updateCheck;
-const path = require('path');
+const fs = require('fs');
+const p = require('path');
 const sinon = require('sinon').createSandbox();
 const updateNotifier = require('update-notifier');
 
 // Fake location of the package.json file and verify the code behaves well
 test('missing package.json', (t) => {
-  t.plan(1);
-  let resolveStub = sinon.stub(path, 'resolve');
-  resolveStub.onFirstCall().returns('falseDir');
-  resolveStub.onSecondCall().returns('falseFile');
+  const fsStub = sinon.stub(fs, 'existsSync');
+  fsStub.withArgs(p.join(__dirname, '../', 'package.json')).returns(false);
 
   t.tearDown(() => {
-    resolveStub.restore();
+    fsStub.restore();
   });
 
   t.equal(
@@ -24,9 +23,22 @@ test('missing package.json', (t) => {
   t.end();
 });
 
-// Run updateNotifier API for the basic package. THe target is to verify API still stands
+test('STANDALONE declaration present', (t) => {
+  const fsStub = sinon.stub(fs, 'existsSync');
+  fsStub.withArgs(p.join(__dirname, '../', 'package.json')).returns(true);
+  fsStub.withArgs(p.join(__dirname, '../src', 'STANDALONE')).returns(true);
+
+  t.tearDown(() => {
+    fsStub.restore();
+  });
+
+  t.equal(updateCheck(), false, 'Notifier was not started for binary build');
+  t.end();
+});
+
+// Run updateNotifier API for the basic package. The target is to verify API still stands
 test('verify updater', (t) => {
-  var pkg = {
+  const pkg = {
     name: 'snyk',
     version: '1.0.0',
   };


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

During the packaging process for the binary adds a `STANDALONE` to the bundle. The `updateCheck` will then bail out early without displaying the upgrade prompt. The aim of this is to prevent users who installed without node being prompted to upgrade `npm`. 
