### PR TITLE
fix: docker error on monitoring multiple projects

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -103,7 +103,7 @@ runCmdAsDockerUser "touch \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\""
 if [ -n "$MONITOR" ]; then
   echo "Monitoring & generating report ..."
   runCmdAsDockerUser "PATH=$PATH snyk monitor --json ${SNYK_PARAMS} ${ADDITIONAL_ENV} > ${MONITOR_OUTPUT_FILE} 2>$ERROR_FILE"
-  runCmdAsDockerUser "cat ${MONITOR_OUTPUT_FILE} | jq -r \".uri\" | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>>\"${ERROR_FILE}\""
+  runCmdAsDockerUser "cat ${MONITOR_OUTPUT_FILE} | jq -r 'if type==\"array\" then .[].uri? else .uri? end' | awk '{print \"<center><a target=\\\"_blank\\\" href=\\\"\" \$0 \"\\\">View On Snyk.io</a></center>\"}' > \"${PROJECT_PATH}/${PROJECT_FOLDER}/${HTML_FILE}\" 2>>\"${ERROR_FILE}\""
 fi
 
 


### PR DESCRIPTION
#### What does this PR do?

Fixes an error thrown by `jq` when using our Docker images to monitor multiple projects (i.e. using `--all-projects`.

The error thrown by jq is: 

```
jq: error (at <stdin>:737): Cannot index array with string "uri"
```

#### How should this be manually tested?

- Pull down branch
- Build local docker image (`cd docker && docker build -f Dockerfile.docker . -t snyk/snyk-cli:local`
- Monitor a single project via this docker image
  - `docker run --rm -e 'SNYK_TOKEN=***-**-**' -e 'MONITOR=true' -v <full-path-to-repo>:/project snyk/snyk-cli:local test -d`
- Monitor a multi project directory via this docker image
  - `docker run --rm -e 'SNYK_TOKEN=***-**-**' -e 'MONITOR=true' -v <full-path-to-repo>:/project snyk/snyk-cli:local test --all-projects '--detection-depth=3' -d`
- Confirm that no errors occur and the HTML file for both single and multi projects includes link(s) to view the project on Snyk at the top

#### Any background context you want to provide?

This error occurs because the following line expects the results JSON to be an object with `uri` key, but in the case of multiple projects it's an array of objects with `uri` keys:

https://github.com/snyk/snyk/blob/d282b35e62874350f818a0bd6726e5994c3be700/docker/docker-entrypoint.sh#L106

#### Screenshots
![Screenshot 2020-05-01 at 14 42 42](https://user-images.githubusercontent.com/6598617/80809725-2b9b5700-8bba-11ea-9419-5703ae9aadbb.png)
