### PR TITLE
fix: protect will not fail when there are not vulns to patch

### DIFF
--- a/src/cli/commands/protect/index.ts
+++ b/src/cli/commands/protect/index.ts
@@ -98,7 +98,7 @@ async function patch(options: types.PolicyOptions & types.Options) {
     analytics.add('success', true);
     return 'Successfully applied Snyk patches';
   } catch (e) {
-    if (e.code === 'ALREADY_PATCHED') {
+    if (e.strCode === 'ALREADY_PATCHED') {
       analytics.add('success', true);
       return e.message + ', nothing to do';
     }

--- a/test/acceptance/cli-protect-no-vulns-to-patch.test.ts
+++ b/test/acceptance/cli-protect-no-vulns-to-patch.test.ts
@@ -1,0 +1,22 @@
+import { test } from 'tap';
+import * as cli from '../../src/cli/commands';
+import * as sinon from 'sinon';
+import * as snyk from '../../src/lib';
+
+test('`protect` with no vulns to patch', async (t) => {
+  t.plan(1);
+  const vulns = require('./fixtures/npm-package/test-graph-result.json');
+  vulns.vulnerabilities = undefined;
+  const testStub = sinon.stub(snyk, 'test').returns(vulns);
+
+  try {
+    const result = await cli.protect();
+    t.match(result, 'Code is already patched, nothing to do');
+  } catch (err) {
+    t.fail('should not fail');
+  } finally {
+    testStub.restore();
+  }
+
+  t.end();
+});

--- a/test/acceptance/cli-protect.test.ts
+++ b/test/acceptance/cli-protect.test.ts
@@ -165,6 +165,7 @@ test('`protect` with no policy', async (t) => {
   const req = server.popRequest();
   const policySentToServer = req.body.policy;
   t.equal(policySentToServer, projectPolicy, 'sends correct policy');
+
   t.end();
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Prevents `snyk protect` from failing if no vulnerabilities were found.

Without this fix, if the project didn't have vulns it would fail with
```
 'error-message': 'Code is already patched',
    error: 'CustomError: Code is already patched\n' +
      '    at patch (/Users/andrejasiskis/workspace/snyk/snyk-cli/src/cli/commands/protect/index.ts:92:17)\n' +
      '    at processTicksAndRejections (internal/process/task_queues.js:94:5)\n' +
      '    at runCommand (/Users/andrejasiskis/workspace/snyk/snyk-cli/src/cli/index.ts:49:25)\n' +
      '    at main (/Users/andrejasiskis/workspace/snyk/snyk-cli/src/cli/index.ts:288:11)',
```



