### PR TITLE
feat: send remoteUrl with payload when doing a snyk test

### DIFF
--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -8,12 +8,8 @@ export { ConnectionTimeoutError } from './connection-timeout-error';
 export { FailedToLoadPolicyError } from './failed-to-load-policy-error';
 export { PolicyNotFoundError } from './policy-not-found-error';
 export { InternalServerError } from './internal-server-error';
-export {
-  FailedToGetVulnerabilitiesError,
-} from './failed-to-get-vulnerabilities-error';
+export { FailedToGetVulnerabilitiesError } from './failed-to-get-vulnerabilities-error';
 export { UnsupportedFeatureFlagError } from './unsupported-feature-flag-error';
-export {
-  UnsupportedPackageManagerError,
-} from './unsupported-package-manager-error';
+export { UnsupportedPackageManagerError } from './unsupported-package-manager-error';
 export { FailedToRunTestError } from './failed-to-run-test-error';
 export { TooManyVulnPaths } from './too-many-vuln-paths';

--- a/src/lib/project-metadata/target-builders/git.ts
+++ b/src/lib/project-metadata/target-builders/git.ts
@@ -10,31 +10,32 @@ export async function getInfo(packageInfo): Promise<GitTarget | null> {
     return null;
   }
 
+  const target: GitTarget = {};
+
   try {
-    origin = (await subProcess.execute('git', [
-      'remote',
-      'get-url',
-      'origin',
-    ])).trim();
+    origin = (
+      await subProcess.execute('git', ['remote', 'get-url', 'origin'])
+    ).trim();
 
-    if (!origin) {
-      return null;
+    if (origin) {
+      const parsedOrigin = GitUrlParse(origin);
+      target.remoteUrl = parsedOrigin.toString('http');
     }
-
-    const parsedOrigin = GitUrlParse(origin);
-    const branch = (await subProcess.execute('git', [
-      'rev-parse',
-      '--abbrev-ref',
-      'HEAD',
-    ])).trim();
-
-    return {
-      remoteUrl: parsedOrigin.toString('http'),
-      branch,
-    };
   } catch (err) {
     // Swallowing exception since we don't want to break the monitor if there is a problem
     // executing git commands.
-    return null;
   }
+
+  try {
+    const branch = (
+      await subProcess.execute('git', ['rev-parse', '--abbrev-ref', 'HEAD'])
+    ).trim();
+
+    target.branch = branch;
+  } catch (err) {
+    // Swallowing exception since we don't want to break the monitor if there is a problem
+    // executing git commands.
+  }
+
+  return target;
 }

--- a/src/lib/project-metadata/types.ts
+++ b/src/lib/project-metadata/types.ts
@@ -1,4 +1,4 @@
 export interface GitTarget {
-  remoteUrl: string;
+  remoteUrl?: string;
   branch?: string;
 }

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -14,6 +14,9 @@ import snyk = require('../');
 import spinner = require('../spinner');
 import common = require('./common');
 import { DepTree, TestOptions } from '../types';
+import * as projectMetadata from '../project-metadata';
+import { GitTarget } from '../project-metadata/types';
+
 import {
   convertTestDepGraphResultToLegacy,
   AnnotatedIssue,
@@ -51,6 +54,7 @@ interface PayloadBody {
   projectNameOverride?: string;
   hasDevDependencies?: boolean;
   docker?: any;
+  target?: any;
 }
 
 interface Payload {
@@ -377,6 +381,7 @@ async function assembleLocalPayloads(
         policy: policy && policy.toString(),
         docker: pkg.docker,
         hasDevDependencies: (pkg as any).hasDevDependencies,
+        target: await getTarget(pkg, options),
       };
 
       if (options.vulnEndpoint) {
@@ -499,4 +504,17 @@ function pluckPolicies(pkg) {
       })
       .filter(Boolean),
   );
+}
+
+async function getTarget(
+  pkg: DepTree,
+  options: any,
+): Promise<GitTarget | null> {
+  const target = await projectMetadata.getInfo(pkg);
+
+  // Override the remoteUrl if the --remote-repo-url flag was set
+  if (options['remote-repo-url']) {
+    return { ...target, remoteUrl: options['remote-repo-url'] };
+  }
+  return target;
 }

--- a/test/acceptance/cli-test.acceptance.test.ts
+++ b/test/acceptance/cli-test.acceptance.test.ts
@@ -159,6 +159,29 @@ test('`test npm-package with custom --project-name`', async (t) => {
   t.match(req.body.targetFile, undefined, 'target is undefined');
 });
 
+test('test npm-package remoteUrl', async (t) => {
+  chdirWorkspaces();
+  process.env.GIT_DIR = 'npm-package/gitdir';
+  await cli.test('npm-package');
+  const req = server.popRequest();
+  t.equal(
+    req.body.target.remoteUrl,
+    'http://github.com/snyk/npm-package',
+    'git remoteUrl is passed',
+  );
+
+  delete process.env.GIT_DIR;
+});
+
+test('test npm-package remoteUrl with --remote-repo-url', async (t) => {
+  chdirWorkspaces();
+  await cli.test('npm-package', {
+    'remote-repo-url': 'foo',
+  });
+  const req = server.popRequest();
+  t.equal(req.body.target.remoteUrl, 'foo', 'specified remoteUrl is passed');
+});
+
 test('`test empty --file=Gemfile`', async (t) => {
   chdirWorkspaces();
   try {

--- a/test/acceptance/workspaces/npm-package/gitdir/HEAD
+++ b/test/acceptance/workspaces/npm-package/gitdir/HEAD
@@ -1,0 +1,1 @@
+ref: refs/heads/master

--- a/test/acceptance/workspaces/npm-package/gitdir/config
+++ b/test/acceptance/workspaces/npm-package/gitdir/config
@@ -1,0 +1,10 @@
+[core]
+	repositoryformatversion = 0
+	filemode = true
+	bare = false
+	logallrefupdates = true
+	ignorecase = true
+	precomposeunicode = true
+[remote "origin"]
+	url = https://github.com/snyk/npm-package
+	fetch = +refs/heads/*:refs/remotes/origin/*

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -245,7 +245,7 @@ test('auth via invalid key', async (t) => {
 });
 
 test('auth via github', async (t) => {
-  let tokenRequest: Url & { token?: string } | null = null;
+  let tokenRequest: (Url & { token?: string }) | null = null;
 
   const openSpy = sinon.spy((url) => {
     tokenRequest = parse(url);


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

By sending the remoteUrl it will be possible to auto-detect open source projects.

#### Where should the reviewer start?

This follows the same logic as `snyk monitor`:
https://github.com/snyk/snyk/blob/master/src/lib/monitor.ts#L401-L412

#### How should this be manually tested?

- Run `snyk test` on a project that has a `.git` directory, the `remoteUrl` from the `.git/config` will be sent.
- Run `snyk test` on a project with no `.git` directory, the `remoteUrl` will not be sent
- Run `snyk test` with a specified `--remote-repo-url` flag set, the `remoteUrl` will be set to whatever you specify
