### PR TITLE
fix: check that provided remote url is a string

### DIFF
--- a/src/lib/errors/invalid-remote-url-error.ts
+++ b/src/lib/errors/invalid-remote-url-error.ts
@@ -1,0 +1,10 @@
+import { CustomError } from './custom-error';
+
+export class InvalidRemoteUrlError extends CustomError {
+  private static ERROR_MESSAGE =
+    'Invalid argument provided for --remote-repo-url. Value must be a string.';
+
+  constructor() {
+    super(InvalidRemoteUrlError.ERROR_MESSAGE);
+  }
+}

--- a/src/lib/monitor.ts
+++ b/src/lib/monitor.ts
@@ -15,7 +15,6 @@ import { MonitorError, ConnectionTimeoutError } from './errors';
 import { countPathsToGraphRoot, pruneGraph } from './prune';
 import { GRAPH_SUPPORTED_PACKAGE_MANAGERS } from './package-managers';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
-import { GitTarget } from './project-metadata/types';
 
 const debug = Debug('snyk');
 
@@ -183,7 +182,7 @@ export async function monitor(
   }
   const policy = await snyk.policy.load(policyLocations, { loose: true });
 
-  const target = await getTarget(pkg, meta);
+  const target = await projectMetadata.getInfo(pkg, meta);
   const targetFileRelativePath = targetFile
     ? path.join(path.resolve(root), targetFile)
     : '';
@@ -293,7 +292,7 @@ export async function monitorGraph(
   }
   const policy = await snyk.policy.load(policyLocations, { loose: true });
 
-  const target = await getTarget(pkg, meta);
+  const target = await projectMetadata.getInfo(pkg, meta);
   const targetFileRelativePath = targetFile
     ? path.join(path.resolve(root), targetFile)
     : '';
@@ -396,17 +395,4 @@ function pluckPolicies(pkg) {
       })
       .filter(Boolean),
   );
-}
-
-async function getTarget(
-  pkg: DepTree,
-  meta: MonitorMeta,
-): Promise<GitTarget | null> {
-  const target = await projectMetadata.getInfo(pkg);
-
-  // Override the remoteUrl if the --remote-repo-url flag was set
-  if (meta['remote-repo-url']) {
-    return { ...target, remoteUrl: meta['remote-repo-url'] };
-  }
-  return target;
 }

--- a/src/lib/project-metadata/index.ts
+++ b/src/lib/project-metadata/index.ts
@@ -1,15 +1,32 @@
 import * as gitTargetBuilder from './target-builders/git';
 import { GitTarget } from './types';
 import { DepTree } from '../types';
+import { InvalidRemoteUrlError } from '../errors/invalid-remote-url-error';
 
 const TARGET_BUILDERS = [gitTargetBuilder];
 
-export async function getInfo(packageInfo: DepTree): Promise<GitTarget | null> {
+interface Options {
+  'remote-repo-url'?: string;
+}
+
+export async function getInfo(
+  packageInfo: DepTree,
+  options: Options,
+): Promise<GitTarget | null> {
   for (const builder of TARGET_BUILDERS) {
     const target = await builder.getInfo(packageInfo);
 
     if (target) {
-      return target;
+      const remoteUrl = options['remote-repo-url'];
+
+      if (!remoteUrl) {
+        return target;
+      }
+
+      if (typeof remoteUrl !== 'string') {
+        throw new InvalidRemoteUrlError();
+      }
+      return { ...target, remoteUrl };
     }
   }
 

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -383,7 +383,7 @@ async function assembleLocalPayloads(
         policy: policy && policy.toString(),
         docker: pkg.docker,
         hasDevDependencies: (pkg as any).hasDevDependencies,
-        target: await getTarget(pkg, options),
+        target: await projectMetadata.getInfo(pkg, options),
       };
 
       if (options.vulnEndpoint) {
@@ -506,17 +506,4 @@ function pluckPolicies(pkg) {
       })
       .filter(Boolean),
   );
-}
-
-async function getTarget(
-  pkg: DepTree,
-  options: Options,
-): Promise<GitTarget | null> {
-  const target = await projectMetadata.getInfo(pkg);
-
-  // Override the remoteUrl if the --remote-repo-url flag was set
-  if (options['remote-repo-url']) {
-    return { ...target, remoteUrl: options['remote-repo-url'] };
-  }
-  return target;
 }

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -409,6 +409,23 @@ test('`monitor npm-package with custom --remote-repo-url`', async (t) => {
   t.equal(req.body.target.remoteUrl, 'a-fake-remote');
 });
 
+test('it fails when the custom --remote-repo-url is invalid', async (t) => {
+  t.plan(1);
+  chdirWorkspaces();
+  try {
+    await cli.monitor('npm-package', {
+      'remote-repo-url': true,
+    });
+    t.fail('should not succeed');
+  } catch (err) {
+    t.contains(
+      err,
+      /Invalid argument provided for --remote-repo-url/,
+      'correct error message',
+    );
+  }
+});
+
 test('`monitor npm-package with dev dep flag`', async (t) => {
   chdirWorkspaces();
   await cli.monitor('npm-package', { dev: true });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Check that the value passed to --remote-repo-url is a string (it is possible for it to be a boolean otherwise)

#### Any background context you want to provide?
Setting the flag with no argument caused the value `true` to be persisted
