### PR TITLE
fix: revert to nodejs8 on standalone binaries

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -4,7 +4,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . -t node10-alpine-x64,node10-linux-x64,node10-macos-x64,node10-win-x64"
+      "cmd": "npm i -g pkg && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

For some reason, nodejs10 alpine build segfaults. Need to investigate, reverting for now.
