### PR TITLE
fix: downgrade ansi escapes

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@snyk/gemfile": "1.2.0",
     "@types/agent-base": "^4.2.0",
     "abbrev": "^1.1.1",
-    "ansi-escapes": "^4.1.0",
+    "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",
     "configstore": "^3.1.2",
     "debug": "^3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This package is node8+, downgrade for node 6 support

#### Any background context you want to provide?
https://github.com/snyk/snyk/issues/724
