### PR TITLE
fix: prune depGraph paths accuracy

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,6 @@
 {
   "API": "https://snyk.io/api/v1",
   "devDeps": false,
-  "PRUNE_DEPS_THRESHOLD": 40000
+  "PRUNE_DEPS_THRESHOLD": 40000,
+  "MAX_PATH_COUNT": 100000
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -5,6 +5,7 @@ import * as url from 'url';
 const DEFAULT_TIMEOUT = 5 * 60; // in seconds
 interface Config {
   PRUNE_DEPS_THRESHOLD: number;
+  MAX_PATH_COUNT: number;
   API: string;
   api: string;
   disableSuggestions: string;

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -311,7 +311,7 @@ export async function monitorGraph(
     debug('Trying to prune the graph');
     prePruneDepCount = countPathsToGraphRoot(depGraph);
     debug('pre prunedPathsCount: ' + prePruneDepCount);
-    prunedGraph = await pruneGraph(depGraph, packageManager);
+    prunedGraph = await pruneGraph(depGraph, packageManager, meta.prune);
   }
 
   return new Promise((resolve, reject) => {

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -447,13 +447,19 @@ async function assembleLocalPayloads(
         debug('done converting dep-tree to dep-graph', {
           uniquePkgsCount: depGraph.getPkgs().length,
         });
-        if (options['prune-repeated-subdependencies'] && packageManager) {
+
+        const pruneIsRequired = options['prune-repeated-subdependencies'];
+
+        if (pruneIsRequired && packageManager) {
           debug('Trying to prune the graph');
           const prePruneDepCount = countPathsToGraphRoot(depGraph);
           debug('pre prunedPathsCount: ' + prePruneDepCount);
 
-          depGraph = await pruneGraph(depGraph, packageManager);
-
+          depGraph = await pruneGraph(
+            depGraph,
+            packageManager,
+            pruneIsRequired,
+          );
           analytics.add('prePrunedPathsCount', prePruneDepCount);
           const postPruneDepCount = countPathsToGraphRoot(depGraph);
           debug('post prunedPathsCount: ' + postPruneDepCount);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
The goal of this pr is to remove the previously logic that did not make much sense,
and makes the way that we prune depGraphs more accurate
