### PR TITLE
chore: update help text for --prune flag

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -56,7 +56,7 @@ Options:
   --print-deps ....... (test and monitor commands only)
                        Print the dependency tree before sending it for analysis.
   --prune-repeated-subdependencies
-                       (test and monitor command only)
+                       (test command only)
                        Prune dependency trees, removing duplicate sub-dependencies.
                        Will still find all vulnerabilities, but potentially not all
                        of the vulnerable paths.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
We do not currently support `--prune-repeated-subdependencies` for snyk monitor apart from for npm and sbt with additional FF 