### PR TITLE
fix: align indent for legal instructions

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -373,7 +373,7 @@ function formatIssue(
     `  ✗ ${chalk.bold(title)}${newBadge} [${titleCaseText(severity)} Severity]`,
   ) + `[${config.ROOT}/vuln/${id}]` + name
     + introducedBy
-    + (legalInstructions ? `${chalk.bold('\n  Legal instructions')}:\n  ${formatLegalText}` : '');
+    + (legalInstructions ? `${chalk.bold('\n    Legal instructions')}:\n    ${formatLegalText}` : '');
 }
 
 function titleCaseText(text) {

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -17,7 +17,7 @@ Issues to fix by pinning sub-dependencies:
     introduced by flask@0.12.2 > Jinja2@2.9.6
 
   Pin Werkzeug to 0.15.3 to fix
-  ✗ Insufficient Randomness (new) [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
+  ✗ Insufficient Randomness [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-WERKZEUG-458931] in Werkzeug@0.12.2
     introduced by flask@0.12.2 > Werkzeug@0.12.2
 
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix alignment of legal instructions text

<img width="745" alt="Screenshot 2019-09-10 at 17 42 45" src="https://user-images.githubusercontent.com/50448372/64633320-e50ea780-d3f2-11e9-9a3e-7a3dd5e0b189.png">
