### PR TITLE
feat: expose snyk-test debug context

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -25,6 +25,7 @@ alias.t = 'test';
 // The -d flag enables printing the messages for predefined namespaces.
 // Additional ones can be specified (comma-separated) in the DEBUG environment variable.
 const DEBUG_DEFAULT_NAMESPACES = [
+  'snyk-test',
   'snyk',
   'snyk-gradle-plugin',
   'snyk-sbt-plugin',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
When using `--all-projects` the debug is not showing with `-d` making it hard to see errors which we silence on purpose to not spam the user. Expose the rleevant debug context so it is visible with `-d`


#### How should this be manually tested?
run `snyk test` on an out of sync yarn project with and without `--all-projects`

#### Screenshots
*Before*
<img width="800" alt="Screen Shot 2020-06-17 at 17 46 43" src="https://user-images.githubusercontent.com/2911613/84926148-db714900-b0c2-11ea-997c-07dd96793770.png">

*After*
<img width="812" alt="Screen Shot 2020-06-17 at 17 46 25" src="https://user-images.githubusercontent.com/2911613/84926155-ddd3a300-b0c2-11ea-8b9f-7bf877cab7e1.png">