### PR TITLE
chore: make Flow code owner for reachability formatters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # Snyk Boost will be required for a review on every PR
 README.md  @snyk/content @snyk/boost
+src/cli/commands/test/formatters/format-reachability.ts  @snyk/flow
 help/  @snyk/content @snyk/boost
 *  @snyk/hammer @snyk/boost


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Make @snyk/flow the owners of the reachability formatters since Flow owns reachable vulns.

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
