### PR TITLE
fix: image static scanning to send correct image ID (digest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "2.4.0",
+    "snyk-docker-plugin": "2.6.1",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

bump snyk-docker-plugin to a version where the image ID we collect is fixed to align with what the dynamic image scanning collects (which is actually the image digest)

#### How should this be manually tested?

```node ./dist/cli/index.js monitor --docker debian --experimental```

#### Any background context you want to provide?

https://github.com/snyk/snyk-docker-plugin/pull/164

#### Screenshots

![image](https://user-images.githubusercontent.com/1255387/77331848-f46b9780-6d29-11ea-8594-615b10b1e8fc.png)