### PR TITLE
feat: switch to open (opn was deprecated and renamed to open)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "inquirer": "^6.2.2",
     "lodash": "^4.17.14",
     "needle": "^2.2.4",
-    "opn": "^5.5.0",
+    "open": "^6.4.0",
     "os-name": "^3.0.0",
     "proxy-agent": "^3.1.0",
     "proxy-from-env": "^1.0.0",

--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -1,5 +1,5 @@
 import * as Debug from 'debug';
-import * as open from 'opn';
+import * as open from 'open';
 import * as snyk from '../../../lib';
 import * as config from '../../../lib/config';
 import {isCI} from '../../../lib/is-ci';

--- a/test/fixtures/pkg-mean-io/npm-shrinkwrap.json
+++ b/test/fixtures/pkg-mean-io/npm-shrinkwrap.json
@@ -1298,10 +1298,10 @@
           "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.3.tgz"
         },
-        "opn": {
-          "version": "1.0.2",
-          "from": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        "open": {
+          "version": "6.4.0",
+          "from": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz"
         },
         "p-throttler": {
           "version": "0.1.1",

--- a/test/fixtures/protect-via-snyk/yarn.lock
+++ b/test/fixtures/protect-via-snyk/yarn.lock
@@ -637,9 +637,9 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-opn@^5.2.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/opn/-/opn-5.4.0.tgz#cb545e7aab78562beb11aa3bfabc7042e1761035"
+open@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-6.4.0.tgz#5c13e96d0dc894686164f18965ecfe889ecfc8a9"
   dependencies:
     is-wsl "^1.1.0"
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Switch using `opn` package to `open`. `opn` is deprecated and renamed to `open`.