### PR TITLE
Feat/add integration name to analytics

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -22,6 +22,9 @@ function analytics(data) {
     data = {};
   }
 
+  analytics.add('integrationName', process.env.SNYK_INTEGRATION_NAME || '');
+  analytics.add('integrationVersion', process.env.SNYK_INTEGRATION_VERSION || '');
+
   // merge any new data with data we picked up along the way
   if (Array.isArray(data.args)) {
     // this is an overhang from the cli/args.js and we don't want it

--- a/src/lib/is-ci.ts
+++ b/src/lib/is-ci.ts
@@ -14,6 +14,7 @@ const ciEnvs = new Set([
   'GOCD_SERVER_HOST',
   'BUILDKITE',
   'TF_BUILD',
+  'SYSTEM_TEAMFOUNDATIONSERVERURI', // for Azure DevOps Pipelines
 ]);
 
 export function isCI(): boolean {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Looks for two env vars - SNYK_INTEGRATION_NAME and SNYK_INTEGRATION_VERSION - and if they are set adds them to the metadata section of the analytics. These are for identifying which (if any) Snyk tool/plugin/extension/pipe/etc might be making the CLI calls. For example, the Snyk Azure Pipelines task, the Bitbucket Pipe, the CircleCI Orb, IDE plugins, etc.

#### Any background context you want to provide?
We would like to have production monitoring to have better insights into when things are working or not and how much the various CI/IDE/etc tools are used.

