### PR TITLE
feat: allow a mode displays its custom help message

### DIFF
--- a/help/container.txt
+++ b/help/container.txt
@@ -1,0 +1,28 @@
+Container:
+
+  $ snyk container [command] [options] [image]
+
+Find vulnerabilities in your a container images.
+
+Commands:
+
+  test ............... Test for any known vulnerabilities.
+  monitor ............ Record the state of dependencies and any
+                       vulnerabilities on snyk.io.
+
+Options:
+
+  --exclude-base-image-vulns ............. Exclude from display base image vulnerabilities.
+  --file=<string> ........................ Include the path to the image's Dockerfile for more detailed advice.
+  -h, --help
+  --json
+  --print-deps ............................ Print the dependency tree before sending it for analysis.
+  --severity-threshold=<low|medium|high>... Only report vulnerabilities of provided level or higher.
+
+Examples:
+
+  $ snyk container test alpine
+
+Pro tip: use `snyk container test --file=Dockerfile` for more detailed advice.
+
+For more information see https://snyk.io

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,7 +1,7 @@
 import * as abbrev from 'abbrev';
 
 import debugModule = require('debug');
-import { parseMode } from './modes';
+import { parseMode, displayModeHelp } from './modes';
 
 export declare interface Global extends NodeJS.Global {
   ignoreUnknownCA: boolean;
@@ -114,6 +114,7 @@ export function args(rawArgv: string[]): Args {
   let command = argv._.shift() as string; // can actually be undefined
 
   // snyk [mode?] [command] [paths?] [options-double-dash]
+  command = displayModeHelp(command, argv);
   command = parseMode(command, argv);
 
   // alias switcheroo - allows us to have

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -51,6 +51,18 @@ export function modeValidation(args: object) {
   }
 }
 
+export function displayModeHelp(mode: string, args) {
+  if (isValidMode(mode)) {
+    const command: string = args._[0];
+
+    if (!isValidCommand(mode, command) || args['help']) {
+      args['help'] = mode;
+    }
+  }
+
+  return mode;
+}
+
 function isValidMode(mode: string): boolean {
   return Object.keys(modes).includes(mode);
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -186,3 +186,54 @@ test('test command line "container protect"', (t) => {
   t.notOk(result.options.docker);
   t.end();
 });
+
+test('test command line "container" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'container',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(
+    result.options.help,
+    'container',
+    'help option should be assigned to container',
+  );
+  t.end();
+});
+
+test('test command line "container --help" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'container',
+    '--help',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(
+    result.options.help,
+    'container',
+    'help option should be assigned to container',
+  );
+  t.end();
+});
+
+test('test command line "container test --help" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'container',
+    'test',
+    '--help',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(
+    result.options.help,
+    'container',
+    'help option should be assigned to container',
+  );
+  t.end();
+});

--- a/test/modes.test.ts
+++ b/test/modes.test.ts
@@ -3,10 +3,15 @@ import {
   UnsupportedOptionCombinationError,
   CustomError,
 } from '../src/lib/errors';
-import { parseMode, modeValidation } from '../src/cli/modes';
+import { parseMode, modeValidation, displayModeHelp } from '../src/cli/modes';
 
