### PR TITLE
fix: snyk always being added as dependency when running wizard

### DIFF
--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -45,10 +45,7 @@ import {
   WizardOptions,
 } from '../../../lib/types';
 import { LegacyVulnApiResult } from '../../../lib/snyk-test/legacy';
-import {
-  SinglePackageResult,
-  MultiProjectResult,
-} from '@snyk/cli-interface/legacy/plugin';
+import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
 
 function wizard(options?: Options) {
   options = options || ({} as Options);
@@ -472,9 +469,13 @@ function processAnswers(answers, policy, options) {
       let lbl = 'Updating package.json...';
       const addSnykToDependencies =
         answers['misc-add-test'] || answers['misc-add-protect'];
-      let updateSnykFunc = () =>
-        protect.install(packageManager, ['snyk'], live);
+      let updateSnykFunc = () => {
+        return;
+      }; // noop
 
+      if (addSnykToDependencies) {
+        updateSnykFunc = () => protect.install(packageManager, ['snyk'], live);
+      }
       if (addSnykToDependencies) {
         debug('updating %s', packageFile);
 

--- a/test/fixtures/basic-npm/answers.json
+++ b/test/fixtures/basic-npm/answers.json
@@ -1,0 +1,67 @@
+{
+  "npm:minimatch:20160620-u4": {
+    "vuln": {
+      "title": "Regular Expression Denial of Service",
+      "creationTime": "2016-06-20T16:00:06.484Z",
+      "modificationTime": "2016-06-20T16:00:06.484Z",
+      "publicationTime": "2016-06-20T15:52:52.000Z",
+      "disclosureTime": "2016-06-20T15:52:52.000Z",
+      "semver": {
+        "vulnerable": "<=3.0.1",
+        "unaffected": ">=3.0.2"
+      },
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "severity": "high",
+      "identifiers": {
+        "CWE": [
+          "CWE-400"
+        ],
+        "CVE": [],
+        "NSP": 118
+      },
+      "patches": [
+        {
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/minimatch/20160620/minimatch_20160620_0_0_6944abf9e0694bd22fd9dad293faa40c2bc8a955.patch"
+          ],
+          "version": "<=3.0.1 >2.0.5",
+          "modificationTime": "2016-06-20T16:00:06.484Z",
+          "comments": [],
+          "id": "patch:npm:minimatch:20160620:0"
+        }
+      ],
+      "moduleName": "minimatch",
+      "id": "npm:minimatch:20160620",
+      "from": [
+        "minimatch@3.0.0"
+      ],
+      "upgradePath": [
+        false,
+        "minimatch@3.0.2"
+      ],
+      "version": "3.0.0",
+      "name": "minimatch",
+      "isUpgradable": true,
+      "isPatchable": true,
+      "__filename": "/Users/oakfang/dev/SC-1472/node_modules/minimatch/package.json",
+      "parentDepType": "dev",
+      "grouped": {
+        "affected": {
+          "name": "tap",
+          "version": "3.1.2",
+          "full": "tap@3.1.2"
+        },
+        "main": true,
+        "id": "npm:minimatch:20160620-4",
+        "count": 3,
+        "upgrades": [
+          "minimatch@3.0.2"
+        ]
+      }
+    },
+    "choice": "update"
+  },
+  "misc-add-test": false,
+  "misc-add-protect": false,
+  "misc-test-no-monitor": true
+}

--- a/test/fixtures/basic-npm/package.json
+++ b/test/fixtures/basic-npm/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "package-file-basic",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "^1.0.0",
+    "minimatch": "3.0.0"
+  }
+}

--- a/test/wizard-process-answers.test.js
+++ b/test/wizard-process-answers.test.js
@@ -311,3 +311,25 @@ test('wizard updates vulns and retains indentation', async function(t) {
   process.chdir(old);
   t.end();
 });
+
+test('wizard updates vulns but does not install snyk', async function(t) {
+  const old = process.cwd();
+  const dir = path.resolve(__dirname, 'fixtures', 'basic-npm');
+  const answersPath = path.resolve(dir, 'answers.json');
+
+  const answers = JSON.parse(fs.readFileSync(answersPath, 'utf-8'));
+
+  const installCommands = [
+    ['uninstall', ['minimatch'], true, undefined, undefined],
+    ['install', ['minimatch@3.0.2'], true, null, ['--save-dev']],
+  ];
+
+  process.chdir(dir);
+
+  await wizard.processAnswers(answers, mockPolicy);
+
+  t.deepEqual(execSpy.args, installCommands, 'snyk not installed');
+
+  process.chdir(old);
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix for issue where snyk gets added as a dependency whenever there are version updates to anything in package.json.