### PR TITLE
feat: better error for setup.py when deps are not installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "snyk-nuget-plugin": "1.16.0",
     "snyk-php-plugin": "1.7.0",
     "snyk-policy": "1.13.5",
-    "snyk-python-plugin": "1.14.1",
+    "snyk-python-plugin": "1.16.0",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.9.2",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Bump snyk-python-plugin to introduce a better error when deps are not installed for setup.py