### PR TITLE
refactor: init changes to allow deptree and depgraph

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -20,7 +20,7 @@ import * as spinner from '../../../lib/spinner';
 import * as analytics from '../../../lib/analytics';
 import { MethodArgs, ArgsOptions } from '../../args';
 import { apiTokenExists } from '../../../lib/api-token';
-import { maybePrintDeps } from '../../../lib/print-deps';
+import { printDepTree, printDepGraph } from '../../../lib/print-deps';
 import { monitor as snykMonitor } from '../../../lib/monitor';
 import { processJsonMonitorResponse } from './process-json-monitor';
 import snyk = require('../../../lib'); // TODO(kyegupov): fix import
@@ -187,10 +187,17 @@ async function monitor(...args0: MethodArgs): Promise<any> {
           options as MonitorOptions & Options,
         );
         analytics.add('packageManager', extractedPackageManager);
-        maybePrintDeps(options, projectDeps.depTree);
 
-        debug(`Processing ${projectDeps.depTree.name}...`);
-        maybePrintDeps(options, projectDeps.depTree);
+        if (projectDeps.depTree) {
+          debug(`Processing ${projectDeps.depTree.name}...`);
+          printDepTree(options, projectDeps.depTree);
+        }
+
+        //TODO @boost: add new snyk-cli-interface with depGraph
+        if ((projectDeps as any).depGraph) {
+          debug(`Processing ${projectDeps.depTree.name}...`);
+          printDepGraph(options, (projectDeps as any).depGraph);
+        }
 
         const tFile = projectDeps.targetFile || targetFile;
         const targetFileRelativePath = tFile

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -1,9 +1,20 @@
+import { DepGraph } from '@snyk/dep-graph';
 import { DepDict, Options, MonitorOptions } from './types';
 import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 
+export function printDepGraph(
+  options: Options | MonitorOptions,
+  depGraph: DepGraph,
+) {
+  if (options['print-deps']) {
+    // TODO(boost): add a output graphviz 'dot' file to visualize?
+    console.log(JSON.stringify(depGraph.toJSON(), null, 2));
+  }
+}
+
 // This option is still experimental and might be deprecated.
 // It might be a better idea to convert it to a command (i.e. do not perform test/monitor).
-export function maybePrintDeps(
+export function printDepTree(
   options: Options | MonitorOptions,
   rootPackage: legacyApi.DepTree,
 ) {

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -29,7 +29,7 @@ import * as common from './common';
 import * as config from '../config';
 import * as analytics from '../analytics';
 import { pluckPolicies } from '../policy';
-import { maybePrintDeps } from '../print-deps';
+import { printDepTree } from '../print-deps';
 import { GitTarget, ContainerTarget } from '../project-metadata/types';
 import * as projectMetadata from '../project-metadata';
 import { DepTree, Options, TestOptions, SupportedProjectTypes } from '../types';
@@ -357,7 +357,7 @@ async function assembleLocalPayloads(
       const pkg = scannedProject.depTree;
       if (options['print-deps']) {
         await spinner.clear<void>(spinnerLbl)();
-        maybePrintDeps(options, pkg);
+        printDepTree(options, pkg);
       }
       const project = scannedProject as ScannedProjectCustom;
       const packageManager = extractPackageManager(project, deps, options);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Initial refactor changes to allow the coexistence of deptree and depgraph.

That we started on this branch https://github.com/snyk/snyk/pull/1158