### PR TITLE
fix: abridge call graph creation error messages in analytics

### DIFF
--- a/src/lib/error-format.ts
+++ b/src/lib/error-format.ts
@@ -1,0 +1,12 @@
+export function abridgeErrorMessage(
+  msg: string,
+  maxLen: number,
+  ellipsis?: string,
+): string {
+  if (msg.length <= maxLen) {
+    return msg;
+  }
+  const e = ellipsis || ' ... ';
+  const toKeep = (maxLen - e.length) / 2;
+  return msg.slice(0, toKeep) + e + msg.slice(msg.length - toKeep, msg.length);
+}

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -51,8 +51,11 @@ import {
 } from './utils';
 import { countPathsToGraphRoot } from '../utils';
 import * as alerts from '../alerts';
+import { abridgeErrorMessage } from '../error-format';
 
 const debug = Debug('snyk');
+
+const ANALYTICS_PAYLOAD_MAX_LENGTH = 1024;
 
 // TODO(kyegupov): clean up the type, move to snyk-cli-interface repository
 
@@ -220,7 +223,13 @@ async function monitorDepTree(
   let callGraphPayload;
   if (options.reachableVulns && scannedProject.callGraph?.innerError) {
     const err = scannedProject.callGraph as CallGraphError;
-    analytics.add('callGraphError', err.innerError.toString());
+    analytics.add(
+      'callGraphError',
+      abridgeErrorMessage(
+        err.innerError.toString(),
+        ANALYTICS_PAYLOAD_MAX_LENGTH,
+      ),
+    );
     alerts.registerAlerts([
       {
         type: 'error',

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -55,8 +55,11 @@ import { assembleIacLocalPayloads, parseIacTestResult } from './run-iac-test';
 import { Payload, PayloadBody, DepTreeFromResolveDeps } from './types';
 import { CallGraphError } from '@snyk/cli-interface/legacy/common';
 import * as alerts from '../alerts';
+import { abridgeErrorMessage } from '../error-format';
 
 const debug = debugModule('snyk');
+
+const ANALYTICS_PAYLOAD_MAX_LENGTH = 1024;
 
 export = runTest;
 
@@ -520,7 +523,13 @@ async function assembleLocalPayloads(
         (scannedProject.callGraph as CallGraphError).innerError
       ) {
         const err = scannedProject.callGraph as CallGraphError;
-        analytics.add('callGraphError', err.innerError.toString());
+        analytics.add(
+          'callGraphError',
+          abridgeErrorMessage(
+            err.innerError.toString(),
+            ANALYTICS_PAYLOAD_MAX_LENGTH,
+          ),
+        );
         alerts.registerAlerts([
           {
             type: 'error',

--- a/test/error-format.test.ts
+++ b/test/error-format.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'tap';
+import { abridgeErrorMessage } from '../src/lib/error-format';
+
+test('abridge empty string', async (t) => {
+  t.equal(abridgeErrorMessage('', 10), '');
+});
+
+test('abridge shorter than max length', async (t) => {
+  t.equal(abridgeErrorMessage('hello', 10), 'hello');
+});
+
+test('abridge same length as max length', async (t) => {
+  t.equal(abridgeErrorMessage('hello', 5), 'hello');
+});
+
+test('abridge longer than max length', async (t) => {
+  t.equal(abridgeErrorMessage('hello there', 10), 'he ... ere');
+});
+
+test('abridge longer than max length (custom ellipsis)', async (t) => {
+  t.equal(abridgeErrorMessage('hello there', 10, '--'), 'hell--here');
+});


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Since the call graph error messages can get pretty big, abridge them to something more manageable. This keep the beginning, and end of the message since, presumably, that's where the most important details are.