### PR TITLE
feat: unify policy handling & plucking

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -12,6 +12,8 @@ import {
   MonitorMeta,
   MonitorResult,
   Options,
+  PolicyOptions,
+  Contributors,
 } from '../../../lib/types';
 import * as config from '../../../lib/config';
 import * as detect from '../../../lib/detect';
@@ -61,10 +63,10 @@ async function promiseOrCleanup<T>(
 // or an error message.
 async function monitor(...args0: MethodArgs): Promise<any> {
   let args = [...args0];
-  let options: MonitorOptions = {};
+  let monitorOptions = {};
   const results: Array<GoodResult | BadResult> = [];
   if (typeof args[args.length - 1] === 'object') {
-    options = (args.pop() as ArgsOptions) as MonitorOptions;
+    monitorOptions = args.pop() as ArgsOptions;
   }
   args = args.filter(Boolean);
 
@@ -72,6 +74,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
   if (args.length === 0) {
     args.unshift(process.cwd());
   }
+  const options = monitorOptions as Options & PolicyOptions & MonitorOptions;
 
   if (options.id) {
     snyk.id = options.id;
@@ -89,7 +92,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
 
   apiTokenExists();
 
-  let contributors: { userId: string; lastCommitDate: string }[] = [];
+  let contributors: Contributors[] = [];
   if (!options.docker && analytics.allowAnalytics()) {
     try {
       const repoPath = process.cwd();

--- a/src/cli/commands/protect/index.ts
+++ b/src/cli/commands/protect/index.ts
@@ -12,7 +12,7 @@ import * as errors from '../../../lib/errors';
 const debug = debugModule('snyk');
 
 async function protectFunc(
-  options: types.ProtectOptions & types.Options & types.TestOptions,
+  options: types.PolicyOptions & types.Options & types.TestOptions,
 ) {
   const protectOptions = { ...options };
   protectOptions.loose = true; // replace missing policies with empty ones
@@ -79,7 +79,7 @@ async function protectFunc(
   }
 }
 
-async function patch(options: types.ProtectOptions & types.Options) {
+async function patch(options: types.PolicyOptions & types.Options) {
   try {
     const response = (await snyk.test(
       process.cwd(),

--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -43,6 +43,7 @@ import {
   MonitorMeta,
   MonitorResult,
   WizardOptions,
+  PackageJson,
 } from '../../../lib/types';
 import { LegacyVulnApiResult } from '../../../lib/snyk-test/legacy';
 import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
@@ -318,13 +319,6 @@ function calculatePkgFileIndentation(packageFile: string): number {
   return pkgIndentation;
 }
 
-interface Pkg {
-  scripts: any;
-  snyk: boolean;
-  dependencies: any;
-  devDependencies: any;
-}
-
 function processAnswers(answers, policy, options) {
   if (!options) {
     options = {};
@@ -347,7 +341,7 @@ function processAnswers(answers, policy, options) {
     targetFile.endsWith('package-lock.json') ||
     targetFile.endsWith('yarn.lock');
 
-  let pkg = {} as Pkg;
+  let pkg = {} as PackageJson;
   let pkgIndentation = 2;
 
   sendWizardAnalyticsData(answers);
@@ -599,6 +593,7 @@ function processAnswers(answers, policy, options) {
               cwd,
               meta as MonitorMeta,
               (inspectRes as MultiProjectResult).scannedProjects[0],
+              options,
               inspectRes.plugin,
               options,
             );

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -14,7 +14,6 @@ import {
   MonitorResult,
   PolicyOptions,
   MonitorOptions,
-  PackageJson,
   Options,
   Contributors,
 } from '../types';
@@ -190,7 +189,9 @@ async function monitorDepTree(
     root,
     meta.isDocker ? 'docker' : packageManager!,
     options,
-    depTree as PackageJson, // TODO: fix this and send only a manifest
+    // TODO: fix this and send only send when we used resolve-deps for node
+    // it should be a ExpandedPkgTree type instead
+    depTree,
   );
 
   const target = await projectMetadata.getInfo(scannedProject, meta, depTree);
@@ -446,7 +447,9 @@ async function experimentalMonitorDepGraphFromDepTree(
     root,
     meta.isDocker ? 'docker' : packageManager!,
     options,
-    depTree as PackageJson, // TODO: fix this and send only a manifest
+    // TODO: fix this and send only send when we used resolve-deps for node
+    // it should be a ExpandedPkgTree type instead
+    depTree,
   );
 
   if (['npm', 'yarn'].includes(meta.packageManager)) {

--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as fs from 'then-fs';
 import * as resolveNodeDeps from 'snyk-resolve-deps';
-import { PkgTree } from 'snyk-nodejs-lockfile-parser';
 
 import * as spinner from '../../spinner';
 import * as analytics from '../../analytics';
@@ -11,7 +10,7 @@ export async function parse(
   root: string,
   targetFile: string,
   options: Options,
-): Promise<PkgTree> {
+): Promise<resolveNodeDeps.PackageExpanded> {
   const nodeModulesPath = path.join(
     path.dirname(path.resolve(root, targetFile)),
     'node_modules',

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -1,5 +1,6 @@
 import * as snykPolicyLib from 'snyk-policy';
 import * as debugModule from 'debug';
+import { PackageExpanded } from 'snyk-resolve-deps';
 
 import { pluckPolicies } from '.';
 import { SupportedPackageManagers } from '../package-managers';
@@ -12,7 +13,7 @@ export async function findAndLoadPolicy(
   root: string,
   scanType: SupportedPackageManagers | 'docker',
   options: PolicyOptions,
-  pkg?: PackageJson,
+  pkg?: PackageExpanded,
 ): Promise<string | undefined> {
   const isDocker = scanType === 'docker';
   const isNodeProject = ['npm', 'yarn'].includes(scanType);

--- a/src/lib/policy/find-and-load-policy.ts
+++ b/src/lib/policy/find-and-load-policy.ts
@@ -1,0 +1,46 @@
+import * as snykPolicyLib from 'snyk-policy';
+import * as debugModule from 'debug';
+
+import { pluckPolicies } from '.';
+import { SupportedPackageManagers } from '../package-managers';
+import { PackageJson, PolicyOptions } from '../types';
+import * as analytics from '../analytics';
+
+const debug = debugModule('snyk');
+
+export async function findAndLoadPolicy(
+  root: string,
+  scanType: SupportedPackageManagers | 'docker',
+  options: PolicyOptions,
+  pkg?: PackageJson,
+): Promise<string | undefined> {
+  const isDocker = scanType === 'docker';
+  const isNodeProject = ['npm', 'yarn'].includes(scanType);
+  // monitor
+  let policyLocations: string[] = [options['policy-path'] || root];
+  if (isDocker) {
+    policyLocations = policyLocations.filter((loc) => loc !== root);
+  } else if (isNodeProject) {
+    // TODO: pluckPolicies expects a package.json object to
+    // find and apply policies in node_modules
+    policyLocations = policyLocations.concat(pluckPolicies(pkg as PackageJson));
+  }
+  debug('Potential policy locations found:', policyLocations);
+  analytics.add('policies', policyLocations.length);
+  analytics.add('policyLocations', policyLocations);
+
+  if (policyLocations.length === 0) {
+    return;
+  }
+  let policy;
+  try {
+    policy = await snykPolicyLib.load(policyLocations, options);
+  } catch (err) {
+    // note: inline catch, to handle error from .load
+    // if the .snyk file wasn't found, it is fine
+    if (err.code !== 'ENOENT') {
+      throw err;
+    }
+  }
+  return policy;
+}

--- a/src/lib/policy/index.ts
+++ b/src/lib/policy/index.ts
@@ -1,1 +1,2 @@
 export { pluckPolicies } from './pluck-policies';
+export { findAndLoadPolicy } from './find-and-load-policy';

--- a/src/lib/policy/pluck-policies.ts
+++ b/src/lib/policy/pluck-policies.ts
@@ -1,23 +1,22 @@
 import * as _ from '@snyk/lodash';
+import { PackageJson } from '../types';
 
-export function pluckPolicies(pkg) {
+export function pluckPolicies(pkg: PackageJson): string[] {
   if (!pkg) {
-    return null;
+    return [];
   }
 
   if (pkg.snyk) {
-    return pkg.snyk;
+    return []; // why is this check here?
   }
 
   if (!pkg.dependencies) {
-    return null;
+    return [];
   }
 
   return _.flatten(
     Object.keys(pkg.dependencies)
-      .map((name) => {
-        return pluckPolicies(pkg.dependencies[name]);
-      })
+      .map((name: string) => pluckPolicies(pkg.dependencies[name]))
       .filter(Boolean),
   );
 }

--- a/src/lib/policy/pluck-policies.ts
+++ b/src/lib/policy/pluck-policies.ts
@@ -1,13 +1,13 @@
 import * as _ from '@snyk/lodash';
-import { PackageJson } from '../types';
+import { PackageExpanded } from 'snyk-resolve-deps';
 
-export function pluckPolicies(pkg: PackageJson): string[] {
+export function pluckPolicies(pkg: PackageExpanded): string[] | string {
   if (!pkg) {
     return [];
   }
 
   if (pkg.snyk) {
-    return []; // why is this check here?
+    return pkg.snyk;
   }
 
   if (!pkg.dependencies) {

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -37,7 +37,6 @@ import {
   TestOptions,
   SupportedProjectTypes,
   PolicyOptions,
-  PackageJson,
 } from '../types';
 import { pruneGraph } from '../prune';
 import { getDepsFromPlugin } from '../plugins/get-deps-from-plugin';
@@ -408,7 +407,9 @@ async function assembleLocalPayloads(
         root,
         options.docker ? 'docker' : packageManager!,
         options,
-        pkg as PackageJson, // TODO: fix this and send only a manifest
+        // TODO: fix this and send only send when we used resolve-deps for node
+        // it should be a ExpandedPkgTree type instead
+        pkg,
       );
 
       analytics.add('packageManager', packageManager);

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -28,11 +28,17 @@ import { isCI } from '../is-ci';
 import * as common from './common';
 import * as config from '../config';
 import * as analytics from '../analytics';
-import { pluckPolicies } from '../policy';
 import { maybePrintDepTree, maybePrintDepGraph } from '../print-deps';
 import { GitTarget, ContainerTarget } from '../project-metadata/types';
 import * as projectMetadata from '../project-metadata';
-import { DepTree, Options, TestOptions, SupportedProjectTypes } from '../types';
+import {
+  DepTree,
+  Options,
+  TestOptions,
+  SupportedProjectTypes,
+  PolicyOptions,
+  PackageJson,
+} from '../types';
 import { pruneGraph } from '../prune';
 import { getDepsFromPlugin } from '../plugins/get-deps-from-plugin';
 import { ScannedProjectCustom } from '../plugins/get-multi-plugin-result';
@@ -44,6 +50,7 @@ import { getSubProjectCount } from '../plugins/get-sub-project-count';
 import { serializeCallGraphWithMetrics } from '../reachable-vulns';
 import { validateOptions } from '../options-validator';
 import { countPathsToGraphRoot } from '../utils';
+import { findAndLoadPolicy } from '../policy';
 
 const debug = debugModule('snyk');
 
@@ -57,7 +64,7 @@ interface DepTreeFromResolveDeps extends DepTree {
 interface PayloadBody {
   depGraph?: depGraphLib.DepGraph; // missing for legacy endpoint (options.vulnEndpoint)
   callGraph?: any;
-  policy: string;
+  policy?: string;
   targetFile?: string;
   targetFileRelativePath?: string;
   projectNameOverride?: string;
@@ -319,7 +326,7 @@ function assemblePayloads(
 // Payload to send to the Registry for scanning a package from the local filesystem.
 async function assembleLocalPayloads(
   root,
-  options: Options & TestOptions,
+  options: Options & TestOptions & PolicyOptions,
 ): Promise<Payload[]> {
   // For --all-projects packageManager is yet undefined here. Use 'all'
   const analysisType =
@@ -397,20 +404,13 @@ async function assembleLocalPayloads(
         }
       }
 
-      let policyLocations: string[] = [options['policy-path'] || root];
-      if (options.docker) {
-        policyLocations = policyLocations.filter((loc) => {
-          return loc !== root;
-        });
-      } else if (
-        packageManager &&
-        ['npm', 'yarn'].indexOf(packageManager) > -1
-      ) {
-        policyLocations = policyLocations.concat(pluckPolicies(pkg));
-      }
-      debug('policies found', policyLocations);
+      const policy = await findAndLoadPolicy(
+        root,
+        options.docker ? 'docker' : packageManager!,
+        options,
+        pkg as PackageJson, // TODO: fix this and send only a manifest
+      );
 
-      analytics.add('policies', policyLocations.length);
       analytics.add('packageManager', packageManager);
       if (scannedProject.depGraph) {
         const depGraph = pkg as depGraphLib.DepGraph;
@@ -419,19 +419,6 @@ async function assembleLocalPayloads(
       if (scannedProject.depTree) {
         const depTree = pkg as DepTree;
         addPackageAnalytics(depTree.name!, depTree.version!);
-      }
-
-      let policy;
-      if (policyLocations.length > 0) {
-        try {
-          policy = await snyk.policy.load(policyLocations, options);
-        } catch (err) {
-          // note: inline catch, to handle error from .load
-          //   if the .snyk file wasn't found, it is fine
-          if (err.code !== 'ENOENT') {
-            throw err;
-          }
-        }
       }
 
       // todo: normalize what target file gets used across plugins and functions
@@ -466,7 +453,7 @@ async function assembleLocalPayloads(
         targetFileRelativePath: `${targetFileRelativePath}`, // Forcing string
         projectNameOverride: options.projectName,
         originalProjectName,
-        policy: policy && policy.toString(),
+        policy: policy ? policy.toString() : undefined,
         foundProjectCount: getSubProjectCount(deps),
         displayTargetFile: targetFile,
         docker: (pkg as DepTree).docker,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,13 +20,23 @@ export interface TestOptions {
   failOn?: FailOn;
   reachableVulns?: boolean;
 }
-export interface ProtectOptions {
-  loose: boolean;
-}
 
 export interface WizardOptions {
   newPolicy: boolean;
 }
+
+export interface Contributors {
+  userId: string;
+  lastCommitDate: string;
+}
+
+export interface PolicyOptions {
+  'ignore-policy'?: boolean; // used in snyk/policy lib
+  'trust-policies'?: boolean; // used in snyk/policy lib
+  'policy-path'?: string;
+  loose?: boolean;
+}
+
 export interface Options {
   org?: string | null;
   path: string;
@@ -38,9 +48,6 @@ export interface Options {
   projectName?: string;
   insecure?: boolean;
   'dry-run'?: boolean;
-  'ignore-policy'?: boolean;
-  'trust-policies'?: boolean; // used in snyk/policy lib
-  'policy-path'?: boolean;
   allSubProjects?: boolean;
   'project-name'?: string;
   'show-vulnerable-paths'?: string;
@@ -90,6 +97,12 @@ export interface MonitorMeta {
   'remote-repo-url'?: string;
 }
 
+export interface PackageJson {
+  scripts: any;
+  snyk: boolean;
+  dependencies: any;
+  devDependencies: any;
+}
 export interface MonitorResult {
   org?: string;
   id: string;

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -1531,8 +1531,7 @@ test('`monitor foo:latest --docker` doesnt send policy from cwd', async (t) => {
     'calls docker plugin with expected arguments',
   );
 
-  const emptyPolicy = await snykPolicy.create();
-  t.deepEqual(req.body.policy, emptyPolicy.toString(), 'empty policy is sent');
+  t.deepEqual(req.body.policy, undefined, 'no policy is sent');
 });
 
 test('`monitor foo:latest --docker` with custom policy path', async (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

- Unify how we find & load policies for all the 4 places where we need to do the exact same thing.
- add some types
- update pluck policies to always return an string or string array


#### Any background context you want to provide?
There is a policy handling but with `--all-project` , `gradle sub-projects` and `--file` where we look for policy in the root of where the command is run and not next to the manifest, which can be exposed in a test and fixed in a PR after this initial refactor so that the change is made in one place not 4.
