### PR TITLE
fix: reinstate --all-sub-project support for Gradle

### DIFF
--- a/src/lib/module-info/index.ts
+++ b/src/lib/module-info/index.ts
@@ -1,12 +1,12 @@
 import * as _ from 'lodash';
 import * as Debug from 'debug';
-import { SingleDepRootResult } from '../types';
+import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 
 const debug = Debug('snyk-module-info');
 
 export function ModuleInfo(plugin, policy) {
   return {
-    async inspect(root, targetFile, options): Promise<SingleDepRootResult> {
+    async inspect(root, targetFile, options): Promise<pluginApi.SinglePackageResult> {
       const pluginOptions = _.merge({
         args: options._doubleDashArgs,
       }, options);

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -59,18 +59,3 @@ export function loadPlugin(packageManager: SupportedPackageManagers,
     }
   }
 }
-
-export function getPluginOptions(packageManager: string, options: types.Options): types.Options {
-  const pluginOptions: types.Options = {};
-  switch (packageManager) {
-    case 'gradle': {
-      if (options['all-sub-projects']) {
-        pluginOptions.multiDepRoots = true;
-      }
-      return pluginOptions;
-    }
-    default: {
-      return pluginOptions;
-    }
-  }
-}

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -4,7 +4,7 @@ export interface InspectResult {
     runtime?: string;
   };
   package?: any;
-  depRoots?: any;
+  scannedProjects?: any;
 }
 
 export interface Options {
@@ -13,7 +13,7 @@ export interface Options {
   traverseNodeModules?: boolean;
   dev?: boolean;
   strictOutOfSync?: boolean | 'true' | 'false';
-  multiDepRoots?: boolean;
+  allSubProjects?: boolean;
   debug?: boolean;
   packageManager?: string;
   composerIsFine?: boolean;

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -1,8 +1,9 @@
-import { DepDict, Options, MonitorOptions, DepTree } from './types';
+import { DepDict, Options, MonitorOptions } from './types';
+import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 
 // This option is still experimental and might be deprecated.
 // It might be a better idea to convert it to a command (i.e. do not perform test/monitor).
-export function maybePrintDeps(options: Options | MonitorOptions, rootPackage: DepTree) {
+export function maybePrintDeps(options: Options | MonitorOptions, rootPackage: legacyApi.DepTree) {
   if (options['print-deps']) {
     if (options.json) {
       // Will produce 2 JSON outputs, one for the deps, one for the vuln scan.

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,5 @@
 import { SupportedPackageManagers } from './package-managers';
-
-// TODO(kyegupov): use a shared repository snyk-cli-interface
+import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 
 export interface PluginMetadata {
   name: string;
@@ -19,45 +18,7 @@ export interface DepDict {
   [name: string]: DepTree;
 }
 
-export interface DepTree {
-  name: string;
-  version: string;
-  dependencies?: DepDict;
-  packageFormatVersion?: string;
-  docker?: any;
-  files?: any;
-  targetFile?: string;
-  missingLockFileEntry?: boolean;
-
-  labels?: {
-    [key: string]: string;
-
-    // Known keys:
-    // pruned: identical subtree already presents in the parent node.
-    //         See --prune-repeated-subdependencies flag.
-  };
-}
-
-export interface DepRoot {
-  depTree: DepTree; // to be soon replaced with depGraph
-  targetFile?: string;
-}
-
-// Legacy result type. Will be deprecated soon.
-export interface SingleDepRootResult {
-  plugin: PluginMetadata;
-  package: DepTree;
-}
-
-export interface MultiDepRootsResult {
-  plugin: PluginMetadata;
-  depRoots: DepRoot[];
-}
-
-// https://www.typescriptlang.org/docs/handbook/advanced-types.html#user-defined-type-guards
-export function isMultiResult(pet: SingleDepRootResult | MultiDepRootsResult): pet is MultiDepRootsResult {
-  return !!(pet as MultiDepRootsResult).depRoots;
-}
+export type DepTree = legacyApi.DepTree;
 
 export interface TestOptions {
   traverseNodeModules: boolean;
@@ -81,7 +42,7 @@ export interface Options {
   'ignore-policy'?: boolean;
   'trust-policies'?: boolean; // used in snyk/policy lib
   'policy-path'?: boolean;
-  'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
+  allSubProjects?: boolean;
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
   showVulnPaths?: boolean;
@@ -100,7 +61,7 @@ export interface MonitorOptions {
   file?: string;
   policy?: string;
   json?: boolean;
-  'all-sub-projects'?: boolean; // Corresponds to multiDepRoot in plugins
+  allSubProjects?: boolean;
   'project-name'?: string;
   'print-deps'?: boolean;
   'experimental-dep-graph'?: boolean;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes `--all-sub-project` flag broken by the Gradle plugin upgrade.
Also, fully use the plugin type definitions from the snyk-cli-interface package.