### PR TITLE
Add `--json-file-output=<file>` option to directly save JSON output to file

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,7 @@ export interface Options {
   allProjects?: boolean;
   detectionDepth?: number;
   exclude?: string;
+  'json-file-output'?: string;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This allows a user to directly save JSON format output to a file as specified by the `--json-file-output=<file>` parameter, regardless of whether they are using the human-readable or json output. The primary use-case of this is to enable users (and Snyk CI plugins) to simultaneously get the human readable output while saving a JSON format output to a file for other purposes (for example, generating a report).

#### Where should the reviewer start?
Please take a look at the code and advise as to testing best-practices. I will then include appropriate tests for this PR.

#### How should this be manually tested?
Say you want to save the JSON output to a file called "snyk-output.json" in the current directory. You could then run `snyk test --json-file-output=snyk-output.json` which should do a normal snyk test and generate the human-readable output to stdout but at the same time save the JSON format output to `snyk-output.json`.

#### Any background context you want to provide?
We need this for https://github.com/snyk/snyk/issues/1027 and https://github.com/snyk/snyk-azure-pipelines-task/issues/30 as well as for another CI plugin we're currently working on.

#### What are the relevant tickets?
- https://github.com/snyk/snyk/issues/1027
- https://github.com/snyk/snyk-azure-pipelines-task/issues/30

#### Screenshots


#### Additional questions
