### PR TITLE
fix: include package version in vulns lookup

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -146,7 +146,8 @@ async function runTest(
 
       if (res.docker && dockerfilePackages) {
         res.vulnerabilities = res.vulnerabilities.map((vuln) => {
-          const dockerfilePackage = dockerfilePackages[vuln.name.split('/')[0]];
+          const pkg = vuln.name.split('/')[0] + '-' + vuln.version;
+          const dockerfilePackage = dockerfilePackages[pkg];
           if (dockerfilePackage) {
             (vuln as DockerIssue).dockerfileInstruction =
               dockerfilePackage.instruction;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fix the lookup for the associated Dockerfile instruction that introduced a package.
The lookup key should include both the package name and version and not just the package name.

#### How should this be manually tested?

Perform a test on an image which is a product of a Dockerfile such as:
```
FROM python:3.7-alpine3.8
RUN apk add --no-cache --update git=2.18.1-r0
```
Expect the **git** vulnerability to be introduced by instruction in the Dockerfile and not by the base image.

#### Screenshots

![image](https://user-images.githubusercontent.com/45512489/66128795-46432880-e5f7-11e9-8207-91e0573f7303.png)

Before this fix, the **git** vulnerability was wrongly identified as Introduced by the base image