### PR TITLE
fix: vuln in transitive pkg of configstore (dot-prop) - rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@snyk/dep-graph": "1.13.1",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.0.1",
-    "@snyk/update-notifier": "^2.5.1-rc1",
+    "@snyk/update-notifier": "^2.5.1-rc2",
     "@types/agent-base": "^4.2.0",
     "@types/restify": "^4.3.6",
     "abbrev": "^1.1.1",


### PR DESCRIPTION
- [X] Ready for review

#### What does this PR do?
Fix the problem caused by https://github.com/snyk/snyk/pull/990 which broke the functionality of `update-notifier`.
The issues was raised on https://github.com/snyk/snyk/issues/991.
Bumping to the latest version of `@snyk/update-notifier` will fix the issue :)