### PR TITLE
fix: missing dep in nodejs-lockfile-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.17.1",
-    "snyk-nodejs-lockfile-parser": "1.26.1",
+    "snyk-nodejs-lockfile-parser": "1.26.2",
     "snyk-nuget-plugin": "1.18.1",
     "snyk-php-plugin": "1.9.0",
     "snyk-policy": "1.14.1",


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Missing `lodash` dep in nodejs-lockfile-parser module
