### PR TITLE
Snyk test results contain wrong path if scanning a multi-module project

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -41,6 +41,7 @@ import {
   summariseReachableVulns,
   summariseVulnerableResults,
 } from './formatters';
+import * as utils from './utils';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -132,7 +133,13 @@ async function test(...args: MethodArgs): Promise<string> {
     const resArray: any[] = Array.isArray(res) ? res : [res];
 
     for (let i = 0; i < resArray.length; i++) {
-      results.push(_.assign(resArray[i], { path }));
+      const pathWithOptionalProjectName = utils.getPathWithOptionalProjectName(
+        path,
+        resArray[i],
+      );
+      results.push(
+        _.assign(resArray[i], { path: pathWithOptionalProjectName }),
+      );
       // currently testOpts are identical for each test result returned even if it's for multiple projects.
       // we want to return the project names, so will need to be crafty in a way that makes sense.
       if (!testOpts.projectNames) {

--- a/src/cli/commands/test/utils.ts
+++ b/src/cli/commands/test/utils.ts
@@ -1,0 +1,21 @@
+import { TestResult } from '../../../lib/snyk-test/legacy';
+
+export function getPathWithOptionalProjectName(
+  currPath: string,
+  testResult: TestResult,
+): string {
+  let projectName = testResult.projectName;
+  if (projectName) {
+    const index = projectName.indexOf('/');
+    if (index > -1) {
+      projectName = projectName.substr(index + 1);
+    } else {
+      projectName = undefined;
+    }
+  }
+  const pathWithOptionalProjectName = projectName
+    ? `${currPath}/${projectName}`
+    : currPath;
+
+  return pathWithOptionalProjectName;
+}

--- a/test/commands/test/utils.test.ts
+++ b/test/commands/test/utils.test.ts
@@ -1,0 +1,66 @@
+import * as utils from '../../../src/cli/commands/test/utils';
+import { test } from 'tap';
+import { TestResult } from '../../../src/lib/snyk-test/legacy';
+
+test('project name is undefined', (t) => {
+  t.plan(1);
+
+  const testResult: TestResult = {
+    vulnerabilities: [],
+    ok: true,
+    dependencyCount: 0,
+    org: 'test-org',
+    policy: 'test-policy',
+    isPrivate: true,
+    licensesPolicy: null,
+    packageManager: 'test-packageManager',
+    ignoreSettings: null,
+    summary: 'test-summary',
+    projectName: '',
+  };
+
+  const res = utils.getPathWithOptionalProjectName('/tmp/hydra', testResult);
+  t.equal(res, '/tmp/hydra');
+});
+
+test('project name has no sub dir', (t) => {
+  t.plan(1);
+
+  const testResult: TestResult = {
+    vulnerabilities: [],
+    ok: true,
+    dependencyCount: 0,
+    org: 'test-org',
+    policy: 'test-policy',
+    isPrivate: true,
+    licensesPolicy: null,
+    packageManager: 'test-packageManager',
+    ignoreSettings: null,
+    summary: 'test-summary',
+    projectName: 'hydra',
+  };
+
+  const res = utils.getPathWithOptionalProjectName('/tmp/hydra', testResult);
+  t.equal(res, '/tmp/hydra');
+});
+
+test('project name has sub dir', (t) => {
+  t.plan(1);
+
+  const testResult: TestResult = {
+    vulnerabilities: [],
+    ok: true,
+    dependencyCount: 0,
+    org: 'test-org',
+    policy: 'test-policy',
+    isPrivate: true,
+    licensesPolicy: null,
+    packageManager: 'test-packageManager',
+    ignoreSettings: null,
+    summary: 'test-summary',
+    projectName: 'hydra/subdir',
+  };
+
+  const res = utils.getPathWithOptionalProjectName('/tmp/hydra', testResult);
+  t.equal(res, '/tmp/hydra/subdir');
+});


### PR DESCRIPTION
- [ X] Ready for review
- [ X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ X] Reviewed by Snyk internal team

#### What does this PR do?
When we have a multi project the path we return back from the CLI is correct only for the first (master) project.
It came from an on-call ticket where the customer was trying to snyk-to-html the results from snyk test and he saw:
![image](https://user-images.githubusercontent.com/16254901/81704371-9a539c80-9465-11ea-9ccf-a2a958072861.png)


After the fix the page looks like that:
![image](https://user-images.githubusercontent.com/16254901/81704326-8c9e1700-9465-11ea-824f-1b32208268dc.png)
