### PR TITLE
fix: check command exists before calling toString()

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,7 +50,7 @@ async function runCommand(args: Args) {
     org: args.options.org,
   });
 
-  const result = commandResult.toString();
+  const result = commandResult?.toString();
 
   if (result && !args.options.quiet) {
     if (args.options.copy) {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When running `snyk --ignore` we ended up finishing the command with an error, make the toString() call safe to get rid of it

<img width="707" alt="Screen Shot 2020-06-17 at 18 54 03" src="https://user-images.githubusercontent.com/2911613/84953684-deccfa80-b0eb-11ea-8fac-e8a0356b1406.png">
