### PR TITLE
feat: add support for yarn workspaces pattern in workspaces.packages

### DIFF
--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -58,7 +58,7 @@ export async function processYarnWorkspaces(
       ...getWorkspacesMap(packageJson),
     };
     for (const workspaceRoot of Object.keys(yarnWorkspacesMap)) {
-      const workspaces = yarnWorkspacesMap[workspaceRoot].workspaces || [];
+      const workspaces = yarnWorkspacesMap[workspaceRoot].workspaces?.packages || yarnWorkspacesMap[workspaceRoot].workspaces || [];
       const match = workspaces
         .map((pattern) => {
           return packageJsonFileName.includes(pattern.replace(/\*/, ''));

--- a/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json
+++ b/test/acceptance/workspaces/yarn-workspace-out-of-sync/package.json
@@ -1,8 +1,10 @@
 {
   "private": true,
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ]
+  },
   "resolutions": {
     "node-fetch": "^2.3.0"
   },


### PR DESCRIPTION
fixes https://github.com/snyk/snyk/issues/1251

- [ ] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fixes https://github.com/snyk/snyk/issues/1251 by adding support for the alternative Yarn Workspaces config structure:
```
{
  "name": "my-workspace",
  "private": true,
  "workspaces": {
    "packages": [ "packages/*" ]
  }
}
```

#### Where should the reviewer start?
There's only one changed line :)

#### How should this be manually tested?
Create a Yarn Workspaces setup using the alternate configuration

#### Any background context you want to provide?
Snyk is awesome

#### What are the relevant tickets?
https://github.com/snyk/snyk/issues/1251