### PR TITLE
feat: bump snyk-docker-plugin to 2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "2.4.0",
+    "snyk-docker-plugin": "2.6.0",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
to send os-release's PRETTY_NAME to the backend

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

container scanning: sends PRETTY_NAME info from the /etc/os-release file

#### Where should the reviewer start?

https://github.com/snyk/snyk-docker-plugin/releases/tag/v2.6.0
