### PR TITLE
feat: support reachable vulnerabilities output for `snyk test`

### DIFF
--- a/src/cli/commands/test/formatters/format-reachability.ts
+++ b/src/cli/commands/test/formatters/format-reachability.ts
@@ -1,0 +1,45 @@
+import * as wrap from 'wrap-ansi';
+import chalk from 'chalk';
+
+import { REACHABILITY } from '../../../../lib/snyk-test/legacy';
+
+const reachabilityLevels: {
+  [key in REACHABILITY]: { color: Function; text: string };
+} = {
+  [REACHABILITY.FUNCTION]: {
+    color: chalk.redBright,
+    text: 'Reachable by function call',
+  },
+  [REACHABILITY.PACKAGE]: {
+    color: chalk.yellow,
+    text: 'Reachable by package import',
+  },
+  [REACHABILITY.UNREACHABLE]: {
+    color: chalk.blueBright,
+    text: 'Unreachable',
+  },
+  [REACHABILITY.NO_INFO]: {
+    color: (str) => str,
+    text: '',
+  },
+};
+
+export function formatReachability(reachability?: REACHABILITY): string {
+  if (!reachability) {
+    return '';
+  }
+  const reachableInfo = reachabilityLevels[reachability];
+  const textFunc = reachableInfo ? reachableInfo.color : (str) => str;
+  const text =
+    reachableInfo && reachableInfo.text ? `[${reachableInfo.text}]` : '';
+
+  return wrap(textFunc(text), 100);
+}
+
+export function getReachabilityText(reachability?: REACHABILITY): string {
+  if (!reachability) {
+    return '';
+  }
+  const reachableInfo = reachabilityLevels[reachability];
+  return reachableInfo ? reachableInfo.text : '';
+}

--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -15,6 +15,7 @@ import {
   DockerIssue,
 } from '../../../../lib/snyk-test/legacy';
 import { formatLegalInstructions } from './legal-license-instructions';
