### PR TITLE
feat: gradle support of depgraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "snyk-config": "3.1.0",
     "snyk-docker-plugin": "3.12.2",
     "snyk-go-plugin": "1.14.2",
-    "snyk-gradle-plugin": "3.4.0",
+    "snyk-gradle-plugin": "3.5.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.17.1",
     "snyk-nodejs-lockfile-parser": "1.22.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Brings snyk-gradle-plugin support of dep-graph and drop the usage of dep-tree.

- Solve OOM Issues
- get correct project version (no longer 0.0.0 by default) 
- Performance Improvements
- Allow projects of large scale to be imported
