### PR TITLE
fix: avoid stack overflow with spread operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "2.2.0",
-    "@snyk/dep-graph": "1.12.0",
+    "@snyk/dep-graph": "1.13.1",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "1.0.3",
     "@types/agent-base": "^4.2.0",


### PR DESCRIPTION
#### What does this PR do?
Bumping `@snyk/dep-graph` to version `1.13.1`. This change should fix this issue - https://github.com/snyk/dep-graph/commit/0bd6afbfdec6131ea7ca55357930b1edec736d2a