### PR TITLE
fix: allow tests to be run against any snyk API

### DIFF
--- a/test/policy-display.test.ts
+++ b/test/policy-display.test.ts
@@ -3,6 +3,10 @@ import { test } from 'tap';
 import * as fs from 'then-fs';
 import { display } from '../src/lib/display-policy';
 import stripAnsi from 'strip-ansi';
+import { URL } from 'url';
+
+const SNYK_API = process.env.SNYK_API || 'https://snyk.io/api/v1';
+const { hostname } = new URL(SNYK_API);
 
 test('test sensibly bails if gets an old .snyk format', async (t) => {
   const filename = __dirname + '/fixtures/snyk-config-no-version';
@@ -21,6 +25,8 @@ test('test sensibly bails if gets an old .snyk format', async (t) => {
       .join('\n');
     const expected = expectedFileString
       .trim()
+      // replace hostname in policy if using env var SNYK_API
+      .replace(/snyk\.io/g, hostname)
       .split('\n')
       .slice(3)
       .join('\n');


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Allow CLI tests to be run against any snyk API.
Enables us to switch AppVeyor to test against our dev API.

#### How should this be manually tested?

`SNYK_API="......" SNYK_API_KEY="......" npm test`

#### Any background context you want to provide?

Will clean up dashboards reporting CLI usage, at the moment AppVeyor clutters these dashboard with each CI run.