### PR TITLE
fix: stop sending full error to bq

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -93,7 +93,7 @@ async function handleError(args, error) {
 
   if (!vulnsFound && !error.stack) {
     // log errors that are not error objects
-    analytics.add('error', JSON.stringify(analyticsError));
+    analytics.add('error', true);
     analytics.add('command', args.command);
   } else {
     analytics.add('error-message', analyticsError.message);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
instead of sending full json string of error, only send that there was an error