### PR TITLE
feat: use 8 as min supported runtime message

### DIFF
--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,9 +1,9 @@
 import { gte } from 'semver';
 
-const MIN_RUNTIME = '6.5.0';
+const MIN_RUNTIME = '8.0.0';
 
 export const supportedRange = `>= ${MIN_RUNTIME}`;
 
-export function isSupported(runtimeVersion) {
+export function isSupported(runtimeVersion: string): boolean {
   return gte(runtimeVersion, MIN_RUNTIME);
 }

--- a/test/runtime.test.ts
+++ b/test/runtime.test.ts
@@ -1,16 +1,16 @@
 import { test } from 'tap';
 import * as runtime from '../src/cli/runtime';
 
-test('nodejs runtime versions support ', (t) => {
+test('nodejs runtime versions support ', async (t) => {
   t.ok(
     runtime.isSupported(process.versions.node),
     'Current runtime is supported',
   );
-  t.ok(runtime.isSupported('6.16.0'), '6.16.0 is supported');
+  t.notOk(runtime.isSupported('6.16.0'), '6.16.0 is not supported');
+  t.ok(runtime.isSupported('8.0.0'), '8.0.0 is supported');
   t.ok(runtime.isSupported('11.0.0-pre'), 'pre-release is supported');
   t.notOk(runtime.isSupported('0.10.48'), '0.10 is not supported');
   t.notOk(runtime.isSupported('0.12.18'), '0.12 is not supported');
   t.notOk(runtime.isSupported('4.0.0'), '4.0.0 is not supported');
   t.notOk(runtime.isSupported('6.4.0'), '6.4.0 is not supported');
-  t.end();
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- Update our minSupportedRuntime function to no longer consider `6` supported.
