### PR TITLE
fix: add analytics for new issues format

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -23,6 +23,7 @@ import {
   formatIssuesWithRemediation,
   getSeverityValue,
 } from './formatters/remediation-based-format-issues';
+import * as analytics from '../../../lib/analytics';
 
 const debug = Debug('snyk');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -377,12 +378,14 @@ function displayResult(res, options: Options & TestOptions) {
 
   let groupedVulnInfoOutput;
   if (res.remediation) {
+    analytics.add('actionableRemediation', true);
     groupedVulnInfoOutput = formatIssuesWithRemediation(
       filteredSortedGroupedVulns,
       res.remediation,
       options,
     );
   } else {
+    analytics.add('actionableRemediation', false);
     groupedVulnInfoOutput = filteredSortedGroupedVulns.map((vuln) =>
       formatIssues(vuln, options),
     );


### PR DESCRIPTION
For smooth rollout of new issues format with actionable remmediation,
it's useful to monitor how it is used and verify potential edgecases.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds an analytics property to recored which format of remediation was used.

#### How should this be manually tested?
Running `snyk test -d` and check analytics output.

#### Any background context you want to provide?
It's very hard to test this automatically because of the current test suite. In order to speed up the release, I've decided to be happy with the manual verification.

#### Screenshots
<img width="671" alt="image" src="https://user-images.githubusercontent.com/5753758/66578702-dba46680-eb7b-11e9-9321-1ebefa09e8af.png">

