### PR TITLE
fix: Ignore snyk Docker generated reports and result files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,8 @@ tmp
 !/test/fixtures/**/package-lock.json
 .idea
 .eslintcache
+snyk-error.log
+snyk-result.json
+snyk_report.css
+snyk_report.html
+!/docker/snyk_report.css


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Ignore generated reports files to avoid accidentally commiting generated files when using snyk CLI with Docker

