### PR TITLE
feat: Add longFormProjectName option

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -77,7 +77,13 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
 
+  if(options.longFormProjectName && !options.allProjects) {
+    throw new Error('`--longFormProjectName` is only compatible with `--all-projects`');
+  }
+
   apiTokenExists();
+
+  
 
   // Part 1: every argument is a scan target; process them sequentially
   for (const path of args as string[]) {
@@ -116,6 +122,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
       analytics.add('pluginOptions', options);
       debug('getDepsFromPlugin ...');
+      
 
       // each plugin will be asked to scan once per path
       // some return single InspectResult & newer ones return Multi
@@ -155,6 +162,10 @@ async function monitor(...args0: MethodArgs): Promise<any> {
         maybePrintDeps(options, projectDeps.depTree);
 
         debug(`Processing ${projectDeps.depTree.name}...`);
+        if(options.longFormProjectName){
+          options["project-name"] = projectDeps.depTree.name + ':' +projectDeps.depTree.version
+        }
+        
         maybePrintDeps(options, projectDeps.depTree);
 
         const tFile = projectDeps.targetFile || targetFile;

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -77,13 +77,13 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
 
-  if(options.longFormProjectName && !options.allProjects) {
-    throw new Error('`--longFormProjectName` is only compatible with `--all-projects`');
+  if (options.longFormProjectName && !options.allProjects) {
+    throw new Error(
+      '`--longFormProjectName` is only compatible with `--all-projects`',
+    );
   }
 
   apiTokenExists();
-
-  
 
   // Part 1: every argument is a scan target; process them sequentially
   for (const path of args as string[]) {
@@ -122,7 +122,6 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
       analytics.add('pluginOptions', options);
       debug('getDepsFromPlugin ...');
-      
 
       // each plugin will be asked to scan once per path
       // some return single InspectResult & newer ones return Multi
@@ -162,10 +161,11 @@ async function monitor(...args0: MethodArgs): Promise<any> {
         maybePrintDeps(options, projectDeps.depTree);
 
         debug(`Processing ${projectDeps.depTree.name}...`);
-        if(options.longFormProjectName){
-          options["project-name"] = projectDeps.depTree.name + ':' +projectDeps.depTree.version
+        if (options.longFormProjectName) {
+          options['project-name'] =
+            projectDeps.depTree.name + ':' + projectDeps.depTree.version;
         }
-        
+
         maybePrintDeps(options, projectDeps.depTree);
 
         const tFile = projectDeps.targetFile || targetFile;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,7 +70,7 @@ export interface MonitorOptions {
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   'prune-repeated-subdependencies'?: boolean;
-  'longFormProjectName'?: boolean;
+  longFormProjectName?: boolean;
 }
 
 export interface MonitorMeta {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -70,6 +70,7 @@ export interface MonitorOptions {
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   'prune-repeated-subdependencies'?: boolean;
+  'longFormProjectName'?: boolean;
 }
 
 export interface MonitorMeta {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Add an option when using --all-projects to have each scanned project to be labelled in its "long" form, meaning including the version.

#### Where should the reviewer start?
src/cli/commands/monitor/index.ts

#### How should this be manually tested?
snyk monitor --all-projects --longFormProjectName

#### Any background context you want to provide?
This is especially helpful when combined with remote-repo-url to group given versions of a project to monitor those versions over time. Numerous frameworks/library owner want to keep an eye on a variety of versions that they know is used still out there.

#### What are the relevant tickets?

#### Screenshots
![image](https://user-images.githubusercontent.com/5722228/77649307-f15eea00-6f69-11ea-8ad3-45c5b1d3a816.png)
vs 
![image](https://user-images.githubusercontent.com/5722228/77649340-00de3300-6f6a-11ea-8ef8-a36de4ca799b.png)

#### Additional questions
