### PR TITLE
fix: bump snyk-docker-plugin to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "2.2.0",
+    "snyk-docker-plugin": "2.2.2",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

support scratch images in the snyk-docker-plugin for the dynamic image scanning flow

#### Where should the reviewer start?

https://github.com/snyk/snyk-docker-plugin/pull/143
https://github.com/snyk/snyk-docker-plugin/pull/144

#### How should this be manually tested?

npm install, build, then
```node dist/cli/index.js test --docker busybox:1.31.1```

#### Any background context you want to provide?

https://www.notion.so/snyk/Improve-how-we-handle-scratch-images-6fe2d0dbb1584c69b2d185a0cee9e976

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/RUN-728

#### Screenshots

![image](https://user-images.githubusercontent.com/1255387/75779151-ca920700-5d61-11ea-81fc-afc8920457da.png)