### PR TITLE
feat: upgrade cocoapods plugin (bundle shrink)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@snyk/inquirer": "6.2.2-patch",
     "@snyk/lodash": "^4.17.15-patch",
     "@snyk/ruby-semver": "2.2.0",
-    "@snyk/snyk-cocoapods-plugin": "2.2.0",
+    "@snyk/snyk-cocoapods-plugin": "2.3.0",
     "abbrev": "^1.1.1",
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
#### What does this PR do?

Upgrade a plugin. The upgrade brings the removal of two huge dependencies, giving us a 16MB smaller (pre-compression) bundle size / install size.