### PR TITLE
fix: correct object path to mvn and java version

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -301,12 +301,12 @@ async function assembleLocalPayloads(
     analytics.add('pluginName', deps.plugin.name);
     const javaVersion = _.get(
       deps.plugin,
-      'meta?.versionBuildInfo?.metaBuildVersion.javaVersion',
+      'meta.versionBuildInfo.metaBuildVersion.javaVersion',
       null,
     );
     const mvnVersion = _.get(
       deps.plugin,
-      'meta?.versionBuildInfo?.metaBuildVersion.mvnVersion',
+      'meta.versionBuildInfo.metaBuildVersion.mvnVersion',
       null,
     );
     if (javaVersion) {


### PR DESCRIPTION
Optional chaining operator was forgotten in new analytics path in
lodash.get.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Just fixes wrong object path.