### PR TITLE
feat: enable composer.lock for --all-projects

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -43,6 +43,7 @@ export const AUTO_DETECTABLE_FILES: string[] = [
   'project.assets.json',
   'Podfile',
   'Podfile.lock',
+  'composer.lock',
 ];
 
 // when file is specified with --file, we look it up here

--- a/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
@@ -199,6 +199,35 @@ export const AllProjectsTests: AcceptanceTests = {
         'Same body for --all-projects and --file=pom.xml',
       );
     },
+    '`monitor composer-app with --all-projects and without same meta`': (
+      params,
+      utils,
+    ) => async (t) => {
+      utils.chdirWorkspaces();
+      const spyPlugin = sinon.spy(params.plugins, 'loadPlugin');
+      t.teardown(spyPlugin.restore);
+
+      await params.cli.monitor('composer-app', {
+        allProjects: true,
+      });
+      // Pop all calls to server and filter out calls to `featureFlag` endpoint
+      const [composerAll] = params.server
+        .popRequests(2)
+        .filter((req) => req.url.includes('/monitor/'));
+
+      await params.cli.monitor('composer-app', {
+        file: 'composer.lock',
+      });
+      const [requestsComposer] = params.server
+        .popRequests(2)
+        .filter((req) => req.url.includes('/monitor/'));
+
+      t.deepEqual(
+        composerAll.body,
+        requestsComposer.body,
+        'Same body for --all-projects and --file=composer.lock',
+      );
+    },
     '`monitor mono-repo-project with lockfiles --all-projects --json`': (
       params,
       utils,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Auto detect and scan Composer (Php) projects
when `snyk test` or `snyk monitor` is run with
`--all-projects`
