### PR TITLE
fix: leave proxy-agent as bundled only to fix yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,6 @@
     "needle": "^2.2.4",
     "opn": "^5.5.0",
     "os-name": "^3.0.0",
-    "proxy-agent": "file:proxy-agent-3.1.0.tgz",
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix yarn installation of snyk cli with bundled deps

#### What are the relevant tickets?
https://github.com/snyk/snyk/issues/796