### PR TITLE
fix: Improve parsing for marker expressions for python projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "snyk-nuget-plugin": "1.12.1",
     "snyk-php-plugin": "1.6.4",
     "snyk-policy": "1.13.5",
-    "snyk-python-plugin": "^1.13.2",
+    "snyk-python-plugin": "^1.13.3",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.8.0",


### PR DESCRIPTION
Support 'or' operators in marker expressions when parsing `requirements.txt` files.