### PR TITLE
fix: Update interface of DepTree from lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "snyk-gradle-plugin": "3.1.0",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.4.0",
-    "snyk-nodejs-lockfile-parser": "1.16.0",
+    "snyk-nodejs-lockfile-parser": "1.16.1",
     "snyk-nuget-plugin": "1.13.1",
     "snyk-php-plugin": "1.6.4",
     "snyk-policy": "1.13.5",

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -115,7 +115,10 @@ function filterOutMissingDeps(depTree: DepTree): FilteredDepTree {
 
   for (const depKey of Object.keys(depTree.dependencies)) {
     const dep = depTree.dependencies[depKey];
-    if ((dep as any).missingLockFileEntry) {
+    if (
+      (dep as any).missingLockFileEntry ||
+      (dep as any).labels.missingLockFileEntry
+    ) {
       // TODO(kyegupov): add field to the type
       missingDeps.push(`${dep.name}@${dep.version}`);
     } else {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
DepTree interface in snyk-nodejs-lockfile-parser was aligned with standard used in DepGraph library. Dependency update is marked as a fix to catch hidden issues sooner than later.