### PR TITLE
fix: move --all-projects help text

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -27,6 +27,18 @@ Commands:
 
 Options:
 
+  --all-projects ..... (test & monitor commands only)
+                       Auto detect all projects in working directory.
+                       Note gradle is not supported, use --all-sub-projects instead.
+  --detection-depth=<number>
+                       (test & monitor commands only)
+                       Use with --all-projects to indicate how many sub-directories to search.
+                       Defaults to 2 (the current working directory and one sub-directory).
+  --exclude=<comma seperated list of directory names>
+                       (test & monitor commands only)
+                       Can only be used with --all-projects to indicate sub-directories to exclude.
+                       Directories must be comma seperated.
+                       If using with --detection-depth exclude ignores directories at any level deep.
   --dev .............. Include devDependencies (defaults to production only).
   --file=<File> ...... Sets package file. For more help run `snyk help file`.
   --org=<org-name> ... Specify the org machine-name to run Snyk with a specific
@@ -124,22 +136,6 @@ Docker options:
                        remediation advice.
   --exclude-base-image-vulns
                        Exclude from display Docker base image vulnerabilities.
-
-Experimental options:
-  The following options may change without notice, we do not recommend using them in production.
-
-  --all-projects ..... (test & monitor commands only)
-                       Auto detect all projects in working directory.
-                       Currently npm, yarn, ruby and maven projects are supported.
-  --detection-depth=<number>
-                       (test & monitor commands only)
-                       Use with --all-projects to indicate how many sub-directories to search.
-                       Defaults to 2 (the current working directory and one sub-directory).
-  --exclude=<comma seperated list of directory names>
-                       (test & monitor commands only)
-                       Can only be used with --all-projects to indicate sub-directories to exclude.
-                       Directories must be comma seperated.
-                       If using with --detection-depth exclude ignores directories at any level deep.
 
 Examples:
 


### PR DESCRIPTION

- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Moving --all-projects, --detection-depth and --exclude help test
out of experimental section, and higher up now that this feature
has been released.

#### How should this be manually tested?
`snyk help`

#### Screenshots
<img width="886" alt="Screenshot 2020-01-28 at 16 28 01" src="https://user-images.githubusercontent.com/6598617/73283559-31fcea00-41eb-11ea-8c3f-b29c012120b0.png">

