### PR TITLE
Handle undefined return from CLI command

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,5 +1,5 @@
 import * as abbrev from 'abbrev';
-import { CommandResult } from './commands/types';
+import { MethodResult } from './commands/types';
 
 import debugModule = require('debug');
 import { parseMode, displayModeHelp } from './modes';
@@ -40,11 +40,9 @@ function dashToCamelCase(dash) {
 // Last item is ArgsOptions, the rest are strings (positional arguments, e.g. paths)
 export type MethodArgs = Array<string | ArgsOptions>;
 
-export type Method = (...args: MethodArgs) => Promise<CommandResult | string>;
-
 export interface Args {
   command: string;
-  method: Method; // command resolved to a function
+  method: (...args: MethodArgs) => Promise<MethodResult>; // command resolved to a function
   options: ArgsOptions;
 }
 
@@ -150,7 +148,7 @@ export function args(rawArgv: string[]): Args {
     argv._.unshift(tmp.shift()!);
   }
 
-  let method: () => Promise<CommandResult | string> = cli[command];
+  let method: () => Promise<MethodResult> = cli[command];
 
   if (!method) {
     // if we failed to find a command, then default to an error

--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -6,13 +6,14 @@ import * as authorization from '../../lib/authorization';
 import * as auth from './auth/is-authed';
 import { apiTokenExists } from '../../lib/api-token';
 import { isCI } from '../../lib/is-ci';
+import { MethodResult } from './types';
 
 import * as Debug from 'debug';
 const debug = Debug('snyk');
 
 import { MisconfiguredAuthInCI } from '../../lib/errors/misconfigured-auth-in-ci-error';
 
-function ignore(options) {
+function ignore(options): Promise<MethodResult> {
   debug('snyk ignore called with options: %O', options);
 
   return auth

--- a/src/cli/commands/types.ts
+++ b/src/cli/commands/types.ts
@@ -1,3 +1,5 @@
+export type MethodResult = CommandResult | string | void;
+
 export class CommandResult {
   result: string;
   constructor(result: string) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -10,7 +10,7 @@ import * as analytics from '../lib/analytics';
 import * as alerts from '../lib/alerts';
 import * as sln from '../lib/sln';
 import { args as argsLib, Args } from './args';
-import { CommandResult, TestCommandResult } from './commands/types';
+import { TestCommandResult } from './commands/types';
 import { copy } from './copy';
 import spinner = require('../lib/spinner');
 import errors = require('../lib/errors/legacy-errors');
@@ -40,15 +40,17 @@ const EXIT_CODES = {
 };
 
 async function runCommand(args: Args) {
-  const commandResult: CommandResult | string = await args.method(
-    ...args.options._,
-  );
+  const commandResult = await args.method(...args.options._);
 
   const res = analytics({
     args: args.options._,
     command: args.command,
     org: args.options.org,
   });
+
+  if (!commandResult) {
+    return;
+  }
 
   const result = commandResult.toString();
 


### PR DESCRIPTION
- [x] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes an issue where if one of the CLI commands (specifically ignore) does not return a CommandResult | string, but rather returns nothing, causes a failure.

#### Any background context you want to provide?
The `ignore` command does not return anything when it runs successfully and that was causing a failure in runCommand when we tried to .toString() the result.

#### What are the relevant tickets?
- HAMMER-70
