### PR TITLE
feat: analytics include org

### DIFF
--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -32,11 +32,6 @@ export function formatIssues(
     }),
   ).join(', ');
 
-  let version;
-  if (vuln.metadata.packageManager.toLowerCase() === 'upstream') {
-    version = vuln.metadata.version;
-  }
-
   const vulnOutput = {
     issueHeading: createSeverityBasedIssueHeading(
       vuln.metadata.severity,

--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import * as wrap from 'wrap-ansi';
 import * as config from '../../../../lib/config';
 import { TestOptions } from '../../../../lib/types';
 import {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ async function runCommand(args: Args) {
   const res = analytics({
     args: args.options._,
     command: args.command,
+    org: args.options.org,
   });
 
   if (result && !args.options.quiet) {
@@ -106,6 +107,7 @@ async function handleError(args, error) {
   const res = analytics({
     args: args.options._,
     command,
+    org: args.options.org,
   });
 
   return { res, exitCode };

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -62,12 +62,23 @@ function postAnalytics(data) {
       data.ci = isCI();
       data.durationMs = Date.now() - startTime;
 
+      const queryStringParams = {};
+      if (data.org) {
+        queryStringParams.org = data.org;
+      }
+
       debug('analytics', data);
+
+      const queryString =
+        Object.keys(queryStringParams).length > 0
+          ? queryStringParams
+          : undefined;
 
       return request({
         body: {
           data: data,
         },
+        qs: queryString,
         url: config.API + '/analytics/cli',
         json: true,
         method: 'post',

--- a/src/lib/project-metadata/target-builders/git.ts
+++ b/src/lib/project-metadata/target-builders/git.ts
@@ -1,4 +1,3 @@
-import fs = require('fs');
 import gitUrlParse = require('git-url-parse');
 
 import subProcess = require('../../sub-process');

--- a/src/lib/request/types.ts
+++ b/src/lib/request/types.ts
@@ -1,4 +1,4 @@
-import { IncomingHttpHeaders, OutgoingHttpHeaders } from 'http';
+import { OutgoingHttpHeaders } from 'http';
 import { NeedleHttpVerbs } from 'needle';
 
 export interface Payload {

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -67,6 +67,83 @@ test('analytics', (t) => {
       ].sort(),
       'keys as expected',
     );
+
+    const queryString = spy.lastCall.args[0].qs;
+    t.deepEqual(queryString, undefined, 'query string is empty');
+  });
+});
+
+test('analytics with args', (t) => {
+  const spy = sinon.spy();
+  const analytics = proxyquire('../src/lib/analytics', {
+    './request': spy,
+  });
+
+  analytics.add('foo', 'bar');
+
+  return analytics({
+    command: '__test__',
+    args: [],
+  }).then(() => {
+    const body = spy.lastCall.args[0].body.data;
+    t.deepEqual(
+      Object.keys(body).sort(),
+      [
+        'command',
+        'os',
+        'version',
+        'id',
+        'ci',
+        'metadata',
+        'args',
+        'nodeVersion',
+        'durationMs',
+      ].sort(),
+      'keys as expected',
+    );
+
+    const queryString = spy.lastCall.args[0].qs;
+    t.deepEqual(queryString, undefined, 'query string is empty');
+  });
+});
+
+test('analytics with args and org', (t) => {
+  const spy = sinon.spy();
+  const analytics = proxyquire('../src/lib/analytics', {
+    './request': spy,
+  });
+
+  analytics.add('foo', 'bar');
+
+  return analytics({
+    command: '__test__',
+    args: [],
+    org: 'snyk',
+  }).then(() => {
+    const body = spy.lastCall.args[0].body.data;
+    t.deepEqual(
+      Object.keys(body).sort(),
+      [
+        'command',
+        'os',
+        'version',
+        'id',
+        'ci',
+        'metadata',
+        'args',
+        'nodeVersion',
+        'durationMs',
+        'org',
+      ].sort(),
+      'keys as expected',
+    );
+
+    const queryString = spy.lastCall.args[0].qs;
+    t.deepEqual(
+      queryString,
+      { org: 'snyk' },
+      'query string has the expected values',
+    );
   });
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Up until now the analytics payload that we send did not include the organisation specified as the --org parameter.
While normal calls to `snyk test` resulted in the right org, analytics was saving data to the user's default organisation.
This change now correctly collects the specified org so that the data is connected correctly.

#### How should this be manually tested?

Run a local backend and point your snyk CLI there.
Set a breakpoint in `analytics.js` line 8 (to capture the `/cli` API call).
Run `snyk test --org=<some org other than your preferred or default org>`

Notice the organisation is now the one specified by `--org`!

#### Any background context you want to provide?

[Report in #boost-asks](https://snyk.slack.com/archives/CFTAUCYQ7/p1574784548361700)

#### What are the relevant tickets?

[Jira ticket BST-425](https://snyksec.atlassian.net/browse/BST-425)
