### PR TITLE
feat: switch back to upstream versions of forks

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@snyk/lodash": "^4.17.15-patch",
     "@snyk/ruby-semver": "2.2.0",
     "@snyk/snyk-cocoapods-plugin": "2.2.0",
-    "@snyk/update-notifier": "^2.5.1-rc2",
     "@types/agent-base": "^4.2.0",
     "abbrev": "^1.1.1",
     "ansi-escapes": "3.2.0",
@@ -98,6 +97,7 @@
     "strip-ansi": "^5.2.0",
     "tempfile": "^2.0.0",
     "then-fs": "^2.0.0",
+    "update-notifier": "^4.1.0",
     "uuid": "^3.3.2",
     "wrap-ansi": "^5.1.0"
   },
@@ -107,6 +107,7 @@
     "@types/node": "8.10.59",
     "@types/restify": "^8.4.2",
     "@types/sinon": "^7.5.0",
+    "@types/update-notifier": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "2.18.0",
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "6.8.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "2.6.0",
-    "@snyk/configstore": "^3.2.0-rc1",
     "@snyk/dep-graph": "1.18.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",
@@ -67,6 +66,7 @@
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",
     "cli-spinner": "0.2.10",
+    "configstore": "^5.0.1",
     "debug": "^3.1.0",
     "diff": "^4.0.1",
     "git-url-parse": "11.1.2",

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,4 +1,4 @@
-import * as updateNotifier from '@snyk/update-notifier';
+import * as updateNotifier from 'update-notifier';
 import * as fs from 'fs';
 import * as p from 'path';
 

--- a/src/lib/user-config.ts
+++ b/src/lib/user-config.ts
@@ -1,3 +1,3 @@
-const Configstore = require('@snyk/configstore');
+const Configstore = require('configstore');
 const pkg = require(__dirname + '/../../package.json');
 export const config = new Configstore(pkg.name);

--- a/test/updater.test.ts
+++ b/test/updater.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import { updateCheck } from '../src/lib/updater';
 import * as path from 'path';
 import * as sinon from 'sinon';
-import * as updateNotifier from '@snyk/update-notifier';
+import * as updateNotifier from 'update-notifier';
 
 // Fake location of the package.json file and verify the code behaves well
 test('missing package.json', (t) => {

--- a/test/updater.test.ts
+++ b/test/updater.test.ts
@@ -36,13 +36,14 @@ test('STANDALONE declaration present', (t) => {
 });
 
 // Run updateNotifier API for the basic package. The target is to verify API still stands
-test('verify updater', (t) => {
+test('verify updater', async (t) => {
   const pkg = {
     name: 'snyk',
     version: '1.0.0',
   };
   const notifier = updateNotifier({ pkg });
+  const info = await notifier.fetchInfo();
 
-  t.equal(notifier.packageName, 'snyk', 'Successfull call to notifier');
+  t.equal(info.name, 'snyk', 'Successful call to notifier');
   t.end();
 });


### PR DESCRIPTION
#### What does this PR do?

Undo the workaround added in #990, as upstream have fixed the issues. Their major version bumps are mostly about dropping support for older node.
