### PR TITLE
fix: remove duplicated call to maybePrintDeps

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -190,8 +190,6 @@ async function monitor(...args0: MethodArgs): Promise<any> {
         maybePrintDeps(options, projectDeps.depTree);
 
         debug(`Processing ${projectDeps.depTree.name}...`);
-        maybePrintDeps(options, projectDeps.depTree);
-
         const tFile = projectDeps.targetFile || targetFile;
         const targetFileRelativePath = tFile
           ? pathUtil.join(pathUtil.resolve(path), tFile)


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

We are accidentally printing deps twice