### PR TITLE
fix: propagate failed scans with --all-projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ key.pem
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+# test fixture build artifacts
+/test/acceptance/workspaces/**/project/
+/test/acceptance/workspaces/**/target/

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -110,7 +110,7 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
     testOpts.path = path;
     testOpts.projectName = testOpts['project-name'];
 
-    let res;
+    let res: (TestResult | TestResult[]) | Error;
 
     try {
       res = await snyk.test(path, testOpts);

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -3,7 +3,10 @@ import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
 import { find } from '../find-files';
 import { Options, TestOptions, MonitorOptions } from '../types';
 import { NoSupportedManifestsFoundError } from '../errors';
-import { getMultiPluginResult } from './get-multi-plugin-result';
+import {
+  getMultiPluginResult,
+  MultiProjectResultCustom,
+} from './get-multi-plugin-result';
 import { getSinglePluginResult } from './get-single-plugin-result';
 import {
   detectPackageFile,
@@ -32,7 +35,7 @@ const multiProjectProcessors = {
 export async function getDepsFromPlugin(
   root: string,
   options: Options & (TestOptions | MonitorOptions),
-): Promise<pluginApi.MultiProjectResult> {
+): Promise<pluginApi.MultiProjectResult | MultiProjectResultCustom> {
   let inspectRes: pluginApi.InspectResult;
 
   if (Object.keys(multiProjectProcessors).some((key) => options[key])) {

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -12,6 +12,7 @@ import { convertSingleResultToMultiCustom } from './convert-single-splugin-res-t
 import { convertMultiResultToMultiCustom } from './convert-multi-plugin-res-to-multi-custom';
 import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import { CallGraph } from '@snyk/cli-interface/legacy/common';
+import { FailedToRunTestError } from '../errors';
 
 const debug = debugModule('snyk-test');
 export interface ScannedProjectCustom
@@ -20,9 +21,16 @@ export interface ScannedProjectCustom
   plugin: PluginMetadata;
   callGraph?: CallGraph;
 }
+
+interface FailedProjectScanError {
+  targetFile?: string;
+  error?: Error;
+  errMessage: string;
+}
 export interface MultiProjectResultCustom
   extends cliInterface.legacyPlugin.MultiProjectResult {
   scannedProjects: ScannedProjectCustom[];
+  failedResults?: FailedProjectScanError[];
 }
 
 export async function getMultiPluginResult(
@@ -31,6 +39,8 @@ export async function getMultiPluginResult(
   targetFiles: string[],
 ): Promise<MultiProjectResultCustom> {
   const allResults: ScannedProjectCustom[] = [];
+  const failedResults: FailedProjectScanError[] = [];
+
   for (const targetFile of targetFiles) {
     const optionsClone = _.cloneDeep(options);
     optionsClone.file = path.relative(root, targetFile);
@@ -68,8 +78,24 @@ export async function getMultiPluginResult(
 
       allResults.push(...pluginResultWithCustomScannedProjects.scannedProjects);
     } catch (err) {
-      debug(chalk.bold.red(err.message));
+      // TODO: propagate this all the way back and include in --json output
+      failedResults.push({
+        targetFile,
+        error: err,
+        errMessage: err.message || 'Something went wrong getting dependencies',
+      });
+      debug(
+        chalk.bold.red(
+          `\n✗ Failed to get dependencies for ${targetFile}\nERROR: ${err.message}\n`,
+        ),
+      );
     }
+  }
+
+  if (!allResults.length) {
+    throw new FailedToRunTestError(
+      `Failed to get dependencies for all ${targetFiles.length} potential projects. Run with \`-d\` for debug output and contact support@snyk.io`,
+    );
   }
 
   return {
@@ -77,5 +103,6 @@ export async function getMultiPluginResult(
       name: 'custom-auto-detect',
     },
     scannedProjects: allResults,
+    failedResults,
   };
 }

--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -34,6 +34,7 @@ export async function parse(
     'Analyzing npm dependencies for ' +
     path.dirname(path.resolve(root, targetFile));
   try {
+    await spinner.clear<void>(resolveModuleSpinnerLabel)();
     await spinner(resolveModuleSpinnerLabel);
     if (targetFile.endsWith('yarn.lock')) {
       options.file =

--- a/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.all-projects.spec.ts
@@ -171,10 +171,14 @@ export const AllProjectsTests: AcceptanceTests = {
       utils.chdirWorkspaces();
       const spyPlugin = sinon.spy(params.plugins, 'loadPlugin');
       t.teardown(spyPlugin.restore);
-
-      const result = await params.cli.monitor('monorepo-bad-project', {
-        allProjects: true,
-      });
+      let result;
+      try {
+        await params.cli.monitor('monorepo-bad-project', {
+          allProjects: true,
+        });
+      } catch (error) {
+        result = error.message;
+      }
       t.ok(spyPlugin.withArgs('rubygems').calledOnce, 'calls rubygems plugin');
       t.ok(spyPlugin.withArgs('yarn').calledOnce, 'calls npm plugin');
       t.ok(spyPlugin.withArgs('maven').notCalled, 'did not call  maven plugin');
@@ -184,11 +188,10 @@ export const AllProjectsTests: AcceptanceTests = {
         'rubygems/graph/some/project-id',
         'rubygems project was monitored',
       );
-
-      t.notMatch(
+      t.match(
         result,
-        'yarn/graph/some/project-id',
-        'yarn project was not monitored',
+        'Dependency snyk was not found in yarn.lock',
+        'yarn project had an error and we displayed it',
       );
 
       const request = params.server.popRequest();

--- a/test/acceptance/cli-test/cli-test.all-projects.spec.ts
+++ b/test/acceptance/cli-test/cli-test.all-projects.spec.ts
@@ -7,6 +7,23 @@ import { CommandResult } from '../../../src/cli/commands/types';
 export const AllProjectsTests: AcceptanceTests = {
   language: 'Mixed',
   tests: {
+    '`test yarn-out-of-sync` out of sync fails': (params, utils) => async (
+      t,
+    ) => {
+      utils.chdirWorkspaces();
+      try {
+        await params.cli.test('yarn-workspace-out-of-sync', {
+          allProjects: true,
+        });
+        t.fail('Should fail');
+      } catch (e) {
+        t.equal(
+          e.message,
+          '\nTesting yarn-workspace-out-of-sync...\n\nFailed to get dependencies for all 3 potential projects. Run with `-d` for debug output and contact support@snyk.io',
+          'Contains enough info about err',
+        );
+      }
+    },
     '`test mono-repo-with-ignores --all-projects` respects .snyk policy': (
       params,
       utils,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

- Collect failed dependency extractions with `--all-projects` and propagate it higher up.
- For `monitor` these are now propagated all the way and will appear in output + json output. This may affect the existing error code as previously we silently skipped failure like these but not failures to get vulnerabilities during monitor or when a path test failed. So it was inconsistent.
- For test more work / refactor needed to get these to the output & json so for now warning the user & providing instructions how to see the error with `-d`
#### Where should the reviewer start?
https://github.com/snyk/snyk/compare/fix/throw-erorr-if-all-tests-failed?expand=1#diff-e4ec2ebbae5004d31be7a5b680580a46R42

#### How should this be manually tested?
You can use `cd snyk/test/acceptance/workspaces && snyk test --all-projects` and `cd snyk/test/acceptance/workspaces && snyk monitor --all-projects` to see the output.


#### Any background context you want to provide?

Sometimes users see a blank screen when 100% of `-all-projects` scans fail and we do not flag about other failures as it was too noisy unless you run with `-d`

#### Screenshots

<img width="893" alt="Screen Shot 2020-07-31 at 14 27 22" src="https://user-images.githubusercontent.com/2911613/89041238-f3ccb880-d33c-11ea-86b9-9e5549a7c0d5.png">
<img width="1163" alt="Screen Shot 2020-07-31 at 14 42 06" src="https://user-images.githubusercontent.com/2911613/89041241-f4fde580-d33c-11ea-89c9-21903810e9ae.png">
<img width="996" alt="Screen Shot 2020-07-31 at 14 49 03" src="https://user-images.githubusercontent.com/2911613/89041262-fb8c5d00-d33c-11ea-9c10-51dfb092fb1a.png">
<img width="1073" alt="Screen Shot 2020-07-31 at 16 45 33" src="https://user-images.githubusercontent.com/2911613/89052199-44e4a880-d34d-11ea-91e5-c1d816444c5d.png">
