### PR TITLE
feat: add --remote-repo-url flag

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -57,6 +57,9 @@ Options:
                        Prune dependency trees, removing duplicate sub-dependencies.
                        Will still find all vulnerabilities, but potentially not all
                        of the vulnerable paths.
+  --remote-repo-url=<string>
+                       (monitor command only)
+                       Set or override the remote URL for the repository that you would like to monitor.
 
 Gradle options:
   --sub-project=<string> (alias: --gradle-sub-project)

--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -80,6 +80,10 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--all-sub-projects` is currently not compatible with `--project-name`');
   }
 
+  if (options.docker && options['remote-repo-url']) {
+    throw new Error('`--remote-repo-url` is not supported for container scans');
+  }
+
   apiTokenExists();
 
   if (options['experimental-dep-graph']) {
@@ -148,6 +152,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
         'isDocker': !!options.docker,
         'prune': !!options['prune-repeated-subdependencies'],
         'experimental-dep-graph': !!options['experimental-dep-graph'],
+        'remote-repo-url': options['remote-repo-url'],
     };
 
       // We send results from "all-sub-projects" scanning as different Monitor objects

--- a/src/lib/project-metadata/types.ts
+++ b/src/lib/project-metadata/types.ts
@@ -1,4 +1,4 @@
 export interface GitTarget {
   remoteUrl: string;
-  branch: string;
+  branch?: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -79,6 +79,7 @@ export interface MonitorMeta {
   isDocker: boolean;
   prune: boolean;
   'experimental-dep-graph'?: boolean;
+  'remote-repo-url'?: string;
 }
 
 export interface MonitorResult {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -2485,6 +2485,15 @@ test('`monitor npm-package with custom --project-name`', async (t) => {
   t.equal(req.body.meta.projectName, 'custom-project-name');
 });
 
+test('`monitor npm-package with custom --remote-repo-url`', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-package', {
+    'remote-repo-url': 'a-fake-remote',
+  });
+  const req = server.popRequest();
+  t.equal(req.body.target.remoteUrl, 'a-fake-remote');
+});
+
 test('`monitor npm-package with dev dep flag`', async (t) => {
   chdirWorkspaces();
   await cli.monitor('npm-package', { dev: true });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add an optional `--remote-repo-url` flag to `snyk monitor` which sets the `remoteUrl` for the target (or overrides it if it was obtained from git). This enables manual specifying of the remote for environments without git configured to support grouping in the web interface.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/UNICORN-431


#### Screenshots
<img width="1107" alt="Screenshot 2019-08-14 at 17 45 07" src="https://user-images.githubusercontent.com/12794858/63039489-55d9a700-bebb-11e9-99e7-11378fb7f642.png">
<img width="1410" alt="Screenshot 2019-08-14 at 17 45 30" src="https://user-images.githubusercontent.com/12794858/63039490-55d9a700-bebb-11e9-96f8-8801bfbb88c6.png">


Various different types of project:
<img width="1421" alt="Screenshot 2019-08-15 at 16 05 11" src="https://user-images.githubusercontent.com/12794858/63104263-8af6ff80-bf76-11e9-8d19-5b6105ada64a.png">


#### Additional questions