-test('when is missing command', (c) => {
-  c.test('should do nothing', (t) => {
+test('display help message', (c) => {
+  c.test('should do nothing when it is missing command', (t) => {
+    const expectedCommand = 'container';
+    const expectedArgs = {
+      _: [],
+      'package-manager': 'pip',
+    };
     const cliCommand = 'container';
     const cliArgs = {
       _: [],
@@ -15,11 +20,91 @@ test('when is missing command', (c) => {
 
     const command = parseMode(cliCommand, cliArgs);
 
-    t.equal(command, cliCommand);
-    t.equal(cliArgs, cliArgs);
-    t.notOk(cliArgs['docker']);
+    t.equal(command, expectedCommand, 'command should be "container"');
+    t.same(cliArgs, expectedArgs, 'args should be the same');
+    t.notOk(cliArgs['docker'], 'should not set docker option');
     t.end();
   });
+
+  c.test('should change the command to help with help="container"', (t) => {
+    const expectedCommand = 'container';
+    const expectedArgs = {
+      _: [],
+      help: 'container',
+      'package-manager': 'pip',
+    };
+    const cliCommand = 'container';
+    const cliArgs = {
+      _: [],
+      'package-manager': 'pip',
+    };
+
+    const command = displayModeHelp(cliCommand, cliArgs);
+
+    t.equal(command, expectedCommand, 'command should be "container"');
+    t.same(
+      cliArgs,
+      expectedArgs,
+      'args should contain "help" as key and "container" as value',
+    );
+    t.end();
+  });
+
+  c.test(
+    'command "container --help" should change the command to help with help="container"',
+    (t) => {
+      const expectedCommand = 'container';
+      const expectedArgs = {
+        _: [],
+        help: 'container',
+        'package-manager': 'pip',
+      };
+      const cliCommand = 'container';
+      const cliArgs = {
+        _: [],
+        help: true,
+        'package-manager': 'pip',
+      };
+
+      const command = displayModeHelp(cliCommand, cliArgs);
+
+      t.equal(command, expectedCommand, 'command should be "container"');
+      t.same(
+        cliArgs,
+        expectedArgs,
+        'args should contain "help" as key and "container" as value',
+      );
+      t.end();
+    },
+  );
+
+  c.test(
+    'command "container test --help" should change the command to help with help="container"',
+    (t) => {
+      const expectedCommand = 'container';
+      const expectedArgs = {
+        _: ['test'],
+        help: 'container',
+        'package-manager': 'pip',
+      };
+      const cliCommand = 'container';
+      const cliArgs = {
+        _: ['test'],
+        help: true,
+        'package-manager': 'pip',
+      };
+
+      const command = displayModeHelp(cliCommand, cliArgs);
+
+      t.equal(command, expectedCommand, 'command should be "container"');
+      t.same(
+        cliArgs,
+        expectedArgs,
+        'args should contain "help" as key and "container" as value',
+      );
+      t.end();
+    },
+  );
   c.end();
 });
 


### PR DESCRIPTION
 Allow mode displays its custom help message. It follows up work to create a "snyk container test" and "snyk container monitor" that doesn't require Docker engine running.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
It allows all `modes` to have a custom help message. Also it includes a help message for `snyk container` modes. 

#### Where should the reviewer start?
Execute the command `snyk container --help` to see the custom help message. After taking a look at files `src/cli/args.ts` and `src/cli/modes.ts`.
It's good to notice that the previous behaviour for help command was not changed. `snyk test --help` and `snyk test --help=config` still having the same behaviour that it had before.

#### How should this be manually tested?
For manual testing you should run `snyk container`, `snyk container --help` and `snyk container test -h` and the result should be the custom help message for the container, as you can see in the screenshot below.

#### Any background context you want to provide?
This work follow up the previous PR https://github.com/snyk/snyk/pull/1124.

#### What are the relevant tickets?
- [RUN-589](https://snyksec.atlassian.net/browse/RUN-589)
- [RUN-941](https://snyksec.atlassian.net/browse/RUN-941)

#### Screenshots
<img width="1235" alt="Screenshot 2020-05-22 at 15 51 27" src="https://user-images.githubusercontent.com/838518/82680504-42c2e700-9c44-11ea-9f7d-259b775947e0.png">

<img width="1207" alt="Screenshot 2020-05-22 at 15 51 19" src="https://user-images.githubusercontent.com/838518/82680479-3b9bd900-9c44-11ea-8a50-0d96de3cae84.png">

<img width="1225" alt="Screenshot 2020-05-22 at 15 51 09" src="https://user-images.githubusercontent.com/838518/82680458-32127100-9c44-11ea-8da9-a7613cd82730.png">

