### PR TITLE
fix: don't fail when there are no deps in csproj

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.4.0",
     "snyk-nodejs-lockfile-parser": "1.16.0",
-    "snyk-nuget-plugin": "1.13.0",
+    "snyk-nuget-plugin": "1.13.1",
     "snyk-php-plugin": "1.6.4",
     "snyk-policy": "1.13.5",
     "snyk-python-plugin": "^1.13.3",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bump `snyk-nuget-plugin` to enable the fix of https://github.com/snyk/snyk-nuget-plugin/pull/66