### PR TITLE
fix: Remove tree-kill dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - "8"
   - "6"
 cache:
+  npm: false
   directories:
     - node_modules
 notifications:

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "snyk-python-plugin": "^1.14.0",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
-    "snyk-sbt-plugin": "2.9.0",
+    "snyk-sbt-plugin": "2.9.1",
     "snyk-tree": "^1.0.0",
     "snyk-try-require": "1.3.1",
     "source-map-support": "^0.5.11",


### PR DESCRIPTION
The `tree-kill` package, introduced by `snyk-sbt-plugin` has a RCE vulnerability. This patch raises the version of `snyk-sbt-plugin` to remove the vulnerability.

See https://github.com/snyk/snyk-sbt-plugin/pull/72 for further information
