### PR TITLE
feat: add CocoaPods support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
+    "@snyk/cli-interface": "^2.0.3",
     "@snyk/dep-graph": "1.12.0",
     "@snyk/gemfile": "1.2.0",
     "@types/agent-base": "^4.2.0",
@@ -69,6 +70,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
+    "@snyk/snyk-cocoapods-plugin": "1.0.2",
     "snyk-docker-plugin": "1.29.1",
     "snyk-go-plugin": "1.11.0",
     "snyk-gradle-plugin": "^3.0.2",

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -53,6 +53,10 @@ const DETECTABLE_PACKAGE_MANAGERS: {
   'project.json': 'nuget',
   'paket.dependencies': 'paket',
   'composer.lock': 'composer',
+  'Podfile.lock': 'cocoapods',
+  'CocoaPods.podfile.yaml': 'cocoapods',
+  'CocoaPods.podfile': 'cocoapods',
+  'Podfile': 'cocoapods',
 };
 
 export function isPathToPackageFile(path) {

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -1,6 +1,6 @@
 export type SupportedPackageManagers = 'rubygems' | 'npm' | 'yarn' |
 'maven' | 'pip' | 'sbt' | 'gradle' | 'golangdep' | 'govendor' | 'gomodules' |
-'nuget' | 'paket' | 'composer';
+'nuget' | 'paket' | 'composer' | 'cocoapods';
 
 export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   readonly [packageManager in SupportedPackageManagers]: string;
@@ -18,6 +18,7 @@ export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   nuget: 'NuGet',
   paket: 'Paket',
   composer: 'Composer',
+  cocoapods: 'CocoaPods',
 };
 
 export const WIZARD_SUPPORTED_PACKAGE_MANAGERS: SupportedPackageManagers[]

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -8,6 +8,7 @@ import * as goPlugin from 'snyk-go-plugin';
 import * as nugetPlugin from 'snyk-nuget-plugin';
 import * as phpPlugin from 'snyk-php-plugin';
 import * as nodejsPlugin from './nodejs-plugin';
+import * as cocoapodsPlugin from '@snyk/snyk-cocoapods-plugin';
 import * as types from './types';
 import {SupportedPackageManagers} from '../package-managers';
 import { UnsupportedPackageManagerError } from '../errors';
@@ -53,6 +54,9 @@ export function loadPlugin(packageManager: SupportedPackageManagers,
     }
     case 'composer': {
       return phpPlugin;
+    }
+    case 'cocoapods': {
+      return cocoapodsPlugin;
     }
     default: {
       throw new UnsupportedPackageManagerError(packageManager);

--- a/test/acceptance/workspaces/cocoapods-app/Podfile
+++ b/test/acceptance/workspaces/cocoapods-app/Podfile
@@ -1,0 +1,4 @@
+target 'SampleApp' do
+  platform :ios, '6.0'
+  pod 'Reachability', '3.1.0'
+end

--- a/test/acceptance/workspaces/cocoapods-app/Podfile.lock
+++ b/test/acceptance/workspaces/cocoapods-app/Podfile.lock
@@ -1,0 +1,14 @@
+PODS:
+  - Reachability (3.1.0)
+
+DEPENDENCIES:
+  - Reachability (= 3.1.0)
+
+SPEC REPOS:
+  trunk:
+    - Reachability
+
+SPEC CHECKSUMS:
+  Reachability: 3c8fe9643e52184d17f207e781cd84158da8c02b
+
+PODFILE CHECKSUM: eef52b2296b88c87f94cf0f232f010176b9f11cd


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR integrates the [CocoaPods plugin](https://github.com/snyk/snyk-cocoapods-plugin) to the Snyk CLI:
* adding CocoaPods and its artifacts as supported dependency managers in respective enums
* testing the integration via the acceptance tests
* ~~adding a help text to document the `--strict-out-of-sync` option~~ (postponed to regular release, with auto-detect / without explicit opt-in)

#### How should this be manually tested?

The CocoaPods plugin repo includes some tests, which have fixtures with `Podfile` and `Podfile.lock`. These can be used for `snyk test` or `snyk monitor`
