### PR TITLE
chore: install osslsigncode in release step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,7 @@ jobs:
       - checkout
       - install_deps
       - run: sudo npm i -g semantic-release @semantic-release/exec pkg
+      - run: sudo apt-get install -y osslsigncode
       - run:
           name: Publish to GitHub
           command: semantic-release


### PR DESCRIPTION
[Missing osslsigncode](https://app.circleci.com/pipelines/github/snyk/snyk/1576/workflows/5d9ffe13-b75a-4cde-b1c1-e229516a3953/jobs/7778) for Windows binary signing