### PR TITLE
feat: send targetfile same as for monitor

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -378,7 +378,7 @@ async function assembleLocalPayloads(
       }
 
       let body: PayloadBody = {
-        targetFile: pkg.targetFile,
+        targetFile: deps.plugin.targetFile,
         projectNameOverride: options.projectName,
         policy: policy && policy.toString(),
         docker: pkg.docker,

--- a/test/acceptance/cli-test/cli-test.ruby.spec.ts
+++ b/test/acceptance/cli-test/cli-test.ruby.spec.ts
@@ -480,7 +480,7 @@ export const RubyTests: AcceptanceTests = {
         ['ruby-app@', 'json@2.0.2', 'lynx@0.4.0'].sort(),
         'depGraph looks fine',
       );
-      t.equal(req.body.targetFile, 'Gemfile', 'specifies target');
+      t.notOk(req.body.targetFile, 'does not specify target');
     },
 
     '`test monorepo --file=sub-ruby-app/Gemfile`': (params, utils) => async (
@@ -506,11 +506,7 @@ export const RubyTests: AcceptanceTests = {
         'depGraph looks fine',
       );
 
-      t.equal(
-        req.body.targetFile,
-        path.join('sub-ruby-app', 'Gemfile'),
-        'specifies target',
-      );
+      t.notOk(req.body.targetFile, 'does not specify target');
     },
 
     '`test empty --file=Gemfile`': (params, utils) => async (t) => {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

To match a project on the BE the targetFile must be send only if the plugin exposes it, just like for monitor. This will allow us to always match the same project by name

Original PR that added this: https://github.com/snyk/snyk/pull/662

