### PR TITLE
feat: enable paket to be autodetected with --all-projects

### DIFF
--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -39,6 +39,7 @@ export const AUTO_DETECTABLE_FILES: string[] = [
   'Gemfile.lock',
   'pom.xml',
   'packages.config',
+  'paket.dependencies',
   'project.json',
   'project.assets.json',
   'Podfile',

--- a/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
@@ -26,6 +26,9 @@ export const AllProjectsTests: AcceptanceTests = {
       t.ok(spyPlugin.withArgs('rubygems').calledOnce, 'calls rubygems plugin');
       t.ok(spyPlugin.withArgs('npm').calledOnce, 'calls npm plugin');
       t.ok(spyPlugin.withArgs('maven').calledOnce, 'calls maven plugin');
+      t.ok(spyPlugin.withArgs('nuget').calledOnce, 'calls nuget plugin');
+      t.ok(spyPlugin.withArgs('paket').calledOnce, 'calls nuget plugin');
+
       // npm
       t.match(
         result,
@@ -38,18 +41,39 @@ export const AllProjectsTests: AcceptanceTests = {
         'rubygems/some/project-id',
         'rubygems project was monitored',
       );
-
+      // nuget
+      t.match(result, 'nuget/some/project-id', 'nuget project was monitored');
+      // paket
+      t.match(result, 'paket/some/project-id', 'paket project was monitored');
       // maven
       t.match(result, 'maven/some/project-id', 'maven project was monitored ');
       // Pop all calls to server and filter out calls to `featureFlag` endpoint
       const requests = params.server
-        .popRequests(4)
+        .popRequests(6)
         .filter((req) => req.url.includes('/monitor/'));
-      t.equal(requests.length, 3, 'Correct amount of monitor requests');
+      t.equal(requests.length, 5, 'Correct amount of monitor requests');
+
+      const pluginsWithoutTragetFilesInBody = [
+        'snyk-nodejs-lockfile-parser',
+        'bundled:maven',
+        'bundled:rubygems',
+      ];
 
       requests.forEach((req) => {
         t.match(req.url, '/monitor/', 'puts at correct url');
-        t.notOk(req.body.targetFile, "doesn't send the targetFile");
+        if (
+          pluginsWithoutTragetFilesInBody.includes(req.body.meta.pluginName)
+        ) {
+          t.notOk(
+            req.body.targetFile,
+            `doesn\'t send the targetFile for ${req.body.meta.pluginName}`,
+          );
+        } else {
+          t.ok(
+            req.body.targetFile,
+            `does send the targetFile ${req.body.meta.pluginName}`,
+          );
+        }
         t.equal(req.method, 'PUT', 'makes PUT request');
         t.equal(
           req.headers['x-snyk-cli-version'],
@@ -147,8 +171,22 @@ export const AllProjectsTests: AcceptanceTests = {
         detectionDepth: 1,
       });
       // Pop all calls to server and filter out calls to `featureFlag` endpoint
-      const [rubyAll, npmAll, mavenAll] = params.server
-        .popRequests(4)
+      const [
+        rubyAll,
+        npmAll,
+        nugetAll,
+        paketAll,
+        mavenAll,
+      ] = params.server
+        .popRequests(6)
+        .filter((req) => req.url.includes('/monitor/'));
+
+      // nuget
+      await params.cli.monitor('mono-repo-project', {
+        file: 'packages.config',
+      });
+      const [requestsNuget] = params.server
+        .popRequests(2)
         .filter((req) => req.url.includes('/monitor/'));
 
       // Ruby
@@ -175,6 +213,14 @@ export const AllProjectsTests: AcceptanceTests = {
         .popRequests(2)
         .filter((req) => req.url.includes('/monitor/'));
 
+      // paket
+      await params.cli.monitor('mono-repo-project', {
+        file: 'paket.dependencies',
+      });
+      const [requestsPaket] = params.server
+        .popRequests(2)
+        .filter((req) => req.url.includes('/monitor/'));
+
       // Ruby project
 
       t.deepEqual(
@@ -191,12 +237,28 @@ export const AllProjectsTests: AcceptanceTests = {
         'Same body for --all-projects and --file=package-lock.json',
       );
 
+      // NUGET project
+
+      t.deepEqual(
+        nugetAll.body,
+        requestsNuget.body,
+        'Same body for --all-projects and --file=packages.config',
+      );
+
       // Maven project
 
       t.deepEqual(
         mavenAll.body,
         requestsMaven.body,
         'Same body for --all-projects and --file=pom.xml',
+      );
+
+      // Paket project
+
+      t.deepEqual(
+        paketAll.body,
+        requestsPaket.body,
+        'Same body for --all-projects and --file=paket.dependencies',
       );
     },
     '`monitor mono-repo-project with lockfiles --all-projects --json`': (

--- a/test/acceptance/workspaces/mono-repo-project/packages.config
+++ b/test/acceptance/workspaces/mono-repo-project/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
+</packages>

--- a/test/acceptance/workspaces/mono-repo-project/paket.dependencies
+++ b/test/acceptance/workspaces/mono-repo-project/paket.dependencies
@@ -1,0 +1,5 @@
+redirects: on
+source https://nuget.org/api/v2
+
+nuget FSharp.Formatting
+nuget FAKE

--- a/test/acceptance/workspaces/mono-repo-project/paket.lock
+++ b/test/acceptance/workspaces/mono-repo-project/paket.lock
@@ -1,0 +1,10 @@
+REDIRECTS: ON
+NUGET
+  remote: https://www.nuget.org/api/v2
+    FAKE (5.8.4)
+    FSharp.Compiler.Service (2.0.0.6)
+    FSharp.Formatting (2.14.4)
+      FSharp.Compiler.Service (2.0.0.6)
+      FSharpVSPowerTools.Core (>= 2.3 < 2.4)
+    FSharpVSPowerTools.Core (2.3)
+      FSharp.Compiler.Service (>= 2.0.0.3)


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Enables paket projets to be autodetected with the --all-projects option set.