### PR TITLE
Feat/move to target dirs for call graph creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "snyk-go-plugin": "1.16.0",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.17.3",
+    "snyk-mvn-plugin": "2.18.0",
     "snyk-nodejs-lockfile-parser": "1.26.3",
     "snyk-nuget-plugin": "1.18.1",
     "snyk-php-plugin": "1.9.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -35,6 +35,7 @@ const DEBUG_DEFAULT_NAMESPACES = [
   'snyk-gradle-plugin',
   'snyk-sbt-plugin',
   'snyk-mvn-plugin',
+  'snyk-java-call-graph-builder',
 ];
 
 // NOTE[muscar] This is accepted in seconds for UX reasons, the mavem plugin

--- a/src/lib/error-format.ts
+++ b/src/lib/error-format.ts
@@ -1,12 +1,13 @@
 export function abridgeErrorMessage(
   msg: string,
   maxLen: number,
-  ellipsis?: string,
+  ellipsis = ' ... ',
 ): string {
   if (msg.length <= maxLen) {
     return msg;
   }
-  const e = ellipsis || ' ... ';
-  const toKeep = (maxLen - e.length) / 2;
-  return msg.slice(0, toKeep) + e + msg.slice(msg.length - toKeep, msg.length);
+  const toKeep = Math.floor((maxLen - ellipsis.length) / 2);
+  return (
+    msg.slice(0, toKeep) + ellipsis + msg.slice(msg.length - toKeep, msg.length)
+  );
 }

--- a/test/error-format.test.ts
+++ b/test/error-format.test.ts
@@ -14,9 +14,14 @@ test('abridge same length as max length', async (t) => {
 });
 
 test('abridge longer than max length', async (t) => {
-  t.equal(abridgeErrorMessage('hello there', 10), 'he ... ere');
+  t.equal(abridgeErrorMessage('hello there', 10), 'he ... re');
 });
 
 test('abridge longer than max length (custom ellipsis)', async (t) => {
   t.equal(abridgeErrorMessage('hello there', 10, '--'), 'hell--here');
+});
+
+test('abridge is not longer than max length', async (t) => {
+  const maxLength = 10;
+  t.true(abridgeErrorMessage('hello there', maxLength).length < maxLength);
 });


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Bumping mvn plugin to include dirs instead of files for entrypoints for call graph construction.
Also, a small refactor and making sure the call graph generator is being printed in the debug output.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/FLOW-330


#### Additional questions
