### PR TITLE
feat: process monitor json results

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -22,6 +22,7 @@ import { MonitorError } from '../../../lib/errors';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { formatMonitorOutput } from './formatters/format-monitor-response';
 import { getSubProjectCount } from '../../../lib/plugins/get-sub-project-count';
+import { processJsonMonitorResponse } from './process-json-monitor';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -204,25 +205,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
   }
   // Part 2: process the output from the Registry
   if (options.json) {
-    let dataToSend = results.map((result) => {
-      if (result.ok) {
-        const jsonData = JSON.parse(result.data);
-        if (result.projectName) {
-          jsonData.projectName = result.projectName;
-        }
-        return jsonData;
-      }
-      return { ok: false, error: result.data.message, path: result.path };
-    });
-    // backwards compat - strip array if only one result
-    dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;
-    const json = JSON.stringify(dataToSend, null, 2);
-
-    if (results.every((res) => res.ok)) {
-      return json;
-    }
-
-    throw new Error(json);
+    return processJsonMonitorResponse(results);
   }
 
   const output = results

--- a/src/cli/commands/monitor/process-json-monitor.ts
+++ b/src/cli/commands/monitor/process-json-monitor.ts
@@ -1,0 +1,25 @@
+import { GoodResult, BadResult } from './types';
+
+export function processJsonMonitorResponse(
+  results: Array<GoodResult | BadResult>,
+): string {
+  let dataToSend = results.map((result) => {
+    if (result.ok) {
+      const jsonData = JSON.parse(result.data);
+      if (result.projectName) {
+        jsonData.projectName = result.projectName;
+      }
+      return jsonData;
+    }
+    return { ok: false, error: result.data.message, path: result.path };
+  });
+  // backwards compat - strip array if only one result
+  dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;
+  const json = JSON.stringify(dataToSend, null, 2);
+
+  if (results.every((res) => res.ok)) {
+    return json;
+  }
+
+  throw new Error(json);
+}

--- a/src/cli/commands/monitor/types.ts
+++ b/src/cli/commands/monitor/types.ts
@@ -1,0 +1,14 @@
+import { MonitorError } from '../../../lib/errors';
+
+export interface GoodResult {
+  ok: true;
+  data: string;
+  path: string;
+  projectName?: string;
+}
+
+export interface BadResult {
+  ok: false;
+  data: MonitorError;
+  path: string;
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Split out the functionality to handle the monitor response if `--json` flag is set