### PR TITLE
fix: bumps dep-graph to v1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.3.2",
     "@snyk/configstore": "^3.2.0-rc1",
-    "@snyk/dep-graph": "1.13.1",
+    "@snyk/dep-graph": "1.16.1",
     "@snyk/gemfile": "1.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.0.1",
     "@snyk/update-notifier": "^2.5.1-rc2",

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -235,11 +235,17 @@ test('`monitor npm-package-pruneable --prune-repeated-subdependencies`', async (
   t.ok(req.body.meta.prePruneDepCount, 'sends meta.prePruneDepCount');
   const depGraphJSON = req.body.depGraphJSON;
   t.ok(depGraphJSON);
-  const packageC = depGraphJSON.graph.nodes.find(
-    (pkg) => pkg.pkgId === 'c@1.0.0',
+
+  const packageC1 = depGraphJSON.graph.nodes.find(
+    (pkg) => pkg.nodeId === 'c@1.0.0|1',
   );
-  t.ok(packageC.info.labels.pruned, 'a.d.c is pruned');
-  t.notOk(packageC.dependencies, 'a.d.c has no dependencies');
+  const packageC2 = depGraphJSON.graph.nodes.find(
+    (pkg) => pkg.nodeId === 'c@1.0.0|2',
+  );
+  t.notOk(packageC1.info.labels.pruned, 'a.d.c first instance is not pruned');
+  t.ok(packageC2.info.labels.pruned, 'a.d.c second instance is pruned');
+  t.ok(packageC1.deps.length, 'a.d.c has dependencies');
+  t.notOk(packageC2.deps.length, 'a.d.c has no dependencies');
 });
 
 test('`monitor npm-package-pruneable --prune-repeated-subdependencies --experimental-dep-graph`', async (t) => {


### PR DESCRIPTION
#### What does this PR do?

Bumps the version of dep-graph to v1.16.1 to help fix an issue with pruned subdependency labeling

https://github.com/snyk/dep-graph/releases/tag/v1.16.1

A test needed updating as it was incorrectly validating a that a pruned package was given the label when actually, it was the second, non-deps version which is pruned. It also was incorrectly looking for a `dependencies` value on the object when it was actually `deps`.

Here is the correct shape of the data which is tested for.
```
{
        "nodeId": "c@1.0.0|1",
        "pkgId": "c@1.0.0",
        "deps": [{ "nodeId": "v@5.0.0" }],
        "info": { "labels": { "scope": "prod" } }
      },
      {
        "nodeId": "c@1.0.0|2",
        "pkgId": "c@1.0.0",
        "deps": [],
        "info": { "labels": { "scope": "prod", "pruned": "true" } }
      },
```