### PR TITLE
fix: show more meaningful error message for failed auth

### DIFF
--- a/test/system/auth.test.ts
+++ b/test/system/auth.test.ts
@@ -1,0 +1,85 @@
+import * as _ from 'lodash';
+import { test } from 'tap';
+import * as sinon from 'sinon';
+import * as isAuthed from '../../src/cli/commands/auth/is-authed';
+import stripAnsi from 'strip-ansi';
+const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+
+const apiKey = '123456789';
+const notAuthorizedApiKey = 'notAuthorized';
+process.env.SNYK_API = 'http://localhost:' + port + '/api/v1';
+process.env.SNYK_HOST = 'http://localhost:' + port;
+process.env.LOG_LEVEL = '0';
+
+// tslint:disable-next-line:no-var-requires
+const server = require('../cli-server')(
+  process.env.SNYK_API,
+  apiKey,
+  notAuthorizedApiKey,
+);
+
+// ensure this is required *after* the demo server, since this will
+// configure our fake configuration too
+import * as cli from '../../src/cli/commands';
+
+test('setup', (t) => {
+  t.plan(1);
+
+  server.listen(port, () => {
+    t.pass('started demo server');
+  });
+});
+
+test('auth shows an appropriate error message when a request times out', async (t) => {
+  const errors = require('../../src/lib/errors/legacy-errors');
+  const failedReq = new Promise((resolve) => {
+    return resolve({ res: { statusCode: 502 } });
+  });
+  const verifyStub = sinon.stub(isAuthed, 'verifyAPI').returns(failedReq);
+
+  t.teardown(() => {
+    verifyStub.restore();
+  });
+
+  try {
+    await cli.auth(apiKey);
+    t.fail('Authentication should have failed');
+  } catch (e) {
+    const message = stripAnsi(errors.message(e));
+    t.ok(message.includes('request has timed out'), 'correct error message');
+  }
+});
+
+test('auth shows an appropriate error message when a request fails with a user message', async (t) => {
+  const errors = require('../../src/lib/errors/legacy-errors');
+  const userMessage = 'Oh no! The request failed';
+  const failedReq = new Promise((resolve) => {
+    return resolve({ res: { statusCode: 502, body: { userMessage } } });
+  });
+  const verifyStub = sinon.stub(isAuthed, 'verifyAPI').returns(failedReq);
+
+  t.teardown(() => {
+    verifyStub.restore();
+  });
+
+  try {
+    await cli.auth(apiKey);
+    t.fail('Authentication should have failed');
+  } catch (e) {
+    const message = stripAnsi(errors.message(e));
+    t.equal(message, userMessage, 'userMessage shown on auth failure');
+  }
+});
+
+test('teardown', (t) => {
+  t.plan(2);
+
+  delete process.env.SNYK_API;
+  delete process.env.SNYK_HOST;
+  delete process.env.SNYK_PORT;
+  t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
+
+  server.close(() => {
+    t.pass('server shutdown');
+  });
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Previously when `snyk auth` failed for any reason we would always show the `AuthFailed` error without checking what the status code was. This PR attempts to make the error message more useful to the user by distinguishing failed authorisation checks from other types of errors (network timeouts etc.)

#### How should this be manually tested?

Run against a local registry, override the endpoint called by `verifyAPI` to return a 502 response (or any other).

#### Any background context you want to provide?

There is already handling in place for 502 errors, but coercing all error types into a Not Authorised error resulted in it never being reached

#### What are the relevant tickets?

Zendesk


