### PR TITLE
fix: do not display empty "licenses" block

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -89,6 +89,10 @@ function constructLicenseText(
   },
 ): string[] {
 
+  if (!(Object.keys(basicLicenseInfo).length > 0)) {
+    return [];
+  }
+
   const licenseTextArray = [chalk.bold.green('\nLicense issues:')];
 
   for (const id of Object.keys(basicLicenseInfo)) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Do not display empty "licenses" block in the new style output.