### PR TITLE
feat: now is possible to assign python version with --python= property.

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -123,8 +123,11 @@ CocoaPods options:
                        Prevent testing out of sync lockfiles. Defaults to false.
 
 Python options:
-  --command=<string>   Python interpreter to use. Default: "python", set to
-                       "python2" or "python3" to use a specific version.
+  --python=<2|3> Python command to use. 
+                        The default is 'python' which will execute your systems default python version. 
+                        Run 'python -V' to find out what version that is. 
+                        To override use --python=2 to execute 'python2' or --python=3 for 'python3'.
+
   --skip-unresolved=<true|false>
                        Allow skipping packages that are not found
                        in the environment.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -42,6 +42,7 @@ export type Method = (...args: MethodArgs) => Promise<string>;
 export interface Args {
   command: string;
   method: Method; // command resolved to a function
+  python: string;
   options: ArgsOptions;
 }
 
@@ -143,6 +144,8 @@ export function args(rawArgv: string[]): Args {
     argv._.unshift(tmp.shift()!);
   }
 
+  const python = argv.python as string; // can actually be undefined
+
   let method: () => Promise<string> = cli[command];
 
   if (!method) {
@@ -221,6 +224,7 @@ export function args(rawArgv: string[]): Args {
   return {
     command,
     method,
+    python,
     options: argv,
   };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -37,6 +37,7 @@ async function runCommand(args: Args) {
   const res = analytics({
     args: args.options._,
     command: args.command,
+    python: args.python,
     org: args.options.org,
   });
 

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -78,6 +78,27 @@ test('test command line test --gradle-sub-project=foo', (t) => {
   t.end();
 });
 
+test('test command line test --python=2', (t) => {
+  const cliArgs = ['node', '$SNYK_CLI_LOCAL_DIST', '--python=2', 'test'];
+  const result = args(cliArgs);
+  t.equal(result.python, '2');
+  t.end();
+});
+
+test('test command line test --python=3', (t) => {
+  const cliArgs = ['node', '$SNYK_CLI_LOCAL_DIST', '--python=3', 'test'];
+  const result = args(cliArgs);
+  t.equal(result.python, '3');
+  t.end();
+});
+
+test('test command line test --python=maven does not work if pass wrong arg', (t) => {
+  const cliArgs = ['node', '$SNYK_CLI_LOCAL_DIST', '--python=maven', 'test'];
+  const result = args(cliArgs);
+  t.notEqual(result.python, '2' || '3');
+  t.end();
+});
+
 test('test command line test --strict-out-of-sync', (t) => {
   const cliArgs = [
     '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR adds new property to set a python version while using snyk-cli.
To work is required snyk-python-plugin updated version with new property.
This new command is handling properly the error message upon e.g. --python=maven which is a wrong way of execute it.

#### Any background context you want to provide?
On this pr the old command='python2' still works perfectly, the goal was only
to introduce a new command that repeats its behaviour.

Working case
#### Screenshots
<img width="637" alt="Screen Shot 2020-02-27 at 15 27 24" src="https://user-images.githubusercontent.com/40601533/75449965-a22b9680-5976-11ea-929c-7f88461a5b22.png">

Throw Error on bad usage
<img width="631" alt="Screen Shot 2020-02-27 at 15 37 30" src="https://user-images.githubusercontent.com/40601533/75450320-41508e00-5977-11ea-94d2-cc444928a907.png">

check snyk-python-plugin pr:
https://github.com/snyk/snyk-python-plugin/pull/102