### PR TITLE
feat: asynchronously process monitor args

### DIFF
--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -1161,6 +1161,34 @@ test('`monitor foo:latest --docker`', async (t) => {
   );
 });
 
+test('monitor with multiple paths', async (t) => {
+  chdirWorkspaces();
+  await cli.monitor('npm-package', 'yarn-app', 'ruby-app');
+  // test last three requests to fake server
+  server.popRequests(3).forEach((req) => {
+    t.equal(req.method, 'PUT', 'makes PUT request');
+    t.equal(
+      req.headers['x-snyk-cli-version'],
+      versionNumber,
+      'sends version number',
+    );
+    t.match(req.url, /\/monitor\/(npm|yarn|rubygems)/, 'puts at correct url');
+    t.match(
+      req.body,
+      {
+        meta: {
+          name: /(npm-package|yarn-app|ruby-app)/,
+        },
+        package: {
+          name: /(npm-package|yarn-app|ruby-app)/,
+        },
+      },
+      'sends name in body',
+    );
+    t.ok(req.body.package.dependencies, 'sends dependencies in body');
+  });
+});
+
 test('`monitor foo:latest --docker --file=Dockerfile`', async (t) => {
   const dockerImageId =
     'sha256:' +

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -5,6 +5,7 @@ interface FakeServer extends restify.Server {
   _nextResponse?: restify.Response;
   _nextStatusCode?: number;
   popRequest: () => restify.Request;
+  popRequests: (num: number) => restify.Request[];
   setNextResponse: (r: any) => void;
   setNextStatusCodeAndResponse: (c: number, r: any) => void;
 }
@@ -17,6 +18,9 @@ export function fakeServer(root, apikey) {
   server._reqLog = [];
   server.popRequest = function() {
     return server._reqLog.pop()!;
+  };
+  server.popRequests = function(num: number) {
+    return server._reqLog.splice(server._reqLog.length - num, num);
   };
   server.use(restify.acceptParser(server.acceptable));
   server.use(restify.queryParser());


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Use Promise.all on each path passed to monitor.
Added test for monitor using multiple paths.

#### How should this be manually tested?

Run 'snyk monitor ./path1 ./path2 ./path3 ...'
Use DEBUG=* to see each path is now processed asynchronously.

#### Any background context you want to provide?

In preparation for auto detect --all-projects feature.

#### What are the relevant tickets?

BST-1079