### PR TITLE
fix: correctly count graph packages

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -195,12 +195,10 @@ async function parseRes(
       pkgManager,
       options.severityThreshold,
     );
-
     // For Node.js: inject additional information (for remediation etc.) into the response.
     if (payload.modules) {
       res.dependencyCount =
-        payload.modules.numDependencies ||
-        depGraph.countPathsToRoot(depGraph.rootPkg);
+        payload.modules.numDependencies || depGraph.getPkgs().length - 1;
       if (res.vulnerabilities) {
         res.vulnerabilities.forEach((vuln) => {
           if (payload.modules && payload.modules.pluck) {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
When modules count is not provided we need to count the packages from graph ourselves. Fixing a bug where the calculation was incorrect and returned `1` most of the time.


Repro:
run `snyk test --yarn-workspaces` for some reason it only affects this flow.

Fixed:
<img width="636" alt="Screen Shot 2020-07-24 at 18 02 39" src="https://user-images.githubusercontent.com/2911613/88416385-093f6100-cdd8-11ea-9b7d-d4e4132b3720.png">
