### PR TITLE
feat: in the new output mode, show the test summary first

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -66,7 +66,7 @@ export function formatIssuesWithRemediation(
     }
   }
 
-  const results = [chalk.bold.white('Remediation advice')];
+  const results = [''];
 
   let upgradeTextArray: string[];
   if (remediationInfo.pin && Object.keys(remediationInfo.pin).length) {

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -1,7 +1,7 @@
 
 Testing pip-app-transitive-vuln...
 
-Remediation advice
+Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vulnerable paths.
 
 
 Issues to fix by upgrading existing dependencies:
@@ -27,5 +27,3 @@ Package manager:   pip
 Target file:       requirements.txt
 Open source:       no
 Project path:      pip-app-transitive-vuln
-
-Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vulnerable paths.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
In the new ("actionable") output format, show the test summary at the top.

https://snyksec.atlassian.net/browse/FIX-20

#### Screenshots:
Old-style output is unchanged:
![image](https://user-images.githubusercontent.com/502156/64788315-1e1d5800-d56a-11e9-86f9-a9b26b94aa75.png)

New-style output, before this change:
![image](https://user-images.githubusercontent.com/502156/64788426-54f36e00-d56a-11e9-9fac-ffc8cf0056a4.png)

New-style output, after this change:
![image](https://user-images.githubusercontent.com/502156/64788460-676da780-d56a-11e9-9f49-a771736f5326.png)

