### PR TITLE
test: skip test that uses previous bad version

### DIFF
--- a/test/protect-patch-filter.test.js
+++ b/test/protect-patch-filter.test.js
@@ -1,12 +1,12 @@
 var debug = require('debug')('snyk');
 var policy = require('snyk-policy');
 var path = require('path');
-var test = require('tape');
+var test = require('tap');
 var vulns = require('./fixtures/semver-vuln.json');
 var exec = require('child_process').exec;
 
 // skipped intentially - only used for debugging tests
-test(
+test.skip(
   'patch is correctly skipped during tests',
   { timeout: 1000 * 60 * 3 },
   function(t) {


### PR DESCRIPTION
#### What does this PR do?

- Skips a `test` that is invalid (as it uses the previously released version)
- Needed to unblock release