### PR TITLE
chore: add hammer team as codeowners on CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,6 @@
 README.md  @snyk/content @snyk/boost
 help/  @snyk/content @snyk/boost
 *  @snyk/boost
+*  @snyk/hammer
 
 


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds 🔨  as co-codeowners for the CLI