### PR TITLE
fix: propagate correct path on sln scan error

### DIFF
--- a/src/lib/sln/index.ts
+++ b/src/lib/sln/index.ts
@@ -26,7 +26,7 @@ export const parsePathsFromSln = (slnFile) => {
     .filter(Boolean)
     // convert path separators
     .map((projectPath) => {
-      return projectPath.replace(/\\/g, path.sep);
+      return path.dirname(projectPath.replace(/\\/g, path.sep));
     });
 
   debug('extracted paths from solution file: ', paths);
@@ -47,10 +47,7 @@ export const updateArgs = (args) => {
 
   const foldersWithSupportedProjects = projectFolders
     .map((projectPath) => {
-      const projectFolder = path.resolve(
-        slnFilePath,
-        path.dirname(projectPath),
-      );
+      const projectFolder = path.resolve(slnFilePath, projectPath);
       const manifestFile = detect.detectPackageFile(projectFolder);
       return manifestFile ? projectFolder : undefined;
     })

--- a/test/acceptance/sln-app.test.ts
+++ b/test/acceptance/sln-app.test.ts
@@ -5,8 +5,8 @@ import * as sln from '../../src/lib/sln';
 test('parseFoldersFromSln when passed an existent filename', (t) => {
   const slnFile = 'test/acceptance/workspaces/sln-example-app/mySolution.sln';
   const expected = JSON.stringify([
-    'dotnet2_new_mvc_project' + path.sep + 'new_mvc_project.csproj',
-    'WebApplication2' + path.sep + 'WebApplication2.csproj',
+    'dotnet2_new_mvc_project',
+    'WebApplication2',
   ]);
   const actual = JSON.stringify(sln.parsePathsFromSln(slnFile));
   t.equal(actual, expected, 'should parse & extract csproj folders');
@@ -28,13 +28,17 @@ test('parseFoldersFromSln when non existent filename', (t) => {
 
 test('parseFoldersFromSln when no supported files found', (t) => {
   let response;
-  const slnFile =
-    'test/acceptance/workspaces/sln-no-supported-files/mySolution1.sln';
+  const file =
+    'test/acceptance/workspaces/sln-no-supported-files/mySolution.sln';
   try {
-    response = sln.parsePathsFromSln(slnFile);
+    response = sln.updateArgs({ options: { file } });
     t.fail('an exception should be thrown');
   } catch (e) {
-    t.match(e.message, 'File not found: ', 'should throw exception');
+    t.match(
+      e.message,
+      'Could not detect supported target files in dotnet2_new_mvc_project, WebApplication2',
+      'should throw exception',
+    );
     t.equal(response, undefined, 'shouldnt return');
   }
   t.end();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
When unsupported file found upon specifying .sln file, show the folder path, not the .*proj file path

https://github.com/snyk/snyk/issues/841