### PR TITLE
feat: switching from usage to help documentation by default

### DIFF
--- a/help/usage.txt
+++ b/help/usage.txt
@@ -1,3 +1,0 @@
-Usage: snyk <command>
-
-See "snyk --help" for more.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -129,7 +129,7 @@ export function args(rawArgv: string[]): Args {
     command = 'help';
 
     if (!argv._.length) {
-      argv._.unshift((argv.help as string) || 'usage');
+      argv._.unshift((argv.help as string) || 'help');
     }
   }
 

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -5,7 +5,7 @@ const debug = Debug('snyk');
 
 export = async function help(item: string | boolean) {
   if (!item || item === true || typeof item !== 'string') {
-    item = 'usage';
+    item = 'help';
   }
 
   // cleanse the filename to only contain letters

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -47,6 +47,16 @@ test('`test multiple paths with --project-name=NAME`', (t) => {
   });
 });
 
+test('`test that running snyk without any args displays help text`', (t) => {
+  t.plan(1);
+  exec(`node ${main}`, (err, stdout) => {
+    if (err) {
+      throw err;
+    }
+    t.match(stdout.trim(), /Usage/, '`snyk help` text is shown as output');
+  });
+});
+
 test('`test --file=file.sln --project-name=NAME`', (t) => {
   t.plan(1);
   exec(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
The current `snyk` cli shows a `usage.txt` help file when no command is given. That `usage.txt` file points to executing `snyk --help` to get more information in the usage. This PR simplifies that and directly shows `help`

#### Where should the reviewer start?
Run `snyk` and see if the `help.txt` is displayed by default

#### How should this be manually tested?
Executing `snyk`, `snyk --help` should both display `help.txt`

#### Any background context you want to provide?
It's just an improvement, making it a little bit more user friendly.

#### What are the relevant tickets?
None. Encountered this on first usage, and wanted to fix it directly. Let me know if you need a github issue.

#### Screenshots
*before*
<img width="297" alt="Screen Shot 2020-01-07 at 10 29 48" src="https://user-images.githubusercontent.com/2911613/71888774-bacabd80-3138-11ea-8bb9-15f99425aa33.png">
*after*
<img width="730" alt="Screen Shot 2020-01-07 at 10 29 59" src="https://user-images.githubusercontent.com/2911613/71888775-bacabd80-3138-11ea-946e-42d9bf2d4982.png">

#### Additional questions
None