### PR TITLE
fix: reinstate Gradle subproject arguments

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -59,7 +59,7 @@ Options:
                        of the vulnerable paths.
 
 Gradle options:
-  --gradle-sub-project=<string>
+  --sub-project=<string> (alias: --gradle-sub-project)
                        For Gradle "multi project" configurations,
                        test a specific sub-project.
   --all-sub-projects   For "multi project" configurations, test all

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -160,12 +160,21 @@ export function args(rawArgv: string[]): Args {
     'packages-folder',
     'severity-threshold',
     'strict-out-of-sync',
+    'all-sub-projects',
+    'sub-project',
+    'gradle-sub-project',
   ]) {
     if (argv[dashedArg]) {
       const camelCased = dashToCamelCase(dashedArg);
       argv[camelCased] = argv[dashedArg];
       delete argv[dashedArg];
     }
+  }
+
+  // Alias
+  if (argv.gradleSubProject) {
+    argv.subProject = argv.gradleSubProject;
+    delete argv.gradleSubProject;
   }
 
   if (argv.insecure) {

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -50,6 +50,31 @@ test('test --insecure', function(t) {
     '--insecure',
   ];
   var result = args(cliArgs);
-  t.equal(global.ignoreUnknownCA, true, 'ignoreUnknownCA true');
+  t.equal(global.ignoreUnknownCA, true, 'ignoreUnknownCA true')
+  t.end();
+});
+
+
+test('test command line test --all-sub-projects', function(t) {
+  t.plan(1);
+  var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--all-sub-projects',
+  ];
+  var result = args(cliArgs);
+  t.ok(result.options.allSubProjects);
+  t.end();
+});
+
+test('test command line test --gradle-sub-project=foo', function(t) {
+  t.plan(1);
+  var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--gradle-sub-project=foo',
+  ];
+  var result = args(cliArgs);
+  t.equal(result.options.subProject, 'foo');
   t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes Gradle subproject arguments that were lost after upgrading Gradle plugin to version 2.x
