### PR TITLE
feat: introduce ora spinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "glob": "^7.1.3",
     "needle": "^2.5.0",
     "open": "^7.0.3",
+    "ora": "4.0.5",
     "os-name": "^3.0.0",
     "proxy-agent": "^3.1.1",
     "proxy-from-env": "^1.0.0",

--- a/src/lib/protect/strip-versions.js
+++ b/src/lib/protect/strip-versions.js
@@ -3,7 +3,5 @@ module.exports = stripVersions;
 const { parsePackageString: moduleToObject } = require('snyk-module');
 
 function stripVersions(packages) {
-  return packages.map((pkg) => {
-    return moduleToObject(pkg).name;
-  });
+  return packages.map((pkg) => moduleToObject(pkg).name);
 }

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -15,12 +15,12 @@ const iswindows =
 // TODO(kyegupov): make these work in Windows
 test('snyk test command should fail when --file is not specified correctly', (t) => {
   t.plan(1);
-  exec(`node ${main} test --file package-lock.json`, (err, stdout) => {
+  exec(`node ${main} test --file package-lock.json`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }
     t.match(
-      stdout.trim(),
+      stderr.trim(),
       'Empty --file argument. Did you mean --file=path/to/file ?',
       'correct error output',
     );
@@ -47,12 +47,12 @@ test(
 
 test('snyk test command should fail when --packageManager is not specified correctly', (t) => {
   t.plan(1);
-  exec(`node ${main} test --packageManager=hello`, (err, stdout) => {
+  exec(`node ${main} test --packageManager=hello`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }
     t.match(
-      stdout.trim(),
+      stderr.trim(),
       'Unsupported package manager',
       'correct error output',
     );
@@ -61,12 +61,12 @@ test('snyk test command should fail when --packageManager is not specified corre
 
 test('snyk test command should fail when iac file is not specified', (t) => {
   t.plan(1);
-  exec(`node ${main} iac test`, (err, stdout) => {
+  exec(`node ${main} iac test`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }
     t.match(
-      stdout.trim(),
+      stderr.trim(),
       'iac option works only with specified files',
       'correct error output',
     );
@@ -77,12 +77,12 @@ test('snyk test command should fail when iac file is not supported', (t) => {
   t.plan(1);
   exec(
     `node ${main} iac test --file=./test/acceptance/workspaces/empty/readme.md`,
-    (err, stdout) => {
+    (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
       t.match(
-        stdout.trim(),
+        stderr.trim(),
         'CustomError: Illegal infrastructure as code target file',
         'correct error output',
       );
@@ -94,12 +94,12 @@ test('snyk test command should fail when iac file is not supported', (t) => {
   t.plan(1);
   exec(
     `node ${main} iac test --file=./test/acceptance/workspaces/helmconfig/Chart.yaml`,
-    (err, stdout) => {
+    (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
       t.match(
-        stdout.trim(),
+        stderr.trim(),
         'CustomError: Not supported infrastructure as code target files in',
         'correct error output',
       );
@@ -108,16 +108,19 @@ test('snyk test command should fail when iac file is not supported', (t) => {
 });
 test('`test multiple paths with --project-name=NAME`', (t) => {
   t.plan(1);
-  exec(`node ${main} test pathA pathB --project-name=NAME`, (err, stdout) => {
-    if (err) {
-      throw err;
-    }
-    t.match(
-      stdout.trim(),
-      'The following option combination is not currently supported: multiple paths + project-name',
-      'correct error output',
-    );
-  });
+  exec(
+    `node ${main} test pathA pathB --project-name=NAME`,
+    (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      }
+      t.match(
+        stderr.trim(),
+        'The following option combination is not currently supported: multiple paths + project-name',
+        'correct error output',
+      );
+    },
+  );
 });
 
 test('`test that running snyk without any args displays help text`', (t) => {
@@ -134,12 +137,12 @@ test('`test --file=file.sln --project-name=NAME`', (t) => {
   t.plan(1);
   exec(
     `node ${main} test --file=file.sln --project-name=NAME`,
-    (err, stdout) => {
+    (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
       t.match(
-        stdout.trim(),
+        stderr.trim(),
         'The following option combination is not currently supported: file=*.sln + project-name',
         'correct error output',
       );
@@ -149,16 +152,19 @@ test('`test --file=file.sln --project-name=NAME`', (t) => {
 
 test('`test --file=blah --scan-all-unmanaged`', (t) => {
   t.plan(1);
-  exec(`node ${main} test --file=blah --scan-all-unmanaged`, (err, stdout) => {
-    if (err) {
-      throw err;
-    }
-    t.match(
-      stdout.trim(),
-      'The following option combination is not currently supported: file + scan-all-unmanaged',
-      'correct error output',
-    );
-  });
+  exec(
+    `node ${main} test --file=blah --scan-all-unmanaged`,
+    (err, stdout, stderr) => {
+      if (err) {
+        throw err;
+      }
+      t.match(
+        stderr.trim(),
+        'The following option combination is not currently supported: file + scan-all-unmanaged',
+        'correct error output',
+      );
+    },
+  );
 });
 
 const argsNotAllowedWithYarnWorkspaces = [
@@ -172,26 +178,32 @@ const argsNotAllowedWithYarnWorkspaces = [
 argsNotAllowedWithYarnWorkspaces.forEach((arg) => {
   test(`using --${arg} and --yarn-workspaces displays error message`, (t) => {
     t.plan(2);
-    exec(`node ${main} test --${arg} --yarn-workspaces`, (err, stdout) => {
-      if (err) {
-        throw err;
-      }
-      t.deepEqual(
-        stdout.trim(),
-        `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
-        'when using test',
-      );
-    });
-    exec(`node ${main} monitor --${arg} --yarn-workspaces`, (err, stdout) => {
-      if (err) {
-        throw err;
-      }
-      t.deepEqual(
-        stdout.trim(),
-        `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
-        'when using monitor',
-      );
-    });
+    exec(
+      `node ${main} test --${arg} --yarn-workspaces`,
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        t.match(
+          stderr.trim(),
+          `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
+          'when using test',
+        );
+      },
+    );
+    exec(
+      `node ${main} monitor --${arg} --yarn-workspaces`,
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        t.match(
+          stderr.trim(),
+          `The following option combination is not currently supported: ${arg} + yarn-workspaces`,
+          'when using monitor',
+        );
+      },
+    );
   });
 });
 const argsNotAllowedWithAllProjects = [
@@ -206,37 +218,40 @@ const argsNotAllowedWithAllProjects = [
 argsNotAllowedWithAllProjects.forEach((arg) => {
   test(`using --${arg} and --all-projects displays error message`, (t) => {
     t.plan(2);
-    exec(`node ${main} test --${arg} --all-projects`, (err, stdout) => {
+    exec(`node ${main} test --${arg} --all-projects`, (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
-      t.deepEqual(
-        stdout.trim(),
+      t.match(
+        stderr.trim(),
         `The following option combination is not currently supported: ${arg} + all-projects`,
         'when using test',
       );
     });
-    exec(`node ${main} monitor --${arg} --all-projects`, (err, stdout) => {
-      if (err) {
-        throw err;
-      }
-      t.deepEqual(
-        stdout.trim(),
-        `The following option combination is not currently supported: ${arg} + all-projects`,
-        'when using monitor',
-      );
-    });
+    exec(
+      `node ${main} monitor --${arg} --all-projects`,
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        t.match(
+          stderr.trim(),
+          `The following option combination is not currently supported: ${arg} + all-projects`,
+          'when using monitor',
+        );
+      },
+    );
   });
 });
 
 test('`test --exclude without --all-project displays error message`', (t) => {
   t.plan(1);
-  exec(`node ${main} test --exclude=test`, (err, stdout) => {
+  exec(`node ${main} test --exclude=test`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }
-    t.equals(
-      stdout.trim(),
+    t.match(
+      stderr.trim(),
       'The --exclude option can only be use in combination with --all-projects or --yarn-workspaces.',
     );
   });
@@ -244,12 +259,12 @@ test('`test --exclude without --all-project displays error message`', (t) => {
 
 test('`test --exclude without any value displays error message`', (t) => {
   t.plan(1);
-  exec(`node ${main} test --all-projects --exclude`, (err, stdout) => {
+  exec(`node ${main} test --all-projects --exclude`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }
-    t.equals(
-      stdout.trim(),
+    t.match(
+      stderr.trim(),
       'Empty --exclude argument. Did you mean --exclude=subdirectory ?',
     );
   });
@@ -260,12 +275,12 @@ test('`test --exclude=path/to/dir displays error message`', (t) => {
   const exclude = 'path/to/dir'.replace(/\//g, sep);
   exec(
     `node ${main} test --all-projects --exclude=${exclude}`,
-    (err, stdout) => {
+    (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
-      t.equals(
-        stdout.trim(),
+      t.match(
+        stderr.trim(),
         'The --exclude argument must be a comma separated list of directory names and cannot contain a path.',
       );
     },
@@ -290,16 +305,19 @@ test('`other commands not allowed with --json-file-output`', (t) => {
   t.plan(commandsNotCompatibleWithJsonFileOutput.length);
 
   for (const nextCommand of commandsNotCompatibleWithJsonFileOutput) {
-    exec(`node ${main} ${nextCommand} --json-file-output`, (err, stdout) => {
-      if (err) {
-        throw err;
-      }
-      t.match(
-        stdout.trim(),
-        `The following option combination is not currently supported: ${nextCommand} + json-file-output`,
-        `correct error output when ${nextCommand} is used with --json-file-output`,
-      );
-    });
+    exec(
+      `node ${main} ${nextCommand} --json-file-output`,
+      (err, stdout, stderr) => {
+        if (err) {
+          throw err;
+        }
+        t.match(
+          stderr.trim(),
+          `The following option combination is not currently supported: ${nextCommand} + json-file-output`,
+          `correct error output when ${nextCommand} is used with --json-file-output`,
+        );
+      },
+    );
   }
 });
 
@@ -315,12 +333,12 @@ test('`test --json-file-output no value produces error message`', (t) => {
 
   const validate = (jsonFileOutputOption: string) => {
     const fullCommand = `node ${main} test ${jsonFileOutputOption}`;
-    exec(fullCommand, (err, stdout) => {
+    exec(fullCommand, (err, stdout, stderr) => {
       if (err) {
         throw err;
       }
-      t.equals(
-        stdout.trim(),
+      t.match(
+        stderr.trim(),
         'Empty --json-file-output argument. Did you mean --file=path/to/output-file.json ?',
       );
     });
@@ -338,7 +356,11 @@ test('`test --json-file-output can save JSON output to file while sending human 
       if (err) {
         throw err;
       }
-      t.match(stdout, 'Organization:', 'contains human readable output');
+      t.match(
+        stdout,
+        'dependencies for known issues, no vulnerable paths found',
+        'contains human readable output',
+      );
       const outputFileContents = readFileSync(
         'snyk-direct-json-test-output.json',
         'utf-8',

--- a/test/acceptance/workspaces/sbt-simple-struts/project/plugins.sbt
+++ b/test/acceptance/workspaces/sbt-simple-struts/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")

--- a/test/smoke/spec/snyk_basic_spec.sh
+++ b/test/smoke/spec/snyk_basic_spec.sh
@@ -55,10 +55,11 @@ Describe "Snyk CLI basics"
   Describe "snyk auth"
     It "fails if given bogus token"
       When run snyk auth abc123
-      The output should include "Authentication failed. Please check the API token"
+      The output should include ""
       The status should be failure
       # TODO: unusable with our current docker issues
-      The stderr should equal ""
+      The stderr should include "✖ Encountered an error. Exited with code: 2."
+      The stderr should include "Authentication failed. Please check the API token on https://snyk.io"
     End
 
     It "updates config file if given legit token"

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -5,6 +5,7 @@ Describe "Snyk test command"
     It "finds vulns in a project"
       When run snyk test "../fixtures/basic-npm"
       The status should be failure
+      The output should include "Node.js 8 reached End Of Life on December 31, 2019 and the Snyk CLI will stop supporting it in the near future."
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
       The stderr should equal ""
     End


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Start introducing `Ora` spinner since we dropped Node 6 support. Adding in gradually to reduce the risk of breaking things.
- Use ora for auth flow
- Use ora to display the final result 
- Also display the exit code to user
- Redirect actual errors to `stderr`

<img width="718" alt="Screen Shot 2020-08-03 at 14 41 48" src="https://user-images.githubusercontent.com/2911613/89189829-7ac99d00-d598-11ea-9d9d-ae87a67c35e8.png">

<img width="657" alt="Screen Shot 2020-08-03 at 14 35 55" src="https://user-images.githubusercontent.com/2911613/89189825-78674300-d598-11ea-8c40-3d4c94082ed2.png">
<img width="714" alt="Screen Shot 2020-08-03 at 14 40 01" src="https://user-images.githubusercontent.com/2911613/89189827-79987000-d598-11ea-9ad0-8eb139fbef46.png">

## Auth flow
### Before
<img width="717" alt="Screen Shot 2020-08-03 at 14 50 31" src="https://user-images.githubusercontent.com/2911613/89190525-810c4900-d599-11ea-8821-d34e9326eb8a.png">

### After

<img width="722" alt="Screen Shot 2020-08-03 at 14 53 55" src="https://user-images.githubusercontent.com/2911613/89190420-54f0c800-d599-11ea-9e94-113a9250b66d.png">
