### PR TITLE
fix: pass --dev to yarn workspace scan

### DIFF
--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -16,7 +16,7 @@ export async function processYarnWorkspaces(
   root: string,
   settings: {
     strictOutOfSync?: boolean;
-    scanDevDependencies?: boolean;
+    dev?: boolean;
   },
   targetFiles: string[],
 ): Promise<MultiProjectResultCustom> {
@@ -83,7 +83,7 @@ export async function processYarnWorkspaces(
       const res = await lockFileParser.buildDepTree(
         packageJson.content,
         yarnLock.content,
-        settings.scanDevDependencies,
+        settings.dev,
         lockFileParser.LockfileType.yarn,
         settings.strictOutOfSync !== false,
       );


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Pass `dev` which is the property from `--dev` option passed to CLI in a workspace workflow