### PR TITLE
feat: add check for `experimental-dep-graph`  for monitor

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,7 @@ export interface MonitorOptions {
   'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
   'project-name'?: string;
   'print-deps'?: boolean;
+  'experimental-dep-graph'?: boolean;
 
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   'prune-repeated-subdependencies'?: boolean;


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Allow to check for `experimentalDepGraph` feature flag in monitor flow.

#### What are the relevant tickets?
[BST-771](https://snyksec.atlassian.net/browse/BST-771)