### PR TITLE
fix: throw error when cli runs with multiple paths or sln and project-name option

### DIFF
--- a/src/lib/errors/unsupported-option-combination-error.ts
+++ b/src/lib/errors/unsupported-option-combination-error.ts
@@ -1,0 +1,15 @@
+import { CustomError } from './custom-error';
+
+export class UnsupportedOptionCombinationError extends CustomError {
+  private static ERROR_MESSAGE =
+    'The following option combination is not currently supported: ';
+
+  constructor(options: string[]) {
+    super(
+      UnsupportedOptionCombinationError.ERROR_MESSAGE + JSON.stringify(options),
+    );
+    this.code = 422;
+    this.userMessage =
+      UnsupportedOptionCombinationError.ERROR_MESSAGE + JSON.stringify(options);
+  }
+}

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -34,3 +34,39 @@ test('snyk test command should fail when --packageManager is not specified corre
     );
   });
 });
+
+test('`test multiple paths with --project-name=NAME`', (t) => {
+  t.plan(1);
+
+  exec(
+    `node ${main} test pathA pathB --project-name=NAME`,
+    (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      }
+      t.equals(
+        stdout.trim(),
+        'The following option combination is not currently supported: ["multiple paths","project-name"]',
+        'correct error output',
+      );
+    },
+  );
+});
+
+test('`test --file=file.sln --project-name=NAME`', (t) => {
+  t.plan(1);
+
+  exec(
+    `node ${main} test --file=file.sln --project-name=NAME`,
+    (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      }
+      t.equals(
+        stdout.trim(),
+        'The following option combination is not currently supported: ["file=*.sln","project-name"]',
+        'correct error output',
+      );
+    },
+  );
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
throw error when cli runs with multiple paths or sln and project-name option

#### How should this be manually tested?
run `snyk-local test path1 path2 --project-name="blah"`

#### What are the relevant tickets?
https://snyk.zendesk.com/agent/tickets/2401