### PR TITLE
fix: make container commands use always static scan

### DIFF
--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -11,6 +11,7 @@ const modes: Record<string, ModeData> = {
     allowedCommands: ['test', 'monitor'],
     config: (args): [] => {
       args['docker'] = true;
+      args['experimental'] = true;
 
       return args;
     },

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -160,6 +160,7 @@ test('test command line "container test"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
+  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -172,6 +173,7 @@ test('test command line "container monitor"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
+  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -184,6 +186,7 @@ test('test command line "container protect"', (t) => {
   ];
   const result = args(cliArgs);
   t.notOk(result.options.docker);
+  t.notOk(result.options.experimental);
   t.end();
 });
 

--- a/test/modes.test.ts
+++ b/test/modes.test.ts
@@ -135,6 +135,7 @@ test('when is a valid mode', (c) => {
         const expectedArgs = {
           _: [],
           docker: true,
+          experimental: true,
           'package-manager': 'pip',
         };
         const cliCommand = 'container';
@@ -148,6 +149,7 @@ test('when is a valid mode', (c) => {
         t.equal(command, expectedCommand);
         t.same(cliArgs, expectedArgs);
         t.ok(cliArgs['docker']);
+        t.ok(cliArgs['experimental']);
         t.end();
       },
     );
@@ -158,6 +160,7 @@ test('when is a valid mode', (c) => {
         const expectedArgs = {
           _: [],
           docker: true,
+          experimental: true,
           'package-manager': 'pip',
         };
         const cliCommand = 'container';
@@ -171,6 +174,7 @@ test('when is a valid mode', (c) => {
         t.equal(command, expectedCommand);
         t.same(cliArgs, expectedArgs);
         t.ok(cliArgs['docker']);
+        t.ok(cliArgs['experimental']);
         t.end();
       });
       t.end();
@@ -198,6 +202,7 @@ test('when is a valid mode', (c) => {
         t.equal(command, expectedCommand);
         t.same(cliArgs, expectedArgs);
         t.notOk(cliArgs['docker']);
+        t.notOk(cliArgs['experimental']);
         t.end();
       },
     );


### PR DESCRIPTION
 Continue the efforts to have "snyk container test" or "snyk container monitor" commands that doesn't require Docker engine running. In this step we make these commands always use the static scan. Although it's not relevant to all users, more flexibility here is both more technically correct, future proofs our technology, and is important to several separate strategic partners.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
It makes the command `snyk container` always use the static scan.

#### Where should the reviewer start?
The result for `snyk container test <image>...` has to be equal `snyk test --docker --experimental <image>...`

#### How should this be manually tested?
Run the following command and compare the output. It has to me the same:
 - `snyk container test <image>...`
 - `snyk test --docker --experimental <image>...`

#### Any background context you want to provide?


#### What are the relevant tickets?
 - [RUN-986](https://snyksec.atlassian.net/browse/RUN-986)
 - [RUN-1002](https://snyksec.atlassian.net/browse/RUN-1002)

#### Screenshots
<img width="688" alt="Screenshot 2020-06-12 at 12 52 15" src="https://user-images.githubusercontent.com/838518/84500015-9c4e8c80-acab-11ea-846c-8fcbb71008dd.png">

<img width="673" alt="Screenshot 2020-06-12 at 12 52 21" src="https://user-images.githubusercontent.com/838518/84500031-a3759a80-acab-11ea-88e4-0cb2721a6883.png">

