### PR TITLE
fix: upgrade @snyk/snyk/nodejs-lockfile-parser from 1.17.0 to 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",
     "snyk-mvn-plugin": "2.9.0",
-    "snyk-nodejs-lockfile-parser": "1.17.0",
+    "snyk-nodejs-lockfile-parser": "1.18.0",
     "snyk-nuget-plugin": "1.16.0",
     "snyk-php-plugin": "1.7.0",
     "snyk-policy": "1.13.5",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Upgrade Snyk CLI with new nodejs-lockfile-parser