### PR TITLE
fix: only send analytics Monitor Graph as true when appropriate

### DIFF
--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -73,7 +73,6 @@ export async function monitor(
   const packageManager = meta.packageManager;
   analytics.add('packageManager', packageManager);
   analytics.add('isDocker', !!meta.isDocker);
-  analytics.add('monitorGraph', true);
 
   if (GRAPH_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)) {
     const monitorGraphSupportedRes = await isFeatureFlagSupportedForOrg(


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

We are wrongly sending the same analytic twice but this one is in the wrong place. Leave the one tracking graphMonitor correctly in place