### PR TITLE
fix: npm-lock-parser npm-shrinkwrap's error msg.

### DIFF
--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -33,10 +33,10 @@ export async function parse(
 
   if (fs.existsSync(shrinkwrapFullPath)) {
     throw new Error(
-      '`npm-shrinkwrap.json` was found while using lockfile.\n' +
-        'Please run your command again without `--file=' +
-        targetFile +
-        '` flag.',
+      'Both `npm-shrinkwrap.json` and `package-lock.json` were found in ' +
+        fullPath.dir +
+        '.\n' +
+        'Please run your command again specifying `--file=package.json` flag.',
     );
   }
 

--- a/test/acceptance/cli-test/cli-test.npm.spec.ts
+++ b/test/acceptance/cli-test/cli-test.npm.spec.ts
@@ -208,7 +208,7 @@ export const NpmTests: AcceptanceTests = {
       } catch (e) {
         t.includes(
           e.message,
-          '--file=package-lock.json',
+          '--file=package.json',
           'Contains enough info about err',
         );
       }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
replaces npm-shrinkwrap.json throw error message when exists as well a package-lock.json file on the same project.

Check https://snyksec.atlassian.net/browse/BST-502

#### Screenshots
![Screen Shot 2020-02-25 at 10 52 31](https://user-images.githubusercontent.com/40601533/75230822-09055000-57bd-11ea-82d7-e7bdd6e2f982.png)
![Screen Shot 2020-02-25 at 10 52 52](https://user-images.githubusercontent.com/40601533/75230825-0b67aa00-57bd-11ea-8b98-685953e590a4.png)
