### PR TITLE
feat: add lib for dev count

### DIFF
--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -41,10 +41,18 @@ function analytics(data) {
   return postAnalytics(data);
 }
 
+analytics.allowAnalytics = () => {
+  if (snyk.config.get('disable-analytics') || config.DISABLE_ANALYTICS) {
+    return false;
+  } else {
+    return true;
+  }
+};
+
 function postAnalytics(data) {
   // if the user opt'ed out of analytics, then let's bail out early
   // ths applies to all sending to protect user's privacy
-  if (snyk.config.get('disable-analytics') || config.DISABLE_ANALYTICS) {
+  if (!analytics.allowAnalytics()) {
     debug('analytics disabled');
     return Promise.resolve();
   }

--- a/src/lib/monitor/dev-count-analysis.ts
+++ b/src/lib/monitor/dev-count-analysis.ts
@@ -1,0 +1,219 @@
+/**
+ * This is to count the number of "contributing" developers using Snyk on a given repo.
+ * "Contributing" is defined as having contributed a commit in the last 90 days.
+ * This is use only on the `snyk monitor` command as that is used to monitor a project's dependencies in an
+ * on-going manner.
+ * It collects only a hash of the email of a git user and the most recent commit timestamp (both per the `git log`
+ * output) and can be disabled by config (see https://snyk.io/policies/tracking-and-analytics/).
+ */
+import * as crypto from 'crypto';
+import { exec } from 'child_process';
+
+export const SERIOUS_DELIMITER = '_SNYK_SEPARATOR_';
+export const CONTRIBUTING_DEVELOPER_PERIOD_DAYS = 90;
+
+export class GitCommitInfo {
+  authorHashedEmail: string;
+  commitTimestamp: string; // use ISO 8601 format
+
+  constructor(authorHashedEmail: string, commitTimestamp: string) {
+    if (isSha1Hash(authorHashedEmail)) {
+      this.authorHashedEmail = authorHashedEmail;
+      this.commitTimestamp = commitTimestamp;
+    } else {
+      throw new Error('authorHashedEmail must be a sha1 hash');
+    }
+  }
+}
+
+export class GitRepoCommitStats {
+  commitInfos: GitCommitInfo[];
+
+  constructor(commitInfos: GitCommitInfo[]) {
+    this.commitInfos = commitInfos;
+  }
+
+  public static empty(): GitRepoCommitStats {
+    return new GitRepoCommitStats([]);
+  }
+
+  public addCommitInfo(info: GitCommitInfo) {
+    this.commitInfos.push(info);
+  }
+
+  public getUniqueAuthorsCount(): number {
+    const uniqueAuthorHashedEmails = this.getUniqueAuthorHashedEmails();
+    return uniqueAuthorHashedEmails.size;
+  }
+
+  public getCommitsCount(): number {
+    return this.commitInfos.length;
+  }
+
+  public getUniqueAuthorHashedEmails(): Set<string> {
+    const allCommitAuthorHashedEmails: string[] = this.commitInfos.map(
+      (c) => c.authorHashedEmail,
+    );
+    const uniqueAuthorHashedEmails: Set<string> = new Set(
+      allCommitAuthorHashedEmails,
+    );
+    return uniqueAuthorHashedEmails;
+  }
+
+  public getRepoContributors(): { userId: string; lastCommitDate: string }[] {
+    const uniqueAuthorHashedEmails = this.getUniqueAuthorHashedEmails();
+    const contributors: { userId: string; lastCommitDate: string }[] = [];
+
+    // for each uniqueAuthorHashedEmails, get the latest commit
+    for (const nextUniqueAuthorHashedEmail of uniqueAuthorHashedEmails) {
+      const latestCommitTimestamp = this.getMostRecentCommitTimestamp(
+        nextUniqueAuthorHashedEmail,
+      );
+      contributors.push({
+        userId: nextUniqueAuthorHashedEmail,
+        lastCommitDate: latestCommitTimestamp,
+      });
+    }
+    return contributors;
+  }
+
+  public getMostRecentCommitTimestamp(authorHashedEmail: string): string {
+    for (const nextGI of this.commitInfos) {
+      if (nextGI.authorHashedEmail === authorHashedEmail) {
+        return nextGI.commitTimestamp;
+      }
+    }
+    return '';
+  }
+}
+
+export function parseGitLogLine(logLine: string): GitCommitInfo {
+  const lineComponents = logLine.split(SERIOUS_DELIMITER);
+  const authorEmail = lineComponents[2];
+  const commitTimestamp = lineComponents[3];
+  const hashedAuthorEmail = hashData(authorEmail);
+  const commitInfo = new GitCommitInfo(hashedAuthorEmail, commitTimestamp);
+  return commitInfo;
+}
+
+export function parseGitLog(gitLog: string): GitRepoCommitStats {
+  if (gitLog.trim() === '') {
+    return GitRepoCommitStats.empty();
+  }
+  const logLines = separateLines(gitLog);
+  const logLineInfos: GitCommitInfo[] = logLines.map(parseGitLogLine);
+  const stats: GitRepoCommitStats = new GitRepoCommitStats(logLineInfos);
+  return stats;
+}
+
+export function hashData(s: string): string {
+  const hashedData = crypto
+    .createHash('sha1')
+    .update(s)
+    .digest('hex');
+  return hashedData;
+}
+
+export function isSha1Hash(data: string): boolean {
+  // sha1 hash must be exactly 40 characters of 0-9 / a-f (i.e. lowercase hex characters)
+  // ^ == start anchor
+  // [0-9a-f] == characters 0,1,2,3,4,5,6,7,8,9,a,b,c,d,e,f only
+  // {40} 40 of the [0-9a-f] characters
+  // $ == end anchor
+  const matchRegex = new RegExp('^[0-9a-f]{40}$');
+  const looksHashed = matchRegex.test(data);
+  return looksHashed;
+}
+
+/**
+ * @returns time stamp in seconds-since-epoch of 90 days ago since 90 days is the "contributing devs" timeframe
+ */
+export function getTimestampStartOfContributingDevTimeframe(
+  dNow: Date,
+  timespanInDays: number = CONTRIBUTING_DEVELOPER_PERIOD_DAYS,
+): number {
+  const nowUtcEpocMS = dNow.getTime();
+  const nowUtcEpocS = Math.floor(nowUtcEpocMS / 1000);
+  const ONE_DAY_IN_SECONDS = 86400;
+  const lookbackTimespanSeconds = timespanInDays * ONE_DAY_IN_SECONDS;
+  const startOfPeriodEpochSeconds = nowUtcEpocS - lookbackTimespanSeconds;
+  return startOfPeriodEpochSeconds;
+}
+
+export async function runGitLog(
+  timestampEpochSecondsStartOfPeriod: number,
+  repoPath: string,
+  fnShellout: (cmd: string, workingDirectory: string) => Promise<string>,
+): Promise<string> {
+  try {
+    const gitLogCommand = `git --no-pager log --pretty=tformat:"%H${SERIOUS_DELIMITER}%an${SERIOUS_DELIMITER}%ae${SERIOUS_DELIMITER}%aI" --after="${timestampEpochSecondsStartOfPeriod}"`;
+    const gitLogStdout: string = await fnShellout(gitLogCommand, repoPath);
+    return gitLogStdout;
+  } catch {
+    return '';
+  }
+}
+
+export function separateLines(inputText: string): string[] {
+  const linuxStyleNewLine = '\n';
+  const windowsStyleNewLine = '\r\n';
+  const reg = new RegExp(`${linuxStyleNewLine}|${windowsStyleNewLine}`);
+  const lines = inputText.trim().split(reg);
+  return lines;
+}
+
+export function execShell(
+  cmd: string,
+  workingDirectory: string,
+): Promise<string> {
+  const options = {
+    cwd: workingDirectory,
+  };
+
+  return new Promise((resolve, reject) => {
+    exec(cmd, options, (error, stdout, stderr) => {
+      if (error) {
+        // TODO: we can probably remove this after unshipping Node 8 support
+        // and then just directly get the error code like `error.code`
+        let exitCode = 0;
+        try {
+          exitCode = parseInt(error['code']);
+        } catch {
+          exitCode = -1;
+        }
+
+        const e = new ShellOutError(
+          error.message,
+          exitCode,
+          stdout,
+          stderr,
+          error,
+        );
+        reject(e);
+      } else {
+        resolve(stdout ? stdout : stderr);
+      }
+    });
+  });
+}
+
+export class ShellOutError extends Error {
+  public innerError: Error | undefined;
+  public exitCode: number | undefined;
+  public stdout: string | undefined;
+  public stderr: string | undefined;
+
+  constructor(
+    message: string,
+    exitCode: number | undefined,
+    stdout: string,
+    stderr: string,
+    innerError: Error | undefined,
+  ) {
+    super(message);
+    this.exitCode = exitCode;
+    this.stdout = stdout;
+    this.stderr = stderr;
+    this.innerError = innerError;
+  }
+}

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -48,6 +48,7 @@ interface MonitorBody {
   target: {};
   targetFileRelativePath: string;
   targetFile: string;
+  contributors?: { userId: string; lastCommitDate: string }[];
 }
 
 interface Meta {
@@ -75,6 +76,7 @@ export async function monitor(
   options,
   pluginMeta: PluginMetadata,
   targetFileRelativePath?: string,
+  contributors?: { userId: string; lastCommitDate: string }[],
 ): Promise<MonitorResult> {
   apiTokenExists();
   let treeMissingDeps: string[] = [];
@@ -102,6 +104,7 @@ export async function monitor(
         scannedProject,
         pluginMeta,
         targetFileRelativePath,
+        contributors,
       );
     }
     if (monitorGraphSupportedRes.userMessage) {
@@ -205,6 +208,7 @@ export async function monitor(
           // WARNING: be careful changing this as it affects project uniqueness
           targetFile: getTargetFile(scannedProject, pluginMeta),
           targetFileRelativePath,
+          contributors: contributors,
         } as MonitorBody,
         gzip: true,
         method: 'PUT',
@@ -243,6 +247,7 @@ export async function monitorGraph(
   scannedProject: ScannedProject,
   pluginMeta: PluginMetadata,
   targetFileRelativePath?: string,
+  contributors?: { userId: string; lastCommitDate: string }[],
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
   analytics.add('monitorGraph', true);
@@ -320,6 +325,7 @@ export async function monitorGraph(
           target,
           targetFile: getTargetFile(scannedProject, pluginMeta),
           targetFileRelativePath,
+          contributors: contributors,
         } as MonitorBody,
         gzip: true,
         method: 'PUT',

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -27,6 +27,21 @@ tap.afterEach((done) => {
   done();
 });
 
+test('analyticsAllowed returns false if disable-analytics set in snyk config', (t) => {
+  t.plan(1);
+  snyk.config.set('disable-analytics', '1');
+  const analytics = require('../src/lib/analytics');
+  const analyticsAllowed: boolean = analytics.allowAnalytics();
+  t.notOk(analyticsAllowed);
+});
+
+test('analyticsAllowed returns true if disable-analytics is not set snyk config', (t) => {
+  t.plan(1);
+  const analytics = require('../src/lib/analytics');
+  const analyticsAllowed: boolean = analytics.allowAnalytics();
+  t.ok(analyticsAllowed);
+});
+
 test('analytics disabled', (t) => {
   const spy = sinon.spy();
   snyk.config.set('disable-analytics', '1');

--- a/test/dev-count-analysis.jest-test.ts
+++ b/test/dev-count-analysis.jest-test.ts
@@ -1,0 +1,267 @@
+import { test } from 'tap';
+const osName = require('os-name');
+
+const isWindows =
+  osName()
+    .toLowerCase()
+    .indexOf('windows') === 0;
+
+import {
+  GitCommitInfo,
+  parseGitLog,
+  GitRepoCommitStats,
+  parseGitLogLine,
+  isSha1Hash,
+  hashData,
+  getTimestampStartOfContributingDevTimeframe,
+  separateLines,
+  execShell,
+  ShellOutError,
+  runGitLog,
+} from '../src/lib/monitor/dev-count-analysis';
+
+const expectedEmailHashes = {
+  'someemail-1@somedomain.com': '069598f5bf317927731aecc6648bd521f6a12c92',
+  'someemail-2@somedomain.com': '15726593ee5b5182412ca858e2472477f4ce9f30',
+};
+
+test('hashData works', (t) => {
+  t.plan(2);
+
+  const email1 = 'someemail-1@somedomain.com';
+  const hashedEmail1 = hashData(email1);
+  t.equal(hashedEmail1, expectedEmailHashes['someemail-1@somedomain.com']);
+
+  const email2 = 'someemail-2@somedomain.com';
+  const hashedEmail2 = hashData(email2);
+  t.equal(hashedEmail2, expectedEmailHashes['someemail-2@somedomain.com']);
+});
+
+test('isSha1Hash works', (t) => {
+  t.plan(6);
+  t.ok(isSha1Hash('069598f5bf317927731aecc6648bd521f6a12c92'));
+  t.ok(isSha1Hash('0123456789abcdef0123456789abcdef01234567')); // all the possible hex characters
+  t.notOk(isSha1Hash('abcdefghijklmnopqrstuvwxyz01234567890')); // contains letters which are not hex characters
+  t.notOk(isSha1Hash('0123456789abcdef0123456789abcdef01234567a')); // more than 40 characters
+  t.notOk(isSha1Hash('0123456789abcdef0123456789abcdef0123456')); // less than 40 characters
+  t.notOk(isSha1Hash('someemail-1@somedomain.com')); // obviously an email
+});
+
+test('you cannot create a new GitCommitInfo if the email is not hashed', (t) => {
+  t.plan(1);
+  try {
+    new GitCommitInfo(
+      'someemail-1@somedomain.com',
+      '2020-02-06T11:43:11+00:00',
+    );
+    t.fail(
+      'GitCommitInfo constructor should throw exception if you try to pass a non-hahsed email',
+    );
+  } catch (err) {
+    t.pass();
+  }
+});
+
+test('can calculate start of contributing developer period', (t) => {
+  t.plan(1);
+  const dEndMilliseconds = 1590174610000; // arbitrary timestamp in ms since epoch
+  const exectedStartTimestampSeconds = 1590174610 - 90 * 24 * 60 * 60;
+  const dEnd = new Date(dEndMilliseconds);
+  const tStart = getTimestampStartOfContributingDevTimeframe(dEnd, 90);
+  t.equal(tStart, exectedStartTimestampSeconds);
+});
+
+test('can parse a git log line', (t) => {
+  t.plan(1);
+  const line =
+    '0bd4d3c394a54ba54f6c44705ac73d7d87b39525_SNYK_SEPARATOR_some-user_SNYK_SEPARATOR_someemail-1@somedomain.com_SNYK_SEPARATOR_2020-02-06T11:43:11+00:00';
+  const commitInfo: GitCommitInfo = parseGitLogLine(line);
+  t.equal(
+    commitInfo.authorHashedEmail,
+    expectedEmailHashes['someemail-1@somedomain.com'],
+  );
+});
+
+test('can handle an empty git log', (t) => {
+  t.plan(3);
+  const gitLog = '';
+  const stats = parseGitLog(gitLog);
+  t.equal(stats.getCommitsCount(), 0);
+  t.equal(stats.getUniqueAuthorsCount(), 0);
+
+  const authorTimestamps = stats.getRepoContributors();
+  const keys: string[] = Object.keys(authorTimestamps);
+  t.equal(keys.length, 0);
+});
+
+test('can call legit command with execShell', async (t) => {
+  t.plan(1);
+  const res = await execShell('echo hello', process.cwd());
+  t.equals(res.trim(), 'hello');
+});
+
+test('execShell can handle it when a command does not exist', async (t) => {
+  t.plan(3);
+  try {
+    const res = await execShell('command-no-exist some params', process.cwd());
+    t.fail('should have rejected');
+  } catch (e) {
+    t.notOk(e.stdout);
+    if (isWindows) {
+      t.ok(e.stderr.includes('not recognized'));
+      t.equals(e.exitCode, 1);
+    } else {
+      t.ok(e.stderr.includes('not found'));
+      t.equals(e.exitCode, 127);
+    }
+  }
+});
+
+test('execShell can handle it when we call a command with wonky arguments', async (t) => {
+  t.plan(3);
+
+  try {
+    const res = await execShell('git log bad args non sense', process.cwd()); // git log, should return exit code 128
+    throw new Error('should not return');
+  } catch (e) {
+    t.notOk(e.stdout); // expect empty / falsy
+    t.ok(e.stderr); // is truthy - i.e. has some output but we don't really care what it is
+    t.equals(e.exitCode, 128);
+  }
+});
+
+test('runGitLog returns empty string and does not throw error when git log command fails', async (t) => {
+  t.plan(1);
+  const mockExecShell = (
+    cmd: string,
+    workingDirectory: string,
+  ): Promise<string> => {
+    const e = new ShellOutError(
+      'mock error',
+      1,
+      '',
+      'the command failed',
+      undefined,
+    );
+    return Promise.reject(e);
+  };
+
+  try {
+    const gitLog = await runGitLog(123456789, '/some/fake/path', mockExecShell);
+    t.equals(gitLog, '');
+  } catch (e) {
+    t.fail('should not throw');
+  }
+});
+
+function validateGitParsing(gitLog: string, t) {
+  t.plan(17);
+  const stats: GitRepoCommitStats = parseGitLog(gitLog);
+
+  t.equal(stats.getCommitsCount(), 3);
+  t.equal(stats.getUniqueAuthorsCount(), 2);
+
+  const uniqueAuthors: Set<string> = stats.getUniqueAuthorHashedEmails();
+  t.equal(uniqueAuthors.size, 2);
+
+  t.notOk(uniqueAuthors.has('someemail-1@somedomain.com'));
+  t.notOk(uniqueAuthors.has('someemail-2@somedomain.com'));
+  t.ok(uniqueAuthors.has(expectedEmailHashes['someemail-1@somedomain.com']));
+  t.ok(uniqueAuthors.has(expectedEmailHashes['someemail-2@somedomain.com']));
+
+  const mostRecentCommitTimestampSomeEmail1 = stats.getMostRecentCommitTimestamp(
+    expectedEmailHashes['someemail-1@somedomain.com'],
+  );
+  t.equal(mostRecentCommitTimestampSomeEmail1, '2020-02-06T11:43:11+00:00');
+  const mostRecentCommitTimestampSomeEmail2 = stats.getMostRecentCommitTimestamp(
+    expectedEmailHashes['someemail-2@somedomain.com'],
+  );
+  t.equal(mostRecentCommitTimestampSomeEmail2, '2020-02-02T23:31:13+02:00');
+  t.equal(stats.getMostRecentCommitTimestamp('missing-email'), '');
+
+  const contributors: {
+    userId: string;
+    lastCommitDate: string;
+  }[] = stats.getRepoContributors();
+  t.equal(contributors.length, 2);
+
+  t.notOk(
+    contributors.map((c) => c.userId).includes('someemail-1@somedomain.com'),
+  );
+  t.notOk(
+    contributors.map((c) => c.userId).includes('someemail-2@somedomain.com'),
+  );
+  t.ok(
+    contributors
+      .map((c) => c.userId)
+      .includes(expectedEmailHashes['someemail-1@somedomain.com']),
+  );
+  t.ok(
+    contributors
+      .map((c) => c.userId)
+      .includes(expectedEmailHashes['someemail-2@somedomain.com']),
+  );
+
+  const getTimestampById = (userId: string): string => {
+    for (const c of contributors) {
+      if (c.userId === userId) {
+        return c.lastCommitDate;
+      }
+    }
+    throw new Error('contributor not found');
+  };
+
+  t.equal(
+    getTimestampById(expectedEmailHashes['someemail-1@somedomain.com']),
+    '2020-02-06T11:43:11+00:00',
+  );
+  t.equal(
+    getTimestampById(expectedEmailHashes['someemail-2@somedomain.com']),
+    '2020-02-02T23:31:13+02:00',
+  );
+}
+
+test('can parse a git log (Linux/OSX line endings)', (t) => {
+  const gitLogLinuxOSXLineEndings =
+    '0bd4d3c394a54ba54f6c44705ac73d7d87b39525_SNYK_SEPARATOR_some-user-1_SNYK_SEPARATOR_someemail-1@somedomain.com_SNYK_SEPARATOR_2020-02-06T11:43:11+00:00\n' +
+    'c20267ac84a9b81a30e6e41e4437906a69e6b8c0_SNYK_SEPARATOR_some-user-2_SNYK_SEPARATOR_someemail-2@somedomain.com_SNYK_SEPARATOR_2020-02-02T23:31:13+02:00\n' +
+    '9dabba3667520f7e2baf1ac75fb58369ea16050c_SNYK_SEPARATOR_some-user-2_SNYK_SEPARATOR_someemail-2@somedomain.com_SNYK_SEPARATOR_2020-02-02T23:23:41+02:00\n';
+  validateGitParsing(gitLogLinuxOSXLineEndings, t);
+});
+
+test('can parse a git log (Windows line endings)', (t) => {
+  const gitLogWindowsLineEndings =
+    '0bd4d3c394a54ba54f6c44705ac73d7d87b39525_SNYK_SEPARATOR_some-user-1_SNYK_SEPARATOR_someemail-1@somedomain.com_SNYK_SEPARATOR_2020-02-06T11:43:11+00:00\r\n' +
+    'c20267ac84a9b81a30e6e41e4437906a69e6b8c0_SNYK_SEPARATOR_some-user-2_SNYK_SEPARATOR_someemail-2@somedomain.com_SNYK_SEPARATOR_2020-02-02T23:31:13+02:00\r\n' +
+    '9dabba3667520f7e2baf1ac75fb58369ea16050c_SNYK_SEPARATOR_some-user-2_SNYK_SEPARATOR_someemail-2@somedomain.com_SNYK_SEPARATOR_2020-02-02T23:23:41+02:00\r\n';
+  validateGitParsing(gitLogWindowsLineEndings, t);
+});
+
+test('can separate lines with Linux/OSX line endings', (t) => {
+  t.plan(6);
+
+  const linuxOrOSXStyleFileData =
+    'line 0\n' + 'line 1\n' + 'line 2\n' + 'line 3\n' + 'line 4\n';
+
+  const lines = separateLines(linuxOrOSXStyleFileData);
+  t.equal(lines.length, 5);
+  t.ok(lines.includes('line 0'));
+  t.ok(lines.includes('line 1'));
+  t.ok(lines.includes('line 2'));
+  t.ok(lines.includes('line 3'));
+  t.ok(lines.includes('line 4'));
+});
+
+test('can separate lines Windows line endings', (t) => {
+  t.plan(6);
+  const windowsStyleFileData =
+    'line 0\r\n' + 'line 1\r\n' + 'line 2\r\n' + 'line 3\r\n' + 'line 4\r\n';
+
+  const lines = separateLines(windowsStyleFileData);
+  t.equal(lines.length, 5);
+  t.ok(lines.includes('line 0'));
+  t.ok(lines.includes('line 1'));
+  t.ok(lines.includes('line 2'));
+  t.ok(lines.includes('line 3'));
+  t.ok(lines.includes('line 4'));
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Upon `snyk monitor`, run git log in the direcotry `snyk monitor` is run; this means that that we are assuming it is run from a directory which is in a git repo. We git log only the last 90 days. Look at the hash(author email) and the commit timestamps. We create a map of (hashed author email) -> (latest commit timestamp for that author). Send that along with the API call to Snyk that is already used in monitor.


#### Any background context you want to provide?
This is for the "contributing developer" count feature.

#### What are the relevant tickets?
HAMMER-36

#### Related PRs
https://github.com/snyk/registry/pull/13742
