### PR TITLE
fix/add build essentials python

### DIFF
--- a/docker/Dockerfile.python-2
+++ b/docker/Dockerfile.python-2
@@ -8,7 +8,7 @@ WORKDIR /home/node
 # Install Python utilities, node, Snyk CLI
 RUN pip install pip pipenv virtualenv -U && \
     apt-get update && \
-    apt-get install -y curl git && \
+    apt-get install -y build-essential curl git && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs jq && \
     npm install --global snyk snyk-to-html && \

--- a/docker/Dockerfile.python-3
+++ b/docker/Dockerfile.python-3
@@ -8,7 +8,7 @@ WORKDIR /home/node
 # Install Python utilities, node, Snyk CLI
 RUN pip install pip pipenv virtualenv -U && \
     apt-get update && \
-    apt-get install -y curl git && \
+    apt-get install -y build-essential curl git && \
     curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
     apt-get install -y nodejs jq && \
     npm install --global snyk snyk-to-html && \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Some python dependencies need a C compiler to be installed

Example (uwsgi):

During handling of the above exception, another exception occurred:
 ```
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-install-1ow3u21k/uwsgi/setup.py", line 138, in <module>
      'Programming Language :: Python :: 3.6',
    File "/home/node/snyk/lib/python3.7/site-packages/setuptools/__init__.py", line 145, in setup
      return distutils.core.setup(**attrs)
    File "/usr/local/lib/python3.7/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/local/lib/python3.7/distutils/dist.py", line 966, in run_commands
      self.run_command(cmd)
    File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/home/node/snyk/lib/python3.7/site-packages/wheel/bdist_wheel.py", line 228, in run
      self.run_command('install')
    File "/usr/local/lib/python3.7/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/local/lib/python3.7/distutils/dist.py", line 985, in run_command
      cmd_obj.run()
    File "/tmp/pip-install-1ow3u21k/uwsgi/setup.py", line 77, in run
      conf = uc.uConf(get_profile())
    File "/tmp/pip-install-1ow3u21k/uwsgi/uwsgiconfig.py", line 750, in __init__
      raise Exception("you need a C compiler to build uWSGI")
  Exception: you need a C compiler to build uWSGI
  ----------------------------------------
  ERROR: Failed building wheel for uwsgi
  Running setup.py clean for uwsgi
```