### PR TITLE
fix: suggest --skip-unresolved for python test

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "snyk-nuget-plugin": "1.17.0",
     "snyk-php-plugin": "1.9.0",
     "snyk-policy": "1.14.1",
-    "snyk-python-plugin": "1.17.0",
+    "snyk-python-plugin": "1.17.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.11.0",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

CLI command is `--skip-unresolved` but the legacy alias for python plugin was `--allow-missing`, drop suggesting the older alias and suggest the new one only.