### PR TITLE
feat: show reachable paths for supported projects

### DIFF
--- a/src/cli/commands/test/formatters/types.ts
+++ b/src/cli/commands/test/formatters/types.ts
@@ -1,0 +1,35 @@
+import {
+  CallPath,
+  LegalInstruction,
+  REACHABILITY,
+  SEVERITY,
+} from '../../../../lib/snyk-test/legacy';
+
+export interface SampleReachablePaths {
+  pathCount: number;
+  paths: CallPath[];
+}
+
+export interface BasicVulnInfo {
+  type: string;
+  title: string;
+  severity: SEVERITY;
+  isNew: boolean;
+  name: string;
+  version: string;
+  fixedIn: string[];
+  legalInstructions?: LegalInstruction[];
+  paths: string[][];
+  note: string | false;
+  reachability?: REACHABILITY;
+  sampleReachablePaths?: SampleReachablePaths;
+}
+
+interface TopLevelPackageUpgrade {
+  name: string;
+  version: string;
+}
+
+export interface UpgradesByAffectedPackage {
+  [pkgNameAndVersion: string]: TopLevelPackageUpgrade[];
+}

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -85,6 +85,18 @@ export interface IssueData {
   reachability?: REACHABILITY;
 }
 
+export type CallPath = string[];
+
+export interface ReachableFunctionPaths {
+  functionName: string;
+  callPaths: CallPath[];
+}
+
+export interface ReachablePaths {
+  pathCount: number;
+  reachablePaths: ReachableFunctionPaths[];
+}
+
 interface AnnotatedIssue extends IssueData {
   credit: any;
   name: string;
@@ -106,6 +118,8 @@ interface AnnotatedIssue extends IssueData {
   patch?: any;
   note?: string | false;
   publicationTime?: string;
+
+  reachablePaths?: ReachablePaths;
 }
 
 // Mixin, to be added to GroupedVuln / AnnotatedIssue

--- a/test/reachable-vulns.test.ts
+++ b/test/reachable-vulns.test.ts
@@ -5,6 +5,8 @@ import {
   formatReachability,
   summariseReachableVulns,
   getReachabilityText,
+  formatReachablePaths,
+  formatReachablePath,
 } from '../src/cli/commands/test/formatters/format-reachability';
 import { AnnotatedIssue, REACHABILITY } from '../src/lib/snyk-test/legacy';
 import {
@@ -100,6 +102,64 @@ test('formatReachabilitySummaryText', (t) => {
     ]),
     'In addition, found 2 vulnerabilities with a reachable path.',
     'two reachable functions and no info one, should count only the function reachable once',
+  );
+
+  t.end();
+});
+
+test('formatReachablePaths', (t) => {
+  function reachablePathsTemplate(
+    samplePaths: string[],
+    extraPathsCount: number,
+  ): string {
+    if (samplePaths.length === 0) {
+      return `\n    reachable via at least ${extraPathsCount} paths`;
+    }
+    let reachableVia = '\n    reachable via:\n';
+    for (const p of samplePaths) {
+      reachableVia += `    ${p}\n`;
+    }
+    if (extraPathsCount > 0) {
+      reachableVia += `    and at least ${extraPathsCount} other path(s)`;
+    }
+    return reachableVia;
+  }
+
+  const noReachablePaths = {
+    pathCount: 0,
+    paths: [],
+  };
+
+  const reachablePaths = {
+    pathCount: 3,
+    paths: [
+      ['f', 'g', 'h', 'i', 'j', 'vulnFunc1'],
+      ['k', 'l', 'm', 'n', 'o', 'vulnFunc1'],
+      ['p', 'q', 'r', 's', 't', 'vulnFunc2'],
+    ],
+  };
+
+  t.equal(
+    formatReachablePaths(reachablePaths, 0, reachablePathsTemplate),
+    reachablePathsTemplate([], 3),
+  );
+
+  t.equal(
+    formatReachablePaths(reachablePaths, 2, reachablePathsTemplate),
+    reachablePathsTemplate(
+      reachablePaths.paths.slice(0, 2).map(formatReachablePath),
+      1,
+    ),
+  );
+
+  t.equal(
+    formatReachablePaths(reachablePaths, 5, reachablePathsTemplate),
+    reachablePathsTemplate(reachablePaths.paths.map(formatReachablePath), 0),
+  );
+
+  t.equal(
+    formatReachablePaths(noReachablePaths, 2, reachablePathsTemplate),
+    reachablePathsTemplate([], 0),
   );
 
   t.end();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This change set makes the `test` command show a number of sample call paths from the user code to the affected function of each vulnerability, if any could be found. Currently this shows only 2 compressed code paths. A compressed call path shows only the 2 leading an 2 trailing function calls.

#### Where should the reviewer start?

`src/cli/commands/test/formatters/remediation-based-format-issues.ts:518` is where we build the output message. The most interesting functions are `formatReachablePaths` and `reachablePathsTemplate`.

#### How should this be manually tested?

Clone a maven project (https://github.com/snyk-flow/JMinerGuide is a good candidate), build it, and run this version of the `snyk` CLI with `test --reachable-vulns` from the project root. You need to have reachable vulns enabled on your account.

#### Any background context you want to provide?

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/FLOW-296

#### Screenshots

![image](https://user-images.githubusercontent.com/90345/85838040-d8e0b480-b790-11ea-839a-f609c4a9109d.png)

#### Additional questions
