### PR TITLE
feat: update resolve-deps to remove @types/package-json dependancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "snyk-policy": "1.13.5",
     "snyk-python-plugin": "^1.13.0",
     "snyk-resolve": "1.0.1",
-    "snyk-resolve-deps": "4.3.0",
+    "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.7.0",
     "snyk-tree": "^1.0.0",
     "snyk-try-require": "1.3.1",


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Update `snyk-resolve-deps` to not have vulnerable dependency that brought only 1 type into package