### PR TITLE
Show message when using a custom API endpoint and validate its value

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
 import * as snykConfig from 'snyk-config';
+import { InvalidEndpointConfigError } from './errors/invalid-endpoint-config-error';
 import { config as userConfig } from './user-config';
 import * as url from 'url';
 
@@ -21,9 +22,18 @@ const config = (snykConfig.loadConfig(
   __dirname + '/../..',
 ) as unknown) as Config;
 
-// allow user config override of the api end point
+// allow user config override of the API endpoint
 const endpoint = userConfig.get('endpoint');
-if (endpoint) {
+if (endpoint && endpoint !== config.API) {
+  const parsedEndpoint = url.parse(endpoint);
+  // Endpoint option must be a valid URL including protocol
+  if (!parsedEndpoint || !parsedEndpoint.protocol || !parsedEndpoint.host) {
+    throw new InvalidEndpointConfigError();
+  }
+  console.info(
+    'Using a custom API endpoint from `snyk config` (tip: it should contain path to `/api`):',
+    endpoint,
+  );
   config.API = endpoint;
 }
 

--- a/src/lib/errors/invalid-endpoint-config-error.ts
+++ b/src/lib/errors/invalid-endpoint-config-error.ts
@@ -1,0 +1,10 @@
+import { CustomError } from './custom-error';
+
+export class InvalidEndpointConfigError extends CustomError {
+  private static ERROR_MESSAGE =
+    "Invalid 'endpoint' config option. Endpoint must be a full and valid URL including protocol and for Snyk.io it should contain path to '/api'";
+
+  constructor() {
+    super(InvalidEndpointConfigError.ERROR_MESSAGE);
+  }
+}

--- a/test/endpoint-config.test.ts
+++ b/test/endpoint-config.test.ts
@@ -1,0 +1,119 @@
+import { test, tearDown } from 'tap';
+import * as Proxyquire from 'proxyquire';
+const proxyquire = Proxyquire.noPreserveCache();
+import { InvalidEndpointConfigError } from '../src/lib/errors/invalid-endpoint-config-error';
+
+const DEFAULT_API = 'https://snyk.io/api/v1';
+const originalSnykApiEndpoint = process.env.SNYK_API;
+delete process.env.SNYK_API;
+
+tearDown(() => {
+  process.env.SNYK_API = originalSnykApiEndpoint;
+});
+
+test('uses default endpoint when none is provided by user', (t) => {
+  const config = proxyquire('../src/lib/config', {
+    './user-config': {
+      config: {
+        get: () => {
+          // No user options provided
+          return;
+        },
+      },
+    },
+  });
+  t.equal(config.API, DEFAULT_API);
+  t.end();
+});
+
+test('uses default endpoint when user endpoint is the same', (t) => {
+  const config = proxyquire('../src/lib/config', {
+    './user-config': {
+      config: {
+        get: (key) => {
+          if (key === 'endpoint') {
+            return DEFAULT_API;
+          }
+          return;
+        },
+      },
+    },
+  });
+  t.equal(config.API, DEFAULT_API);
+  t.end();
+});
+
+test('uses a valid custom endpoint when provided', (t) => {
+  const providedEndpoint = 'https://myendpoint.local/api';
+  const config = proxyquire('../src/lib/config', {
+    './user-config': {
+      config: {
+        get: (key) => {
+          if (key === 'endpoint') {
+            return providedEndpoint;
+          }
+          return;
+        },
+      },
+    },
+  });
+  t.equal(config.API, providedEndpoint);
+  t.end();
+});
+
+test('uses a valid custom endpoint when provided by SNYK_API environment', (t) => {
+  const providedEndpoint = 'https://myendpoint.local/api';
+  process.env.SNYK_API = providedEndpoint;
+  const config = proxyquire('../src/lib/config', {
+    './user-config': {
+      config: {
+        get: () => {
+          // No user options provided
+          return;
+        },
+      },
+    },
+  });
+  t.equal(config.API, providedEndpoint);
+  delete process.env.SNYK_API;
+  t.end();
+});
+
+test('uses a valid custom localhost endpoint when provided', (t) => {
+  const providedEndpoint = 'http://localhost:8000';
+  const config = proxyquire('../src/lib/config', {
+    './user-config': {
+      config: {
+        get: (key) => {
+          if (key === 'endpoint') {
+            return providedEndpoint;
+          }
+          return;
+        },
+      },
+    },
+  });
+  t.equal(config.API, providedEndpoint);
+  t.end();
+});
+
+test('throws an error when endpoint option is not a valid URL', (t) => {
+  const providedEndpoint = 'myendpoint.local/api';
+  t.throws(
+    () =>
+      proxyquire('../src/lib/config', {
+        './user-config': {
+          config: {
+            get: (key) => {
+              if (key === 'endpoint') {
+                return providedEndpoint;
+              }
+              return;
+            },
+          },
+        },
+      }),
+    InvalidEndpointConfigError,
+  );
+  t.end();
+});


### PR DESCRIPTION
Adds a info log that `endpoint` is set in config, and adds a URL validation.

This fixes 2 use cases:

- users having `endpoint` in snyk config, without even realising it's there: CLI now announces it's trying to connect somewhere non-standard
- user having invalid `endpoint` in snyk config, resulting in `$ snyk auth` URL being `null//null/login?token=<token>`

https://snyksec.atlassian.net/browse/HAMMER-40