### PR TITLE
fix: monitor --json errors are valid json

### DIFF
--- a/src/cli/commands/monitor/process-json-monitor.ts
+++ b/src/cli/commands/monitor/process-json-monitor.ts
@@ -15,11 +15,12 @@ export function processJsonMonitorResponse(
   });
   // backwards compat - strip array if only one result
   dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;
-  const json = JSON.stringify(dataToSend, null, 2);
+  const stringifiedData = JSON.stringify(dataToSend, null, 2);
 
   if (results.every((res) => res.ok)) {
-    return json;
+    return stringifiedData;
   }
-
-  throw new Error(json);
+  const err = new Error(stringifiedData) as any;
+  err.json = dataToSend;
+  throw err;
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- attach json object to monitor error response when `--json` flag is used just like we do for `snyk test` so the response is always correctly processed and only valid json is output.
- add tests to verify correct monitor json data is sent on success & error
#### Screenshots
*Single monitor*
<img width="730" alt="Screen Shot 2020-01-06 at 11 08 19" src="https://user-images.githubusercontent.com/2911613/71814750-509d1480-3075-11ea-85c4-893b38d65d8a.png">

*Multiple monitored* `snyk monitor --json . bundler-app`
<img width="808" alt="Screen Shot 2020-01-06 at 11 45 34" src="https://user-images.githubusercontent.com/2911613/71816467-97413d80-307a-11ea-97cb-a81d86f05bc6.png">
