### PR TITLE
fix: increase tool flexibility for container static analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
-    "snyk-docker-plugin": "3.13.1",
+    "snyk-docker-plugin": "3.16.0",
     "snyk-go-plugin": "1.16.0",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -7,6 +7,7 @@ import {
   SupportedCliCommands,
   SupportedUserReachableFacingCliArgs,
 } from '../lib/types';
+import { getContainerImageSavePath } from '../lib/container';
 
 export declare interface Global extends NodeJS.Global {
   ignoreUnknownCA: boolean;
@@ -159,6 +160,13 @@ export function args(rawArgv: string[]): Args {
     // if we failed to find a command, then default to an error
     method = require('../lib/errors/legacy-errors');
     argv._.push(command);
+  }
+
+  // TODO: Once experimental flag became default this block should be
+  // moved to inside the parseModes function for container mode
+  const imageSavePath = getContainerImageSavePath();
+  if (imageSavePath) {
+    argv['imageSavePath'] = imageSavePath;
   }
 
   const commands: SupportedCliCommands[] = [

--- a/src/lib/container/index.ts
+++ b/src/lib/container/index.ts
@@ -1,5 +1,9 @@
 import { ScannedProject } from '@snyk/cli-interface/legacy/common';
 import { MonitorMeta } from '../types';
+import { config as userConfig } from '../user-config';
+
+export const IMAGE_SAVE_PATH_OPT = 'imageSavePath';
+export const IMAGE_SAVE_PATH_ENV_VAR = 'SNYK_IMAGE_SAVE_PATH';
 
 export function isContainer(scannedProject: ScannedProject): boolean {
   return scannedProject.meta?.imageName?.length;
@@ -37,4 +41,12 @@ export function getContainerProjectName(
     name = meta['project-name'];
   }
   return name;
+}
+
+export function getContainerImageSavePath(): string | undefined {
+  return (
+    process.env[IMAGE_SAVE_PATH_ENV_VAR] ||
+    userConfig.get(IMAGE_SAVE_PATH_OPT) ||
+    undefined
+  );
 }

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'tap';
 import { args } from '../src/cli/args';
+import { config as userConfig } from '../src/lib/user-config';
 
 test('test command line arguments', (t) => {
   const cliArgs = [
@@ -188,6 +189,68 @@ test('test command line "container protect"', (t) => {
   t.notOk(result.options.docker);
   t.notOk(result.options.experimental);
   t.end();
+});
+
+test('when command line "container"', (c) => {
+  c.test('set option imageSavePath via config set', (t) => {
+    delete process.env['SNYK_IMAGE_SAVE_PATH'];
+    userConfig.set('imageSavePath', './my/custom/image/save/path');
+    const cliArgs = [
+      '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+      '/Users/dror/work/snyk/snyk-internal/cli',
+      'container',
+      'test',
+    ];
+
+    const result = args(cliArgs);
+
+    t.equal(
+      result.options.imageSavePath,
+      './my/custom/image/save/path',
+      'the custom path should be assigned with path',
+    );
+    userConfig.delete('imageSavePath');
+    t.end();
+  });
+
+  c.test('set option imageSavePath via env var', (t) => {
+    process.env['SNYK_IMAGE_SAVE_PATH'] = './my/custom/image/save/path';
+    const cliArgs = [
+      '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+      '/Users/dror/work/snyk/snyk-internal/cli',
+      'container',
+      'test',
+    ];
+
+    const result = args(cliArgs);
+
+    t.equal(
+      result.options.imageSavePath,
+      './my/custom/image/save/path',
+      'the custom path should be assigned with path',
+    );
+    delete process.env['SNYK_IMAGE_SAVE_PATH'];
+    t.end();
+  });
+
+  c.test('does not set option imageSavePath', (t) => {
+    delete process.env['SNYK_IMAGE_SAVE_PATH'];
+    const cliArgs = [
+      '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+      '/Users/dror/work/snyk/snyk-internal/cli',
+      'container',
+      'test',
+    ];
+
+    const result = args(cliArgs);
+
+    t.notOk(
+      result.options.imageSavePath,
+      'the custom path should not be assigned',
+    );
+    t.end();
+  });
+  c.end();
 });
 
 test('test command line "container" should display help for mode', (t) => {

--- a/test/container.test.ts
+++ b/test/container.test.ts
@@ -2,6 +2,7 @@ import { test } from 'tap';
 import * as container from '../src/lib/container';
 import { ScannedProject } from '@snyk/cli-interface/legacy/common';
 import { MonitorMeta } from '../src/lib/types';
+import { config as userConfig } from '../src/lib/user-config';
 
 const stubScannedProjectContainer = () => {
   return {
@@ -138,4 +139,39 @@ test('getContainerProjectName returns --project-name opt name when container pro
     overriddenNameStubMeta,
   );
   t.equal(res, 'override-name-my-project');
+});
+
+test('getContainerImageSavePath return path via config set', (t) => {
+  t.plan(1);
+  userConfig.set(container.IMAGE_SAVE_PATH_OPT, './my/custom/path');
+
+  const customPath = container.getContainerImageSavePath();
+
+  t.equal(
+    customPath,
+    './my/custom/path',
+    'returns the image save path from config',
+  );
+  userConfig.delete(container.IMAGE_SAVE_PATH_OPT);
+});
+
+test('getContainerImageSavePath return path via env var', (t) => {
+  t.plan(1);
+  process.env[container.IMAGE_SAVE_PATH_ENV_VAR] = './my/custom/path';
+
+  const customPath = container.getContainerImageSavePath();
+
+  t.equal(
+    customPath,
+    './my/custom/path',
+    'returns the image save path from env var',
+  );
+  delete process.env[container.IMAGE_SAVE_PATH_ENV_VAR];
+});
+
+test('getContainerImageSavePath does not return path', (t) => {
+  t.plan(1);
+  const customPath = container.getContainerImageSavePath();
+
+  t.notOk(customPath, 'does not returns a path');
 });


### PR DESCRIPTION
  Increase the tool flexibility allowing the user choose a location on disk with the best storage characteristics for storage images during the static analysis process.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
It captures the option `imageSavePath` from env var or configured via `snyk config` to allow the `container` static analysis flow to store the downloaded image in a custom path given by the user.

#### Where should the reviewer start?
Take a look at `args.ts` file. 

#### How should this be manually tested?
1. Run the command `snyk container test nginx:latest` to check the tool behaviour without the new option.
2. `SNYK_IMAGE_SAVE_PATH=./your/custom/path snyk container test nginx:latest` and check if the result was the same as the previous command. Also the path `./your/custom/path` would be created and it has to be empty.

#### What are the relevant tickets?
 - [RUN-582](https://snyksec.atlassian.net/browse/RUN-582)
