### PR TITLE
feat: bump snyk-docker-plugin to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.5.2",
+    "snyk-docker-plugin": "3.6.0",
     "snyk-go-plugin": "1.14.0",
     "snyk-gradle-plugin": "3.2.7",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Increase to latest snyk-docker-plugin version. The plugin has an implementation change so that it no longer relies on the existance of the docker binary to export images from the local daemon. 
