### PR TITLE
chore: Add Dockerfiles for maven 3.6.1

### DIFF
--- a/docker/Dockerfile.maven-3.6.1
+++ b/docker/Dockerfile.maven-3.6.1
@@ -1,0 +1,35 @@
+FROM openjdk:8-jdk-slim
+
+MAINTAINER Snyk Ltd
+
+RUN mkdir /home/node
+WORKDIR /home/node
+
+# Install maven, node, cli
+RUN apt-get update && \
+  apt-get install -y curl git && \
+  curl -L -o apache-maven-3.6.1-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
+  tar -xvzf apache-maven-3.6.1-bin.tar.gz && \
+  rm -f apache-maven-3.6.1-bin.tar.gz && \
+  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+  apt-get install -y nodejs jq && \
+  npm install --global snyk snyk-to-html && \
+  apt-get autoremove -y && \
+  apt-get clean && \
+  chmod -R a+wrx /home/node
+
+ENV HOME /home/node
+ENV M2 /home/node/.m2
+ENV PATH /home/node/apache-maven-3.6.1/bin:$PATH
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+ADD docker-entrypoint.sh .
+ADD snyk_report.css .
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]

--- a/docker/Dockerfile.maven-3.6.1_java-11
+++ b/docker/Dockerfile.maven-3.6.1_java-11
@@ -1,0 +1,35 @@
+FROM openjdk:11-jdk-slim
+
+MAINTAINER Snyk Ltd
+
+RUN mkdir /home/node
+WORKDIR /home/node
+
+# Install maven, node, cli
+RUN apt-get update && \
+  apt-get install -y curl git && \
+  curl -L -o apache-maven-3.6.1-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
+  tar -xvzf apache-maven-3.6.1-bin.tar.gz && \
+  rm -f apache-maven-3.6.1-bin.tar.gz && \
+  curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+  apt-get install -y nodejs jq && \
+  npm install --global snyk snyk-to-html && \
+  apt-get autoremove -y && \
+  apt-get clean && \
+  chmod -R a+wrx /home/node
+
+ENV HOME /home/node
+ENV M2 /home/node/.m2
+ENV PATH /home/node/apache-maven-3.6.1/bin:$PATH
+
+# The path at which the project is mounted (-v runtime arg)
+ENV PROJECT_PATH /project
+
+ADD docker-entrypoint.sh .
+ADD snyk_report.css .
+
+ENTRYPOINT ["./docker-entrypoint.sh"]
+
+# Default command is `snyk test`
+# Override with `docker run ... snyk/snyk-cli <command> <args>`
+CMD ["test"]


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds 2 new Dockerfiles.
One for for maven 3.6.1 with Java 8 and one for maven 3.6.1 with java 11

Currently there is only a dockerfile for maven 3.5.4 with java 8.   
Given that there are several dockerfile for different gradle versions, I added a new Dockerfile for the latest maven version instead of updating the existing Dockerfile.

#### Where should the reviewer start?

#### How should this be manually tested?


Build the Dockerfiles :smiley:  and use the image on a maven project.

#### Any background context you want to provide?


#### What are the relevant tickets?

Maven 3.6.1 is the latest version of maven and Java 8 and 11 are the two most used java versions.

#### Screenshots


#### Additional questions
