### PR TITLE
chore: fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,4 @@
 # Snyk Boost will be required for a review on every PR
 README.md  @snyk/content @snyk/boost
 help/  @snyk/content @snyk/boost
-*  @snyk/boost
-*  @snyk/hammer
-
-
+*  @snyk/hammer @snyk/boost


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

now boost and hammer are codeowners
<img width="152" alt="Screen Shot 2020-06-18 at 13 03 45" src="https://user-images.githubusercontent.com/40601533/85007423-3018d080-b164-11ea-8897-ff8bae954e80.png">

