### PR TITLE
fix: update blocker on npm

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -15,6 +15,11 @@
       "//": "shasum all binaries",
       "path": "@semantic-release/exec",
       "cmd": "shasum -a 256 snyk-linux > snyk-linux.sha256 && shasum -a 256 snyk-macos > snyk-macos.sha256 && shasum -a 256 snyk-win.exe > snyk-win.exe.sha256 && shasum -a 256 snyk-alpine > snyk-alpine.sha256"
+    },
+    {
+      "//": "removes the file we use to identify a build as a standalone binary",
+      "path": "@semantic-release/exec",
+      "cmd": "echo 'Demonstrate that the dist/STANDALONE file is removed prior to publication'"
     }
   ],
   "publish": [


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an issue where our semantic release build pipeline includes a file intended only for the standalone binary. 

It appears that our semantic release process is adding STANDALONE to all builds of our CLI, not only those intended to be used by pkg.

#### How should this be manually tested?

Run a deployment of the CLI
