### PR TITLE
feat/support depgraph deptree coexistence from plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/cli-interface": "2.6.0",
+    "@snyk/cli-interface": "2.7.0",
     "@snyk/dep-graph": "1.18.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/cli-interface": "2.7.0",
+    "@snyk/cli-interface": "2.8.0",
     "@snyk/dep-graph": "1.18.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -181,6 +181,9 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
       // Post the project dependencies to the Registry
       for (const projectDeps of perProjectResult.scannedProjects) {
+        if (!projectDeps.depTree) {
+          continue;
+        }
         const extractedPackageManager = extractPackageManager(
           projectDeps,
           perProjectResult,

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -85,6 +85,7 @@ export async function monitor(
   analytics.add('isDocker', !!meta.isDocker);
 
   if (GRAPH_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)) {
+    // TODO @boost: remove the code below once 'experimental-dep-graph' is deleted
     const monitorGraphSupportedRes = await isFeatureFlagSupportedForOrg(
       _.camelCase('experimental-dep-graph'),
       options.org || config.org,
@@ -97,7 +98,7 @@ export async function monitor(
       );
     }
     if (monitorGraphSupportedRes.ok) {
-      return await monitorGraph(
+      return await experimentalMonitorDepGraph(
         root,
         meta,
         scannedProject,
@@ -264,7 +265,10 @@ async function monitorDepTree(
   });
 }
 
-export async function monitorGraph(
+// @deprecated: it will be deleted once experimentalDepGraph FF will be deleted
+// and npm, yarn, sbt and rubygems usage of `experimentalMonitorDepGraph`
+// will be replaced with `monitorDepGraph` method
+export async function experimentalMonitorDepGraph(
   root: string,
   meta: MonitorMeta,
   scannedProject: ScannedProject,
@@ -273,7 +277,7 @@ export async function monitorGraph(
   contributors?: { userId: string; lastCommitDate: string }[],
 ): Promise<MonitorResult> {
   const packageManager = meta.packageManager;
-  analytics.add('monitorGraph', true);
+  analytics.add('experimentalMonitorDepGraph', true);
 
   let treeMissingDeps: string[];
   let pkg = scannedProject.depTree;

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -17,7 +17,7 @@ import {
   AuthFailedError,
   FailedToRunTestError,
 } from '../errors';
-import { countPathsToGraphRoot, pruneGraph } from '../prune';
+import { pruneGraph } from '../prune';
 import { GRAPH_SUPPORTED_PACKAGE_MANAGERS } from '../package-managers';
 import { isFeatureFlagSupportedForOrg } from '../feature-flags';
 import { countTotalDependenciesInTree } from './count-total-deps-in-tree';
@@ -35,6 +35,7 @@ import {
   getProjectName,
   getTargetFile,
 } from './utils';
+import { countPathsToGraphRoot } from '../utils';
 
 const debug = Debug('snyk');
 

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -169,7 +169,7 @@ async function monitorDepTree(
   }
   const policy = await snyk.policy.load(policyLocations, { loose: true });
 
-  const target = await projectMetadata.getInfo(scannedProject, depTree, meta);
+  const target = await projectMetadata.getInfo(scannedProject, meta, depTree);
 
   if (isGitTarget(target) && target.branch) {
     analytics.add('targetBranch', target.branch);
@@ -318,7 +318,7 @@ export async function experimentalMonitorDepGraph(
   }
   const policy = await snyk.policy.load(policyLocations, { loose: true });
 
-  const target = await projectMetadata.getInfo(scannedProject, depTree, meta);
+  const target = await projectMetadata.getInfo(scannedProject, meta, depTree);
 
   if (isGitTarget(target) && target.branch) {
     analytics.add('targetBranch', target.branch);

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -45,6 +45,7 @@ export const GRAPH_SUPPORTED_PACKAGE_MANAGERS: SupportedPackageManagers[] = [
   'npm',
   'sbt',
   'yarn',
+  'gradle',
   'rubygems',
 ];
 // For ecosystems with a flat set of libraries (e.g. Python, JVM), one can

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -79,7 +79,7 @@ export async function getDepsFromPlugin(
   // but don't want to send to Registry in the Payload.
   // TODO(kyegupov): decouple inspect and payload so that we don't need this hack
   (options as any).projectNames = inspectRes.scannedProjects.map(
-    (scannedProject) => scannedProject.depTree.name,
+    (scannedProject) => scannedProject?.depTree?.name,
   );
   return convertMultiResultToMultiCustom(inspectRes, options.packageManager);
 }

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -64,7 +64,7 @@ export async function getDepsFromPlugin(
   inspectRes = await getSinglePluginResult(root, options);
 
   if (!pluginApi.isMultiResult(inspectRes)) {
-    if (!inspectRes.package) {
+    if (!inspectRes.package && !inspectRes.dependencyGraph) {
       // something went wrong if both are not present...
       throw Error(
         `error getting dependencies from ${

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -63,7 +63,7 @@ export async function getMultiPluginResult(
       // for test & monitor
       // TODO: refactor how we display meta to not have to do this
       (options as any).projectNames = resultWithScannedProjects.scannedProjects.map(
-        (scannedProject) => scannedProject.depTree.name,
+        (scannedProject) => scannedProject?.depTree?.name,
       );
 
       allResults.push(...pluginResultWithCustomScannedProjects.scannedProjects);

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -1,9 +1,20 @@
+import { DepGraph } from '@snyk/dep-graph';
 import { DepDict, Options, MonitorOptions } from './types';
 import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 
+export function maybePrintDepGraph(
+  options: Options | MonitorOptions,
+  depGraph: DepGraph,
+) {
+  if (options['print-deps']) {
+    // TODO @boost: add as output graphviz 'dot' file to visualize?
+    console.log(JSON.stringify(depGraph.toJSON(), null, 2));
+  }
+}
+
 // This option is still experimental and might be deprecated.
 // It might be a better idea to convert it to a command (i.e. do not perform test/monitor).
-export function maybePrintDeps(
+export function maybePrintDepTree(
   options: Options | MonitorOptions,
   rootPackage: legacyApi.DepTree,
 ) {

--- a/src/lib/project-metadata/index.ts
+++ b/src/lib/project-metadata/index.ts
@@ -13,15 +13,15 @@ interface Options {
 }
 export async function getInfo(
   scannedProject: ScannedProject,
-  packageInfo: DepTree,
   options: Options,
+  packageInfo?: DepTree,
 ): Promise<GitTarget | ContainerTarget | null> {
   const isFromContainer = options.docker || options.isDocker || false;
   for (const builder of TARGET_BUILDERS) {
     const target = await builder.getInfo(
+      isFromContainer,
       scannedProject,
       packageInfo,
-      isFromContainer,
     );
 
     if (target) {

--- a/src/lib/project-metadata/target-builders/container.ts
+++ b/src/lib/project-metadata/target-builders/container.ts
@@ -3,9 +3,9 @@ import { ContainerTarget } from '../types';
 import { ScannedProject } from '@snyk/cli-interface/legacy/common';
 
 export async function getInfo(
-  scannedProject: ScannedProject,
-  packageInfo: DepTree,
   isFromContainer: boolean,
+  scannedProject: ScannedProject,
+  packageInfo?: DepTree,
 ): Promise<ContainerTarget | null> {
   // safety check
   if (!isFromContainer) {
@@ -16,6 +16,6 @@ export async function getInfo(
     scannedProject.meta && scannedProject.meta.imageName;
   return {
     image:
-      imageNameOnProjectMeta || (packageInfo as any).image || packageInfo.name,
+      imageNameOnProjectMeta || (packageInfo as any)?.image || packageInfo?.name,
   };
 }

--- a/src/lib/project-metadata/target-builders/container.ts
+++ b/src/lib/project-metadata/target-builders/container.ts
@@ -16,6 +16,8 @@ export async function getInfo(
     scannedProject.meta && scannedProject.meta.imageName;
   return {
     image:
-      imageNameOnProjectMeta || (packageInfo as any)?.image || packageInfo?.name,
+      imageNameOnProjectMeta ||
+      (packageInfo as any)?.image ||
+      packageInfo?.name,
   };
 }

--- a/src/lib/project-metadata/target-builders/git.ts
+++ b/src/lib/project-metadata/target-builders/git.ts
@@ -1,15 +1,11 @@
 import * as url from 'url';
 import subProcess = require('../../sub-process');
-import { DepTree } from '../../types';
 import { GitTarget } from '../types';
-import { ScannedProject } from '@snyk/cli-interface/legacy/common';
 
 // for scp-like syntax [user@]server:project.git
 const originRegex = /(.+@)?(.+):(.+$)/;
 
 export async function getInfo(
-  scannedProject: ScannedProject,
-  packageInfo: DepTree,
   isFromContainer: boolean,
 ): Promise<GitTarget | null> {
   // safety check

--- a/src/lib/prune.ts
+++ b/src/lib/prune.ts
@@ -6,16 +6,11 @@ import * as config from './config';
 import { TooManyVulnPaths } from './errors';
 import * as analytics from '../lib/analytics';
 import { SupportedPackageManagers } from './package-managers';
+import { countPathsToGraphRoot } from './utils';
 
 const debug = _debug('snyk:prune');
 
 const { depTreeToGraph, graphToDepTree } = legacy;
-
-export function countPathsToGraphRoot(graph: DepGraph): number {
-  return graph
-    .getPkgs()
-    .reduce((acc, pkg) => acc + graph.countPathsToRoot(pkg), 0);
-}
 
 export async function pruneGraph(
   depGraph: DepGraph,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -33,7 +33,7 @@ import { maybePrintDepTree, maybePrintDepGraph } from '../print-deps';
 import { GitTarget, ContainerTarget } from '../project-metadata/types';
 import * as projectMetadata from '../project-metadata';
 import { DepTree, Options, TestOptions, SupportedProjectTypes } from '../types';
-import { countPathsToGraphRoot, pruneGraph } from '../prune';
+import { pruneGraph } from '../prune';
 import { getDepsFromPlugin } from '../plugins/get-deps-from-plugin';
 import { ScannedProjectCustom } from '../plugins/get-multi-plugin-result';
 
@@ -43,6 +43,7 @@ import { extractPackageManager } from '../plugins/extract-package-manager';
 import { getSubProjectCount } from '../plugins/get-sub-project-count';
 import { serializeCallGraphWithMetrics } from '../reachable-vulns';
 import { validateOptions } from '../options-validator';
+import { countPathsToGraphRoot } from '../utils';
 
 const debug = debugModule('snyk');
 

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -355,6 +355,11 @@ async function assembleLocalPayloads(
 
     for (const scannedProject of deps.scannedProjects) {
       const pkg = scannedProject.depTree;
+
+      if (!pkg) {
+        continue;
+      }
+      
       if (options['print-deps']) {
         await spinner.clear<void>(spinnerLbl)();
         maybePrintDeps(options, pkg);

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { DepGraph } from '@snyk/dep-graph';
+
+export function countPathsToGraphRoot(graph: DepGraph): number {
+  return graph
+    .getPkgs()
+    .reduce((acc, pkg) => acc + graph.countPathsToRoot(pkg), 0);
+}

--- a/test/get-remote-url.test.ts
+++ b/test/get-remote-url.test.ts
@@ -6,7 +6,7 @@ test('getInfo returns null for isFromContainer=true', async (t) => {
   const {
     getInfo,
   } = require('../src/lib/project-metadata/target-builders/git');
-  const gitInfo = await getInfo(null as any, null as any, true);
+  const gitInfo = await getInfo(true);
   t.same(gitInfo, null);
 });
 
@@ -22,7 +22,7 @@ test('getInfo handles provided https remote url as http', async (t) => {
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, 'http://myserver.local/myproject.git');
 });
 
@@ -38,7 +38,7 @@ test('getInfo handles provided http remote url', async (t) => {
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, providedUrl);
 });
 
@@ -54,7 +54,7 @@ test('getInfo handles provided ssh remote url as http', async (t) => {
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, 'http://myserver.local/myproject.git');
 });
 
@@ -70,7 +70,7 @@ test('getInfo handles provided scp-like syntax with user in remote url', async (
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, 'http://myserver.local/myproject.git');
 });
 
@@ -86,7 +86,7 @@ test('getInfo handles provided scp-like syntax without user in remote url', asyn
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, 'http://myserver.local/folder/myproject.git');
 });
 
@@ -102,7 +102,7 @@ test('getInfo handles invalid URL by keeping it as is', async (t) => {
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, providedUrl);
 });
 
@@ -118,6 +118,6 @@ test('getInfo handles undefined by returning undefined', async (t) => {
       },
     },
   );
-  const gitInfo = await getInfo(null as any, null as any, false);
+  const gitInfo = await getInfo(false);
   t.same(gitInfo.remoteUrl, undefined);
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

This pr allows snyk-cli of accepts `depGraphs from snyk-plugins`, and keep the current available support to the rest of ecosystem by creating a coexistence path between depgraph and deptrees.

After this pr we will create another one where we will add tests and use
the `snyk-gradle-plugin` coming from this pr 
https://github.com/snyk/snyk-gradle-plugin/pull/127 🚧  
that will be the 1st `snyk-cli` plugin to be sending `depGraph`

The goal of divide this release in two steps is to keep things simple and safer

This PR depends of:
https://github.com/snyk/snyk-cli-interface/pull/34 ✅ 