### PR TITLE
feat: bump snyk-docker-plugin. Added pull if image isn't local logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "1.38.0",
+    "snyk-docker-plugin": "2.2.0",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Bumped `snyk-docker-plugin`. This version includes logic that when using `snyk test --docker <docker image>`, if the image doesn't exist locally, it will be pulled if possible and then scanned.

Previously this used to fail and show an error that the image doesn't exist, but still pull the image in the background (without indication). 


