### PR TITLE
feat: remove then-fs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
     "source-map-support": "^0.5.11",
     "strip-ansi": "^5.2.0",
     "tempfile": "^2.0.0",
-    "then-fs": "^2.0.0",
     "update-notifier": "^4.1.0",
     "uuid": "^3.3.2",
     "wrap-ansi": "^5.1.0"

--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,4 +1,4 @@
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import * as path from 'path';
 import * as Debug from 'debug';
 const debug = Debug('snyk');
@@ -14,7 +14,7 @@ export = async function help(item: string | boolean) {
 
   const filename = path.resolve(__dirname, '../../../help', item + '.txt');
   try {
-    return await fs.readFile(filename, 'utf8');
+    return fs.readFileSync(filename, 'utf8');
   } catch (error) {
     debug(error);
     return `'${item}' help can't be found at location: ${filename}`;

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -1,7 +1,7 @@
 export = monitor;
 
 import chalk from 'chalk';
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import * as Debug from 'debug';
 import * as pathUtil from 'path';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
@@ -274,7 +274,7 @@ function generateMonitorMeta(options, packageManager?): MonitorMeta {
 }
 
 async function validateMonitorPath(path, isDocker) {
-  const exists = await fs.exists(path);
+  const exists = fs.existsSync(path);
   if (!exists && !isDocker) {
     throw new Error('"' + path + '" is not a valid path for "snyk monitor"');
   }

--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -11,7 +11,7 @@ const debug = debugModule('snyk');
 
 import * as path from 'path';
 import * as inquirer from '@snyk/inquirer';
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import * as tryRequire from 'snyk-try-require';
 import chalk from 'chalk';
 import * as url from 'url';
@@ -68,7 +68,7 @@ async function processPackageManager(options: Options) {
     );
   }
 
-  const nodeModulesExist = await fs.exists(path.join('.', 'node_modules'));
+  const nodeModulesExist = fs.existsSync(path.join('.', 'node_modules'));
   if (!nodeModulesExist) {
     // throw a custom error
     throw new Error(
@@ -126,8 +126,8 @@ async function processWizardFlow(options) {
     debug('ignore disabled');
   }
   const intro = __dirname + '/../../../../help/wizard.txt';
-  return fs
-    .readFile(intro, 'utf8')
+
+  return Promise.resolve(fs.readFileSync(intro, 'utf8'))
     .then((str) => {
       if (!isCI()) {
         console.log(str);
@@ -402,8 +402,7 @@ function processAnswers(answers, policy, options) {
     .then(() => {
       // re-read the package.json - because the generatePolicy can apply
       // an `npm install` which will change the deps
-      return fs
-        .readFile(packageFile, 'utf8')
+      return Promise.resolve(fs.readFileSync(packageFile, 'utf8'))
         .then((packageFileString) => {
           pkgIndentation = calculatePkgFileIndentation(packageFileString);
           return packageFileString;
@@ -525,9 +524,7 @@ function processAnswers(answers, policy, options) {
         return (
           spinner(lbl)
             .then(() => {
-              return fs.writeFile(packageFile, packageString);
-            })
-            .then(() => {
+              fs.writeFileSync(packageFile, packageString);
               if (isLockFileBased) {
                 // we need to trigger a lockfile update after adding snyk
                 // as a dep

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -1,4 +1,4 @@
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import * as pathLib from 'path';
 import * as debugLib from 'debug';
 import * as _ from '@snyk/lodash';

--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import * as resolveNodeDeps from 'snyk-resolve-deps';
 import { PkgTree } from 'snyk-nodejs-lockfile-parser';
 

--- a/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
+++ b/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 
 interface File {
   name: string;
@@ -18,10 +18,10 @@ export async function tryGetSpec(
 ): Promise<File | null> {
   const filePath = path.resolve(dir, name);
 
-  if (await fs.exists(filePath)) {
+  if (fs.existsSync(filePath)) {
     return {
       name,
-      contents: Buffer.from(await fs.readFile(filePath)).toString('base64'),
+      contents: Buffer.from(fs.readFileSync(filePath)).toString('base64'),
     };
   }
   return null;

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -6,7 +6,7 @@ const debug = require('debug')('snyk');
 const chalk = require('chalk');
 const glob = require('glob');
 const tempfile = require('tempfile');
-const fs = require('then-fs');
+const fs = require('fs');
 const path = require('path');
 const _ = require('@snyk/lodash');
 const applyPatch = require('./apply-patch');
@@ -64,12 +64,11 @@ function patch(vulns, live) {
               return getPatchFile(url, filename)
                 .then((patch) => {
                   // check whether there's a trace of us having patched before
-                  return fs
-                    .exists(flag)
+                  return Promise.resolve(fs.existsSync(flag))
                     .then((exists) => {
                       // if the file doesn't exist, look for the old style filename
                       // in case and for backwards compatability
-                      return exists || fs.exists(oldFlag);
+                      return exists || fs.existsSync(oldFlag);
                     })
                     .then((exists) => {
                       if (!exists) {

--- a/test/missing-node-modules.test.ts
+++ b/test/missing-node-modules.test.ts
@@ -1,6 +1,6 @@
 import * as tap from 'tap';
 const { test } = tap;
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 
 const apiKey = '123456789';
 const notAuthorizedApiKey = 'notAuthorized';
@@ -42,7 +42,7 @@ test('throws when missing node_modules', async (t) => {
   const dir = baseDir + 'npm/npm-3-no-node-modules';
   // ensure node_modules does not exist
   try {
-    fs.rmdir(dir + '/node_modules');
+    fs.rmdirSync(dir + '/node_modules');
   } catch (err) {
     // ignore
   }

--- a/test/policy-display.test.ts
+++ b/test/policy-display.test.ts
@@ -1,6 +1,6 @@
 import * as policy from 'snyk-policy';
 import { test } from 'tap';
-import * as fs from 'then-fs';
+import * as fs from 'fs';
 import { display } from '../src/lib/display-policy';
 import stripAnsi from 'strip-ansi';
 import { URL } from 'url';
@@ -11,7 +11,7 @@ const { hostname } = new URL(SNYK_API);
 test('test sensibly bails if gets an old .snyk format', async (t) => {
   const filename = __dirname + '/fixtures/snyk-config-no-version';
   const loadedPolicy = await policy.load(filename);
-  const expectedFile = await fs.readFile(filename + '/expected', 'utf8');
+  const expectedFile = await fs.readFileSync(filename + '/expected', 'utf8');
 
   try {
     const [displayPolicy, expectedFileString] = await Promise.all([

--- a/test/protect-apply-same-patch-again.test.js
+++ b/test/protect-apply-same-patch-again.test.js
@@ -1,7 +1,7 @@
 const test = require('tap').test;
 const proxyquire = require('proxyquire');
 const sinon = require('sinon');
-const fs = require('then-fs');
+const fs = require('fs');
 const path = require('path');
 const rimraf = require('rimraf');
 
@@ -84,7 +84,7 @@ test('Same patch is applied multiple times without issue', (t) => {
       fixturesBaseFolderFiles.forEach((file) => {
         const flagMatch = file.match(/\.snyk.*\.flag/);
         if (flagMatch) {
-          fs.unlink(fixturesBaseFolder + file);
+          fs.unlinkSync(path.join(fixturesBaseFolder, file));
         }
       });
     });
@@ -98,7 +98,7 @@ test('Same patch is applied multiple times without issue', (t) => {
 
       fixturesModuleFolderFiles.forEach((file) => {
         if (file !== debugNodeFileFixture) {
-          fs.unlink(fixturesModuleFolder + file);
+          fs.unlinkSync(path.join(fixturesModuleFolder, file));
         }
       });
     });

--- a/test/protect-patch-same-pkg.test.js
+++ b/test/protect-patch-same-pkg.test.js
@@ -21,14 +21,12 @@ var patch = proxyquire('../src/lib/protect/patch', {
   './write-patch-flag': function(now, vuln) {
     return Promise.resolve(vuln);
   },
-  'then-fs': {
-    rename: function(filename) {
+  fs: {
+    renameSync: function(filename) {
       renameSpy(filename);
-      return Promise.resolve();
     },
-    writeFile: function(filename, body) {
+    writeFileSync: function(filename, body) {
       writeSpy(filename, body);
-      return Promise.resolve();
     },
     createWriteStream: function() {
       // fake event emitter (sort of)

--- a/test/wizard-package-changes.test.ts
+++ b/test/wizard-package-changes.test.ts
@@ -17,15 +17,14 @@ tap.tearDown(() => {
 let mockPackage;
 
 const wizard = proxyquire('../src/cli/commands/protect/wizard', {
-  'then-fs': {
-    writeFile(filename, content) {
+  fs: {
+    writeFileSync(filename, content) {
       if (filename.includes('package.json')) {
         writeSpy(JSON.parse(content));
       }
-      return Promise.resolve();
     },
-    readFile(filename) {
-      return Promise.resolve(JSON.stringify(mockPackage));
+    readFileSync() {
+      return JSON.stringify(mockPackage);
     },
     '../../../lib/npm': {
       getVersion() {

--- a/test/wizard-prepare.test.js
+++ b/test/wizard-prepare.test.js
@@ -1,12 +1,12 @@
-var test = require('tap').test;
-var proxyquire = require('proxyquire');
-var sinon = require('sinon');
-var spy = sinon.spy();
-var _ = require('@snyk/lodash');
-var dir = __dirname + '/fixtures/protect-via-snyk/';
-var fixture = require('./fixtures/protect-via-snyk/package.json');
+const test = require('tap').test;
+const proxyquire = require('proxyquire');
+const sinon = require('sinon');
+const spy = sinon.spy();
+const _ = require('@snyk/lodash');
+const dir = __dirname + '/fixtures/protect-via-snyk/';
+const fixture = require('./fixtures/protect-via-snyk/package.json');
 
-var wizard = proxyquire('../src/cli/commands/protect/wizard', {
+const wizard = proxyquire('../src/cli/commands/protect/wizard', {
   '@snyk/inquirer': {
     prompt: function(q, cb) {
       cb(q);
@@ -23,19 +23,18 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     install: () => new Promise((resolve) => resolve()),
     installDev: () => new Promise((resolve) => resolve()),
   },
-  'then-fs': {
-    readFile: function() {
-      return Promise.resolve(JSON.stringify(fixture));
+  fs: {
+    readFileSync: function() {
+      return JSON.stringify(fixture);
     },
-    writeFile: function(filename, body) {
+    writeFileSync: function(filename, body) {
       spy(body);
-      return Promise.resolve();
     },
   },
 });
 
 test('npm - prepare is added and postinstall is removed', function(t) {
-  var expectedResults = _.cloneDeep(fixture);
+  const expectedResults = _.cloneDeep(fixture);
   process.chdir(dir);
 
   return wizard
@@ -51,7 +50,7 @@ test('npm - prepare is added and postinstall is removed', function(t) {
     )
     .then(function() {
       t.equal(spy.callCount, 1, 'write function was only called once');
-      var pkg = JSON.parse(spy.args[0][0]);
+      const pkg = JSON.parse(spy.args[0][0]);
       t.pass('package was valid JSON');
 
       expectedResults.scripts.postinstall = 'true';
@@ -62,7 +61,7 @@ test('npm - prepare is added and postinstall is removed', function(t) {
 });
 
 test('yarn - prepare is added and postinstall is removed', function(t) {
-  var expectedResults = _.cloneDeep(fixture);
+  const expectedResults = _.cloneDeep(fixture);
   process.chdir(dir);
   spy.resetHistory();
   return wizard
@@ -81,7 +80,7 @@ test('yarn - prepare is added and postinstall is removed', function(t) {
     )
     .then(function() {
       t.equal(spy.callCount, 1, 'write function was only called once');
-      var pkg = JSON.parse(spy.args[0][0]);
+      const pkg = JSON.parse(spy.args[0][0]);
       t.pass('package was valid JSON');
 
       expectedResults.scripts.postinstall = 'true';

--- a/test/wizard-prepublish.test.js
+++ b/test/wizard-prepublish.test.js
@@ -21,13 +21,12 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     install: () => new Promise((resolve) => resolve()),
     installDev: () => new Promise((resolve) => resolve()),
   },
-  'then-fs': {
-    readFile: function() {
-      return Promise.resolve(JSON.stringify(fixture));
+  fs: {
+    readFileSync: function() {
+      return JSON.stringify(fixture);
     },
-    writeFile: function(filename, body) {
+    writeFileSync: function(filename, body) {
       spy(body);
-      return Promise.resolve();
     },
   },
 });

--- a/test/wizard-process-answers.test.js
+++ b/test/wizard-process-answers.test.js
@@ -50,10 +50,9 @@ var getVulnSource = proxyquire('../src/lib/protect/get-vuln-source', {
   },
 });
 
-var thenfs = {
-  writeFile: function(filename, body) {
+var mockfs = {
+  writeFileSync: function(filename, body) {
     writeSpy(filename, body);
-    return Promise.resolve();
   },
   createWriteStream: function() {
     // fake event emitter (sort of)
@@ -71,7 +70,7 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     execSpy(cmd);
     return Promise.resolve(true);
   },
-  'then-fs': thenfs,
+  fs: mockfs,
   '../../../src/lib/protect': proxyquire('../src/lib/protect', {
     fs: {
       statSync: function() {
@@ -81,10 +80,10 @@ var wizard = proxyquire('../src/cli/commands/protect/wizard', {
     './get-vuln-source': getVulnSource,
     './patch': proxyquire('../src/lib/protect/patch', {
       './write-patch-flag': proxyquire('../src/lib/protect/write-patch-flag', {
-        'then-fs': thenfs,
+        fs: mockfs,
       }),
       './get-vuln-source': getVulnSource,
-      'then-fs': thenfs,
+      fs: mockfs,
       './apply-patch': function() {
         return Promise.resolve();
       },


### PR DESCRIPTION
Part of the effort to slim down the dependency tree in CLI, this PR removes then-fs and replaces it with a native fs module. Most of the usage don't even need the promisified version, but is fine with a sync one.

Added two TODO on pieces I've found could be improved.