### PR TITLE
feat: Support using Docker JWT token for snyk test

### DIFF
--- a/src/lib/api-token.ts
+++ b/src/lib/api-token.ts
@@ -8,6 +8,10 @@ export function api() {
   return config.api || config.TOKEN || userConfig.get('api');
 }
 
+export function getDockerToken(): string | undefined {
+  return process.env.SNYK_DOCKER_TOKEN;
+}
+
 export function apiTokenExists() {
   const configured = api();
   if (!configured) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface TestOptions {
   reachableVulns?: boolean;
   reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;
+  testDepGraphDockerEndpoint?: string | null;
 }
 
 export interface WizardOptions {

--- a/test/acceptance/docker-token.test.ts
+++ b/test/acceptance/docker-token.test.ts
@@ -1,0 +1,167 @@
+import * as tap from 'tap';
+import * as cli from '../../src/cli/commands';
+import { fakeServer } from './fake-server';
+import * as sinon from 'sinon';
+
+const { test } = tap;
+
+const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+const BASE_API = '/api/v1';
+process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
+process.env.SNYK_HOST = 'http://localhost:' + port;
+process.env.LOG_LEVEL = '0';
+const apiKey = '123456789';
+let oldkey;
+let oldendpoint;
+const server = fakeServer(BASE_API, apiKey);
+
+// This import needs to come after the server init
+// it causes the configured API url to be incorrect.
+import * as plugins from '../../src/lib/plugins/index';
+
+test('setup', async (t) => {
+  t.plan(3);
+
+  let key = await cli.config('get', 'api');
+  oldkey = key;
+  t.pass('existing user config captured: ' + oldkey);
+
+  key = await cli.config('get', 'endpoint');
+  oldendpoint = key;
+  t.pass('existing user endpoint captured: ' + oldendpoint);
+
+  await new Promise((resolve) => {
+    server.listen(port, resolve);
+  });
+  t.pass('started demo server');
+  t.end();
+});
+
+test('prime config', async (t) => {
+  await cli.config('unset', 'endpoint');
+  t.pass('endpoint removed');
+
+  await cli.config('unset', 'api');
+  t.pass('api key removed');
+
+  process.env.SNYK_DOCKER_TOKEN = 'docker-jwt-token';
+  t.pass('docker token set');
+
+  t.end();
+});
+
+test('`snyk test` with docker flag - docker token and no api key', async (t) => {
+  stubDockerPluginResponse(
+    plugins,
+    {
+      plugin: {
+        packageManager: 'deb',
+      },
+      package: {},
+    },
+    t,
+  );
+  try {
+    await cli.test('foo:latest', {
+      docker: true,
+    });
+    const req = server.popRequest();
+    t.equal(req.method, 'POST', 'makes POST request');
+    t.match(req.url, 'docker-jwt/test-dep-graph', 'posts to correct url');
+  } catch (err) {
+    t.fail('did not expect exception to be thrown ' + err);
+  }
+});
+
+test('`snyk test` with docker flag - docker token and api key', async (t) => {
+  stubDockerPluginResponse(
+    plugins,
+    {
+      plugin: {
+        packageManager: 'deb',
+      },
+      package: {},
+    },
+    t,
+  );
+  await cli.config('set', 'api=' + apiKey);
+  try {
+    await cli.test('foo:latest', {
+      docker: true,
+    });
+    const req = server.popRequest();
+    t.equal(req.method, 'POST', 'makes POST request');
+    t.match(req.url, 'test-dep-graph', 'posts to correct url');
+  } catch (err) {
+    t.fail('did not expect exception to be thrown ' + err);
+  }
+  await cli.config('unset', 'api');
+  t.end();
+});
+
+test('`snyk test` without docker flag - docker token and no api key', async (t) => {
+  stubDockerPluginResponse(
+    plugins,
+    {
+      plugin: {
+        packageManager: 'deb',
+      },
+      package: {},
+    },
+    t,
+  );
+  try {
+    await cli.test('foo:latest', {
+      docker: false,
+    });
+    t.fail('expected MissingApiTokenError');
+  } catch (err) {
+    t.equal(err.name, 'MissingApiTokenError', 'should throw if not docker');
+  }
+});
+
+test('teardown', async (t) => {
+  t.plan(4);
+
+  delete process.env.SNYK_API;
+  delete process.env.SNYK_HOST;
+  delete process.env.SNYK_PORT;
+  delete process.env.SNYK_DOCKER_TOKEN;
+  t.notOk(process.env.SNYK_PORT, 'fake env values cleared');
+
+  await new Promise((resolve) => {
+    server.close(resolve);
+  });
+  t.pass('server shutdown');
+
+  if (!oldkey) {
+    await cli.config('unset', 'api');
+  } else {
+    await cli.config('set', 'api=' + oldkey);
+  }
+
+  if (oldendpoint) {
+    await cli.config('set', `endpoint=${oldendpoint}`);
+    t.pass('user endpoint restored');
+  } else {
+    t.pass('no endpoint');
+  }
+  t.pass('user config restored');
+  t.end();
+});
+
+function stubDockerPluginResponse(plugins, fixture: string | object, t) {
+  const plugin = {
+    async inspect() {
+      return typeof fixture === 'object' ? fixture : require(fixture);
+    },
+  };
+  const spyPlugin = sinon.spy(plugin, 'inspect');
+  const loadPlugin = sinon.stub(plugins, 'loadPlugin');
+  loadPlugin
+    .withArgs(sinon.match.any, sinon.match({ docker: true }))
+    .returns(plugin);
+  t.teardown(loadPlugin.restore);
+
+  return spyPlugin;
+}

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -126,6 +126,16 @@ export function fakeServer(root, apikey) {
     return next();
   });
 
+  server.post(root + '/docker-jwt/test-dep-graph', (req, res, next) => {
+    res.send({
+      result: {
+        issuesData: {},
+        affectedPkgs: {},
+      },
+    });
+    return next();
+  });
+
   server.post(root + '/test-iac', (req, res, next) => {
     if (req.query.org && req.query.org === 'missing-org') {
       res.status(404);


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adding support for using `snyk test --docker` without an API key, using a JWT generated by Docker.

#### How should this be manually tested?

Removing the existing api key and setting an env var `SNYK_DOCKER_TOKEN`.
An alternative test endpoint should be called - `docker-jwt/test-dep-graph`.
Note - the entire flow will not work until we deploy the changes to the relevant endpoint. 
