### PR TITLE
feat: Behind FF send graphs to new endpoint + tests

### DIFF
--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -150,7 +150,8 @@ async function monitor(...args0: MethodArgs): Promise<any> {
         'project-name': options['project-name'] || config.PROJECT_NAME,
         'isDocker': !!options.docker,
         'prune': !!options['prune-repeated-subdependencies'],
-      };
+        'experimental-dep-graph': !!options['experimental-dep-graph'],
+    };
 
       // We send results from "all-sub-projects" scanning as different Monitor objects
 

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -176,7 +176,7 @@ export async function monitor(
         return reject(error);
       }
 
-      if (res.statusCode === 200 || res.statusCode === 201) {
+      if (res.statusCode >= 200 && res.statusCode <= 299) {
         resolve(body as MonitorResult);
       } else {
         let err;
@@ -264,7 +264,7 @@ export async function monitorGraph(
         return reject(error);
       }
 
-      if (res.statusCode === 200 || res.statusCode === 201) {
+      if (res.statusCode >= 200 && res.statusCode <= 299) {
         resolve(body as MonitorResult);
       } else {
         let err;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,7 @@ export interface MonitorMeta {
   'project-name': string;
   'isDocker': boolean;
   'prune': boolean;
+  'experimental-dep-graph'?: boolean;
 }
 
 export interface MonitorResult {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -14,9 +14,6 @@ import * as version from '../../src/lib/version';
 // configure our fake configuration too
 import * as snykPolicy from 'snyk-policy';
 
-function getRuntimeVersion(): number {
-  return parseInt(process.version.slice(1).split('.')[0], 10);
-}
 const {test, only} = tap;
 (tap as any).runOnly = false; // <- for debug. set to true, and replace a test to only(..)
 
@@ -1362,7 +1359,7 @@ test('`test nuget-app --file=project.json`', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'project.json',
-        }
+        },
       };
     },
   };
@@ -1448,7 +1445,7 @@ test('`test golang-gomodules --file=go.mod`', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'go.mod',
-        }
+        },
       };
     },
   };
@@ -1491,7 +1488,7 @@ test('`test golang-app` auto-detects golang-gomodules', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'go.mod',
-        }
+        },
       };
     },
   };
@@ -1532,7 +1529,7 @@ test('`test golang-app --file=Gopkg.lock`', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'Gopkg.lock',
-        }
+        },
       };
     },
   };
@@ -1575,7 +1572,7 @@ test('`test golang-app --file=vendor/vendor.json`', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'vendor/vendor.json',
-        }
+        },
       };
     },
   };
@@ -1618,7 +1615,7 @@ test('`test golang-app` auto-detects golang/dep', async (t) => {
           name: 'testplugin',
           runtime: 'testruntime',
           targetFile: 'Gopkg.lock',
-        }
+        },
       };
     },
   };
@@ -1774,9 +1771,9 @@ test('`test composer-app golang-app nuget-app` auto-detects all three projects',
     ['POST', 'POST', 'POST'], 'all post requests');
 
   t.same(
-    reqs.map(r => r.headers['x-snyk-cli-version']),
+    reqs.map((r) => r.headers['x-snyk-cli-version']),
     [versionNumber, versionNumber, versionNumber],
-    'all send version number'
+    'all send version number',
   );
 
   t.same(reqs.map((r) => r.url), [
@@ -2007,14 +2004,14 @@ test('`test foo:latest --docker` supports custom policy', async (t) => {
   t.equal(req.body.depGraph.pkgManager.name, 'deb');
   t.same(spyPlugin.getCall(0).args,
     ['foo:latest', null, {
-      args: null,
-      file: null,
-      docker: true,
-      org: 'explicit-org',
-      projectName: null,
-      packageManager: null,
-      path: 'foo:latest',
-      showVulnPaths: true,
+      'args': null,
+      'file': null,
+      'docker': true,
+      'org': 'explicit-org',
+      'projectName': null,
+      'packageManager': null,
+      'path': 'foo:latest',
+      'showVulnPaths': true,
       'policy-path': 'npm-package-policy/custom-location',
     }], 'calls docker plugin with expected arguments');
 
@@ -2367,7 +2364,8 @@ test('`monitor npm-package`', async (t) => {
 
 test('`monitor npm-package-pruneable --prune-repeated-subdependencies`', async (t) => {
   chdirWorkspaces();
-  await cli.monitor('npm-package-pruneable', {'prune-repeated-subdependencies': true});
+
+  await cli.monitor('npm-package-pruneable', { 'prune-repeated-subdependencies': true });
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.equal(req.headers['x-snyk-cli-version'], versionNumber, 'sends version number');
@@ -2380,7 +2378,11 @@ test('`monitor npm-package-pruneable --prune-repeated-subdependencies`', async (
 
 test('`monitor npm-package-pruneable --prune-repeated-subdependencies --experimental-dep-graph`', async (t) => {
   chdirWorkspaces();
-  await cli.monitor('npm-package-pruneable', {'prune-repeated-subdependencies': true});
+
+  await cli.monitor('npm-package-pruneable', {
+    'prune-repeated-subdependencies': true,
+    'experimental-dep-graph': true,
+  });
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
@@ -2389,7 +2391,8 @@ test('`monitor npm-package-pruneable --prune-repeated-subdependencies --experime
 
 test('`monitor npm-package-pruneable --experimental-dep-graph`', async (t) => {
   chdirWorkspaces();
-  await cli.monitor('npm-package-pruneable');
+
+  await cli.monitor('npm-package-pruneable', { 'experimental-dep-graph': true });
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -2378,6 +2378,24 @@ test('`monitor npm-package-pruneable --prune-repeated-subdependencies`', async (
   t.notOk(adc.dependencies, 'a.d.c has no dependencies');
 });
 
+test('`monitor npm-package-pruneable --prune-repeated-subdependencies --experimental-dep-graph`', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-package-pruneable', {'prune-repeated-subdependencies': true});
+  const req = server.popRequest();
+  t.equal(req.method, 'PUT', 'makes PUT request');
+  t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
+  t.ok(req.body.depGraph, 'sends depGraph');
+});
+
+test('`monitor npm-package-pruneable --experimental-dep-graph`', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-package-pruneable');
+  const req = server.popRequest();
+  t.equal(req.method, 'PUT', 'makes PUT request');
+  t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
+  t.ok(req.body.depGraph, 'sends depGraph');
+});
+
 test('`monitor yarn-package`', async (t) => {
   chdirWorkspaces();
   await cli.monitor('yarn-package');

--- a/test/acceptance/fake-server.js
+++ b/test/acceptance/fake-server.js
@@ -108,6 +108,20 @@ module.exports = function (root, apikey) {
     return next();
   });
 
+  server.get(root + '/cli-config/feature-flags/:featureFlag', (req, res, next) => {
+    res.send({
+      ok: true,
+    });
+    return next();
+  });
+
+  server.put(root + '/monitor/:registry/graph', (req, res, next) => {
+    res.send({
+      id: 'test',
+    });
+    return next();
+  });
+
   server.put(root + '/monitor/:registry', function (req, res, next) {
     res.send({
       id: 'test',


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- behind a feature flag start sending graphs across
- ignore prune flag as it does the same thing as a graph and send to the new endpoint too

#### Any background context you want to provide?
Graphs are a more compact format and should improve performance of sending data between services.
#### What are the relevant tickets?
- [ticket](https://snyksec.atlassian.net/secure/RapidBoard.jspa?rapidView=58&modal=detail&selectedIssue=BST-773)