### PR TITLE
docs: prune flag works on test and monitor

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -53,7 +53,7 @@ Options:
   --print-deps ....... (test and monitor commands only)
                        Print the dependency tree before sending it for analysis.
   --prune-repeated-subdependencies
-                       (monitor command only)
+                       (test and monitor command only)
                        Prune dependency trees, removing duplicate sub-dependencies.
                        Will still find all vulnerabilities, but potentially not all
                        of the vulnerable paths.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Update docs for pruning to reference support for `test` and `monitor`