### PR TITLE
feat: switch to use 'open' since 'opn' is deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "inquirer": "^6.2.2",
     "lodash": "^4.17.14",
     "needle": "^2.2.4",
-    "opn": "^5.5.0",
+    "open": "^7.0.3",
     "os-name": "^3.0.0",
     "proxy-agent": "^3.1.1",
     "proxy-from-env": "^1.0.0",

--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -1,5 +1,5 @@
 import * as Debug from 'debug';
-import * as open from 'opn';
+import * as open from 'open';
 import * as snyk from '../../../lib';
 import * as config from '../../../lib/config';
 import { isCI } from '../../../lib/is-ci';
@@ -64,7 +64,7 @@ async function webAuth(via: AuthCliCommands) {
   try {
     spinner.start();
     await setTimeout(() => {
-      open(urlStr, { wait: false });
+      open(urlStr);
     }, 0);
 
     const res = await testAuthComplete(token);

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -95,9 +95,7 @@ test('auth via invalid key', async (t) => {
 test('auth with no args', async (t) => {
   // stub open so browser window doesn't actually open
   const open = sinon.stub();
-  const auth = proxyquire('../../src/cli/commands/auth', {
-    opn: open,
-  });
+  const auth = proxyquire('../../src/cli/commands/auth', { open });
   // stub CI check (ensure returns false for system test)
   const ciStub = sinon.stub(ciChecker, 'isCI').returns(false);
   // disable console.log
@@ -115,7 +113,6 @@ test('auth with no args', async (t) => {
       'http://localhost:12345/login?token=',
       'opens login with token param',
     );
-    t.same(open.firstCall.args[1], { wait: false }, 'does not wait for open');
     ciStub.restore();
   } catch (e) {
     t.threw(e);
@@ -127,9 +124,7 @@ test('auth with no args', async (t) => {
 test('auth with UTMs in environment variables', async (t) => {
   // stub open so browser window doesn't actually open
   const open = sinon.stub();
-  const auth = proxyquire('../../src/cli/commands/auth', {
-    opn: open,
-  });
+  const auth = proxyquire('../../src/cli/commands/auth', { open });
   // stub CI check (ensure returns false for system test)
   const ciStub = sinon.stub(ciChecker, 'isCI').returns(false);
 
@@ -156,7 +151,6 @@ test('auth with UTMs in environment variables', async (t) => {
       '&utm_medium=ide&utm_source=eclipse&utm_campaign=plugin',
       'opens login with utm tokens provided',
     );
-    t.same(open.firstCall.args[1], { wait: false }, 'does not wait for open');
 
     // clean up environment variables
     delete process.env.SNYK_UTM_MEDIUM;


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?
`opn` is deprecated package. Maintainers moved code to `open` package.
