### PR TITLE
feat: upgrade debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "chalk": "^2.4.2",
     "cli-spinner": "0.2.10",
     "configstore": "^5.0.1",
-    "debug": "^3.1.0",
+    "debug": "^4.1.1",
     "diff": "^4.0.1",
     "glob": "^7.1.3",
     "needle": "^2.2.4",


### PR DESCRIPTION
Old version drops support for node 4 and 5, which doesn't
affect us all that much.
