### PR TITLE
fix: support python_version wildcards in requirements.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "snyk-nuget-plugin": "1.12.1",
     "snyk-php-plugin": "1.6.4",
     "snyk-policy": "1.13.5",
-    "snyk-python-plugin": "^1.13.0",
+    "snyk-python-plugin": "^1.13.2",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.7.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Enables support for lines like `enum34==1.1.6 ; python_version == '2.*'` in requirements.txt
