### PR TITLE
fix: bump snyk-go-plugin to v1.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
     "snyk-docker-plugin": "1.29.1",
-    "snyk-go-plugin": "1.11.0",
+    "snyk-go-plugin": "1.11.1",
     "snyk-gradle-plugin": "3.1.0",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.4.0",


### PR DESCRIPTION
New version of snyk-go-plugin improves go modules error messaging

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Bump snyk-go-plugin version

#### Any background context you want to provide?
New version improves go modules error messaging

#### What are the relevant tickets?
BST-883
https://github.com/snyk/snyk-go-plugin/pull/53