### PR TITLE
fix: bump snyk-docker-deps to 2.2.1 - scratch image support

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "2.2.0",
+    "snyk-docker-plugin": "2.2.1",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

until now, the snyk-docker-plugin would throw errors when scanning scratch images without a dockerfile provided.
the new version of the snyk-docker-plugin now allows scanning of images even when being unable to identify the operating system or package manager data

#### Where should the reviewer start?

https://github.com/snyk/snyk-docker-plugin/pull/143

#### How should this be manually tested?

`snyk test --docker busybox:1.31.1`

#### Any background context you want to provide?

https://www.notion.so/snyk/Improve-how-we-handle-scratch-images-6fe2d0dbb1584c69b2d185a0cee9e976

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-728

#### Screenshots

before:

![image](https://user-images.githubusercontent.com/1255387/75431081-fc1b6480-5954-11ea-8e39-a829ee6de200.png)

after:

![image](https://user-images.githubusercontent.com/1255387/75431029-ec9c1b80-5954-11ea-938f-7d8be04efad9.png)
![image](https://user-images.githubusercontent.com/1255387/75431072-f7ef4700-5954-11ea-85ef-03909039b5ee.png)