### PR TITLE
fix: strip ansi chars when using --json

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -17,6 +17,7 @@ import { isPathToPackageFile } from '../lib/detect';
 import { updateCheck } from '../lib/updater';
 import { MissingTargetFileError, FileFlagBadInputError } from '../lib/errors';
 import { UnsupportedOptionCombinationError } from '../lib/errors/unsupported-option-combination-error';
+import stripAnsi from 'strip-ansi';
 
 const debug = Debug('snyk');
 const EXIT_CODES = {
@@ -59,7 +60,7 @@ async function handleError(args, error) {
     const output = vulnsFound ? error.message : error.stack;
     console.log(output);
   } else if (args.options.json) {
-    console.log(error.json || error.stack);
+    console.log(stripAnsi(error.json || error.stack));
   } else {
     if (!args.options.quiet) {
       const result = errors.message(error);


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Generate valid json when `--json` flag is passed, introducing a better spinner created a regression where ansi escape codes were not stripped

*Before*:

`snyk test --json --severity-threshold=high --org=banana 2>error | more`

```
ESC[2KESC[1GESC[2KESC[1GESC[2KESC[1G{
  "vulnerabilities": [],
  "ok": true,
  "dependencyCount": 351,
  "org": "banana",
  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.5\nignore: {}\npatch: {}\nsuggest: {}\n",
  "isPrivate": true,
  "licensesPolicy": {
    "severities": {},
    "orgLicenseRules": {}
  },
  "packageManager": "npm",
  "ignoreSettings": null,
  "summary": "No high severity vulnerabilities",
  "severityThreshold": "high",
  "filesystemPolicy": true,
  "uniqueCount": 0,
  "path": "/Users/lili/www/snyk/snyk"
}
```


*After*:
```
{
  "vulnerabilities": [],
  "ok": true,
  "dependencyCount": 351,
  "org": "banana",
  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.5\nignore: {}\npatch: {}\nsuggest: {}\n",
  "isPrivate": true,
  "licensesPolicy": {
    "severities": {},
    "orgLicenseRules": {}
  },
  "packageManager": "npm",
  "ignoreSettings": null,
  "summary": "No high severity vulnerabilities",
  "severityThreshold": "high",
  "filesystemPolicy": true,
  "uniqueCount": 0,
  "path": "/Users/lili/www/snyk/snyk"
}
```