### PR TITLE
fix: unblock deploy pipeline by pinning `pkg`

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "npm i -g pkg && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"
+      "cmd": "npm i -g pkg@4.4.0 && pkg . -t node8-alpine-x64,node8-linux-x64,node8-macos-x64,node8-win-x64"
     },
     {
       "//": "shasum all binaries",


### PR DESCRIPTION
The latest release of `pkg`, `4.4.1`, seems to have issues with our usage of require. Rolling back to an older version to unblock the deploy pipeline, until we can address this properly.

zeit/pkg#806
zeit/pkg#807
zeit/pkg#808