### PR TITLE
fix: document --command option for Python

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -90,9 +90,15 @@ Gradle options:
 Npm options:
   --strict-out-of-sync=<true|false>
                        Allow testing out of sync lockfile. Defauls to false.
+
 Yarn options:
   --strict-out-of-sync=<true|false>
                        Allow testing out of sync lockfile. Defauls to false.
+
+Python options:
+  --command=<string>   Python interpreter to use. Default: "python", set to
+                       "python2" or "python3" to use a specific version.
+
 Docker options:
   --docker ........... Test or monitor a local docker image for Linux
                        vulnerabilities. Can be used alongside `--file` and a


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The information on how to select python2 vs python3 in CLI is not visible for the users.
Let's document it.
#### Additional questions
