### PR TITLE
fix: snyk policy command execution error and missed tests

### DIFF
--- a/src/cli/commands/policy.ts
+++ b/src/cli/commands/policy.ts
@@ -2,9 +2,9 @@ import * as policy from 'snyk-policy';
 import {display} from '../../lib/display-policy';
 import {FailedToLoadPolicyError, PolicyNotFoundError} from '../../lib/errors';
 
-export async function displayPolicy(path) {
+async function displayPolicy(path?: string): Promise<string> {
   try {
-    const loadedPolicy = await policy.load(path || process.cwd());
+    const loadedPolicy = await policy.load(path || process.cwd()) as Promise<string>;
     return await display(loadedPolicy);
   } catch (error) {
       if (error.code === 'ENOENT') {
@@ -16,3 +16,5 @@ export async function displayPolicy(path) {
       throw error;
     }
 }
+
+export = displayPolicy;

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -25,6 +25,7 @@ const server = require('../cli-server')(
  // ensure this is required *after* the demo server, since this will
 // configure our fake configuration too
 import * as cli from '../../src/cli/commands';
+import {PolicyNotFoundError} from '../../src/lib/errors';
 
 const before = test;
 const after = test;
@@ -232,6 +233,18 @@ test('auth via github', (t) => {
   }).catch(t.threw).then(() => {
     unhook();
     t.end();
+  });
+});
+
+test('snyk policy', (t) => {
+  t.plan(2);
+
+  cli.policy().then(() => {
+    t.pass('policy called');
+  });
+
+  cli.policy('wrong/path').catch((error) => {
+    t.match(error, PolicyNotFoundError);
   });
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix execution error of CLI command `snyk policy`. 
The problem was with named export instead default. In addition tests and TypeScript notations added.

#### How should this be manually tested?
Run in terminal `snyk policy`
