### PR TITLE
fix: use maven 3.6.3 as 3.6.1 is no longer available

### DIFF
--- a/docker/Dockerfile.maven-3.6.3
+++ b/docker/Dockerfile.maven-3.6.3
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:8-jdk-slim
 
 MAINTAINER Snyk Ltd
 
@@ -8,9 +8,9 @@ WORKDIR /home/node
 # Install maven, node, cli
 RUN apt-get update && \
   apt-get install -y curl git && \
-  curl -L -o apache-maven-3.6.1-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
-  tar -xvzf apache-maven-3.6.1-bin.tar.gz && \
-  rm -f apache-maven-3.6.1-bin.tar.gz && \
+  curl -L -o apache-maven-3.6.3-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+  tar -xvzf apache-maven-3.6.3-bin.tar.gz && \
+  rm -f apache-maven-3.6.3-bin.tar.gz && \
   curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get install -y nodejs jq && \
   npm install --global snyk snyk-to-html && \

--- a/docker/Dockerfile.maven-3.6.3_java11
+++ b/docker/Dockerfile.maven-3.6.3_java11
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim
+FROM openjdk:11-jdk-slim
 
 MAINTAINER Snyk Ltd
 
@@ -8,9 +8,9 @@ WORKDIR /home/node
 # Install maven, node, cli
 RUN apt-get update && \
   apt-get install -y curl git && \
-  curl -L -o apache-maven-3.6.1-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz && \
-  tar -xvzf apache-maven-3.6.1-bin.tar.gz && \
-  rm -f apache-maven-3.6.1-bin.tar.gz && \
+  curl -L -o apache-maven-3.6.3-bin.tar.gz https://www-eu.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz && \
+  tar -xvzf apache-maven-3.6.3-bin.tar.gz && \
+  rm -f apache-maven-3.6.3-bin.tar.gz && \
   curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
   apt-get install -y nodejs jq && \
   npm install --global snyk snyk-to-html && \
@@ -20,7 +20,7 @@ RUN apt-get update && \
 
 ENV HOME /home/node
 ENV M2 /home/node/.m2
-ENV PATH /home/node/apache-maven-3.6.1/bin:$PATH
+ENV PATH /home/node/apache-maven-3.6.3/bin:$PATH
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- 3.6.1 is not available use 3.6.3  https://www-eu.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz