### PR TITLE
feat: multi level auto detect

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -181,6 +181,7 @@ export function args(rawArgv: string[]): Args {
     'scan-all-unmanaged',
     'fail-on',
     'all-projects',
+    'detection-depth',
   ]) {
     if (argv[dashedArg]) {
       const camelCased = dashToCamelCase(dashedArg);

--- a/src/cli/commands/test/formatters/format-test-meta.ts
+++ b/src/cli/commands/test/formatters/format-test-meta.ts
@@ -9,7 +9,7 @@ export function formatTestMeta(
 ): string {
   const padToLength = 19; // chars to align
   const packageManager = res.packageManager || options.packageManager;
-  const targetFile = res.targetFile || options.file;
+  const targetFile = res.targetFile || res.displayTargetFile || options.file;
   const openSource = res.isPrivate ? 'no' : 'yes';
   const meta = [
     chalk.bold(rightPadWithSpaces('Organization: ', padToLength)) + res.org,

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -24,7 +24,6 @@ import {
 } from '../../../lib/package-managers';
 
 import * as analytics from '../../../lib/analytics';
-import { isFeatureFlagSupportedForOrg } from '../../../lib/feature-flags';
 import { FailOnError } from '../../../lib/errors/fail-on-error.ts';
 import {
   summariseVulnerableResults,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -158,18 +158,31 @@ async function main() {
       ]);
     }
 
-    if (
-      (args.options['project-name'] ||
-        args.options.file ||
-        args.options.packageManager ||
-        args.options.docker) &&
-      args.options.allProjects
-    ) {
+    if (args.options['project-name'] && args.options.allProjects) {
       throw new UnsupportedOptionCombinationError([
-        'project-name or file or package-manager or docker',
+        'project-name',
         'all-projects',
       ]);
     }
+    if (args.options.file && args.options.allProjects) {
+      throw new UnsupportedOptionCombinationError(['file', 'all-projects']);
+    }
+    if (args.options.packageManager && args.options.allProjects) {
+      throw new UnsupportedOptionCombinationError([
+        'package-manager',
+        'all-projects',
+      ]);
+    }
+    if (args.options.docker && args.options.allProjects) {
+      throw new UnsupportedOptionCombinationError(['docker', 'all-projects']);
+    }
+    if (args.options.allSubProjects && args.options.allProjects) {
+      throw new UnsupportedOptionCombinationError([
+        'all-sub-projects',
+        'all-projects',
+      ]);
+    }
+
     if (
       args.options.file &&
       typeof args.options.file === 'string' &&

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -24,7 +24,7 @@ export async function getDepsFromPlugin(
   let inspectRes: pluginApi.InspectResult;
 
   if (options.allProjects) {
-    const levelsDeep = 1; // TODO: auto-detect only one-level deep for now
+    const levelsDeep = options.detectionDepth || 1; // default to 1 level deep
     const targetFiles = await find(root, [], AUTO_DETECTABLE_FILES, levelsDeep);
     debug(
       `auto detect manifest files, found ${targetFiles.length}`,

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -26,9 +26,9 @@ export async function getMultiPluginResult(
   const allResults: ScannedProjectCustom[] = [];
   for (const targetFile of targetFiles) {
     const optionsClone = _.cloneDeep(options);
-    optionsClone.file = path.basename(targetFile);
+    optionsClone.file = path.relative(root, targetFile);
     optionsClone.packageManager = detectPackageManagerFromFile(
-      optionsClone.file,
+      path.basename(targetFile),
     );
     try {
       const inspectRes = await getSinglePluginResult(

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -27,19 +27,20 @@ async function test(root, options, callback) {
 
 function executeTest(root, options) {
   try {
-    const packageManager = detect.detectPackageManager(root, options);
-    options.packageManager = packageManager;
+    if (!options.allProjects) {
+      options.packageManager = detect.detectPackageManager(root, options);
+    }
     return run(root, options).then((results) => {
       for (const res of results) {
         if (!res.packageManager) {
-          res.packageManager = packageManager;
+          res.packageManager = options.packageManager;
         }
       }
       if (results.length === 1) {
         // Return only one result if only one found as this is the default usecase
         return results[0];
       }
-      // For gradle and yarnWorkspaces we may be returning more than one result
+      // For gradle, yarnWorkspaces, allProjects we may be returning more than one result
       return results;
     });
   } catch (error) {
@@ -49,7 +50,13 @@ function executeTest(root, options) {
 
 function run(root, options) {
   const packageManager = options.packageManager;
-  if (!(options.docker || pm.SUPPORTED_PACKAGE_MANAGER_NAME[packageManager])) {
+  if (
+    !(
+      options.docker ||
+      options.allProjects ||
+      pm.SUPPORTED_PACKAGE_MANAGER_NAME[packageManager]
+    )
+  ) {
     throw new UnsupportedPackageManagerError(packageManager);
   }
   return runTest(packageManager, root, options);

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -150,6 +150,7 @@ export interface BaseImageRemediationAdvice {
 export interface TestResult extends LegacyVulnApiResult {
   targetFile?: string;
   projectName?: string;
+  displayTargetFile?: string; // used for display only
 }
 
 interface UpgradePathItem {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,7 +30,6 @@ export interface TestOptions {
   'prune-repeated-subdependencies'?: boolean;
   showVulnPaths: ShowVulnPaths;
   failOn?: FailOn;
-  allProjects?: boolean;
 }
 export interface ProtectOptions {
   loose: boolean;
@@ -64,6 +63,8 @@ export interface Options {
   'print-deps'?: boolean;
   'remote-repo-url'?: string;
   scanAllUnmanaged?: boolean;
+  allProjects?: boolean;
+  detectionDepth?: number;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -78,8 +79,6 @@ export interface MonitorOptions {
   'print-deps'?: boolean;
   'experimental-dep-graph'?: boolean;
   scanAllUnmanaged?: boolean;
-  allProjects?: boolean;
-
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   'prune-repeated-subdependencies'?: boolean;
 }

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -78,64 +78,36 @@ test('`test --file=blah --scan-all-unmanaged`', (t) => {
   });
 });
 
-test('`test --file=blah and --all-projects`', (t) => {
-  t.plan(1);
-  exec(`node ${main} test --file=blah --all-projects`, (err, stdout) => {
-    if (err) {
-      throw err;
-    }
-    t.match(
-      stdout.trim(),
-      'The following option combination is not currently supported: project-name or file or package-manager or docker + all-projects',
-      'correct error output',
-    );
-  });
-});
+const argsNotAllowedWithAllProjects = [
+  'file',
+  'package-manager',
+  'project-name',
+  'docker',
+  'all-sub-projects',
+];
 
-test('`test --package-manager and --all-projects`', (t) => {
-  t.plan(1);
-  exec(
-    `node ${main} test --package-manager=npm --all-projects`,
-    (err, stdout) => {
+argsNotAllowedWithAllProjects.forEach((arg) => {
+  test(`using --${arg} and --all-projects throws exception`, (t) => {
+    t.plan(2);
+    exec(`node ${main} test --${arg} --all-projects`, (err, stdout) => {
       if (err) {
         throw err;
       }
       t.match(
         stdout.trim(),
-        'The following option combination is not currently supported: project-name or file or package-manager or docker + all-projects',
-        'correct error output',
+        `The following option combination is not currently supported: ${arg} + all-projects`,
+        'when using test',
       );
-    },
-  );
-});
-
-test('`test --project-name and --all-projects`', (t) => {
-  t.plan(1);
-  exec(
-    `node ${main} test --project-name=my-monorepo --all-projects`,
-    (err, stdout) => {
+    });
+    exec(`node ${main} monitor --${arg} --all-projects`, (err, stdout) => {
       if (err) {
         throw err;
       }
       t.match(
         stdout.trim(),
-        'The following option combination is not currently supported: project-name or file or package-manager or docker + all-projects',
-        'correct error output',
+        `The following option combination is not currently supported: ${arg} + all-projects`,
+        'when using monitor',
       );
-    },
-  );
-});
-
-test('`test --docker and --all-projects`', (t) => {
-  t.plan(1);
-  exec(`node ${main} test --docker --all-projects`, (err, stdout) => {
-    if (err) {
-      throw err;
-    }
-    t.match(
-      stdout.trim(),
-      'The following option combination is not currently supported: project-name or file or package-manager or docker + all-projects',
-      'correct error output',
-    );
+    });
   });
 });

--- a/test/acceptance/workspaces/ruby-app-no-vulns/test-result.json
+++ b/test/acceptance/workspaces/ruby-app-no-vulns/test-result.json
@@ -9,6 +9,7 @@
   "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\nignore: {}\npatch: {}\n",
   "ignoreSettings": null,
   "projectName": "ruby-app-no-vulns",
+  "displayTargetFile": "Gemfile",
   "summary": "No known vulnerabilities",
   "filesystemPolicy": false,
   "uniqueCount": 0,

--- a/test/acceptance/workspaces/ruby-app-policy/test-result-cloud-ignore.json
+++ b/test/acceptance/workspaces/ruby-app-policy/test-result-cloud-ignore.json
@@ -283,6 +283,7 @@
   "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-RUBY-LYNX-20160:\n    - '*':\n        reason: will check again in 2100\n        expires: 2100-01-01T00:00:00.000Z\n        source: cli\n  SNYK-RUBY-SANITIZE-22024:\n    - '*':\n        reason: who needs sanitization anyway\n        created: '2018-11-23T07:33:16.687Z'\n        ignoredBy:\n          id: 3c2d7dd6-e86e-4842-8124-5766bf55e060\n          name: brian@doogdog.com\n          email: brian@doogdog.com\n        reasonType: temporary-ignore\n        disregardIfFixable: false\n        source: api\npatch: {}\n",
   "ignoreSettings": null,
   "summary": "7 vulnerable dependency paths",
+  "displayTargetFile": "Gemfile",
   "filesystemPolicy": true,
   "filtered": {
     "ignore": [

--- a/test/acceptance/workspaces/ruby-app-policy/test-result.json
+++ b/test/acceptance/workspaces/ruby-app-policy/test-result.json
@@ -337,6 +337,7 @@
   "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  SNYK-RUBY-LYNX-20160:\n    - '*':\n        reason: will check again in 2100\n        expires: 2100-01-01T00:00:00.000Z\n        source: cli\npatch: {}\n",
   "ignoreSettings": null,
   "summary": "7 vulnerable dependency paths",
+  "displayTargetFile": "Gemfile",
   "filesystemPolicy": true,
   "filtered": {
     "ignore": [

--- a/test/acceptance/workspaces/ruby-app-thresholds/test-result-high-severity.json
+++ b/test/acceptance/workspaces/ruby-app-thresholds/test-result-high-severity.json
@@ -230,6 +230,7 @@
   "ignoreSettings": null,
   "severityThreshold": "high",
   "summary": "4 high severity vulnerable dependency paths",
+  "displayTargetFile": "Gemfile",
   "filesystemPolicy": false,
   "filtered": {
     "ignore": [],

--- a/test/acceptance/workspaces/ruby-app-thresholds/test-result-low-severity.json
+++ b/test/acceptance/workspaces/ruby-app-thresholds/test-result-low-severity.json
@@ -389,6 +389,7 @@
   "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\nignore: {}\npatch: {}\n",
   "ignoreSettings": null,
   "summary": "7 vulnerable dependency paths",
+  "displayTargetFile": "Gemfile",
   "filesystemPolicy": false,
   "filtered": {
     "ignore": [],

--- a/test/acceptance/workspaces/ruby-app-thresholds/test-result-medium-severity.json
+++ b/test/acceptance/workspaces/ruby-app-thresholds/test-result-medium-severity.json
@@ -338,6 +338,7 @@
   "ignoreSettings": null,
   "severityThreshold": "medium",
   "summary": "6 medium or high severity vulnerable dependency paths",
+  "displayTargetFile": "Gemfile",
   "filesystemPolicy": false,
   "filtered": {
     "ignore": [],

--- a/test/acceptance/workspaces/sbt-simple-struts/legacy-res-json.json
+++ b/test/acceptance/workspaces/sbt-simple-struts/legacy-res-json.json
@@ -1963,6 +1963,7 @@
   "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.13.1\nignore: {}\npatch: {}\n",
   "ignoreSettings": null,
   "summary": "31 vulnerable dependency paths",
+  "displayTargetFile": "build.sbt",
   "filesystemPolicy": false,
   "projectName": "small-app:small-app_2.10",
   "filtered": {


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Add support to CLI to auto detect projects in multiple level deep folders.
Added --detection-depth CLI argument to support user supplied folder depth to search.

#### How should this be manually tested?

snyk test --all-projects --detection-depth=2

To detect all projects in current directory and one subfolder.

#### What are the relevant tickets?

BST-1118

#### Screenshots
snyk test test/acceptance/workspaces/large-mono-repo --all-projects --detection-depth=2
<img width="1500" alt="Screenshot 2020-01-06 at 16 13 37" src="https://user-images.githubusercontent.com/6598617/71830910-b1414700-309f-11ea-94da-8f1dd9afe8bf.png">
