### PR TITLE
fix: use node 10 during travis release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       name: "Danger Zone"
     - stage: Release
       if: branch = master AND type != pull_request
-      node_js: "8"
+      node_js: "10"
       script:
       - npm i -g semantic-release @semantic-release/exec && semantic-release
 branches:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Change node version used during travis release job. Semantic release now requires versions >=10.
https://github.com/semantic-release/semantic-release/releases/tag/v16.0.0