### PR TITLE
fix: Propagate plugin error to users

### DIFF
--- a/src/lib/errors/failed-to-run-test-error.ts
+++ b/src/lib/errors/failed-to-run-test-error.ts
@@ -1,0 +1,13 @@
+import {CustomError} from './custom-error';
+
+export class FailedToRunTestError extends CustomError {
+    private static ERROR_MESSAGE: string =
+        'Failed to run a test';
+
+    constructor(userMessage, errorCode?) {
+      const code = errorCode || 500;
+      super(userMessage || FailedToRunTestError.ERROR_MESSAGE);
+      this.code = errorCode || code;
+      this.userMessage = userMessage || FailedToRunTestError.ERROR_MESSAGE;
+    }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -11,3 +11,4 @@ export {InternalServerError} from './internal-server-error';
 export {FailedToGetVulnerabilitiesError} from './failed-to-get-vulnerabilities-error';
 export {UnsupportedFeatureFlagError} from './unsupported-feature-flag-error';
 export {UnsupportedPackageManagerError} from './unsupported-package-manager-error';
+export {FailedToRunTestError} from './failed-to-run-test-error';

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -21,6 +21,7 @@ import {
   NoSupportedManifestsFoundError,
   InternalServerError,
   FailedToGetVulnerabilitiesError,
+  FailedToRunTestError,
 } from '../errors';
 import { maybePrintDeps } from '../print-deps';
 import { SupportedPackageManagers } from '../package-managers';
@@ -147,7 +148,10 @@ async function runTest(packageManager: SupportedPackageManagers,
       throw NoSupportedManifestsFoundError([root]);
     }
 
-    throw err;
+    throw new FailedToRunTestError(
+      err.userMessage || err.message || `Failed to test ${packageManager} project`,
+      err.code,
+    );
   } finally {
     spinner.clear(spinnerLbl)();
   }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Change errors like this:
<img width="713" alt="Screen Shot 2019-07-30 at 19 27 52" src="https://user-images.githubusercontent.com/2911613/62155201-301ba200-b300-11e9-813d-05a10f258fdb.png">
to this:
<img width="696" alt="Screen Shot 2019-07-30 at 19 28 02" src="https://user-images.githubusercontent.com/2911613/62155199-2e51de80-b300-11e9-9b57-861835813303.png">

