### PR TITLE
Feat: support UTM in login URL from environment variables

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -34,7 +34,11 @@ async function webAuth(via: AuthCliCommands) {
   };
 
   let urlStr = authUrl + '/login?token=' + token;
-  urlStr += '&' + getUtmsAsString();
+
+  const utmParams = getUtmsAsString();
+  if (utmParams) {
+    urlStr += '&' + utmParams;
+  }
 
   // validate that via comes from our code, and not from user & CLI
   if (redirects[via]) {

--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -12,6 +12,7 @@ import { MisconfiguredAuthInCI } from '../../../lib/errors/misconfigured-auth-in
 import { AuthFailedError } from '../../../lib/errors/authentication-failed-error';
 import { verifyAPI } from './is-authed';
 import { CustomError } from '../../../lib/errors';
+import { getUtmsAsString } from '../../../lib/utm';
 
 export = auth;
 
@@ -33,6 +34,7 @@ async function webAuth(via: AuthCliCommands) {
   };
 
   let urlStr = authUrl + '/login?token=' + token;
+  urlStr += '&' + getUtmsAsString();
 
   // validate that via comes from our code, and not from user & CLI
   if (redirects[via]) {

--- a/src/lib/utm.ts
+++ b/src/lib/utm.ts
@@ -1,10 +1,10 @@
 import * as url from 'url';
 
-const SNYK_UTM_MEDIUM = process.env.SNYK_UTM_MEDIUM || '';
-const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || '';
-const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || '';
-
 export function getUtmsAsString(): string {
+  const SNYK_UTM_MEDIUM = process.env.SNYK_UTM_MEDIUM || '';
+  const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || '';
+  const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || '';
+
   /* eslint-disable @typescript-eslint/camelcase */
   const utmQueryParams = new url.URLSearchParams({
     utm_medium: SNYK_UTM_MEDIUM,

--- a/src/lib/utm.ts
+++ b/src/lib/utm.ts
@@ -5,6 +5,10 @@ export function getUtmsAsString(): string {
   const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || '';
   const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || '';
 
+  if (!SNYK_UTM_MEDIUM && !SNYK_UTM_SOURCE && !SNYK_UTM_CAMPAIGN) {
+    return '';
+  }
+
   /* eslint-disable @typescript-eslint/camelcase */
   const utmQueryParams = new url.URLSearchParams({
     utm_medium: SNYK_UTM_MEDIUM,

--- a/src/lib/utm.ts
+++ b/src/lib/utm.ts
@@ -1,0 +1,17 @@
+import * as url from 'url';
+
+const SNYK_UTM_MEDIUM = process.env.SNYK_UTM_MEDIUM || '';
+const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || '';
+const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || '';
+
+export function getUtmsAsString(): string {
+  /* eslint-disable @typescript-eslint/camelcase */
+  const utmQueryParams = new url.URLSearchParams({
+    utm_medium: SNYK_UTM_MEDIUM,
+    utm_source: SNYK_UTM_SOURCE,
+    utm_campaign: SNYK_UTM_CAMPAIGN,
+  });
+  /* eslint-enable @typescript-eslint/camelcase */
+
+  return utmQueryParams.toString();
+}

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -135,7 +135,7 @@ test('auth with UTMs in environment variables', async (t) => {
 
   // read data from console.log
   let stdoutMessages = '';
-  const stubConsoleLog = (msg) => (stdoutMessages += msg);
+  const stubConsoleLog = (msg: string) => (stdoutMessages += msg);
   const origConsoleLog = console.log;
   console.log = stubConsoleLog;
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds support for reading UTM configuration from environment variables, prefixed with SNYK_UTM_* and supports all 3 UTM options: Source, Medium, Campaign.

When UTM data is available, the authentication (a `snyk auth`) flow will append this data to the query params of the URL that is opened in the browser for authenticating.

#### Where should the reviewer start?
Reviewing the auth flow that now gets the UTMs appended to the URL.

#### How should this be manually tested?
To test manually in a cloned repository:

```bash
SNYK_UTM_MEDIUM=test_medium SNYK_UTM_SOURCE=test_source SNYK_UTM_CAMPAIGN=test_campaign node --require ts-node/register src/cli auth
```

and ensure the URL is being opened with the UTMs data as well as shown in the console's stdout from the auth flow.

#### Any background context you want to provide?
This allows to better track and monitor sign-ups and registrations with the Snyk CLI.

#### What are the relevant tickets?
None
