### PR TITLE
fix: Bump snyk docker plugin to handle errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.11.0",
+    "snyk-docker-plugin": "3.12.0",
     "snyk-go-plugin": "1.14.2",
     "snyk-gradle-plugin": "3.4.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumping snyk docker progin lib to v3.12.0, which added error handling when an oci archive provided with docker-archive manifest.

#### What are the relevant tickets?
[RUN-1003](https://snyksec.atlassian.net/browse/RUN-1003)
