### PR TITLE
feat: increase default levels deep to 2 for `--all-projects`

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -130,7 +130,7 @@ Experimental options:
   --detection-depth=<number>
                        (test & monitor commands only)
                        Use with --all-projects to indicate how many sub-directories to search.
-                       Defaults to 1 (the current working directory).
+                       Defaults to 2 (the current working directory and one sub-directory).
   --exclude=<comma seperated list of directory names>
                        (test & monitor commands only)
                        Can only be used with --all-projects to indicate sub-directories to exclude.

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -24,7 +24,7 @@ export async function getDepsFromPlugin(
   let inspectRes: pluginApi.InspectResult;
 
   if (options.allProjects) {
-    const levelsDeep = options.detectionDepth || 1; // default to 1 level deep
+    const levelsDeep = options.detectionDepth;
     const ignore = options.exclude ? options.exclude.split(',') : [];
     const targetFiles = await find(
       root,

--- a/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
@@ -21,6 +21,7 @@ export const AllProjectsTests: AcceptanceTests = {
 
       const result = await params.cli.monitor('mono-repo-project', {
         allProjects: true,
+        detectionDepth: 1,
       });
       t.ok(spyPlugin.withArgs('rubygems').calledOnce, 'calls rubygems plugin');
       t.ok(spyPlugin.withArgs('npm').calledOnce, 'calls npm plugin');
@@ -143,6 +144,7 @@ export const AllProjectsTests: AcceptanceTests = {
 
       await params.cli.monitor('mono-repo-project', {
         allProjects: true,
+        detectionDepth: 1,
       });
       // Pop all calls to server and filter out calls to `featureFlag` endpoint
       const [rubyAll, npmAll, mavenAll] = params.server

--- a/test/acceptance/cli-test/cli-test.all-projects.spec.ts
+++ b/test/acceptance/cli-test/cli-test.all-projects.spec.ts
@@ -16,6 +16,7 @@ export const AllProjectsTests: AcceptanceTests = {
 
       const result = await params.cli.test('mono-repo-project', {
         allProjects: true,
+        detectionDepth: 1,
       });
       t.ok(spyPlugin.withArgs('rubygems').calledOnce, 'calls rubygems plugin');
       t.ok(spyPlugin.withArgs('npm').calledOnce, 'calls npm plugin');
@@ -80,6 +81,7 @@ export const AllProjectsTests: AcceptanceTests = {
 
       await params.cli.test('mono-repo-project', {
         allProjects: true,
+        detectionDepth: 1,
       });
       const [
         rubyAllProjectsBody,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Enable the default detection depths to increase from 1 to 2 folders deep.