### PR TITLE
fix: upgrade snky-docker-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.12.1",
+    "snyk-docker-plugin": "3.12.2",
     "snyk-go-plugin": "1.14.2",
     "snyk-gradle-plugin": "3.4.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
 It updates the `snyk-docker-plugin` verstion to `3.12.2`.

#### Where should the reviewer start?


#### How should this be manually tested?
You should run `snyk test --docker <centos-image>` and get the same result when run `snyk test --docker --experimental <centos-image>`.

#### Any background context you want to provide?
Fix some inconsistency in the static analysis.

#### What are the relevant tickets?
- [RUN-1005](https://snyksec.atlassian.net/browse/RUN-1005)
