### PR TITLE
chore: update nodejs-lockfile-parser that contain pre-yarn2 refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "snyk-gradle-plugin": "3.3.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.15.2",
-    "snyk-nodejs-lockfile-parser": "1.22.0",
+    "snyk-nodejs-lockfile-parser": "1.23.0",
     "snyk-nuget-plugin": "1.18.1",
     "snyk-php-plugin": "1.9.0",
     "snyk-policy": "1.14.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
         ],
         "module": "commonjs",
         "allowJs": true,
+        "skipLibCheck": true,
         "sourceMap": true,
         "strict": true,
         "noImplicitAny": false // Needed to compile tap and ansi-escapes


### PR DESCRIPTION
### What does this PR do?
Update nodejs-lockfile-parser that contain pre-yarn2 refactor