### PR TITLE
feat: convert ruby to send back multi project result

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -35,7 +35,7 @@ async function webAuth(via: AuthCliCommands) {
 
   // validate that via comes from our code, and not from user & CLI
   if (redirects[via]) {
-    urlStr += '&redirectUri=' + new Buffer(redirects[via]).toString('base64');
+    urlStr += '&redirectUri=' + Buffer.from(redirects[via]).toString('base64');
   }
 
   const msg =

--- a/src/lib/plugins/rubygems/index.ts
+++ b/src/lib/plugins/rubygems/index.ts
@@ -1,35 +1,38 @@
 import { inspectors, Spec } from './inspectors';
-import * as types from '../types';
 import { MissingTargetFileError } from '../../errors/missing-targetfile-error';
-
-interface RubyGemsInspectResult extends types.InspectResult {
-  package: {
-    name: string;
-    targetFile: string;
-    files: any;
-  };
-}
+import gemfileLockToDependencies = require('./gemfile-lock-to-dependencies');
+import _ = require('lodash');
+import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
 
 export async function inspect(
   root: string,
   targetFile: string,
-): Promise<RubyGemsInspectResult> {
+): Promise<MultiProjectResult> {
   if (!targetFile) {
     throw MissingTargetFileError(root);
   }
   const specs = await gatherSpecs(root, targetFile);
+  const gemfileLockBase64 = _.get(specs, 'files.gemfileLock.contents');
+  const gemfileLockContents = Buffer.from(
+    gemfileLockBase64,
+    'base64',
+  ).toString();
+  const dependencies = gemfileLockToDependencies(gemfileLockContents);
 
   return {
     plugin: {
       name: 'bundled:rubygems',
       runtime: 'unknown',
     },
-    // TODO: must be a depTree!
-    package: {
-      name: specs.packageName,
-      targetFile: specs.targetFile,
-      files: specs.files,
-    },
+    scannedProjects: [
+      {
+        depTree: {
+          name: specs.packageName,
+          targetFile: specs.targetFile,
+          dependencies,
+        },
+      },
+    ],
   };
 }
 

--- a/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
+++ b/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
@@ -21,7 +21,7 @@ export async function tryGetSpec(
   if (await fs.exists(filePath)) {
     return {
       name,
-      contents: new Buffer(await fs.readFile(filePath)).toString('base64'),
+      contents: Buffer.from(await fs.readFile(filePath)).toString('base64'),
     };
   }
   return null;

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -14,7 +14,6 @@ import snyk = require('../');
 import spinner = require('../spinner');
 import common = require('./common');
 import { DepTree, TestOptions } from '../types';
-import gemfileLockToDependencies = require('../../lib/plugins/rubygems/gemfile-lock-to-dependencies');
 import {
   convertTestDepGraphResultToLegacy,
   AnnotatedIssue,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -345,15 +345,6 @@ async function assembleLocalPayloads(
         }
       }
 
-      if (_.get(pkg, 'files.gemfileLock.contents')) {
-        const gemfileLockBase64 = pkg.files.gemfileLock.contents;
-        const gemfileLockContents = Buffer.from(
-          gemfileLockBase64,
-          'base64',
-        ).toString();
-        pkg.dependencies = gemfileLockToDependencies(gemfileLockContents);
-      }
-
       let policyLocations: string[] = [options['policy-path'] || root];
       if (options.docker) {
         policyLocations = policyLocations.filter((loc) => {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -32,7 +32,6 @@ const after = tap.runOnly ? only : test;
 // Should be after `process.env` setup.
 import * as plugins from '../../src/lib/plugins';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
-import { fail } from 'assert';
 
 function loadJson(filename: string) {
   return JSON.parse(fs.readFileSync(filename, 'utf-8'));
@@ -281,8 +280,9 @@ test('`test ruby-app` meta when no vulns', async (t) => {
   t.match(meta[0], /Organization:\s+test-org/, 'organization displayed');
   t.match(meta[1], /Package manager:\s+rubygems/, 'package manager displayed');
   t.match(meta[2], /Target file:\s+Gemfile/, 'target file displayed');
-  t.match(meta[3], /Open source:\s+no/, 'open source displayed');
-  t.match(meta[4], /Project path:\s+ruby-app/, 'path displayed');
+  t.match(meta[3], /Project name:\s+ruby-app/, 'project name displayed');
+  t.match(meta[4], /Open source:\s+no/, 'open source displayed');
+  t.match(meta[5], /Project path:\s+ruby-app/, 'path displayed');
   t.notMatch(
     meta[5],
     /Local Snyk policy:\s+found/,
@@ -317,8 +317,13 @@ test('`test ruby-app-thresholds`', async (t) => {
       'package manager displayed',
     );
     t.match(meta[2], /Target file:\s+Gemfile/, 'target file displayed');
-    t.match(meta[3], /Open source:\s+no/, 'open source displayed');
-    t.match(meta[4], /Project path:\s+ruby-app-thresholds/, 'path displayed');
+    t.match(
+      meta[3],
+      /Project name:\s+ruby-app-thresholds/,
+      'project name displayed',
+    );
+    t.match(meta[4], /Open source:\s+no/, 'open source displayed');
+    t.match(meta[5], /Project path:\s+ruby-app-thresholds/, 'path displayed');
     t.notMatch(
       meta[5],
       /Local Snyk policy:\s+found/,
@@ -3295,11 +3300,7 @@ test('`monitor ruby-app`', async (t) => {
   );
   t.match(req.url, '/monitor/rubygems', 'puts at correct url');
   t.notOk(req.body.targetFile, 'doesnt send the targetFile');
-  t.match(
-    decode64(req.body.package.files.gemfileLock.contents),
-    'remote: http://rubygems.org/',
-    'attaches Gemfile.lock',
-  );
+  t.ok(req.body.package.dependencies, 'dependencies sent instead of files');
 });
 
 test('`monitor maven-app`', async (t) => {

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -4311,7 +4311,7 @@ function chdirWorkspaces(subdir: string = '') {
 }
 
 function decode64(str) {
-  return new Buffer(str, 'base64').toString('utf8');
+  return Buffer.from(str, 'base64').toString('utf8');
 }
 
 // fixture can be fixture path or object


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Return a dependency tree instead of files from the ruby handler (dropping legacy code)
- Always return an array of results in preparation of allowing scanning multiple of the same project type in one go.