### PR TITLE
feat: add gomodules support depgraph, drop deptree

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
     "snyk-docker-plugin": "3.13.1",
-    "snyk-go-plugin": "1.14.2",
+    "snyk-go-plugin": "1.16.0",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.17.1",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Add support of depgraph to **gomodules**, drop deptree and finally gets rid of the OutOfMemory issues problem

