### PR TITLE
fix: git-repos test inconsistent

### DIFF
--- a/test/git-repos.test.ts
+++ b/test/git-repos.test.ts
@@ -1,5 +1,5 @@
 import * as cli from '../src/cli/commands/';
-import * as tap from 'tap';
+import { test } from 'tap';
 
 const urls = [
   // a repo with no dependencies so it will never be vulnerable (2017-05-15)
@@ -9,15 +9,13 @@ const urls = [
   'Snyk/vulndb-fixtures.git',
 ];
 
-urls.forEach((url) => {
-  // TODO: investigate why this test fails on Windows, Node 8
-  tap.skip('snyk.test supports ' + url + ' structure', async (t) => {
-    try {
-      await cli.test(url);
-      t.pass('url worked');
-    } catch (err) {
-      t.threw(err);
-      t.end();
+test('snyk test supports different URLs', async (t) => {
+  try {
+    for (const url of urls) {
+      const res = await cli.test(url);
+      t.ok(res, `snyk test ${url} ok`);
     }
-  });
+  } catch (err) {
+    t.fail('unexpected error thrown: ' + err.message);
+  }
 });


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Removing t.end since test is async in an attempt to
have the test run more consistantly.

#### Any background context you want to provide?
Appveyor test inconsistant failures for this test.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
