### PR TITLE
feat: add os and isDocker query strings

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -13,11 +13,11 @@ import { isCI } from '../../../lib/is-ci';
 import * as config from '../../../lib/config';
 import request = require('../../../lib/request');
 import { CustomError } from '../../../lib/errors';
-import { getUtmsAsString } from '../../../lib/utm';
 import { AuthFailedError } from '../../../lib/errors';
 import { TokenExpiredError } from '../../../lib/errors/token-expired-error';
 import { MisconfiguredAuthInCI } from '../../../lib/errors/misconfigured-auth-in-ci-error';
 import { Payload } from '../../../lib/request/types';
+import { getQueryParamsAsString } from '../../../lib/query-strings';
 
 export = auth;
 
@@ -42,7 +42,7 @@ async function webAuth(via: AuthCliCommands) {
 
   let urlStr = authUrl + '/login?token=' + token;
 
-  const utmParams = getUtmsAsString();
+  const utmParams = getQueryParamsAsString();
   if (utmParams) {
     urlStr += '&' + utmParams;
   }

--- a/src/lib/is-docker.ts
+++ b/src/lib/is-docker.ts
@@ -1,0 +1,21 @@
+const fs = require('fs');
+
+export function isDocker(): boolean {
+  return hasDockerEnv() || hasDockerCGroup();
+}
+function hasDockerEnv() {
+  try {
+    fs.statSync('/.dockerenv');
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+function hasDockerCGroup() {
+  try {
+    return fs.readFileSync('/proc/self/cgroup', 'utf8').includes('docker');
+  } catch (_) {
+    return false;
+  }
+}

--- a/src/lib/query-strings.ts
+++ b/src/lib/query-strings.ts
@@ -1,21 +1,22 @@
 import * as url from 'url';
+import * as os from 'os';
+import { isDocker } from './is-docker';
 
-export function getUtmsAsString(): string {
+export function getQueryParamsAsString(): string {
   const SNYK_UTM_MEDIUM = process.env.SNYK_UTM_MEDIUM || 'cli';
   const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || 'cli';
   const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || 'cli';
-
-  if (!SNYK_UTM_MEDIUM && !SNYK_UTM_SOURCE && !SNYK_UTM_CAMPAIGN) {
-    return '';
-  }
+  const osType = os.type()?.toLowerCase();
+  const docker = isDocker().toString();
 
   /* eslint-disable @typescript-eslint/camelcase */
-  const utmQueryParams = new url.URLSearchParams({
+  const queryParams = new url.URLSearchParams({
     utm_medium: SNYK_UTM_MEDIUM,
     utm_source: SNYK_UTM_SOURCE,
     utm_campaign: SNYK_UTM_CAMPAIGN,
+    os: osType,
+    docker,
   });
   /* eslint-enable @typescript-eslint/camelcase */
-
-  return utmQueryParams.toString();
+  return queryParams.toString();
 }

--- a/test/is-docker.test.ts
+++ b/test/is-docker.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'tap';
+import * as sinon from 'sinon';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { isDocker } from '../src/lib/is-docker';
+
+test('inside a Docker container (.dockerenv test)', async (t) => {
+  delete require.cache[path.join(__dirname, 'index.js')];
+  const statSyncStub = sinon.stub(fs, 'statSync').returns({} as any);
+  t.true(isDocker());
+  statSyncStub.restore();
+});
+
+test('inside a Docker container (cgroup test)', async (t) => {
+  delete require.cache[path.join(__dirname, 'index.js')];
+
+  const statSyncStub = sinon.stub(fs, 'statSync');
+  statSyncStub
+    .withArgs('/.dockerenv')
+    .throws("ENOENT, no such file or directory '/.dockerinit'");
+  const readFileSyncStub = sinon.stub(fs, 'readFileSync');
+  readFileSyncStub
+    .withArgs('/proc/self/cgroup', 'utf8')
+    .returns('xxx docker yyyy');
+
+  t.true(isDocker());
+
+  statSyncStub.restore();
+  readFileSyncStub.restore();
+});
+
+test('not inside a Docker container', async (t) => {
+  delete require.cache[path.join(__dirname, 'index.js')];
+
+  const statSyncStub = sinon.stub(fs, 'statSync');
+  statSyncStub
+    .withArgs('/.dockerenv')
+    .throws("ENOENT, no such file or directory '/.dockerinit'");
+  const readFileSyncStub = sinon.stub(fs, 'readFileSync');
+  readFileSyncStub.throws('ENOENT, no such file or directory');
+
+  t.false(isDocker());
+  statSyncStub.restore();
+});

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -7,6 +7,9 @@ import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 import * as policy from 'snyk-policy';
 import stripAnsi from 'strip-ansi';
+import * as os from 'os';
+import * as isDocker from '../../src/lib/is-docker';
+
 const port = process.env.PORT || process.env.SNYK_PORT || '12345';
 
 const apiKey = '123456789';
@@ -172,7 +175,8 @@ test('auth with default UTMs', async (t) => {
   const auth = proxyquire('../../src/cli/commands/auth', { open });
   // stub CI check (ensure returns false for system test)
   const ciStub = sinon.stub(ciChecker, 'isCI').returns(false);
-
+  const osStub = sinon.stub(os, 'type').returns('Darwin');
+  const isDockerStub = sinon.stub(isDocker, 'isDocker').returns(false);
   // read data from console.log
   let stdoutMessages = '';
   const stubConsoleLog = (msg: string) => (stdoutMessages += msg);
@@ -189,13 +193,14 @@ test('auth with default UTMs', async (t) => {
     t.ok(open.calledOnce, 'called open once');
     t.match(
       open.firstCall.args[0],
-      '&utm_medium=cli&utm_source=cli&utm_campaign=cli',
+      '&utm_medium=cli&utm_source=cli&utm_campaign=cli&os=darwin&docker=false',
       'defualt utms are exists',
     );
 
     // clean up stubs
     ciStub.restore();
-
+    osStub.restore();
+    isDockerStub.restore();
     // restore original console.log
     console.log = origConsoleLog;
   } catch (e) {


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
- adding 2 query params to `snyk-auth` web page
- `os` indicate the os the user have.
- `docker` indicate if the `snyk-auth` command run in docker.

#### How should this be manually tested?
- run snyk-auth in the repo and see the url is expected
- run this docker file with `docker build -f Dockerfile .` inside snyk repo and see the isDocker argument return as `true`

```
FROM node:10-slim

MAINTAINER Koby Ltd
RUN mkdir /home/kobyownz
WORKDIR /home/kobyownz
RUN pwd
COPY . .
RUN rm -rf node_modules
RUN ls
RUN npm i
RUN npm run snyk-auth
CMD ["sleep", "6000"]

```

#### What are the relevant tickets?
[Jira Ticket- TAILWIND-119 ](https://snyksec.atlassian.net/browse/TAILWIND-119)
#### Screenshots

![image](https://user-images.githubusercontent.com/8417060/83615847-bdb6c680-a58f-11ea-8c14-f7434577d070.png)
