### PR TITLE
fix: vuln in transitive pkg of configstore (dot-prop)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "2.3.0",
+    "@snyk/configstore": "^3.2.0-rc1",
     "@snyk/dep-graph": "1.13.1",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.0.1",
@@ -64,7 +65,6 @@
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",
     "cli-spinner": "0.2.10",
-    "configstore": "^3.1.2",
     "debug": "^3.1.0",
     "diff": "^4.0.1",
     "git-url-parse": "11.1.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@snyk/dep-graph": "1.13.1",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.0.1",
+    "@snyk/update-notifier": "^2.5.1-rc1",
     "@types/agent-base": "^4.2.0",
     "@types/restify": "^4.3.6",
     "abbrev": "^1.1.1",
@@ -97,7 +98,6 @@
     "strip-ansi": "^5.2.0",
     "tempfile": "^2.0.0",
     "then-fs": "^2.0.0",
-    "update-notifier": "^2.5.0",
     "uuid": "^3.3.2",
     "wrap-ansi": "^5.1.0"
   },

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,4 +1,4 @@
-import * as updateNotifier from 'update-notifier';
+import * as updateNotifier from '@snyk/update-notifier';
 import * as fs from 'fs';
 import * as p from 'path';
 

--- a/src/lib/user-config.js
+++ b/src/lib/user-config.js
@@ -1,4 +1,4 @@
-const Configstore = require('configstore');
+const Configstore = require('@snyk/configstore');
 const pkg = require(__dirname + '/../../package.json');
 const config = new Configstore(pkg.name);
 

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -4,7 +4,7 @@ const updateCheck = require('../src/lib/updater').updateCheck;
 const fs = require('fs');
 const p = require('path');
 const sinon = require('sinon').createSandbox();
-const updateNotifier = require('update-notifier');
+const updateNotifier = require('@snyk/update-notifier');
 
 // Fake location of the package.json file and verify the code behaves well
 test('missing package.json', (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

# What does this PR do?
Replaces configstore to a fork from snyk which patches version `3.1.2` to use the latest version of `dot-prop`.

# What this commit contains:
- removing direct deps `update-notifier` and `configstore`
- replace them with forked and published versions under `@snyk` scope `@snyk/configstore` `@snyk/update-notifier`
- Each of the new deps has their version of `dot-prop` raised to `5.2.0`
