### PR TITLE
feat: --reachable-vulns supports --all-projects flag in CLI

### DIFF
--- a/src/lib/options-validator.ts
+++ b/src/lib/options-validator.ts
@@ -6,12 +6,13 @@ import * as reachableVulns from './reachable-vulns';
 export async function validateOptions(
   options: (Options & TestOptions) | (Options & MonitorOptions),
   packageManager?: SupportedPackageManagers,
-) {
+): Promise<void> {
   if (options.reachableVulns) {
-    if (!packageManager) {
+    // Throwing error only in case when both packageManager and allProjects not defined
+    if (!packageManager && !options.allProjects) {
       throw new Error('Could not determine package manager');
     }
     const org = options.org || config.org;
-    await reachableVulns.validatePayload(packageManager, org);
+    await reachableVulns.validatePayload(org, options, packageManager);
   }
 }

--- a/src/lib/reachable-vulns.ts
+++ b/src/lib/reachable-vulns.ts
@@ -11,6 +11,7 @@ import {
   FeatureNotSupportedByPackageManagerError,
   UnsupportedFeatureFlagError,
 } from './errors';
+import { MonitorOptions, Options, TestOptions } from './types';
 
 const featureFlag = 'reachableVulns';
 
@@ -29,10 +30,15 @@ export function serializeCallGraphWithMetrics(
 }
 
 export async function validatePayload(
-  packageManager: SupportedPackageManagers,
   org: any,
+  options: (Options & TestOptions) | (Options & MonitorOptions),
+  packageManager?: SupportedPackageManagers,
 ): Promise<boolean> {
-  if (!REACHABLE_VULNS_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)) {
+  if (
+    packageManager &&
+    !options.allProjects &&
+    !REACHABLE_VULNS_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)
+  ) {
     throw new FeatureNotSupportedByPackageManagerError(
       'Reachable vulns',
       packageManager,


### PR DESCRIPTION
#### What does this PR do?
Adding support of `--all-projects` flag altogether with `--reachable-vulns` for `snyk test` CLI command

#### How should this be manually tested?
Run in CLI `snyk test --all-projects --reachable-vulns`
