### PR TITLE
fix: single section in the output for pins and upgrades

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -253,12 +253,13 @@ function constructPinText(
     return [];
   }
 
-  // First, direct upgrades
   const upgradeTextArray: string[] = [];
+  upgradeTextArray.push(chalk.bold.green('\nIssues to fix by upgrading dependencies:'));
+
+  // First, direct upgrades
 
   const upgradeables = Object.keys(pins).filter((name) => !pins[name].isTransitive);
   if (upgradeables.length) {
-    upgradeTextArray.push(chalk.bold.green('\nIssues to fix by upgrading existing dependencies:'));
     processUpgrades(upgradeTextArray, pins, upgradeables, basicVulnInfo, testOptions);
   }
 
@@ -266,8 +267,6 @@ function constructPinText(
   const pinables = Object.keys(pins).filter((name) => pins[name].isTransitive);
 
   if (pinables.length) {
-    upgradeTextArray.push(chalk.bold.green('\nIssues to fix by pinning sub-dependencies:'));
-
     for (const pkgName of pinables) {
       const data = pins[pkgName];
       const vulnIds = data.issues;

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -4,13 +4,11 @@ Testing pip-app-transitive-vuln...
 Tested 6 dependencies for known vulnerabilities, found 4 vulnerabilities, 4 vulnerable paths.
 
 
-Issues to fix by upgrading existing dependencies:
+Issues to fix by upgrading dependencies:
 
   Upgrade flask to 1.0 to fix
   ✗ Improper Input Validation [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
   ✗ Denial of Service (DOS) [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
-
-Issues to fix by pinning sub-dependencies:
 
   Pin Jinja2 to 2.10.1 to fix
   ✗ Sandbox Escape [Medium Severity][http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Combines  "upgrades" and "pinning" sections in the new style output into a single "upgrades" section.
