### PR TITLE
fix: Bump @snyk/dep-graph to 1.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "@snyk/cli-interface": "2.6.0",
     "@snyk/configstore": "^3.2.0-rc1",
-    "@snyk/dep-graph": "1.18.2",
+    "@snyk/dep-graph": "1.18.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",
     "@snyk/inquirer": "6.2.2-patch",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps `@snyk/dep-graph` to 1.18.3

#### How should this be manually tested?
Manual testing not necessary, all unit tests pass

#### Any background context you want to provide?
`@snyk/dep-graph` accidentally included `prettier` as a `dependency` in 1.18.2, so anyone who installs the latest version of `snyk` also installs `prettier` in their `node_modules`. The latest version of `@snyk/dep-graph` moves it to a `devDependency` (https://github.com/snyk/dep-graph/commit/315b5d4fbf4e3d6f48003595b9605e95bb85849c#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R38).