### PR TITLE
BST-884 Change color of remediation package name from cyan to default…

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -332,7 +332,7 @@ function constructUnfixableText(unresolved: IssueData[], basicVulnInfo: Record<s
 }
 
 function printPath(path: string[]) {
-  return path.slice(1).map((name, i) => chalk.cyan(name)).join(' > ');
+  return path.slice(1).join(' > ');
 }
 
 function formatIssue(


### PR DESCRIPTION
… (grey)

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Changes remediation package color from cyan to default (grey)

#### Where should the reviewer start?
remediation-based-format-issues.ts

#### How should this be manually tested?
n/a

#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/BST-884

#### Screenshots
before:
![Screenshot 2019-09-30 at 16 52 56](https://user-images.githubusercontent.com/6598617/65895128-d76d9180-e3a2-11e9-80eb-c8e5250a6917.png)

after:
![Screenshot 2019-09-30 at 16 34 00](https://user-images.githubusercontent.com/6598617/65894946-8b225180-e3a2-11e9-86c8-2fbc4ab65e21.png)


#### Additional questions
