### PR TITLE
feat: show vulnerable paths: 3 modes, support new test output

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -35,10 +35,13 @@ Options:
   --trust-policies ... Applies and uses ignore rules from your dependencies's
                        Snyk policies, otherwise ignore policies are only
                        shown as a suggestion.
-  --show-vulnerable-paths=<boolean>
+  --show-vulnerable-paths=<none|some|all>
+                       (test command only)
                        Display the dependency paths from the top level
-                       dependencies, down to the vulnerable packages (defaults
-                       to true). Applicable to `snyk test`.
+                       dependencies, down to the vulnerable packages.
+                       Defaults to "some" (a few example paths).
+                       "false" is an alias for "none".
+                       Doesn't affect output in JSON mode.
   --project-name=<string>
                        Specify a custom Snyk project name.
   --policy-path ...... Manually pass a path to a policy file.

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -78,7 +78,7 @@ interface AnnotatedIssue extends IssueData {
   credit: any;
   name: string;
   version: string;
-  from: Array<string | boolean>;
+  from: string[];
   upgradePath: Array<string | boolean>;
   isUpgradable: boolean;
   isPatchable: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,10 +21,13 @@ export interface DepDict {
 
 export type DepTree = legacyApi.DepTree;
 
+export type ShowVulnPaths = 'none' | 'some' | 'all';
+
 export interface TestOptions {
   traverseNodeModules: boolean;
   interactive: boolean;
   'prune-repeated-subdependencies'?: boolean;
+  showVulnPaths: ShowVulnPaths;
 }
 export interface ProtectOptions {
   loose: boolean;
@@ -46,7 +49,6 @@ export interface Options {
   allSubProjects?: boolean;
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
-  showVulnPaths?: boolean;
   packageManager: SupportedPackageManagers;
   advertiseSubprojectsCount?: number;
   subProjectNames?: string[];

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -784,7 +784,7 @@ test('`test nuget-app-2 auto-detects project.assets.json`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app-2',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -824,7 +824,7 @@ test('`test nuget-app-2.1 auto-detects obj/project.assets.json`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app-2.1',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -865,7 +865,7 @@ test('`test nuget-app-4 auto-detects packages.config`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app-4',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -906,7 +906,7 @@ test('`test paket-app auto-detects paket.dependencies`', async (t) => {
             projectName: null,
             packageManager: 'paket',
             path: 'paket-app',
-            showVulnPaths: true,
+            showVulnPaths: "some",
         }], 'calls nuget plugin');
 });
 
@@ -947,7 +947,7 @@ test('`test paket-obj-app auto-detects obj/project.assets.json if exists`', asyn
             projectName: null,
             packageManager: 'nuget',
             path: 'paket-obj-app',
-            showVulnPaths: true,
+            showVulnPaths: "some",
         }], 'calls nuget plugin');
 });
 
@@ -1237,7 +1237,7 @@ test('`test pip-app --file=requirements.txt`', async (t) => {
       projectName: null,
       packageManager: 'pip',
       path: 'pip-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls python plugin');
 });
 
@@ -1280,7 +1280,7 @@ test('`test pipenv-app --file=Pipfile`', async (t) => {
       projectName: null,
       packageManager: 'pip',
       path: 'pipenv-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls python plugin');
 });
 
@@ -1323,7 +1323,7 @@ test('`test nuget-app --file=project.assets.json`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -1366,7 +1366,7 @@ test('`test nuget-app --file=packages.config`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -1409,7 +1409,7 @@ test('`test nuget-app --file=project.json`', async (t) => {
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -1452,7 +1452,7 @@ test('`test paket-app --file=paket.dependencies`', async (t) => {
             projectName: null,
             packageManager: 'paket',
             path: 'paket-app',
-            showVulnPaths: true,
+            showVulnPaths: "some",
         }], 'calls nuget plugin');
 });
 
@@ -1495,7 +1495,7 @@ test('`test golang-gomodules --file=go.mod`', async (t) => {
       projectName: null,
       packageManager: 'gomodules',
       path: 'golang-gomodules',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang plugin');
 });
 
@@ -1536,7 +1536,7 @@ test('`test golang-app` auto-detects golang-gomodules', async (t) => {
       projectName: null,
       packageManager: 'gomodules',
       path: 'golang-gomodules',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang-gomodules plugin');
 });
 
@@ -1579,7 +1579,7 @@ test('`test golang-app --file=Gopkg.lock`', async (t) => {
       projectName: null,
       packageManager: 'golangdep',
       path: 'golang-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang plugin');
 });
 
@@ -1622,7 +1622,7 @@ test('`test golang-app --file=vendor/vendor.json`', async (t) => {
       projectName: null,
       packageManager: 'govendor',
       path: 'golang-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang plugin');
 });
 
