### PR TITLE
chore: rename reachable paths field

### DIFF
--- a/src/cli/commands/constants.ts
+++ b/src/cli/commands/constants.ts
@@ -1,0 +1,12 @@
+// Separator used while displaying various paths (e.g. package paths, call
+// paths) to the user
+export const PATH_SEPARATOR = ' > ';
+
+// String used to signify hidden path elements e.g. for abbreviated paths
+export const PATH_HIDDEN_ELEMENTS = '...';
+
+// Number of function names to show in the beginning of an abbreviated call path
+export const CALL_PATH_LEADING_ELEMENTS = 2;
+
+// Number of function names to show in the end of an abbreviated call path
+export const CALL_PATH_TRAILING_ELEMENTS = 2;

--- a/src/cli/commands/protect/prompts.ts
+++ b/src/cli/commands/protect/prompts.ts
@@ -1,3 +1,5 @@
+import { PATH_SEPARATOR } from '../constants';
+
 export {
   getUpdatePrompts,
   getPatchPrompts,
@@ -648,8 +650,8 @@ function generatePrompt(
       );
       messageIntro += '\n    Description: ' + vuln.title;
       fromText =
-        from !== vuln.from.slice(1).join(' > ')
-          ? '    From: ' + vuln.from.slice(1).join(' > ')
+        from !== vuln.from.slice(1).join(PATH_SEPARATOR)
+          ? '    From: ' + vuln.from.slice(1).join(PATH_SEPARATOR)
           : '';
     }
 

--- a/src/cli/commands/test/formatters/format-reachability.ts
+++ b/src/cli/commands/test/formatters/format-reachability.ts
@@ -7,12 +7,12 @@ import {
   REACHABILITY,
 } from '../../../../lib/snyk-test/legacy';
 import { SampleReachablePaths } from './types';
-
-// Number of function names to show in the beginning of an abbreviated code path
-const LEADING_PATH_ELEMENTS = 2;
-
-// Number of function names to show in the end of an abbreviated code path
-const TRAILING_PATH_ELEMENTS = 2;
+import {
+  CALL_PATH_LEADING_ELEMENTS,
+  PATH_SEPARATOR,
+  CALL_PATH_TRAILING_ELEMENTS,
+  PATH_HIDDEN_ELEMENTS,
+} from '../../constants';
 
 const reachabilityLevels: {
   [key in REACHABILITY]: { color: Function; text: string };
@@ -99,9 +99,9 @@ export function formatReachablePaths(
 }
 
 export function formatReachablePath(path: CallPath): string {
-  const head = path.slice(0, LEADING_PATH_ELEMENTS).join('>');
+  const head = path.slice(0, CALL_PATH_LEADING_ELEMENTS).join(PATH_SEPARATOR);
   const tail = path
-    .slice(path.length - TRAILING_PATH_ELEMENTS, path.length)
-    .join('>');
-  return `${head} > ... > ${tail}`;
+    .slice(path.length - CALL_PATH_TRAILING_ELEMENTS, path.length)
+    .join(PATH_SEPARATOR);
+  return `${head}${PATH_SEPARATOR}${PATH_HIDDEN_ELEMENTS}${PATH_SEPARATOR}${tail}`;
 }

--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../../lib/snyk-test/legacy';
 import { formatLegalInstructions } from './legal-license-instructions';
 import { getReachabilityText } from './format-reachability';
+import { PATH_SEPARATOR } from '../../constants';
 
 export function formatIssues(
   vuln: GroupedVuln,
@@ -136,7 +137,7 @@ function createTruncatedVulnsPathsText(
     const fromWithoutBaseProject = i.slice(1);
     // If more than one From path
     if (fromWithoutBaseProject.length) {
-      return i.slice(1).join(' > ');
+      return i.slice(1).join(PATH_SEPARATOR);
     }
     // Else issue is in the core package
     return i;
@@ -221,7 +222,7 @@ function createRemediationText(
           // Example command: snyk test express@3
           const selfUpgradeInfo =
             v.upgradePath.length > 0
-              ? ` (triggers upgrades to ${v.upgradePath.join(' > ')})`
+              ? ` (triggers upgrades to ${v.upgradePath.join(PATH_SEPARATOR)})`
               : '';
           const testedPackageName = snykModule(v.upgradePath[0] as string);
           return (
@@ -230,7 +231,9 @@ function createRemediationText(
           );
         }
         if (shouldUpgradeDirectDep) {
-          const formattedUpgradePath = v.upgradePath.slice(1).join(' > ');
+          const formattedUpgradePath = v.upgradePath
+            .slice(1)
+            .join(PATH_SEPARATOR);
           const upgradeTextInfo = v.upgradePath.length
             ? ` (triggers upgrades to ${formattedUpgradePath})`
             : '';

--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -25,6 +25,7 @@ import {
   SampleReachablePaths,
   UpgradesByAffectedPackage,
 } from './types';
+import { PATH_SEPARATOR } from '../../constants';
 
 // How many reachable paths to show in the output
 const MAX_REACHABLE_PATHS = 2;
@@ -45,7 +46,7 @@ export function formatIssuesWithRemediation(
   for (const vuln of vulns) {
     const allReachablePaths: SampleReachablePaths = { pathCount: 0, paths: [] };
     for (const issue of vuln.list) {
-      const issueReachablePaths = issue.reachablePaths?.reachablePaths || [];
+      const issueReachablePaths = issue.reachablePaths?.paths || [];
       for (const functionReachablePaths of issueReachablePaths) {
         allReachablePaths.paths = allReachablePaths.paths.concat(
           functionReachablePaths.callPaths,
@@ -415,7 +416,7 @@ function constructUnfixableText(
 }
 
 export function printPath(path: string[]) {
-  return path.slice(1).join(' > ');
+  return path.slice(1).join(PATH_SEPARATOR);
 }
 
 export function formatIssue(

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -95,7 +95,7 @@ export interface ReachableFunctionPaths {
 
 export interface ReachablePaths {
   pathCount: number;
-  reachablePaths: ReachableFunctionPaths[];
+  paths: ReachableFunctionPaths[];
 }
 
 interface AnnotatedIssue extends IssueData {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

We renamed the field in the result returned by the server to avoid awkward looking code like `reachablePaths.reachablePaths`. This changes the type definition to use the new name.