### PR TITLE
add a deprecation warning for users using node v6

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -159,6 +159,17 @@ async function main() {
     exitCode = response.exitCode;
   }
 
+  if (runtime.isUsingNode6(process.versions.node)) {
+    alerts.registerAlerts([
+      {
+        msg:
+          'Node.js v6 is past the End-of-Life phase, please upgrade your version. We will soon be dropping support for it.',
+        name: 'Node6EOLWarning',
+        type: 'info',
+      },
+    ]);
+  }
+
   if (!args.options.json) {
     console.log(alerts.displayAlerts());
   }

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,4 +1,4 @@
-import { gte } from 'semver';
+import { gte, satisfies } from 'semver';
 
 const MIN_RUNTIME = '6.5.0';
 
@@ -6,4 +6,8 @@ export const supportedRange = `>= ${MIN_RUNTIME}`;
 
 export function isSupported(runtimeVersion) {
   return gte(runtimeVersion, MIN_RUNTIME);
+}
+
+export function isUsingNode6(runtimeVersion) {
+  return satisfies(runtimeVersion, '6.x');
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- Adds an EOL warning at the end of the CLI output for users that are still using Node v6. 

#### Where should the reviewer start?
[src/cli/index.ts:162](https://github.com/YashdalfTheGray/snyk/blob/master/src/cli/index.ts#L162)

#### How should this be manually tested?

##### Positive
- Either spin up a Docker container or use `nvm` to switch to Node.js v6
- Run any `snyk` command
- **Expected** - should see an EOL warning

##### Negative
- Either spin up a Docker container or use `nvm` to switch to a supported version of Node >=v7
- Run any `snyk` command
- **Expected** - should not see an EOL warning

#### Any background context you want to provide?
I saw that there was a `runtime` module and an alert system built already. So I simply append a new alert for Node.js v6 using the new [`runtime.isUsingNode6()`](https://github.com/YashdalfTheGray/snyk/blob/master/src/cli/runtime.ts#L11) function. 

#### What are the relevant tickets?
#787 

#### Screenshots

##### Node 6

<img width="768" alt="node6" src="https://user-images.githubusercontent.com/3102848/66512140-327f4280-ea8d-11e9-84fc-2a8ecda19192.png">

##### Node 8

<img width="768" alt="node8" src="https://user-images.githubusercontent.com/3102848/66512156-39a65080-ea8d-11e9-87f4-fba624efe419.png">


#### Additional questions