@@ -1663,7 +1663,7 @@ test('`test golang-app` auto-detects golang/dep', async (t) => {
       projectName: null,
       packageManager: 'golangdep',
       path: 'golang-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang plugin');
 });
 
@@ -1696,7 +1696,7 @@ test('`test golang-app-govendor` auto-detects govendor', async (t) => {
       projectName: null,
       packageManager: 'govendor',
       path: 'golang-app-govendor',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golang plugin');
 });
 
@@ -1731,7 +1731,7 @@ test('`test composer-app --file=composer.lock`', async (t) => {
       projectName: null,
       packageManager: 'composer',
       path: 'composer-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls composer plugin');
 });
 
@@ -1764,7 +1764,7 @@ test('`test composer-app` auto-detects composer.lock', async (t) => {
       projectName: null,
       packageManager: 'composer',
       path: 'composer-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls composer plugin');
 });
 
@@ -1820,7 +1820,7 @@ test('`test composer-app golang-app nuget-app` auto-detects all three projects',
       projectName: null,
       packageManager: 'composer',
       path: 'composer-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls composer plugin');
   t.same(calls[1].args,
     ['golang-app', 'Gopkg.lock', {
@@ -1830,7 +1830,7 @@ test('`test composer-app golang-app nuget-app` auto-detects all three projects',
       projectName: null,
       packageManager: 'golangdep',
       path: 'golang-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls golangdep plugin');
   t.same(calls[2].args,
     ['nuget-app', 'project.assets.json', {
@@ -1840,7 +1840,7 @@ test('`test composer-app golang-app nuget-app` auto-detects all three projects',
       projectName: null,
       packageManager: 'nuget',
       path: 'nuget-app',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls nuget plugin');
 });
 
@@ -1870,7 +1870,7 @@ test('`test foo:latest --docker`', async (t) => {
       projectName: null,
       packageManager: null,
       path: 'foo:latest',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls docker plugin with expected arguments');
 });
 
@@ -1950,7 +1950,7 @@ test('`test foo:latest --docker --file=Dockerfile`', async (t) => {
       projectName: null,
       packageManager: null,
       path: 'foo:latest',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls docker plugin with expected arguments');
 });
 
@@ -2000,7 +2000,7 @@ test('`test foo:latest --docker` doesnt collect policy from cwd', async (t) => {
       projectName: null,
       packageManager: null,
       path: 'foo:latest',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls docker plugin with expected arguments');
   const policyString = req.body.policy;
   t.false(policyString, 'policy not sent');
@@ -2032,7 +2032,7 @@ test('`test foo:latest --docker` supports custom policy', async (t) => {
       'projectName': null,
       'packageManager': null,
       'path': 'foo:latest',
-      'showVulnPaths': true,
+      'showVulnPaths': 'some',
       'policy-path': 'npm-package-policy/custom-location',
     }], 'calls docker plugin with expected arguments');
 
@@ -2075,7 +2075,7 @@ test('`test foo:latest --docker with binaries`', async (t) => {
       projectName: null,
       packageManager: null,
       path: 'foo:latest',
-      showVulnPaths: true,
+      showVulnPaths: "some",
     }], 'calls docker plugin with expected arguments');
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Updates `--show-vulnerable-paths` flag support.
3 modes now available: `none`, `some` (3 in the legacy mode, 1 in the actionableCliRemediation mode), `all` (up to 1000).

Old `true` is now `some` (default); old `false` is now `none`.

#### Tickets:
https://snyksec.atlassian.net/browse/FIX-19

#### Screenshots
snyk help
![image](https://user-images.githubusercontent.com/502156/64261499-880f7f00-cf24-11e9-98ec-7a15a351a483.png)

goof actionableCliRemediation=false show-vulnerable-paths=some (current default)
![image](https://user-images.githubusercontent.com/502156/64260932-9dd07480-cf23-11e9-9124-52c4caa947c7.png)

goof actionableCliRemediation=false show-vulnerable-paths=none
![image](https://user-images.githubusercontent.com/502156/64261018-c0fb2400-cf23-11e9-8140-8069e2e9832e.png)

goof actionableCliRemediation=false show-vulnerable-paths=all
![image](https://user-images.githubusercontent.com/502156/64261063-d53f2100-cf23-11e9-82b4-412c5174c0ab.png)

goof actionableCliRemediation=true show-vulnerable-paths=some (upcoming default)
![image](https://user-images.githubusercontent.com/502156/64260691-416d5500-cf23-11e9-9fa0-6182ceabce95.png)

goof actionableCliRemediation=true show-vulnerable-paths=none
![image](https://user-images.githubusercontent.com/502156/64260651-2bf82b00-cf23-11e9-82c1-58c9c840d046.png)

goof actionableCliRemediation=true show-vulnerable-paths=all
![image](https://user-images.githubusercontent.com/502156/64260766-65309b00-cf23-11e9-8c39-22a9e8d83ee1.png)
