### PR TITLE
fix: show gradle suggestion on test too

### DIFF
--- a/src/cli/commands/monitor/formatters/format-monitor-response.ts
+++ b/src/cli/commands/monitor/formatters/format-monitor-response.ts
@@ -30,7 +30,7 @@ export function formatMonitorOutput(
     '\n\n' +
     (advertiseGradleSubProjectsCount && foundProjectCount
       ? chalk.bold.white(
-          `This project has multiple sub-projects (${foundProjectCount}), ` +
+          `Tip: This project has multiple sub-projects (${foundProjectCount}), ` +
             'use --all-sub-projects flag to scan all sub-projects.\n\n',
         )
       : '') +

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -205,9 +205,14 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
   );
 
   let response = results
-    .map((unused, i) => {
+    .map((result, i) => {
       resultOptions[i].pinningSupported = pinningSupported;
-      return displayResult(results[i] as LegacyVulnApiResult, resultOptions[i]);
+
+      return displayResult(
+        results[i] as LegacyVulnApiResult,
+        resultOptions[i],
+        result.foundProjectCount,
+      );
     })
     .join(`\n${SEPARATOR}`);
 
@@ -389,7 +394,7 @@ function displayResult(
     projectType === 'gradle' && !options['gradle-sub-project'];
   if (advertiseGradleSubProjectsCount && foundProjectCount) {
     multiProjAdvice = chalk.bold.white(
-      `\n\nThis project has multiple sub-projects (${foundProjectCount}), ` +
+      `\n\nTip: This project has multiple sub-projects (${foundProjectCount}), ` +
         'use --all-sub-projects flag to scan all sub-projects.',
     );
   }

--- a/test/acceptance/cli-test/cli-test.gradle.spec.ts
+++ b/test/acceptance/cli-test/cli-test.gradle.spec.ts
@@ -148,7 +148,12 @@ export const GradleTests: AcceptanceTests = {
       const plugin = {
         async inspect(): Promise<pluginApi.MultiProjectResult> {
           return {
-            plugin: { name: 'gradle' },
+            plugin: {
+              meta: {
+                allSubProjectNames: ['a', 'b'],
+              },
+              name: 'gradle',
+            },
             scannedProjects: [
               {
                 depTree: {
@@ -190,6 +195,12 @@ export const GradleTests: AcceptanceTests = {
         res,
         /Tested 2 projects/,
         'number projects tested displayed properly',
+      );
+      t.match(res, '(2)', '2 sub projects found');
+      t.match(
+        res,
+        /use --all-sub-projects flag to scan all sub-projects/,
+        'all-sub-projects flag is suggested',
       );
       for (let i = 0; i < tests.length; i++) {
         const meta = tests[i]


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- show the gradle `--all-rub-projects` suggestion when running `test` as well ` monitor`
- add the wording `Tip:` 

#### How should this be manually tested?
run `snyk test --file-build.gradle` on a gradle project with subprojects and `snyk monitor --file-build.gradle` 


#### Screenshots
*Before* only monitor showed the suggestion
<img width="618" alt="Screen Shot 2020-06-22 at 16 41 14" src="https://user-images.githubusercontent.com/2911613/85309203-2c5db480-b4aa-11ea-9b97-560e7ef01e7f.png">

*After* test also shows the suggestion
<img width="622" alt="Screen Shot 2020-06-22 at 16 47 51" src="https://user-images.githubusercontent.com/2911613/85309198-2962c400-b4aa-11ea-9d4a-d62c42e0c859.png">
