### PR TITLE
feat: show missing deps for old monitor too

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,7 +76,6 @@ export interface MonitorOptions {
 
 export interface MonitorMeta {
   method: 'cli' | 'wizard';
-  missingDeps?: string[];
   packageManager: SupportedPackageManagers;
   'policy-path': string;
   'project-name': string;

--- a/test/acceptance/cli.acceptance.test.ts
+++ b/test/acceptance/cli.acceptance.test.ts
@@ -3148,7 +3148,7 @@ test('`monitor npm-package`', async (t) => {
   t.notOk(req.body.meta.prePruneDepCount, "doesn't send meta.prePruneDepCount");
 });
 
-test('`monitor npm-out-of-sync`', async (t) => {
+test('`monitor npm-out-of-sync graph monitor`', async (t) => {
   chdirWorkspaces();
   await cli.monitor('npm-out-of-sync-graph', {
     'experimental-dep-graph': true,
@@ -3165,6 +3165,20 @@ test('`monitor npm-out-of-sync`', async (t) => {
   t.notOk(
     req.body.depGraphJSON.pkgs.find((pkg) => pkg.name === 'body-parser'),
     'filetered out missingLockFileEntry',
+  );
+});
+
+test('`monitor npm-out-of-sync old monitor`', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-out-of-sync-graph', {
+    strictOutOfSync: false,
+  });
+  const req = server.popRequest();
+  t.match(req.url, '/monitor/npm', 'puts at correct url');
+  t.deepEqual(
+    req.body.meta.missingDeps,
+    ['body-parser@^1.18.2'],
+    'missingDeps passed',
   );
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- send back any `missingDeps` as a prop to trigger the UI alert to show in the main app
- we already do this for the new monitor path (with graph)

If any deps are labeled as missing, filter them out
and add them as a prop to monitor.
This will display it as an alert in UI
