### PR TITLE
chore: fix for node 12 assertion error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "12"
+  - "12.0.0"
   - "10"
   - "8"
   - "6"

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -205,7 +205,7 @@ test('`monitor npm-out-of-sync graph monitor`', async (t) => {
   });
   const req = server.popRequest();
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
-  t.ok(req.body.depGraphJSON, 'sends depGraphJSON');
+  t.true(!_.isEmpty(req.body.depGraphJSON), 'sends depGraphJSON');
   t.deepEqual(
     req.body.meta.missingDeps,
     ['body-parser@^1.18.2'],
@@ -252,7 +252,7 @@ test('`monitor npm-package-pruneable --prune-repeated-subdependencies --experime
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
-  t.ok(req.body.depGraphJSON, 'sends depGraphJSON');
+  t.true(!_.isEmpty(req.body.depGraphJSON), 'sends depGraphJSON');
 });
 
 test('`monitor npm-package-pruneable --experimental-dep-graph`', async (t) => {
@@ -264,7 +264,7 @@ test('`monitor npm-package-pruneable --experimental-dep-graph`', async (t) => {
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.match(req.url, '/monitor/npm/graph', 'puts at correct url');
-  t.ok(req.body.depGraphJSON, 'sends depGraphJSON');
+  t.true(!_.isEmpty(req.body.depGraphJSON), 'sends depGraphJSON');
 });
 
 test('`monitor npm-package-pruneable experimental for no-flag org`', async (t) => {
@@ -306,7 +306,7 @@ test('`monitor sbt package --experimental-dep-graph --sbt-graph`', async (t) => 
   const req = server.popRequest();
   t.equal(req.method, 'PUT', 'makes PUT request');
   t.match(req.url, '/monitor/sbt/graph', 'puts at correct url');
-  t.ok(req.body.depGraphJSON, 'sends depGraphJSON');
+  t.true(!_.isEmpty(req.body.depGraphJSON), 'sends depGraphJSON');
   if (process.platform === 'win32') {
     t.true(
       req.body.targetFileRelativePath.endsWith(


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Trying to fix what looks like a **tap** & node **12.16.0** incompatibility, it is probably fine with later versions of tap but we are for using custom forked tap due to legacy issues with TypeScript support & some places still using **tape**
 ```
/home/travis/.nvm/versions/node/v12.16.0/bin/node[5501]: ../src/node_util.cc:216:static void node::util::WeakReference::DecRef(const v8::FunctionCallbackInfo<v8::Value>&): Assertion `(weak_ref->reference_count_) >= (1)' failed.
```