### PR TITLE
fix: calculate package.json indentation when running snyk wizard

### DIFF
--- a/test/fixtures/four-spaces/package.json
+++ b/test/fixtures/four-spaces/package.json
@@ -1,0 +1,17 @@
+{
+    "name": "package-file-withfour-spaces-of-indentation",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "snyk test"
+    },
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "debug": "^1.0.0"
+    },
+    "devDependencies": {
+        "snyk": "*"
+    }
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team
- [x] Ready for review

#### What does this PR do?
Calculates `package.json` indentation when running `snyk wizard`

Fixes https://github.com/snyk/snyk/issues/911

We use to have a default value of 2 as the white indentation number.
This change calculates the indentation used in the package.json file
and uses it when updating the file.