### PR TITLE
feat: Make prepare/prepublish scripts windows compatible

### DIFF
--- a/src/cli/commands/protect/wizard.js
+++ b/src/cli/commands/protect/wizard.js
@@ -222,7 +222,7 @@ function getNewScriptContent(scriptContent, cmd) {
   if (scriptContent) {
     // only add the command if it's not already in the script
     if (scriptContent.indexOf(cmd) === -1) {
-      return cmd + '; ' + scriptContent;
+      return cmd + ' && ' + scriptContent;
     }
     return scriptContent;
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Make `prepare` / `prepublish` scripts windows compatible by using `&&` instead of `;`. This will fail the whole script if `snyk-protect` fails.

#### Issues
https://github.com/snyk/snyk/issues/683
https://github.com/snyk/snyk/issues/646