### PR TITLE
fix: cli error message upon use <snyk test> command>

### DIFF
--- a/src/lib/errors/failed-to-get-vulns-from-unavailable-resource.ts
+++ b/src/lib/errors/failed-to-get-vulns-from-unavailable-resource.ts
@@ -1,0 +1,22 @@
+import { CustomError } from './custom-error';
+import chalk from 'chalk';
+
+export function FailedToGetVulnsFromUnavailableResource(
+  root: string,
+  statusCode: number,
+) {
+  const errorNpmMessage =
+    'please check that the version and name are correct. See more details on what is supported `snyk help`';
+  const errorRepositoryMessage =
+    `please try it on ${chalk.underline('`https://snyk.io/test/`')}` +
+    '. See more details on what is supported `snyk help';
+
+  const isRepository = root.startsWith('http' || 'https');
+  const errorMsg = `Could not test ${root}, ${
+    isRepository ? errorRepositoryMessage : errorNpmMessage
+  }`;
+  const error = new CustomError(errorMsg);
+  error.code = statusCode;
+  error.userMessage = errorMsg;
+  return error;
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -9,6 +9,7 @@ export { FailedToLoadPolicyError } from './failed-to-load-policy-error';
 export { PolicyNotFoundError } from './policy-not-found-error';
 export { InternalServerError } from './internal-server-error';
 export { FailedToGetVulnerabilitiesError } from './failed-to-get-vulnerabilities-error';
+export { FailedToGetVulnsFromUnavailableResource } from './failed-to-get-vulns-from-unavailable-resource';
 export { UnsupportedFeatureFlagError } from './unsupported-feature-flag-error';
 export { UnsupportedPackageManagerError } from './unsupported-package-manager-error';
 export { FailedToRunTestError } from './failed-to-run-test-error';

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -19,6 +19,7 @@ import {
   InternalServerError,
   NoSupportedManifestsFoundError,
   FailedToGetVulnerabilitiesError,
+  FailedToGetVulnsFromUnavailableResource,
   FailedToRunTestError,
 } from '../errors';
 import * as snyk from '../';
@@ -204,8 +205,20 @@ async function runTest(
     debug('Error running test', { error });
     // handling denial from registry because of the feature flag
     // currently done for go.mod
-    if (error.code === 403 && error.message.includes('Feature not allowed')) {
+
+    const isFeatureNotAllowed =
+      error.code === 403 && error.message.includes('Feature not allowed');
+
+    const hasFailedToGetVulnerabilities =
+      error.code === 404 &&
+      error.name.includes('FailedToGetVulnerabilitiesError');
+
+    if (isFeatureNotAllowed) {
       throw NoSupportedManifestsFoundError([root]);
+    }
+
+    if (hasFailedToGetVulnerabilities) {
+      throw FailedToGetVulnsFromUnavailableResource(root, error.code);
     }
 
     throw new FailedToRunTestError(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What it solves
Improve error messaging in CLI - "Internal Error" when scanning repositories or npm pkgs.

#### Screenshots
<img width="678" alt="Screen Shot 2020-02-26 at 18 13 01" src="https://user-images.githubusercontent.com/40601533/75364025-afd41400-58c3-11ea-80a8-0183891563c4.png">

