### PR TITLE
feat: Support setup.py & Pipfile dependencies in the python docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The package argument is optional. If no package is given, Snyk will run the comm
 - **Alert** `snyk monitor` records the state of dependencies and any vulnerabilities on snyk.io so you can be alerted when new vulnerabilities or updates/patches are disclosed that affect your repositories.
 - **Prevent** new vulnerable dependencies from being added to your project by running `snyk test` as part of your CI to fail tests when vulnerable Node.js or Ruby dependencies are added.
 
-## Snyk cli Docker images
+## Snyk CLI Docker images
 
 [See all snyk/snyk-cli images](https://hub.docker.com/r/snyk/snyk-cli)
 
@@ -77,7 +77,6 @@ The following environment variables can be used when running the container on do
 - `ENV_FLAGS` - [OPTIONAL] additional environment parameters to pass to `snyk test` when running the container.
 - `TARGET_FILE` - [OPTIONAL] additional environment parameters to pass to `snyk test` & `snyk monitor` equal to `--file` option in the cli.
 
-
 Docker images are tagged according to the package manager runtime they include, the package manager version and snyk version.
 The general format of tags is [snyk-version]-[package-manager]-[package-manager-version] or just [package-manager]-[package-manager-version] if we want to use the latest version of snyk. Please see available tags to see the available options.
 
@@ -85,52 +84,44 @@ The general format of tags is [snyk-version]-[package-manager]-[package-manager-
 [package-manager] - One of the available package managers (e.g: npm, mvn, gradle, etc...).
 [package-manager-version] - The version of the package manager that is installed inside the image.
 
-
-**Note** We will need to mount the project root folder when running the image so that Snyk can access the code within the container. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
-
-#### Below are examples of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk):
-
-- `snyk test`
-  ```
-  docker run -it
-      -e "SNYK_TOKEN=<TOKEN>"
-      -e "USER_ID=1234"
-      -v "<PROJECT_DIRECTORY>:/project"
-    snyk/snyk-cli:npm
-  ```
-
-- `snyk test` with a report generated via `snyk-to-html`
-  ```
-  docker run -it
-      -e "SNYK_TOKEN=<TOKEN>"
-      -e "USER_ID=1234"
-      -e "MONITOR=true"
-      -v "<PROJECT_DIRECTORY>:/project"
-    snyk/snyk-cli:npm test --json --org=my-org-name
-  ```
-
-- `snyk monitor`
-  ```
-  docker run -it
-      -e "SNYK_TOKEN=<TOKEN>"
-      -e "USER_ID=1234"
-      -v "<PROJECT_DIRECTORY>:/project"
-    snyk/snyk-cli:npm monitor
-  ```
+Please see the following examples on how to run Snyk inside docker:
 
 ### Node.js (npm)
 
-`snyk/snyk-cli:npm` - [see all available `npm` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=npm)
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+
+Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for npm:
+
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+  snyk/snyk-cli:npm test --org=my-org-name
+```
 
 ### RubyGems
 
-`snyk/snyk-cli:rubygems` - [see all available `rubygems` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=rubygems)
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
 
-### Maven 3.5.4 / 3.6.3 / 3.6.3 (Java 11)
+Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for RubyGems:
 
-`snyk/snyk-cli:maven-*` - [see all available `maven` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=maven)
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+  snyk/snyk-cli:rubygems test --org=my-org-name
+```
 
-You may also need to mount the local .m2 and .ivy2 folders, example:
+### Maven 3.5.4
+
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+You may also need to mount the local `.m2` and `.ivy2` folders.
+
+Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Maven:
 
 ```
 docker run -it
@@ -143,51 +134,80 @@ docker run -it
   snyk/snyk-cli:maven-3.5.4 test --org=my-org-name
 ```
 
-### Python 2 / 3
-`snyk/snyk-cli:python-*` - [see all available `python` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=python)
-
-
-- setup.py (example in the current directory with Python 3)
-```
-  docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "TARGET_FILE=setup.py"
-    -v "$PWD:/project"
-    snyk/snyk-cli:python-3
-```
-
-- \*req\*.txt (requirements-dev.txt / prod-reqs.txt etc)
-
-```
-docker run -it -e
-  docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "TARGET_FILE=requirements-dev.txt"
-    -v "$PWD:/project"
-    snyk/snyk-cli:python-3 test --package-manager=pip
-```
-
-
 ### SBT 0.13.16 / SBT 1.0.4
-`snyk/snyk-cli:sbt-*` - [see all available `sbt` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=sbt)
 
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+You may also need to mount the local `.m2` and `.ivy2` folders.
 
-You may also need to mount the local .m2 and .ivy2 folders, example:
+Here are examples of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for SBT:
 
 *Note*: the `dependency-tree` or `sbt-dependency-graph` or `sbt-coursier` (included by default in latest sbt versions) module is required for `snyk` to process Scala projects.
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+    -v "/home/user/.m2:/home/node/.m2"
+    -v "/home/user/.ivy2:/home/node/.ivy2"
+  snyk/snyk-cli:sbt-0.13.16 test --org=my-org-name
+```
 
-For `dependency-tree` you can use [version 0.8.2](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.8.2) for SBT 0.13.16 and [version 0.9.0](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.9.0) for version SBT 1.0.4.
-
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+    -v "/home/user/.m2:/home/node/.m2"
+    -v "/home/user/.ivy2:/home/node/.ivy2"
+  snyk/snyk-cli:sbt-1.0.4 test --org=my-org-name
+```
 
 ### Gradle 2.8 / Gradle 4.4 / Gradle 5.4
-`snyk/snyk-cli:gradle-*` - [see all available `gradle` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=gradle)
 
-You may also need to mount the local .m2 and .ivy2 folders, example:
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+You may also need to mount the local `.gradle`.
 
+Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Gradle:
+
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+    -v "/home/user/.gradle:/home/node/.gradle"
+  snyk/snyk-cli:gradle-2.8 test --org=my-org-name
+```
+
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+    -v "/home/user/.gradle:/home/node/.gradle"
+  snyk/snyk-cli:gradle-4.4 test --org=my-org-name
+```
+
+```
+docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "USER_ID=1234"
+    -e "MONITOR=true"
+    -v "<PROJECT_DIRECTORY>:/project"
+    -v "/home/user/.gradle:/home/node/.gradle"
+  snyk/snyk-cli:gradle-5.4 test --org=my-org-name
+```
 
 ### Docker
 
-`snyk/snyk-cli:docker` - [see all available `docker` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=docker)
+The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+
+The image being tested is expected to be available locally.
+
+Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Docker:
 
 ```
 docker run -it
@@ -196,7 +216,7 @@ docker run -it
     -e "MONITOR=true"
     -v "<PROJECT_DIRECTORY>:/project"
     -v "/var/run/docker.sock:/var/run/docker.sock"
-  snyk/snyk-cli:docker test --docker <APP>:<TAG> --file=<DOCKERFILE>
+  snyk/snyk-cli:docker test --docker myapp:mytag --file=<DOCKERFILE>
 ```
 
 ## Badge

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ The package argument is optional. If no package is given, Snyk will run the comm
 - **Alert** `snyk monitor` records the state of dependencies and any vulnerabilities on snyk.io so you can be alerted when new vulnerabilities or updates/patches are disclosed that affect your repositories.
 - **Prevent** new vulnerable dependencies from being added to your project by running `snyk test` as part of your CI to fail tests when vulnerable Node.js or Ruby dependencies are added.
 
-## Docker
+## Snyk cli Docker images
+
+[See all snyk/snyk-cli images](https://hub.docker.com/r/snyk/snyk-cli)
 
 Snyk is also provided as a set of Docker images that carry the runtime environment of each package manager. For example, the npm image will carry all of the needed setup to run `npm install` on the currently running container. Currently there are images for npm, Ruby, Maven, Gradle and SBT.
 
@@ -70,9 +72,11 @@ The following environment variables can be used when running the container on do
 
 - `SNYK_TOKEN` - Snyk API token, obtained from [https://app.snyk.io/account](https://app.snyk.io/account).
 - `USER_ID` - [OPTIONAL] Current user ID on the host machine. If not provided will take the user ID of the currently running user inside the container. This is used for CI builds such as Jenkins where we are running with a non-privileged user and want to allow the user to access the mounted project folder.
-- `MONITOR` - [OPTIONAL] If set, tells the image that we want to run `snyk monitor` after running `snyk test`.
+- `MONITOR` - [OPTIONAL] If set, will generate an html report via `snyk-to-html` and runs `snyk monitor` after running `snyk test`.
 - `PROJECT_FOLDER` - [OPTIONAL] If set, this will cd to the directory inside the mounted project dir to run snyk inside it.
 - `ENV_FLAGS` - [OPTIONAL] additional environment parameters to pass to `snyk test` when running the container.
+- `TARGET_FILE` - [OPTIONAL] additional environment parameters to pass to `snyk test` & `snyk monitor` equal to `--file` option in the cli.
+
 
 Docker images are tagged according to the package manager runtime they include, the package manager version and snyk version.
 The general format of tags is [snyk-version]-[package-manager]-[package-manager-version] or just [package-manager]-[package-manager-version] if we want to use the latest version of snyk. Please see available tags to see the available options.
@@ -81,37 +85,52 @@ The general format of tags is [snyk-version]-[package-manager]-[package-manager-
 [package-manager] - One of the available package managers (e.g: npm, mvn, gradle, etc...).
 [package-manager-version] - The version of the package manager that is installed inside the image.
 
-Please see the following examples on how to run Snyk inside docker:
+
+**Note** We will need to mount the project root folder when running the image so that Snyk can access the code within the container. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds.
+
+#### Below are examples of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk):
+
+- `snyk test`
+  ```
+  docker run -it
+      -e "SNYK_TOKEN=<TOKEN>"
+      -e "USER_ID=1234"
+      -v "<PROJECT_DIRECTORY>:/project"
+    snyk/snyk-cli:npm
+  ```
+
+- `snyk test` with a report generated via `snyk-to-html`
+  ```
+  docker run -it
+      -e "SNYK_TOKEN=<TOKEN>"
+      -e "USER_ID=1234"
+      -e "MONITOR=true"
+      -v "<PROJECT_DIRECTORY>:/project"
+    snyk/snyk-cli:npm test --json --org=my-org-name
+  ```
+
+- `snyk monitor`
+  ```
+  docker run -it
+      -e "SNYK_TOKEN=<TOKEN>"
+      -e "USER_ID=1234"
+      -v "<PROJECT_DIRECTORY>:/project"
+    snyk/snyk-cli:npm monitor
+  ```
 
 ### Node.js (npm)
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for npm:
-
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-  snyk/snyk-cli:npm test --org=my-org-name
-```
+`snyk/snyk-cli:npm` - [see all available `npm` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=npm)
 
 ### RubyGems
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for RubyGems:
+`snyk/snyk-cli:rubygems` - [see all available `rubygems` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=rubygems)
 
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-  snyk/snyk-cli:rubygems test --org=my-org-name
-```
+### Maven 3.5.4 / 3.6.3 / 3.6.3 (Java 11)
 
-### Maven 3.5.4
+`snyk/snyk-cli:maven-*` - [see all available `maven` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=maven)
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container and mount the local .m2 and .ivy2 folders. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Maven:
+You may also need to mount the local .m2 and .ivy2 folders, example:
 
 ```
 docker run -it
@@ -124,74 +143,51 @@ docker run -it
   snyk/snyk-cli:maven-3.5.4 test --org=my-org-name
 ```
 
+### Python 2 / 3
+`snyk/snyk-cli:python-*` - [see all available `python` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=python)
+
+
+- setup.py (example in the current directory with Python 3)
+```
+  docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "TARGET_FILE=setup.py"
+    -v "$PWD:/project"
+    snyk/snyk-cli:python-3
+```
+
+- \*req\*.txt (requirements-dev.txt / prod-reqs.txt etc)
+
+```
+docker run -it -e
+  docker run -it
+    -e "SNYK_TOKEN=<TOKEN>"
+    -e "TARGET_FILE=requirements-dev.txt"
+    -v "$PWD:/project"
+    snyk/snyk-cli:python-3 test --package-manager=pip
+```
+
+
 ### SBT 0.13.16 / SBT 1.0.4
+`snyk/snyk-cli:sbt-*` - [see all available `sbt` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=sbt)
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container and mount the local .m2 and .ivy2 folders. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here are examples of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for SBT:
 
-NOTE: the `dependency-tree` module is required for `snyk` to process Scala projects. Use [version 0.8.2](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.8.2) for SBT 0.13.16 and [version 0.9.0](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.9.0) for version SBT 1.0.4.
+You may also need to mount the local .m2 and .ivy2 folders, example:
 
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-    -v "/home/user/.m2:/home/node/.m2"
-    -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:sbt-0.13.16 test --org=my-org-name
-```
+*Note*: the `dependency-tree` or `sbt-dependency-graph` or `sbt-coursier` (included by default in latest sbt versions) module is required for `snyk` to process Scala projects.
 
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-    -v "/home/user/.m2:/home/node/.m2"
-    -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:sbt-1.0.4 test --org=my-org-name
-```
+For `dependency-tree` you can use [version 0.8.2](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.8.2) for SBT 0.13.16 and [version 0.9.0](https://github.com/jrudolph/sbt-dependency-graph/tree/v0.9.0) for version SBT 1.0.4.
+
 
 ### Gradle 2.8 / Gradle 4.4 / Gradle 5.4
+`snyk/snyk-cli:gradle-*` - [see all available `gradle` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=gradle)
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container and mount the local .m2 and .ivy2 folders. The host project folder will be mounted to `/project` on the container and will be used to read the dependencies file and write results for CI builds. Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Gradle:
+You may also need to mount the local .m2 and .ivy2 folders, example:
 
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-    -v "/home/user/.m2:/home/node/.m2"
-    -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:gradle-2.8 test --org=my-org-name
-```
-
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-    -v "/home/user/.m2:/home/node/.m2"
-    -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:gradle-4.4 test --org=my-org-name
-```
-
-```
-docker run -it
-    -e "SNYK_TOKEN=<TOKEN>"
-    -e "USER_ID=1234"
-    -e "MONITOR=true"
-    -v "<PROJECT_DIRECTORY>:/project"
-    -v "/home/user/.m2:/home/node/.m2"
-    -v "/home/user/.ivy2:/home/node/.ivy2"
-  snyk/snyk-cli:gradle-5.4 test --org=my-org-name
-```
 
 ### Docker
 
-We will need to mount the project root folder when running the image so that Snyk can access the code within the container and Docker socket so that Snyk can access Docker daemon. The host project folder will be mounted to `/project` on the container and will be used to read the Docker file (with --file). Here's an example of running `snyk test` and `snyk monitor` in the image (with the latest version of Snyk) for Docker:
+`snyk/snyk-cli:docker` - [see all available `docker` tagged images](https://hub.docker.com/r/snyk/snyk-cli/tags?page=1&name=docker)
 
 ```
 docker run -it
@@ -200,7 +196,7 @@ docker run -it
     -e "MONITOR=true"
     -v "<PROJECT_DIRECTORY>:/project"
     -v "/var/run/docker.sock:/var/run/docker.sock"
-  snyk/snyk-cli:docker test --docker myapp:mytag --file=<DOCKERFILE>
+  snyk/snyk-cli:docker test --docker <APP>:<TAG> --file=<DOCKERFILE>
 ```
 
 ## Badge

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The package argument is optional. If no package is given, Snyk will run the comm
 
 Snyk is also provided as a set of Docker images that carry the runtime environment of each package manager. For example, the npm image will carry all of the needed setup to run `npm install` on the currently running container. Currently there are images for npm, Ruby, Maven, Gradle and SBT.
 
-The images can perform `snyk test` by default on the specified project which is mounted to the container as a read/write volume, and `snyk monitor` if the `MONITOR` environment variable is set when running the docker container. If you want an HTML report for `test` command, make sure `--json` parameter is provided. `monitor` command appends it automatically. An HTML file called `snyk_report.html` and a CSS file called `snyk_report.css` will be generated. The image also writes a file called `snyk-res.json` for internal use and `snyk-error.log` for errors that we can look at if something goes wrong.
+The images can perform `snyk test` by default on the specified project which is mounted to the container as a read/write volume, and `snyk monitor` if the `MONITOR` environment variable is set when running the docker container. If you want an HTML report for `test` command (`--json` is appended automatically). An HTML file called `snyk_report.html` and a CSS file called `snyk_report.css` will be generated. The image also writes a file called `snyk-res.json` for internal use and `snyk-error.log` for errors that we can look at if something goes wrong.
 
 The following environment variables can be used when running the container on docker:
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -20,13 +20,13 @@ fi
 
 useradd -o -m -u "${USER_ID}" -d /home/node docker-user 2>/dev/null
 
-runCmdAsDockerUser () {
+runCmdAsDockerUser() {
   su docker-user -m -c "$1"
 
   return $?
 }
 
-exitWithMsg () {
+exitWithMsg() {
   echo "Failed to run the process ..."
 
   if [ -f "$1" ]; then
@@ -46,7 +46,7 @@ exitWithMsg () {
 ## README.md for more info.
 ##
 
-TEST_SETTINGS="";
+TEST_SETTINGS=""
 PROJECT_SUBDIR=""
 
 if [ -n "${TARGET_FILE}" ]; then
@@ -77,8 +77,8 @@ if [ -n "${ENV_FLAGS}" ]; then
   ADDITIONAL_ENV="-- ${ENV_FLAGS}"
 fi
 
-cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" || \
-exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
+cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" ||
+  exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
 
 runCmdAsDockerUser "PATH=${PATH} snyk ${SNYK_COMMAND} ${SNYK_PARAMS} \
 ${ADDITIONAL_ENV} > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
@@ -101,6 +101,7 @@ fi
 runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 
 if [ -n "$MONITOR" ]; then
+  echo "Monitoring & generating report ..."
   runCmdAsDockerUser "PATH=$PATH snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} > ${MONITOR_OUTPUT_FILE} 2>$ERROR_FILE"
   runCmdAsDockerUser "cat ${MONITOR_OUTPUT_FILE} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>>\"${ERROR_FILE}\""
 fi

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -81,7 +81,7 @@ cd "${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" ||
   exitWithMsg "Can't cd to ${PROJECT_PATH}/${PROJECT_FOLDER}/${PROJECT_SUBDIR}" 1
 
 runCmdAsDockerUser "PATH=${PATH} snyk ${SNYK_COMMAND} ${SNYK_PARAMS} \
-${ADDITIONAL_ENV} > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
+${ADDITIONAL_ENV} --json > \"${OUTPUT_FILE}\" 2>\"${ERROR_FILE}\""
 
 RC=$?
 
@@ -115,8 +115,6 @@ sed 's/<\/head>/  <link rel=\"stylesheet\" href=\"snyk_report.css\"><\/head>/' \
 
 runCmdAsDockerUser "cat /home/node/snyk_report.css > \
 \"${PROJECT_PATH}/${PROJECT_FOLDER}/snyk_report.css\""
-# fi
-#
 
 if [ $RC -ne "0" ]; then
   exitWithMsg "${OUTPUT_FILE}" "$RC"

--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 virtualenv -p python snyk
 source snyk/bin/activate
 
@@ -13,6 +12,19 @@ exitWithMsg() {
     fi
 
     exit "$2"
+}
+
+installRequirementsTxtDeps() {
+    echo "Installing dependencies from requirements file"
+    pip install -U -r "$1"
+}
+
+installPipfileDeps() {
+    pushd "${PROJECT_PATH}/"
+    echo "Found Pipfile"
+    pipenv lock
+    pipenv install --system
+    popd
 }
 
 PROJECT_SUBDIR=""
@@ -31,7 +43,7 @@ if [ -n "${TARGET_FILE}" ]; then
     case $MANIFEST_NAME in
     *req*.txt)
         echo "Installing dependencies from requirements file"
-        pip install -U -r "${PROJECT_PATH}/$MANIFEST_NAME"
+        installRequirementsTxtDeps "${PROJECT_PATH}/$MANIFEST_NAME"
         ;;
     *setup.py)
         echo "Installing dependencies from setup.py"
@@ -45,7 +57,9 @@ fi
 
 if [ -f "${PROJECT_PATH}/requirements.txt" ]; then
     echo "Found requirement.txt"
-    pip install -U -r "${PROJECT_PATH}/requirements.txt"
+    installRequirementsTxtDeps "${PROJECT_PATH}/requirements.txt"
+elif [ -f "${PROJECT_PATH}/Pipfile" ]; then
+    installPipfileDeps
 fi
 
 bash docker-entrypoint.sh "$@"

--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -2,9 +2,50 @@
 
 virtualenv -p python snyk
 source snyk/bin/activate
-if [ -f "${PROJECT_PATH}/requirements.txt" ]; then
-    pip install -U -r "${PROJECT_PATH}/requirements.txt"
-elif [ -f "${PROJECT_PATH}/setup.py" ]; then
-    pip install -U "${PROJECT_PATH}"
+
+exitWithMsg() {
+    echo "Failed to run the process ..."
+
+    if [ -f "$1" ]; then
+        cat "$1"
+    else
+        echo "$1"
+    fi
+
+    exit "$2"
+}
+
+PROJECT_SUBDIR=""
+echo "Project path = ${PROJECT_PATH}"
+if [ -n "${TARGET_FILE}" ]; then
+    if [ ! -f "${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}" ]; then
+        exitWithMsg "\"${PROJECT_PATH}/${PROJECT_FOLDER}/${TARGET_FILE}\" does not exist" 1
+    fi
+
+    PROJECT_SUBDIR=$(dirname "${TARGET_FILE}")
+    MANIFEST_NAME=$(basename "${TARGET_FILE}")
+    TEST_SETTINGS="--file=${MANIFEST_NAME} "
+
+    echo "Target file = ${TARGET_FILE}"
+
+    case $MANIFEST_NAME in
+    *req*.txt)
+        echo "Installing dependencies from requirements file"
+        pip install -U -r "${PROJECT_PATH}/$MANIFEST_NAME"
+        ;;
+    *setup.py)
+        echo "Installing dependencies from setup.py"
+        pip install -U -e "${PROJECT_PATH}"
+        ;;
+    *)
+        exitWithMsg "\"${PROJECT_PATH}/${TARGET_FILE}\" is not supported" 1
+        ;;
+    esac
 fi
+
+if [ -f "${PROJECT_PATH}/requirements.txt" ]; then
+    echo "Found requirement.txt"
+    pip install -U -r "${PROJECT_PATH}/requirements.txt"
+fi
+
 bash docker-entrypoint.sh "$@"

--- a/docker/docker-python-entrypoint.sh
+++ b/docker/docker-python-entrypoint.sh
@@ -2,5 +2,9 @@
 
 virtualenv -p python snyk
 source snyk/bin/activate
-pip install -U -r "${PROJECT_PATH}/requirements.txt"
+if [ -f "${PROJECT_PATH}/requirements.txt" ]; then
+    pip install -U -r "${PROJECT_PATH}/requirements.txt"
+elif [ -f "${PROJECT_PATH}/setup.py" ]; then
+    pip install -U "${PROJECT_PATH}"
+fi
 bash docker-entrypoint.sh "$@"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- Setup.py support was added in the python plugin but the image doesn't install the dependencies
- Custom requirements.txt support
- Improve docs / drop repetitive examples

#### How should this be manually tested?
Check the updated README for more examples:

Build the local image from the docker dir:
```docker build -f Dockerfile.python-3  . -t snyk/snyk-cli:python-3-local```

Run on a `setup.py` project:
```
docker run -it -e "SNYK_TOKEN=*******" -e "TARGET_FILE=setup.py" -v "$PWD:/project" snyk/snyk-cli:python-3-local
``` 

### Tickets
https://github.com/snyk/snyk/issues/786
https://github.com/snyk/snyk/issues/332