### PR TITLE
fix: sbt docker images are now buildable

### DIFF
--- a/docker/Dockerfile.sbt-0.13.16
+++ b/docker/Dockerfile.sbt-0.13.16
@@ -8,9 +8,12 @@ WORKDIR /home/node
 # Install sbt, node, cli
 RUN apt-get update && \
     apt-get install -y curl apt-transport-https git && \
-    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-    curl -L -o sbt.deb https://dl.bintray.com/sbt/debian/sbt-0.13.16.deb && \
-    dpkg -i sbt.deb && \
+    curl -L -o sbt-0.13.16.deb https://dl.bintray.com/sbt/debian/sbt-0.13.16.deb && \
+    dpkg -i sbt-0.13.16.deb && \
+    rm sbt-0.13.16.deb && \
+    apt-get update && \
+    apt-get install -y sbt && \
+    sbt sbtVersion && \
     echo "docker-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers  && \
     mkdir -p /root/.sbt/0.13/plugins  && \
     mkdir -p /home/node/.sbt/0.13/plugins  && \

--- a/docker/Dockerfile.sbt-1.0.4
+++ b/docker/Dockerfile.sbt-1.0.4
@@ -8,9 +8,12 @@ WORKDIR /home/node
 # Install sbt, node, cli
 RUN apt-get update && \
     apt-get install -y curl apt-transport-https git && \
-    echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list && \
-    curl -L -o sbt.deb https://dl.bintray.com/sbt/debian/sbt-1.0.4.deb && \
-    dpkg -i sbt.deb && \
+    curl -L -o sbt-1.0.4.deb https://dl.bintray.com/sbt/debian/sbt-1.0.4.deb && \
+    dpkg -i sbt-1.0.4.deb && \
+    rm sbt-1.0.4.deb && \
+    apt-get update && \
+    apt-get install -y sbt && \
+    sbt sbtVersion && \
     echo "docker-user ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers  && \
     mkdir -p /root/.sbt/1.0/plugins  && \
     mkdir -p /home/node/.sbt/1.0/plugins  && \


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Our CLI docker images that include `sbt` were broken for a while due to how we build them:
```
...
Selecting previously unselected package sbt.
(Reading database ... 10366 files and directories currently installed.)
Preparing to unpack sbt.deb ...
Unpacking sbt (1.0.4) ...
Setting up sbt (1.0.4) ...
Creating system group: sbt
Creating system user: sbt in sbt with sbt daemon-user and shell /bin/false

## Installing the NodeSource Node.js 10.x repo...


## Populating apt-get cache...

+ apt-get update
Hit:1 http://security.debian.org/debian-security buster/updates InRelease
Hit:2 http://deb.debian.org/debian buster InRelease
Hit:3 http://deb.debian.org/debian buster-updates InRelease
Ign:4 https://dl.bintray.com/sbt/debian  InRelease
Get:5 https://dl.bintray.com/sbt/debian  Release [815 B]
Get:6 https://dl.bintray.com/sbt/debian  Release.gpg [821 B]
Ign:6 https://dl.bintray.com/sbt/debian  Release.gpg
Reading package lists...
W: GPG error: https://dl.bintray.com/sbt/debian  Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 99E82A75642AC823
E: The repository 'https://dl.bintray.com/sbt/debian  Release' is not signed.
```

A quick tour of the Internetz suggested an alternative approach that works reliably: https://github.com/mozilla/docker-sbt/blob/master/Dockerfile