### PR TITLE
Feat/windows compatible scripts

### DIFF
--- a/src/cli/commands/protect/wizard.js
+++ b/src/cli/commands/protect/wizard.js
@@ -222,7 +222,7 @@ function getNewScriptContent(scriptContent, cmd) {
   if (scriptContent) {
     // only add the command if it's not already in the script
     if (scriptContent.indexOf(cmd) === -1) {
-      return cmd + '; ' + scriptContent;
+      return cmd + '&& ' + scriptContent;
     }
     return scriptContent;
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
### BREAKING CHANGE
- Use `&&` instead of `;` to make scripts windows compatible. This will fail the prepare/prepublish script as `&&` only continues when the first command succeeds.

- Convert a wizard text => .ts

## Linked issue
https://github.com/snyk/snyk/issues/646