### PR TITLE
fix: bug with --experimental-dep-graph and wrong auth token

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -18,7 +18,11 @@ import { MonitorOptions, MonitorMeta } from '../../../lib/types';
 import { MethodArgs, ArgsOptions } from '../../args';
 import { maybePrintDeps } from '../../../lib/print-deps';
 import * as analytics from '../../../lib/analytics';
-import { MonitorError, UnsupportedFeatureFlagError } from '../../../lib/errors';
+import {
+  AuthFailedError,
+  MonitorError,
+  UnsupportedFeatureFlagError,
+} from '../../../lib/errors';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { isFeatureFlagSupportedForOrg } from '../../../lib/feature-flags';
 import { formatMonitorOutput } from './formatters/format-monitor-response';
@@ -87,6 +91,10 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     const isFFSupported = await isFeatureFlagSupportedForOrg(
       _.camelCase('experimental-dep-graph'),
     );
+
+    if (isFFSupported.code === 401) {
+      throw AuthFailedError(isFFSupported.error, isFFSupported.code);
+    }
 
     if (!isFFSupported.ok) {
       throw new UnsupportedFeatureFlagError(

--- a/src/lib/errors/authentication-failed-error.ts
+++ b/src/lib/errors/authentication-failed-error.ts
@@ -1,13 +1,14 @@
 import { CustomError } from './custom-error';
 import * as config from '../config';
 
-export function AuthFailedError(errorMessage, errorCode) {
-  const message = errorMessage
-    ? errorMessage
-    : 'Authentication failed. Please check the API token on ' + config.ROOT;
-  const error = new CustomError(message);
-  error.code = errorCode || 401;
+export function AuthFailedError(
+  errorMessage: string = 'Authentication failed. Please check the API token on ' +
+    config.ROOT,
+  errorCode = 401,
+) {
+  const error = new CustomError(errorMessage);
+  error.code = errorCode;
   error.strCode = 'authfail';
-  error.userMessage = message;
+  error.userMessage = errorMessage;
   return error;
 }

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -13,3 +13,4 @@ export { UnsupportedFeatureFlagError } from './unsupported-feature-flag-error';
 export { UnsupportedPackageManagerError } from './unsupported-package-manager-error';
 export { FailedToRunTestError } from './failed-to-run-test-error';
 export { TooManyVulnPaths } from './too-many-vuln-paths';
+export { AuthFailedError } from './authentication-failed-error';

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -3,8 +3,10 @@ import snyk = require('.'); // TODO(kyegupov): fix import
 import * as config from './config';
 
 interface OrgFeatureFlagResponse {
-  ok: boolean;
+  ok?: boolean;
   userMessage?: string;
+  code?: number;
+  error?: string;
 }
 
 export async function isFeatureFlagSupportedForOrg(

--- a/test/acceptance/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor.acceptance.test.ts
@@ -133,10 +133,32 @@ test('monitor for package with no name in lockfile', async (t) => {
   t.pass('succeed');
 });
 
+test('`monitor npm-package with experimental-dep-graph enabled, but bad auth token`', async (t) => {
+  chdirWorkspaces();
+
+  const validTokenStub = sinon
+    .stub(needle, 'request')
+    .yields(null, null, { code: 401, error: 'Invalid auth token provided' });
+
+  try {
+    await cli.monitor('npm-package', { 'experimental-dep-graph': true });
+    t.fail('shoud have thrown an error');
+  } catch (e) {
+    t.equal(e.name, 'CustomError', 'correct error was thrown');
+    t.equal(
+      e.userMessage,
+      'Invalid auth token provided',
+      'correct default error message',
+    );
+
+    validTokenStub.restore();
+  }
+});
+
 test('`monitor npm-package with experimental-dep-graph not enabled`', async (t) => {
   chdirWorkspaces();
 
-  const featureFlagRequestStub = sinon
+  const needleRequestStub = sinon
     .stub(needle, 'request')
     .yields(null, null, { ok: false });
 
@@ -152,7 +174,7 @@ test('`monitor npm-package with experimental-dep-graph not enabled`', async (t) 
       'correct default error message',
     );
 
-    featureFlagRequestStub.restore();
+    needleRequestStub.restore();
   }
 });
 


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
Fix auth error if experimental-dep-graph exists.

If cli was invoked with experimental-dep-graph flag and invalid token, user will get error message
Feature flag 'experimental-dep-graph' is not currently enabled for your org, to enable please contact snyk support, cos token wasn't checked for validity and line https://github.com/snyk/snyk/blob/master/src/cli/commands/monitor/index.ts#L91 will return actually 401 Not Authorised, but because we do isFFSupported.ok and it was undefined, user will see totally unrelated error message.