### PR TITLE
fix: bump ruby-semver to use min Node 8 instead of 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@snyk/configstore": "^3.2.0-rc1",
     "@snyk/dep-graph": "1.16.1",
     "@snyk/gemfile": "1.2.0",
+    "@snyk/ruby-semver": "2.1.2",
     "@snyk/snyk-cocoapods-plugin": "2.1.1",
     "@snyk/update-notifier": "^2.5.1-rc2",
     "@types/agent-base": "^4.2.0",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
All libraries that are used in CLI must remain using min Node.js version >=8 to maintain support. Reverting the ruby-semver change that upgraded this to 10.

snyk/snyk#1060

