### PR TITLE
[WIP] fix: check token for validity before making any requests

### DIFF
--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -23,7 +23,7 @@ function ignore(options) {
           throw MisconfiguredAuthInCI();
         }
       }
-      apiTokenExists();
+      return apiTokenExists();
     })
     .then(() => {
       return authorization.actionAllowed('cliIgnore', options);

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -81,7 +81,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
 
-  apiTokenExists();
+  await apiTokenExists();
 
   if (options['experimental-dep-graph']) {
     const isFFSupported = await isFeatureFlagSupportedForOrg(

--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -105,7 +105,7 @@ function processWizardFlow(options) {
               throw MisconfiguredAuthInCI();
             }
           }
-          apiTokenExists();
+          return apiTokenExists();
         })
         .then(() => authorization.actionAllowed('cliIgnore', options))
         .then((cliIgnoreAuthorization) => {

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -66,7 +66,7 @@ async function test(...args: MethodArgs): Promise<string> {
     return Promise.reject(new Error('INVALID_SEVERITY_THRESHOLD'));
   }
 
-  apiTokenExists();
+  await apiTokenExists();
 
   // Promise waterfall to test all other paths sequentially
   for (const path of args as string[]) {

--- a/src/lib/api-token.ts
+++ b/src/lib/api-token.ts
@@ -1,17 +1,25 @@
-import { MissingApiTokenError } from '../lib/errors';
+import { AuthFailedError, MissingApiTokenError } from './errors';
 
 import * as config from './config';
 import * as userConfig from './user-config';
+import { isAuthed } from '../cli/commands/auth/is-authed';
 
 export function api() {
   // note: config.TOKEN will potentially come via the environment
   return config.api || config.TOKEN || userConfig.get('api');
 }
 
-export function apiTokenExists() {
+export async function apiTokenExists(): Promise<string> {
   const configured = api();
   if (!configured) {
     throw new MissingApiTokenError();
   }
+
+  const isValid = await isAuthed();
+
+  if (!isValid.ok) {
+    throw AuthFailedError(isValid.message, isValid.code);
+  }
+
   return configured;
 }

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -13,3 +13,4 @@ export { UnsupportedFeatureFlagError } from './unsupported-feature-flag-error';
 export { UnsupportedPackageManagerError } from './unsupported-package-manager-error';
 export { FailedToRunTestError } from './failed-to-run-test-error';
 export { TooManyVulnPaths } from './too-many-vuln-paths';
+export { AuthFailedError } from './authentication-failed-error';

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -142,7 +142,7 @@ export async function monitor(
   info: pluginApi.SinglePackageResult,
   targetFile?: string,
 ): Promise<MonitorResult> {
-  apiTokenExists();
+  await apiTokenExists();
   let treeMissingDeps: string[] = [];
 
   const packageManager = meta.packageManager;


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix auth error if `experimental-dep-graph` exists. 

If cli was invoked with `experimental-dep-graph` flag and invalid token, user will get error message
`Feature flag 'experimental-dep-graph' is not currently enabled for your org, to enable please contact snyk support`, cos token wasn't checked for validity and line https://github.com/snyk/snyk/blob/master/src/cli/commands/monitor/index.ts#L91 will return actually `401 Not Authorised`, but because we do `isFFSupported.ok` and it was `undefined`, user will see totally unrelated error message.
