### PR TITLE
fix: enable mvn plugin logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "snyk-go-plugin": "1.14.0",
     "snyk-gradle-plugin": "3.2.7",
     "snyk-module": "1.9.1",
-    "snyk-mvn-plugin": "2.15.1",
+    "snyk-mvn-plugin": "2.15.2",
     "snyk-nodejs-lockfile-parser": "1.22.0",
     "snyk-nuget-plugin": "1.17.0",
     "snyk-php-plugin": "1.9.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -26,6 +26,7 @@ const DEBUG_DEFAULT_NAMESPACES = [
   'snyk',
   'snyk-gradle-plugin',
   'snyk-sbt-plugin',
+  'snyk-mvn-plugin',
 ];
 
 function dashToCamelCase(dash) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Enable mvn plugin to log when running the cli with `DEBUG=snyk-mvn-plugin snyk monitor --scan-all-unmanaged -d` just like we do for gradle plugin

https://github.com/snyk/snyk-mvn-plugin/pull/65

<img width="816" alt="Screen Shot 2020-05-12 at 23 14 32" src="https://user-images.githubusercontent.com/2911613/81752063-a6148280-94a8-11ea-996f-5411b92272fb.png">

