### PR TITLE
fix: skip --all-projects suggestion when a yarn workspace

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -434,7 +434,10 @@ function displayResult(
     );
   }
   const advertiseAllProjectsCount =
-    projectType !== 'gradle' && !options.allProjects && foundProjectCount;
+    projectType !== 'gradle' &&
+    !options.allProjects &&
+    !options.yarnWorkspaces &&
+    foundProjectCount;
   if (advertiseAllProjectsCount) {
     multiProjAdvice = chalk.bold.white(
       `\n\nTip: Detected multiple supported manifests (${foundProjectCount}), ` +


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Skip suggesting `--all-projects` when scanning a yarn workspace as it essentially does the same thing.

https://github.com/snyk/snyk/issues/350#issuecomment-655571961