### PR TITLE
feat: Multi licenses formatting

### DIFF
--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -9,7 +9,9 @@ import {
   GroupedVuln,
   AnnotatedIssue,
   DockerIssue,
+  LegalInstruction,
 } from '../../../../lib/snyk-test/legacy';
+import { formatLegalInstructions } from './legal-license-instructions';
 
 export function formatIssues(
   vuln: GroupedVuln,
@@ -50,11 +52,10 @@ export function formatIssues(
         : '',
     fixedIn: options.docker ? createFixedInText(vuln) : '',
     dockerfilePackage: options.docker ? dockerfileInstructionText(vuln) : '',
-    legalInstructions: vuln.legalInstructions
-      ? '\n  Legal instructions:\n  ' +
-        wrap(vuln.legalInstructions, 100)
-          .split('\n')
-          .join('\n  ')
+    legalInstructions: vuln.legalInstructionsArray
+      ? chalk.bold('\n  Legal instructions:\n') +
+        ' '.repeat(2) +
+        formatLegalInstructions(vuln.legalInstructionsArray, 2)
       : '',
   };
 

--- a/src/cli/commands/test/formatters/legal-license-instructions.ts
+++ b/src/cli/commands/test/formatters/legal-license-instructions.ts
@@ -1,0 +1,18 @@
+import { LegalInstruction } from '../../../../lib/snyk-test/legacy';
+import * as wrap from 'wrap-ansi';
+import chalk from 'chalk';
+
+export function formatLegalInstructions(
+  legalInstructions: LegalInstruction[],
+  paddingLength = 4,
+): string {
+  const legalContent: string[] = legalInstructions.map((legalData) =>
+    wrap(
+      chalk.bold(`○ for ${legalData.licenseName}: `) + legalData.legalContent,
+      100,
+    )
+      .split('\n')
+      .join('\n' + ' '.repeat(paddingLength)),
+  );
+  return legalContent.join('\n' + ' '.repeat(paddingLength));
+}

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -586,7 +586,7 @@ function groupVulnerabilities(vulns): GroupedVuln[] {
       map[curr.id].dockerfileInstruction = curr.dockerfileInstruction;
       map[curr.id].dockerBaseImage = curr.dockerBaseImage;
       map[curr.id].nearestFixedInVersion = curr.nearestFixedInVersion;
-      map[curr.id].legalInstructions = curr.legalInstructions;
+      map[curr.id].legalInstructionsArray = curr.legalInstructionsArray;
     }
 
     map[curr.id].list.push(curr);

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -47,9 +47,13 @@ export interface GroupedVuln {
   version: string;
   isFixable: boolean;
   fixedIn: string[];
-  legalInstructions?: string;
+  legalInstructionsArray?: LegalInstruction[];
 }
 
+export interface LegalInstruction {
+  licenseName: string;
+  legalContent: string;
+}
 export interface IssueData {
   id: string;
   packageName: string;

--- a/test/acceptance/display-test-results.test.ts
+++ b/test/acceptance/display-test-results.test.ts
@@ -60,7 +60,7 @@ test('`test ruby-app` legal instructions displayed', async (t) => {
     await snykTest('ruby-app');
   } catch (error) {
     const res = error.message;
-    t.match(res, 'Legal instructions');
+    t.match(res, 'I am legal license instruction');
   }
 
   snykTestStub.restore();
@@ -81,7 +81,7 @@ test('`test pip-app-license-issue` legal instructions displayed (legacy formatte
     await snykTest('pip-app-license-issue');
   } catch (error) {
     const res = error.message;
-    t.match(res, 'Legal instructions');
+    t.match(res, 'I am legal license instruction');
   }
 
   snykTestStub.restore();

--- a/test/acceptance/workspaces/pip-app-license-issue/test-pip-stub-with-legal-instructions.json
+++ b/test/acceptance/workspaces/pip-app-license-issue/test-pip-stub-with-legal-instructions.json
@@ -9,7 +9,10 @@
       },
       "id": "snyk:lic:pip:chardet:LGPL-3.0",
       "type": "license",
-      "legalInstructions": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "legalInstructionsArray": [{
+        "licenseName": "LGPL-3.0 license",
+        "legalContent": "I am legal license instruction"
+      }],
       "packageManager": "pip",
       "language": "python",
       "packageName": "chardet",

--- a/test/acceptance/workspaces/ruby-app/test-graph-response-with-legal-instruction.json
+++ b/test/acceptance/workspaces/ruby-app/test-graph-response-with-legal-instruction.json
@@ -306,7 +306,10 @@
       },
       "id": "snyk:lic:rubygems:rack-cache:Unknown",
       "type": "license",
-      "legalInstructions": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+      "legalInstructionsArray": [{
+        "licenseName": "LGPL-3.0 license",
+        "legalContent": "I am legal license instruction"
+      }],
       "packageManager": "rubygems",
       "language": "ruby",
       "packageName": "rack-cache",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Add formatting for licenses new data shape and add some extra styles for multi licenses

#### Screenshots
##### Remediation based format
<img width="718" alt="Screen Shot 2019-10-03 at 14 32 15" src="https://user-images.githubusercontent.com/2911613/66131183-ddee4a00-e5ea-11e9-8413-ea09b9c021ca.png">

##### Non-remediation format
<img width="712" alt="Screen Shot 2019-10-03 at 14 31 07" src="https://user-images.githubusercontent.com/2911613/66131292-12620600-e5eb-11e9-84c2-c82ba867a1e5.png">

##### Older version of CLI (backwards compatibility)
####### remediation based
<img width="713" alt="Screen Shot 2019-10-03 at 14 32 45" src="https://user-images.githubusercontent.com/2911613/66131251-fe1e0900-e5ea-11e9-8da9-ade014eca28c.png">
####### non-remediation
<img width="716" alt="Screen Shot 2019-10-03 at 14 38 41" src="https://user-images.githubusercontent.com/2911613/66131596-987e4c80-e5eb-11e9-8b97-c3aff538820e.png">


Relies on https://github.com/snyk/registry/pull/9720/files
