### PR TITLE
feat: container alias for docker flag

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -133,8 +133,8 @@ Python options:
                        in the environment.
 
 Docker options:
-  --docker ........... Test or monitor a local docker image for Linux
-                       vulnerabilities. 
+  --docker (alias: --container)
+                       Test or monitor a local docker image for Linux vulnerabilities.
   --file=<string> .... Include the path to the image's Dockerfile for more detailed
                        remediation advice.
   --exclude-base-image-vulns

--- a/help/help.txt
+++ b/help/help.txt
@@ -134,7 +134,7 @@ Python options:
 
 Docker options:
   --docker (alias: --container)
-                       Test or monitor a local docker image for Linux vulnerabilities.
+                       Test or monitor a local Docker image for Linux vulnerabilities.
   --file=<string> .... Include the path to the image's Dockerfile for more detailed
                        remediation advice.
   --exclude-base-image-vulns

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -201,9 +201,16 @@ export function args(rawArgv: string[]): Args {
   }
 
   // Alias
-  if (argv.gradleSubProject) {
-    argv.subProject = argv.gradleSubProject;
-    delete argv.gradleSubProject;
+  const aliases = {
+    gradleSubProject: 'subProject',
+    container: 'docker',
+  };
+  for (const argAlias in aliases) {
+    if (argv[argAlias]) {
+      const target = aliases[argAlias];
+      argv[target] = argv[argAlias];
+      delete argv[argAlias];
+    }
   }
 
   if (argv.insecure) {

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -125,3 +125,28 @@ test('test command line test --fail-on=foo', (t) => {
   t.equal(result.options.failOn, 'foo');
   t.end();
 });
+
+test('test command line test --docker', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--docker',
+  ];
+  const result = args(cliArgs);
+  t.ok(result.options.docker);
+  t.end();
+});
+
+test('test command line test --container', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'test',
+    '--container',
+  ];
+  const result = args(cliArgs);
+  t.ok(result.options.docker);
+  t.notOk(result.options.container);
+  t.end();
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds `--container` alias for `--docker` in CLI

#### How should this be manually tested?
Using `--container` should have the same result as using `--docker`

#### What are the relevant tickets?
DC-591
