### PR TITLE
fix: Adding a flag to activate applications scans for container images

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.13.0",
+    "snyk-docker-plugin": "3.13.1",
     "snyk-go-plugin": "1.14.2",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -240,6 +240,14 @@ async function main() {
       (args.options as unknown) as AllSupportedCliOptions,
     );
 
+    if (args.options['app-vulns'] && args.options['json']) {
+      throw new UnsupportedOptionCombinationError([
+        'Application vulnerabilities is currently not supported with JSON output. ' +
+          'Please try using —app-vulns only to get application vulnerabilities, or ' +
+          '—json only to get your image vulnerabilties, excluding the application ones.',
+      ]);
+    }
+
     if (
       args.options.file &&
       typeof args.options.file === 'string' &&

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -12,6 +12,7 @@ const modes: Record<string, ModeData> = {
     config: (args): [] => {
       args['docker'] = true;
       args['experimental'] = true;
+      args['app-vulns'] = args.json ? false : true;
 
       return args;
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,8 @@ export interface Options {
   strictOutOfSync?: boolean;
   // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
   experimental?: boolean;
+  // Used with the Docker plugin only. Allows application scanning.
+  'app-vulns'?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -86,6 +88,8 @@ export interface MonitorOptions {
   'prune-repeated-subdependencies'?: boolean;
   // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
   experimental?: boolean;
+  // Used with the Docker plugin only. Allows application scanning.
+  'app-vulns'?: boolean;
   reachableVulns?: boolean;
   yarnWorkspaces?: boolean;
 }

--- a/test/modes.test.ts
+++ b/test/modes.test.ts
@@ -136,6 +136,7 @@ test('when is a valid mode', (c) => {
           _: [],
           docker: true,
           experimental: true,
+          'app-vulns': true,
           'package-manager': 'pip',
         };
         const cliCommand = 'container';
@@ -155,28 +156,64 @@ test('when is a valid mode', (c) => {
     );
 
     d.test('when there is a command alias', (t) => {
-      t.test('"container t" should set docker option and test command', (t) => {
-        const expectedCommand = 't';
-        const expectedArgs = {
-          _: [],
-          docker: true,
-          experimental: true,
-          'package-manager': 'pip',
-        };
-        const cliCommand = 'container';
-        const cliArgs = {
-          _: ['t'],
-          'package-manager': 'pip',
-        };
+      t.test(
+        '"container test" should set docker option and test command',
+        (t) => {
+          const expectedCommand = 't';
+          const expectedArgs = {
+            _: [],
+            docker: true,
+            experimental: true,
+            'app-vulns': true,
+            'package-manager': 'pip',
+          };
+          const cliCommand = 'container';
+          const cliArgs = {
+            _: ['t'],
+            'package-manager': 'pip',
+          };
 
-        const command = parseMode(cliCommand, cliArgs);
+          const command = parseMode(cliCommand, cliArgs);
 
-        t.equal(command, expectedCommand);
-        t.same(cliArgs, expectedArgs);
-        t.ok(cliArgs['docker']);
-        t.ok(cliArgs['experimental']);
-        t.end();
-      });
+          t.equal(command, expectedCommand);
+          t.same(cliArgs, expectedArgs);
+          t.ok(cliArgs['docker']);
+          t.ok(cliArgs['experimental']);
+          t.end();
+        },
+      );
+      t.end();
+    });
+
+    d.test('when there is a command alias', (t) => {
+      t.test(
+        '"container test" should set docker option and not app-vulns and test command',
+        (t) => {
+          const expectedCommand = 't';
+          const expectedArgs = {
+            _: [],
+            json: true,
+            docker: true,
+            experimental: true,
+            'app-vulns': false,
+            'package-manager': 'pip',
+          };
+          const cliCommand = 'container';
+          const cliArgs = {
+            _: ['t'],
+            json: true,
+            'package-manager': 'pip',
+          };
+
+          const command = parseMode(cliCommand, cliArgs);
+
+          t.equal(command, expectedCommand);
+          t.same(cliArgs, expectedArgs);
+          t.ok(cliArgs['docker']);
+          t.ok(cliArgs['experimental']);
+          t.end();
+        },
+      );
       t.end();
     });
     d.end();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Adding a flag to activate parser based application scanning.

There are a few special cases in the moment:

- Using `snyk --docker --experimental` we do not want to allow `--json` output when requesting application scanning
- Using the `snyk container` alias we don't want to throw an error but rather only show the image project when `--json` output is requested. So the alias is:
```
snyk container test/monitor -> snyk --docker --experimental --app-vulns test/monitor
snyk container test/monitor --json -> snyk --docker --experimental --json test/monitor 
```
See the slack threads or reach out to me if it is still confusing.

#### Where should the reviewer start?

Add a flag next to the experimental flag to the CLI

#### Any background context you want to provide?

See also this slack thread:  https://snyk.slack.com/archives/CLB5WDQRF/p1593610184000200?thread_ts=1592825658.001300&cid=CLB5WDQRF

https://snyk.slack.com/archives/CLB5WDQRF/p1594209146001700
https://snyk.slack.com/archives/CLB5WDQRF/p1594219121008900

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-820

#### Screenshots
![image (3)](https://user-images.githubusercontent.com/49239888/86937705-7c3dac00-c137-11ea-8157-a3b0f0c89433.png)
![image (4)](https://user-images.githubusercontent.com/49239888/86937708-7d6ed900-c137-11ea-90c7-10459b690478.png)
![image (5)](https://user-images.githubusercontent.com/49239888/86937713-7d6ed900-c137-11ea-8f34-3a6855e6c742.png)
![image (6)](https://user-images.githubusercontent.com/49239888/86937715-7e076f80-c137-11ea-87af-cc46eadc2510.png)
