### PR TITLE
Feat/prune graph

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,5 @@
 {
   "API": "https://snyk.io/api/v1",
-  "devDeps": false
+  "devDeps": false,
+  "PRUNE_DEPS_THRESHOLD": 40000
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,6 +4,7 @@ import * as url from 'url';
 
 const DEFAULT_TIMEOUT = 5 * 60; // in seconds
 interface Config {
+  PRUNE_DEPS_THRESHOLD: number;
   API: string;
   api: string;
   disableSuggestions: string;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
WIP: prune the graph for monitor behind ff when the prune option is passedin

#### How should this be manually tested?
`snyk monitor --experimental-dep-graph --prune-repeated-subdependencies`


``` 
snyk analytics { args:
   [ { 'experimental-dep-graph': true,
       'prune-repeated-subdependencies': true,
       debug: true } ],
  command: 'monitor',metadata:
   { packageManager: [ 'npm', 'npm' ],
     pluginOptions: {},
     local: true,
     'generating-node-dependency-tree': { lockFile: false, targetFile: 'package.json' },
     pluginName: 'snyk-nodejs-lockfile-parser',
     prePruneDepCount: 622,
     isDocker: false,
     targetBranch: 'feat/prune-graph',
     payloadSize: 36416,
     gzippedPayloadSize: 5319 },
  version: '1.192.3',
  os: 'macOS High Sierra',
  nodeVersion: 'v6.14.1',
  id: 'c9bf6324be1c2c6cfe06eae1f700ca840d817599',
  ci: false,
  durationMs: 2187 } +0ms```