### PR TITLE
refactor: drop unused gradle from experimental

### DIFF
--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -45,7 +45,6 @@ export const GRAPH_SUPPORTED_PACKAGE_MANAGERS: SupportedPackageManagers[] = [
   'npm',
   'sbt',
   'yarn',
-  'gradle',
   'rubygems',
 ];
 // For ecosystems with a flat set of libraries (e.g. Python, JVM), one can


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Dropping gradle from experimental monitor.
Why? It's unused there, snyk-gradle-plugin sends a graph by default so there is no reason to keep it on experimental monitor.