### PR TITLE
feat: enable experimental docker-archive scanning

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "^2.2.1",
-    "snyk-docker-plugin": "2.6.1",
+    "snyk-docker-plugin": "2.10.0",
     "snyk-go-plugin": "1.13.0",
     "snyk-gradle-plugin": "3.2.5",
     "snyk-module": "1.9.1",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,8 @@ export interface Options {
   allProjects?: boolean;
   detectionDepth?: number;
   exclude?: string;
+  // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
+  experimental?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -72,6 +74,8 @@ export interface MonitorOptions {
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   'prune-repeated-subdependencies'?: boolean;
+  // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
+  experimental?: boolean;
 }
 
 export interface MonitorMeta {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Upgrade the snyk-docker-plugin to allow this new feature under the --experimental flag.

#### How should this be manually tested?

```bash
snyk test --docker --experimental docker-archive:path/to/archive.tar

snyk monitor --docker --experimental docker-archive:path/to/archive.tar
```

#### Any background context you want to provide?

https://github.com/snyk/snyk-docker-plugin/pull/191

Regular scans:
<img width="1427" alt="Screenshot 2020-04-23 at 15 08 10" src="https://user-images.githubusercontent.com/16717473/80369168-b829da80-8885-11ea-97a9-19bd170bec9d.png">

With `--project-name` specified:
<img width="1419" alt="Screenshot 2020-04-24 at 14 56 00" src="https://user-images.githubusercontent.com/16717473/80369196-c4ae3300-8885-11ea-83d9-872ae32bf995.png">


