### PR TITLE
feat: Update snyk-docker-plugin for OCI images support

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.6.3",
+    "snyk-docker-plugin": "3.10.0",
     "snyk-go-plugin": "1.14.2",
     "snyk-gradle-plugin": "3.4.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
snyk-docker-plugin v3.10.0 adds OCI archive scanning support in the `experimental` container flow.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Update to `snyk-docker-plugin` v3.10.0, which adds OCI archive scanning support in the `experimental` container flow.

#### How should this be manually tested?
Manually tested with `snyk container test --experimental` & `snyk container monitor --experimental` for different archives: oci, docker-archive & distroless images.

#### What are the relevant tickets?
[RUN-592](https://snyksec.atlassian.net/browse/RUN-592)
