### PR TITLE
feat: support setup.py & normalise package casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "snyk-nuget-plugin": "1.15.0",
     "snyk-php-plugin": "1.7.0",
     "snyk-policy": "1.13.5",
-    "snyk-python-plugin": "^1.14.0",
+    "snyk-python-plugin": "1.14.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.9.1",


### PR DESCRIPTION
This patch updates the python plugin, rolling out initial support for `setup.py` files (https://github.com/snyk/snyk-python-plugin/commit/90a41409a8414491e0cd3b3cd60ff911929b6de7) and fixing some issues with package casing (https://github.com/snyk/snyk-python-plugin/commit/07e424bb5c2c4986fd04c07a6fa60c96a864071d)

`snyk-python-plugin` releases https://github.com/snyk/snyk-python-plugin/releases