### PR TITLE
Chore/sync validate monitor path

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -117,7 +117,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
   for (const path of args as string[]) {
     debug(`Processing ${path}...`);
     try {
-      await validateMonitorPath(path, options.docker);
+      validateMonitorPath(path, options.docker);
       let analysisType = 'all';
       let packageManager;
       if (options.allProjects) {
@@ -302,7 +302,7 @@ function generateMonitorMeta(options, packageManager?): MonitorMeta {
   };
 }
 
-async function validateMonitorPath(path, isDocker) {
+function validateMonitorPath(path, isDocker) {
   const exists = fs.existsSync(path);
   if (!exists && !isDocker) {
     throw new Error('"' + path + '" is not a valid path for "snyk monitor"');

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -302,7 +302,7 @@ function generateMonitorMeta(options, packageManager?): MonitorMeta {
   };
 }
 
-function validateMonitorPath(path, isDocker) {
+function validateMonitorPath(path: string, isDocker?: boolean): void {
   const exists = fs.existsSync(path);
   if (!exists && !isDocker) {
     throw new Error('"' + path + '" is not a valid path for "snyk monitor"');


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

validateMonitorPath used to use an async flow and await on it. that's no longer the case and the function no longer needs to be async.

#### Where should the reviewer start?

https://github.com/snyk/snyk/commit/99da9c269ce4e0a8e9c34a8869ff2f5f1b816640