### PR TITLE
fix: improve reliability around call graph generation

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -90,6 +90,18 @@ Maven options:
   --scan-all-unmanaged
                        Auto detects maven jars and wars in given directory.
                        Individual testing can be done with --file=<jar-file-name>
+  --reachable
+                       (test and monitor commands only)
+                       Analyze your source code to find which vulnerable
+                       functions and packages are called.
+  --reachable-timeout=<number>
+                       (test and monitor commands only)
+                       The amount of time (in seconds) to wait for Snyk
+                       to gather reachability data. If it takes longer than
+                       the specified interval, Reachable Vulnerabilities are
+                       not reported. This does not affect regular test or
+                       monitor output.
+                       Defaults to waiting 300s (5 minutes).
 
 Gradle options:
   --sub-project=<string> (alias: --gradle-sub-project)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "author": "snyk.io",
   "license": "Apache-2.0",
   "dependencies": {
-    "@snyk/cli-interface": "2.8.0",
+    "@snyk/cli-interface": "2.8.1",
     "@snyk/dep-graph": "1.18.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",
@@ -80,7 +80,7 @@
     "snyk-go-plugin": "1.14.2",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.17.1",
+    "snyk-mvn-plugin": "2.17.3",
     "snyk-nodejs-lockfile-parser": "1.26.3",
     "snyk-nuget-plugin": "1.18.1",
     "snyk-php-plugin": "1.9.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -36,6 +36,10 @@ const DEBUG_DEFAULT_NAMESPACES = [
   'snyk-mvn-plugin',
 ];
 
+// NOTE[muscar] This is accepted in seconds for UX reasons, the mavem plugin
+// turns it into milliseconds before calling the call graph generator
+const REACHABLE_VULNS_TIMEOUT = 5 * 60; // 5 min (in seconds)
+
 function dashToCamelCase(dash) {
   return dash.indexOf('-') < 0
     ? dash
@@ -192,11 +196,17 @@ export function args(rawArgv: string[]): Args {
     'all-projects',
     'yarn-workspaces',
     'detection-depth',
+    'reachable',
     'reachable-vulns',
+    'reachable-timeout',
+    'reachable-vulns-timeout',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {
       const camelCased = dashToCamelCase(dashedArg);
+      if (camelCased === dashedArg) {
+        continue;
+      }
       argv[camelCased] = argv[dashedArg];
       delete argv[dashedArg];
     }
@@ -218,10 +228,20 @@ export function args(rawArgv: string[]): Args {
     }
   }
 
+  if (
+    argv.reachableTimeout === undefined &&
+    argv.reachableVulnsTimeout === undefined
+  ) {
+    argv.reachableVulnsTimeout = REACHABLE_VULNS_TIMEOUT.toString();
+  }
+
   // Alias
   const aliases = {
     gradleSubProject: 'subProject',
     container: 'docker',
+    reachable: 'reachableVulns',
+    reachableTimeout: 'callGraphBuilderTimeout',
+    reachableVulnsTimeout: 'callGraphBuilderTimeout',
   };
   for (const argAlias in aliases) {
     if (argv[argAlias]) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,7 @@ export interface TestOptions {
   showVulnPaths: ShowVulnPaths;
   failOn?: FailOn;
   reachableVulns?: boolean;
+  reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;
 }
 
@@ -91,6 +92,7 @@ export interface MonitorOptions {
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
   reachableVulns?: boolean;
+  reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;
 }
 
@@ -144,7 +146,6 @@ export type SupportedUserReachableFacingCliArgs =
   | 'file'
   | 'policy'
   | 'fail-on'
-  | 'reachable-vulns'
   | 'json'
   | 'package-manager'
   | 'packages-folder'
@@ -160,7 +161,10 @@ export type SupportedUserReachableFacingCliArgs =
   | 'yarn-workspaces'
   | 'detection-depth'
   | 'project-name'
-  | 'reachable-vulns';
+  | 'reachable'
+  | 'reachable-vulns'
+  | 'reachable-timeout'
+  | 'reachable-vulns-timeout';
 
 export type SupportedCliCommands =
   | 'protect'


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This is meant to improve the experience around reachable vulns by:
- giving control to the CLI on how long the call graph generator can run;
- running the user command (e.g. monitor, test) even if the call graph generation failed;
- allowing for better error messages is the call graph generation fails.

Merge after https://github.com/snyk/snyk-cli-interface/pull/36 and https://github.com/snyk/snyk-mvn-plugin/pull/73, and after updating the dependencies to the appropriate versions.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/FLOW-336

#### Screenshots

Running with a timeout:

![step1](https://user-images.githubusercontent.com/90345/87952571-de849e00-caa1-11ea-96ea-467f4d125505.png)

Running with a timeout and passing `-d`:

![step2](https://user-images.githubusercontent.com/90345/87952567-dd537100-caa1-11ea-8259-b5653bbfdf5a.png)
