### PR TITLE
fix: do not clear spinner, stop instead to avoid ansi escape chars

### DIFF
--- a/src/cli/commands/monitor.ts
+++ b/src/cli/commands/monitor.ts
@@ -9,7 +9,7 @@ import * as config from '../../lib/config';
 import * as url from 'url';
 import chalk from 'chalk';
 import * as pathUtil from 'path';
-import * as spinner from '../../lib/spinner';
+import { Spinner } from 'cli-spinner';
 
 import * as detect from '../../lib/detect';
 import * as plugins from '../../lib/plugins';
@@ -39,12 +39,9 @@ interface BadResult {
 
 // This is used instead of `let x; try { x = await ... } catch { cleanup }` to avoid
 // declaring the type of x as possibly undefined.
-async function promiseOrCleanup<T>(
-  p: Promise<T>,
-  cleanup: (x?) => void,
-): Promise<T> {
+async function promiseOrCleanup<T>(p: Promise<T>, spinner): Promise<T> {
   return p.catch((error) => {
-    cleanup();
+    spinner.stop(true);
     throw error;
   });
 }
@@ -125,28 +122,26 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
       const analyzingDepsSpinnerLabel =
         'Analyzing ' + analysisType + ' dependencies for ' + displayPath;
-
-      const postingMonitorSpinnerLabel =
-        'Posting monitor snapshot for ' + displayPath + ' ...';
-
-      await spinner(analyzingDepsSpinnerLabel);
+      const spinner = new Spinner(analyzingDepsSpinnerLabel);
+      spinner.setSpinnerString('|/-\\');
+      spinner.start();
 
       // Scan the project dependencies via a plugin
-
       analytics.add('packageManager', packageManager);
       analytics.add('pluginOptions', options);
 
       // TODO: the type should depend on allSubProjects flag
       const inspectResult: pluginApi.InspectResult = await promiseOrCleanup(
         moduleInfo.inspect(path, targetFile, { ...options }),
-        spinner.clear(analyzingDepsSpinnerLabel),
+        spinner,
       );
 
       analytics.add('pluginName', inspectResult.plugin.name);
 
-      await spinner.clear(analyzingDepsSpinnerLabel)(inspectResult);
+      const postingMonitorSpinnerLabel =
+        'Posting monitor snapshot for ' + displayPath + ' ...';
 
-      await spinner(postingMonitorSpinnerLabel);
+      spinner.setSpinnerTitle(postingMonitorSpinnerLabel);
       if (inspectResult.plugin.packageManager) {
         packageManager = inspectResult.plugin.packageManager;
       }
@@ -194,10 +189,10 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
         const res = await promiseOrCleanup(
           snykMonitor(path, meta, projectDeps, targetFile),
-          spinner.clear(postingMonitorSpinnerLabel),
+          spinner,
         );
 
-        await spinner.clear(postingMonitorSpinnerLabel)(res);
+        spinner.stop(true);
 
         res.path = path;
         const endpoint = url.parse(config.API);

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -254,6 +254,9 @@ function displayResult(res, options: Options & TestOptions) {
   const packageManager = options.packageManager;
   const localPackageTest = isLocalFolder(options.path);
   const prefix = chalk.bold.white('\nTesting ' + options.path + '...\n\n');
+  // clear any previous output
+  const CLEAR = process.stdout.isTTY ? '\u001b[2K' : '\u000d \u000d';
+  process.stdout.write(CLEAR);
 
   // handle errors by extracting their message
   if (res instanceof Error) {

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -69,6 +69,6 @@ export async function parse(
       strictOutOfSync,
     );
   } finally {
-    spinner.stop(true);
+    spinner.stop();
   }
 }

--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -35,8 +35,9 @@ export async function parse(
     path.dirname(path.resolve(root, targetFile));
   const spinner = new Spinner(resolveModuleSpinnerLabel);
   spinner.setSpinnerString('|/-\\');
+  spinner.start();
+
   try {
-    spinner.start();
     if (targetFile.endsWith('yarn.lock')) {
       options.file =
         options.file && options.file.replace('yarn.lock', 'package.json');
@@ -53,6 +54,6 @@ export async function parse(
       Object.assign({}, options, { noFromArrays: true }),
     );
   } finally {
-    await spinner.stop(true);
+    spinner.stop();
   }
 }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -74,6 +74,7 @@ async function runTest(
   const results: LegacyVulnApiResult[] = [];
   const spinner = new Spinner('Querying vulnerabilities database...');
   spinner.setSpinnerString('|/-\\');
+  spinner.start();
 
   try {
     const payloads = await assemblePayloads(root, options);
@@ -89,7 +90,6 @@ async function runTest(
       ) {
         dockerfilePackages = payload.body.docker.dockerfilePackages;
       }
-      spinner.start();
       analytics.add('depGraph', !!depGraph);
       analytics.add('isDocker', !!(payload.body && payload.body.docker));
       // Type assertion might be a lie, but we are correcting that below
@@ -186,7 +186,7 @@ async function runTest(
       error.code,
     );
   } finally {
-    spinner.stop(true);
+    spinner.stop();
   }
 }
 
@@ -318,18 +318,17 @@ async function assembleLocalPayloads(
       pathUtil.relative('..', '.'));
   const spinner = new Spinner(spinnerLbl);
   spinner.setSpinnerString('|/-\\');
+  spinner.start();
 
   try {
     const payloads: Payload[] = [];
-
-    spinner.start();
     const deps = await getDepsFromPlugin(root, options);
     analytics.add('pluginName', deps.plugin.name);
 
     for (const scannedProject of deps.scannedProjects) {
       const pkg = scannedProject.depTree;
       if (options['print-deps']) {
-        spinner.stop(true);
+        spinner.stop();
         maybePrintDeps(options, pkg);
       }
       if (deps.plugin && deps.plugin.packageManager) {
@@ -442,7 +441,7 @@ async function assembleLocalPayloads(
     }
     return payloads;
   } finally {
-    await spinner.stop(true);
+    spinner.stop();
   }
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix ansi escape characters from breaking `--json`, fully clearing the spinner on test was causing problems

https://github.com/snyk/snyk/issues/845



- ✅ `snyk test --json | snyk-to-html` verified locally
- ✅`snyk test` tested with `maven` and `npm` lockfile project

<img width="683" alt="Screen Shot 2019-10-30 at 23 19 53" src="https://user-images.githubusercontent.com/2911613/67906297-06c31a00-fb6c-11e9-857c-46906a6d3e24.png">
