### PR TITLE
fix: correctly document behavior of `--strict-out-of-sync` and avoid string typed booleans

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -89,11 +89,11 @@ Gradle options:
 
 Npm options:
   --strict-out-of-sync=<true|false>
-                       Allow testing out of sync lockfile. Defauls to false.
+                       Allow testing out of sync lockfile. Defauls to true.
 
 Yarn options:
   --strict-out-of-sync=<true|false>
-                       Allow testing out of sync lockfile. Defauls to false.
+                       Allow testing out of sync lockfile. Defauls to true.
 
 Python options:
   --command=<string>   Python interpreter to use. Default: "python", set to

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -171,6 +171,14 @@ export function args(rawArgv: string[]): Args {
     }
   }
 
+  if (argv.strictOutOfSync !== undefined) {
+    if (argv.strictOutOfSync === 'false') {
+      argv.strictOutOfSync = false;
+    } else {
+      argv.strictOutOfSync = true;
+    }
+  }
+
   // Alias
   if (argv.gradleSubProject) {
     argv.subProject = argv.gradleSubProject;

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -2,7 +2,6 @@ import * as baseDebug from 'debug';
 const debug = baseDebug('snyk');
 import * as path from 'path';
 import * as spinner from '../../spinner';
-import * as _ from 'lodash';
 import * as analytics from '../../analytics';
 import * as fs from 'fs';
 import * as lockFileParser from 'snyk-nodejs-lockfile-parser';
@@ -46,7 +45,7 @@ export async function parse(root: string, targetFile: string, options: Options):
   debug(resolveModuleSpinnerLabel);
   try {
     await spinner(resolveModuleSpinnerLabel);
-    const strictOutOfSync = _.get(options, 'strictOutOfSync') !== false;
+    const strictOutOfSync = options.strictOutOfSync !== false;
     return lockFileParser
       .buildDepTree(manifestFile, lockFile, options.dev, lockFileType, strictOutOfSync);
   } finally {

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -46,7 +46,7 @@ export async function parse(root: string, targetFile: string, options: Options):
   debug(resolveModuleSpinnerLabel);
   try {
     await spinner(resolveModuleSpinnerLabel);
-    const strictOutOfSync = _.get(options, 'strictOutOfSync') !== 'false';
+    const strictOutOfSync = _.get(options, 'strictOutOfSync') !== false;
     return lockFileParser
       .buildDepTree(manifestFile, lockFile, options.dev, lockFileType, strictOutOfSync);
   } finally {

--- a/src/lib/plugins/types.ts
+++ b/src/lib/plugins/types.ts
@@ -12,7 +12,7 @@ export interface Options {
   docker?: boolean;
   traverseNodeModules?: boolean;
   dev?: boolean;
-  strictOutOfSync?: boolean | 'true' | 'false';
+  strictOutOfSync?: boolean;
   allSubProjects?: boolean;
   debug?: boolean;
   packageManager?: string;

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -1063,7 +1063,7 @@ test('`test yarn-out-of-sync` out of sync fails', async (t) => {
 
 test('`test yarn-out-of-sync --strict-out-of-sync=false` passes', async (t) => {
   chdirWorkspaces();
-  await cli.test('yarn-out-of-sync', { dev: true, strictOutOfSync: 'false'});
+  await cli.test('yarn-out-of-sync', { dev: true, strictOutOfSync: false});
   const req = server.popRequest();
   t.match(req.url, '/test-dep-graph', 'posts to correct url');
   const depGraph = req.body.depGraph;
@@ -1103,7 +1103,7 @@ test('`test yarn-out-of-sync --strict-out-of-sync=false` passes', async (t) => {
 
 test('`test npm-out-of-sync --strict-out-of-sync=false` passes', async (t) => {
   chdirWorkspaces();
-  await cli.test('npm-out-of-sync', { dev: true, strictOutOfSync: 'false' });
+  await cli.test('npm-out-of-sync', { dev: true, strictOutOfSync: false });
   const req = server.popRequest();
   t.match(req.url, '/test-dep-graph', 'posts to correct url');
   const depGraph = req.body.depGraph;
@@ -2481,7 +2481,7 @@ test('`monitor npm-package`', async (t) => {
 
 test('`monitor npm-out-of-sync`', async (t) => {
   chdirWorkspaces();
-  await cli.monitor('npm-out-of-sync-graph', { 'experimental-dep-graph': true, strictOutOfSync: 'false' });
+  await cli.monitor('npm-out-of-sync-graph', { 'experimental-dep-graph': true, strictOutOfSync: false });
   const req = server.popRequest();
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
   t.ok(req.body.depGraphJSON, 'sends depGraphJSON');

--- a/test/args.test.js
+++ b/test/args.test.js
@@ -78,3 +78,39 @@ test('test command line test --gradle-sub-project=foo', function(t) {
   t.equal(result.options.subProject, 'foo');
   t.end();
 });
+
+test('test command line test --strict-out-of-sync', function(t) {
+  t.plan(1);
+  var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--strict-out-of-sync',
+  ];
+  var result = args(cliArgs);
+  t.equal(result.options.strictOutOfSync, true);
+  t.end();
+});
+
+test('test command line test --strict-out-of-sync=true', function(t) {
+  t.plan(1);
+  var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--strict-out-of-sync=true',
+  ];
+  var result = args(cliArgs);
+  t.equal(result.options.strictOutOfSync, true);
+  t.end();
+});
+
+test('test command line test --strict-out-of-sync=false', function(t) {
+  t.plan(1);
+  var cliArgs = [ '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--strict-out-of-sync=false',
+  ];
+  var result = args(cliArgs);
+  t.equal(result.options.strictOutOfSync, false);
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Changes the help text to document the default behavior of the `--strict-out-of-sync` flag and change the options type signature to eliminate the previously present string typed boolean option values `"true" | "false"`.

#### How should this be manually tested?

The current default behavior was manually verified by @darscan and me, by running `snyk test` on a project with a lockfile (npm and yarn). Also I verified that the behavior is still the same.

#### Any background context you want to provide?

This will make it easier to get the CocoaPods plugin working. This failed because it had a stricter options definition, not including string typed booleans:

```
src/lib/plugins/index.ts:59:7 - error TS2322: Type 'typeof import("/Users/shaun/dev/work/snyk/repos/snyk/node_modules/@snyk/snyk-cocoapods-plugin/dist/index")' is not assignable to type 'Plugin'.
  Types of property 'inspect' are incompatible.
    Type '(root: string, targetFile?: string | undefined, options?: CocoaPodsInspectOptions | undefined) => Promise<SinglePackageResult>' is not assignable to type '(root: string, targetFile: string, options?: Options | undefined) => Promise<InspectResult>'.
      Types of parameters 'options' and 'options' are incompatible.
        Type 'Options | undefined' is not assignable to type 'CocoaPodsInspectOptions | undefined'.
          Type 'Options' is not assignable to type 'CocoaPodsInspectOptions'.
            Types of property 'strictOutOfSync' are incompatible.
              Type 'boolean | "true" | "false" | undefined' is not assignable to type 'boolean | undefined'.
                Type '"true"' is not assignable to type 'boolean | undefined'.

59       return cocoapodsPlugin;
```