### PR TITLE
fix: support show-vulnerable-paths without a value

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -56,8 +56,14 @@ async function test(...args: MethodArgs): Promise<string> {
   options.org = options.org || config.org;
 
   // making `show-vulnerable-paths` 'some' by default.
-  const svpSupplied = (options['show-vulnerable-paths'] || '').toLowerCase();
-  options.showVulnPaths = showVulnPathsMapping[svpSupplied] || 'some';
+  let svpSupplied = options['show-vulnerable-paths'] || '';
+  // Some legacy documentation refers to this as a boolean flag.
+  // We handle the "true" value as "some" (the default).
+  if ((svpSupplied as any) === true) {
+    svpSupplied = 'some';
+  }
+  options.showVulnPaths =
+    showVulnPathsMapping[svpSupplied.toLowerCase()] || 'some';
 
   if (
     options.severityThreshold &&


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Allows to specify `--show-vulnerable-paths` flag without a value (that would map to "all")