+import { getReachabilityText } from './format-reachability';
 
 export function formatIssues(
   vuln: GroupedVuln,
@@ -55,6 +56,7 @@ export function formatIssues(
         ' '.repeat(2) +
         formatLegalInstructions(vuln.legalInstructionsArray, 2)
       : '',
+    reachability: vuln.reachability ? createReachabilityInText(vuln) : '',
   };
 
   return (
@@ -64,6 +66,7 @@ export function formatIssues(
     `${vulnOutput.introducedThrough}\n` +
     vulnOutput.fromPaths +
     // Optional - not always there
+    vulnOutput.reachability +
     vulnOutput.remediationInfo +
     vulnOutput.dockerfilePackage +
     vulnOutput.fixedIn +
@@ -165,6 +168,17 @@ function createFixedInText(vuln: GroupedVuln): string {
   }
 
   return '';
+}
+
+function createReachabilityInText(vuln: GroupedVuln): string {
+  if (!vuln.reachability) {
+    return '';
+  }
+  const reachabilityText = getReachabilityText(vuln.reachability);
+  if (!reachabilityText) {
+    return '';
+  }
+  return `\n  Reachability: ${reachabilityText}`;
 }
 
 function createRemediationText(

--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -12,9 +12,11 @@ import {
   UpgradeRemediation,
   PinRemediation,
   LegalInstruction,
+  REACHABILITY,
 } from '../../../../lib/snyk-test/legacy';
 import { SEVERITIES } from '../../../../lib/snyk-test/common';
 import { formatLegalInstructions } from './legal-license-instructions';
+import { formatReachability } from './format-reachability';
 
 interface BasicVulnInfo {
   type: string;
@@ -27,6 +29,7 @@ interface BasicVulnInfo {
   legalInstructions?: LegalInstruction[];
   paths: string[][];
   note: string | false;
+  reachability?: REACHABILITY;
 }
 
 interface TopLevelPackageUpgrade {
@@ -63,6 +66,7 @@ export function formatIssuesWithRemediation(
       note: vuln.note,
       legalInstructions: vuln.legalInstructionsArray,
       paths: vuln.list.map((v) => v.from),
+      reachability: vuln.reachability,
     };
 
     if (vulnData.type === 'license') {
@@ -243,6 +247,8 @@ function thisUpgradeFixes(
         basicVulnInfo[id].paths,
         testOptions,
         basicVulnInfo[id].note,
+        [],
+        basicVulnInfo[id].reachability,
       ),
     )
     .join('\n');
@@ -393,6 +399,8 @@ function constructUnfixableText(
         issueInfo.paths,
         testOptions,
         issueInfo.note,
+        [],
+        issue.reachability,
       ) + `${extraInfo}`,
     );
   }
@@ -420,6 +428,7 @@ function formatIssue(
   testOptions: TestOptions,
   note: string | false,
   legalInstructions?: LegalInstruction[],
+  reachability?: REACHABILITY,
 ): string {
   const severitiesColourMapping = {
     low: {
@@ -443,6 +452,10 @@ function formatIssue(
   let legalLicenseInstructionsText;
   if (legalInstructions) {
     legalLicenseInstructionsText = formatLegalInstructions(legalInstructions);
+  }
+  let reachabilityText = '';
+  if (reachability) {
+    reachabilityText = `${formatReachability(reachability)}`;
   }
 
   let introducedBy = '';
@@ -479,6 +492,7 @@ function formatIssue(
         severity,
       )} Severity]`,
     ) +
+    reachabilityText +
     `[${config.ROOT}/vuln/${id}]` +
     name +
     introducedBy +

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -537,6 +537,7 @@ function groupVulnerabilities(vulns): GroupedVuln[] {
       map[curr.id].dockerBaseImage = curr.dockerBaseImage;
       map[curr.id].nearestFixedInVersion = curr.nearestFixedInVersion;
       map[curr.id].legalInstructionsArray = curr.legalInstructionsArray;
+      map[curr.id].reachability = curr.reachability;
     }
 
     map[curr.id].list.push(curr);

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -21,6 +21,13 @@ export enum SEVERITY {
   HIGH = 'high',
 }
 
+export enum REACHABILITY {
+  FUNCTION = 'function',
+  PACKAGE = 'package',
+  UNREACHABLE = 'unreachable',
+  NO_INFO = 'no-info',
+}
+
 export interface VulnMetaData {
   id: string;
   title: string;
@@ -48,6 +55,7 @@ export interface GroupedVuln {
   isFixable: boolean;
   fixedIn: string[];
   legalInstructionsArray?: LegalInstruction[];
+  reachability?: REACHABILITY;
 }
 
 export interface LegalInstruction {
@@ -74,6 +82,7 @@ export interface IssueData {
   severity: SEVERITY;
   fixedIn: string[];
   legalInstructions?: string;
+  reachability?: REACHABILITY;
 }
 
 interface AnnotatedIssue extends IssueData {

--- a/test/acceptance/display-test-results.test.ts
+++ b/test/acceptance/display-test-results.test.ts
@@ -88,3 +88,24 @@ test('`test pip-app-license-issue` legal instructions displayed (legacy formatte
   snykTestStub.restore();
   t.end();
 });
+
+test('test reachability info is displayed', async (t) => {
+  chdirWorkspaces();
+  const stubbedResponse = JSON.parse(
+    fs.readFileSync(
+      __dirname +
+        '/workspaces/reachable-vulns/maven/test-dep-graph-response.json',
+      'utf8',
+    ),
+  );
+  const snykTestStub = sinon.stub(snyk, 'test').returns(stubbedResponse);
+  try {
+    await snykTest('maven-app');
+  } catch (error) {
+    const { message } = error;
+    t.match(message, '[Reachable by function call]');
+  }
+
+  snykTestStub.restore();
+  t.end();
+});

--- a/test/acceptance/workspaces/reachable-vulns/maven/test-dep-graph-response.json
+++ b/test/acceptance/workspaces/reachable-vulns/maven/test-dep-graph-response.json
@@ -1,0 +1,88 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": ["A dude"],
+      "cvssScore": 5.6,
+      "description": "Some description",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": ["1.4.11", "1.5.6", "1.6.3", "1.7.1"],
+      "functions": [],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/file.js",
+            "functionName": "theFunctionName"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-PACAKGE-12345",
+      "identifiers": {
+        "CVE": ["CVE-2014-0472"],
+        "CWE": ["CWE-94"]
+      },
+      "language": "java",
+      "modificationTime": "2019-07-11T13:26:49.758445Z",
+      "moduleName": "package-name",
+      "packageManager": "maven",
+      "packageName": "package-name",
+      "patches": [],
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "reachability": "function",
+      "references": [
+        {
+          "title": "Vulnerability Description",
+          "url": "https://www.url.com/page.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": ["[,1.4.11)", "[1.5,1.5.6)", "[1.6,1.6.3)", "[1.7,1.7.1)"]
+      },
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "from": ["root@0.0.0", "package-name@1.6.1"],
+      "upgradePath": [],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "package-name",
+      "version": "1.6.1"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "reachable vulns org",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": null,
+  "summary": "30 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [],
+    "upgrade": {
+      "package-name@1.6.1": {
+        "upgradeTo": "package-name@1.6.3",
+        "vulns": ["SNYK-JAVA-PACAKGE-12345"],
+        "isTransitive": false
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 30
+}

--- a/test/reachable-vulns.test.ts
+++ b/test/reachable-vulns.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'tap';
+
+import {
+  formatReachability,
+  getReachabilityText,
+} from '../src/cli/commands/test/formatters/format-reachability';
+import { REACHABILITY } from '../src/lib/snyk-test/legacy';
+
+test('output formatting', (t) => {
+  t.equal(
+    formatReachability(REACHABILITY.FUNCTION),
+    '[Reachable by function call]',
+  );
+  t.equal(
+    formatReachability(REACHABILITY.PACKAGE),
+    '[Reachable by package import]',
+  );
+  t.equal(formatReachability(REACHABILITY.UNREACHABLE), '[Unreachable]');
+  t.equal(formatReachability(REACHABILITY.NO_INFO), '');
+  t.equal(formatReachability(undefined), '');
+  t.end();
+});
+
+test('reachable text', (t) => {
+  t.equal(
+    getReachabilityText(REACHABILITY.FUNCTION),
+    'Reachable by function call',
+  );
+  t.equal(
+    getReachabilityText(REACHABILITY.PACKAGE),
+    'Reachable by package import',
+  );
+  t.equal(getReachabilityText(REACHABILITY.UNREACHABLE), 'Unreachable');
+  t.equal(getReachabilityText(REACHABILITY.NO_INFO), '');
+  t.equal(getReachabilityText(undefined), '');
+  t.end();
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Support reachable vulnerabilities *output* for `snyk test` and `snyk test --json`.
This diff only deals with the test output to include reachability metadata on the vuln output,     Steps to include it as part of the `snyk test` will be pushed as a subsequent PR.

Those will show only if the metadata is returned for out backend services, which are currently protected behind a feature flag.

**This is not the final design of the output, we will iterate**

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-162


#### Screenshots

![image](https://user-images.githubusercontent.com/5316748/79686196-36afc800-8247-11ea-9909-cedccea65348.png)


