### PR TITLE
Support setup.py in the python docker images

### DIFF
--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -2,5 +2,9 @@
 
 virtualenv -p python snyk
 source snyk/bin/activate
-pip install -U -r "${PROJECT_PATH}/requirements.txt"
+if [ -f "${PROJECT_PATH}/requirements.txt" ]; then
+    pip install -U -r "${PROJECT_PATH}/requirements.txt"
+elif [ -f "${PROJECT_PATH}/setup.py" ]; then
+    pip install -U "${PROJECT_PATH}"
+fi
 bash docker-entrypoint.sh "$@"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Setup.py support was added in the python plugin but the image doesn't install the dependencies

#### How should this be manually tested?
```
docker run -v "/path/to/project:/project" -e "SNYK_TOKEN=..." test-image:latest test --file=setup.py --package-manager=pip
```