### PR TITLE
feat: silence noisy error behind -d for --all-projects

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -36,7 +36,7 @@ import {
   getSeverityValue,
 } from './formatters';
 
-const debug = Debug('snyk');
+const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
 const showVulnPathsMapping: Record<string, ShowVulnPaths> = {

--- a/src/lib/plugins/convert-single-splugin-res-to-multi-custom.ts
+++ b/src/lib/plugins/convert-single-splugin-res-to-multi-custom.ts
@@ -1,7 +1,6 @@
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { MultiProjectResultCustom } from './get-multi-plugin-result';
 import { SupportedPackageManagers } from '../package-managers';
-import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 
 export function convertSingleResultToMultiCustom(
   inspectRes: pluginApi.SinglePackageResult,

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -14,7 +14,7 @@ import analytics = require('../analytics');
 import { convertSingleResultToMultiCustom } from './convert-single-splugin-res-to-multi-custom';
 import { convertMultiResultToMultiCustom } from './convert-multi-plugin-res-to-multi-custom';
 
-const debug = debugModule('snyk');
+const debug = debugModule('snyk-test');
 
 // Force getDepsFromPlugin to return scannedProjects for processing
 export async function getDepsFromPlugin(

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -1,6 +1,8 @@
 import * as _ from 'lodash';
 import * as path from 'path';
 import * as cliInterface from '@snyk/cli-interface';
+import chalk from 'chalk';
+import * as debugModule from 'debug';
 
 import { TestOptions, Options, MonitorOptions } from '../types';
 import { detectPackageManagerFromFile } from '../detect';
@@ -10,6 +12,7 @@ import { convertSingleResultToMultiCustom } from './convert-single-splugin-res-t
 import { convertMultiResultToMultiCustom } from './convert-multi-plugin-res-to-multi-custom';
 import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 
+const debug = debugModule('snyk-test');
 export interface ScannedProjectCustom
   extends cliInterface.legacyCommon.ScannedProject {
   packageManager: SupportedPackageManagers;
@@ -63,7 +66,7 @@ export async function getMultiPluginResult(
 
       allResults.push(...pluginResultWithCustomScannedProjects.scannedProjects);
     } catch (err) {
-      console.log(err);
+      debug(chalk.bold.red(err.message));
     }
   }
 

--- a/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-lock-parser.ts
@@ -1,5 +1,5 @@
 import * as baseDebug from 'debug';
-const debug = baseDebug('snyk');
+const debug = baseDebug('snyk-test');
 import * as path from 'path';
 import * as spinner from '../../spinner';
 import * as analytics from '../../analytics';

--- a/src/lib/sub-process.ts
+++ b/src/lib/sub-process.ts
@@ -15,12 +15,16 @@ export function execute(
     let stderr = '';
 
     const proc = childProcess.spawn(command, args, spawnOptions);
-    proc.stdout.on('data', (data) => {
-      stdout = stdout + data;
-    });
-    proc.stderr.on('data', (data) => {
-      stderr = stderr + data;
-    });
+    if (proc.stdout) {
+      proc.stdout.on('data', (data) => {
+        stdout += data;
+      });
+    }
+    if (proc.stderr) {
+      proc.stderr.on('data', (data) => {
+        stderr += data;
+      });
+    }
 
     proc.on('close', (code) => {
       if (code !== 0) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Hide the failed project scans behind `-d` for `--all-projects` as it is too noisy.
Add some separate debug contexts for for fancy colours

https://github.com/snyk/snyk/issues/993

#### Screenshots
<img width="816" alt="Screen Shot 2020-03-19 at 11 52 52" src="https://user-images.githubusercontent.com/2911613/77086095-2e226280-69f9-11ea-832d-8154b71c0ad7.png">
