### PR TITLE
fix: Do not show duplicate license issues

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -59,10 +59,10 @@ export function formatIssuesWithRemediation(
       paths: vuln.list.map((v) => v.from),
     };
 
-    basicVulnInfo[vuln.metadata.id] = vulnData;
-
     if (vulnData.type === 'license') {
       basicLicenseInfo[vuln.metadata.id] = vulnData;
+    } else {
+      basicVulnInfo[vuln.metadata.id] = vulnData;
     }
   }
 
@@ -320,6 +320,12 @@ function constructUnfixableText(unresolved: IssueData[], basicVulnInfo: Record<s
         issueInfo.paths,
         testOptions,
       ) + `${extraInfo}`);
+  }
+
+  if (unfixableIssuesTextArray.length === 1) {
+    // seems we still only have
+    // the initial section title, so nothing to return
+    return [];
   }
 
   return unfixableIssuesTextArray;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Unresolved contains both vulns & licenses, so they go accidentally shown in both license and unresolved issues.

<img width="980" alt="Screen Shot 2019-09-24 at 10 32 04" src="https://user-images.githubusercontent.com/2911613/65500066-9531e500-deb6-11e9-9f27-dacf865590a8.png">

