### PR TITLE
fix: safely check for vuln info

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -189,8 +189,10 @@ function constructPatchesText(
     return [];
   }
   const patchedTextArray = [chalk.bold.green('\nPatchable issues:')];
-
   for (const id of Object.keys(patches)) {
+    if (!basicVulnInfo[id]) {
+      continue;
+    }
     if (basicVulnInfo[id].type === 'license') {
       continue;
     }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Vulns and remediation get filtered by severity in totally different ways and in different places, we can't expect all vuln data to always be present so check for safety first just like we already do in upgrades.

https://snyk.slack.com/archives/CGHELPDHN/p1571407777053500


To test run `snyk test --severity-threshold=high` in the snyk/goof repo.