### PR TITLE
fix: Remove vendored tree-kill dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "snyk-python-plugin": "1.14.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
-    "snyk-sbt-plugin": "2.9.1",
+    "snyk-sbt-plugin": "2.9.2",
     "snyk-tree": "^1.0.0",
     "snyk-try-require": "1.3.1",
     "source-map-support": "^0.5.11",


### PR DESCRIPTION
We vendored the `tree-kill` dep in `snyk-sbt-plugin` so that we could temporarily patch it to avoid a vulnerability. Now that it has been fixed upstream, the change in `snyk-sbt-plugin` has been reverted, and a new version released with the fixed upstream `tree-kill`.

https://github.com/snyk/snyk-sbt-plugin/pull/73

This patch updates the Snyk CLI with this new release of `snyk-sbt-plugin`.