### PR TITLE
Capture snyk integration name

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -174,16 +174,7 @@ export function args(rawArgv: string[]): Args {
     argv['imageSavePath'] = imageSavePath;
   }
 
-  const commands: SupportedCliCommands[] = [
-    'protect',
-    'test',
-    'monitor',
-    'wizard',
-    'ignore',
-    'woof',
-  ];
-  // TODO decide why we can't do this cart blanche...
-  if (commands.indexOf(command as SupportedCliCommands) !== -1) {
+  if (command in SupportedCliCommands) {
     // copy all the options across to argv._ as an object
     argv._.push(argv);
   }
@@ -209,6 +200,8 @@ export function args(rawArgv: string[]): Args {
     'reachable-vulns',
     'reachable-timeout',
     'reachable-vulns-timeout',
+    'integration-name',
+    'integration-version',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/lib/analytics-sources.ts
+++ b/src/lib/analytics-sources.ts
@@ -1,0 +1,65 @@
+/*
+  We are collecting Snyk CLI usage in our official integrations
+
+  We distinguish them by either:
+  - Setting integrationNameHeader or integrationVersionHeader in environment when CLI is run
+  - passing an --integration-name or --integration-version flags on CLI invocation
+
+  Integration name is validated with a list
+*/
+
+export const integrationNameHeader = 'SNYK_INTEGRATION_NAME';
+export const integrationVersionHeader = 'SNYK_INTEGRATION_VERSION';
+
+enum TrackedIntegration {
+  // Distribution builds/packages
+  NPM = 'NPM', // registry - how can we detect this one? Not standalone?
+  STANDALONE = 'STANDALONE', // Tracked by detecting "isStandalone" flag
+
+  // tracked by passing envvar on CLI invocation
+  HOMEBREW = 'HOMEBREW',
+  SCOOP = 'SCOOP',
+
+  // Our Docker images - tracked by passing envvar on CLI invocation
+  DOCKER_SNYK_CLI = 'DOCKER_SNYK_CLI', // docker snyk/snyk-cli
+  DOCKER_SNYK = 'DOCKER_SNYK', // docker snyk/snyk
+
+  // IDE plugins - tracked by passing flag or envvar on CLI invocation
+  INTELLIJ = 'INTELLIJ',
+  ECLIPSE = 'ECLIPSE',
+  VS_CODE_VULN_COST = 'VS_CODE_VULN_COST',
+
+  // CI - tracked by passing flag or envvar on CLI invocation
+  JENKINS = 'JENKINS',
+  TEAMCITY = 'TEAMCITY',
+  BITBUCKET_PIPELINES = 'BITBUCKET_PIPELINES',
+  AZURE_PIPELINES = 'AZURE_PIPELINES',
+  CIRCLECI_ORB = 'CIRCLECI_ORB',
+  GITHUB_ACTIONS = 'GITHUB_ACTIONS',
+
+  // Partner integrations - tracked by passing envvar on CLI invocation
+  DOCKER_DESKTOP = 'DOCKER_DESKTOP',
+}
+
+// TODO: propagate these to the UTM params
+export const getIntegrationName = (args: Array<any>): string => {
+  const integrationName = String(
+    args[0]?.integrationName || // Integration details passed through CLI flag
+      process.env[integrationNameHeader] ||
+      '',
+  ).toUpperCase();
+  if (integrationName in TrackedIntegration) {
+    return integrationName;
+  }
+
+  return '';
+};
+
+export const getIntegrationVersion = (args): string => {
+  // Integration details passed through CLI flag
+  const integrationVersion = String(
+    args[0]?.integrationVersion || process.env[integrationVersionHeader] || '',
+  );
+
+  return integrationVersion;
+};

--- a/src/lib/analytics.js
+++ b/src/lib/analytics.js
@@ -5,6 +5,10 @@ const snyk = require('../lib');
 const config = require('./config');
 const version = require('./version');
 const request = require('./request');
+const {
+  getIntegrationName,
+  getIntegrationVersion,
+} = require('./analytics-sources');
 const isCI = require('./is-ci').isCI;
 const debug = require('debug')('snyk');
 const os = require('os');
@@ -21,12 +25,6 @@ function analytics(data) {
   if (!data) {
     data = {};
   }
-
-  analytics.add('integrationName', process.env.SNYK_INTEGRATION_NAME || '');
-  analytics.add(
-    'integrationVersion',
-    process.env.SNYK_INTEGRATION_VERSION || '',
-  );
 
   // merge any new data with data we picked up along the way
   if (Array.isArray(data.args)) {
@@ -67,6 +65,8 @@ function postAnalytics(data) {
       data.os = osName(os.platform(), os.release());
       data.nodeVersion = process.version;
       data.standalone = isStandalone;
+      data.integrationName = getIntegrationName(data.args);
+      data.integrationVersion = getIntegrationVersion(data.args);
 
       const seed = uuid.v4();
       const shasum = crypto.createHash('sha1');

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -165,12 +165,20 @@ export type SupportedUserReachableFacingCliArgs =
   | 'reachable'
   | 'reachable-vulns'
   | 'reachable-timeout'
-  | 'reachable-vulns-timeout';
+  | 'reachable-vulns-timeout'
+  | 'integration-name'
+  | 'integration-version';
 
-export type SupportedCliCommands =
-  | 'protect'
-  | 'test'
-  | 'monitor'
-  | 'wizard'
-  | 'ignore'
-  | 'woof';
+export enum SupportedCliCommands {
+  version = 'version',
+  help = 'help',
+  // config = 'config', // TODO: cleanup `$ snyk config` parsing logic before adding it here
+  auth = 'auth',
+  test = 'test',
+  monitor = 'monitor',
+  protect = 'protect',
+  policy = 'policy',
+  ignore = 'ignore',
+  wizard = 'wizard',
+  woof = 'woof',
+}

--- a/test/analytics-sources.test.ts
+++ b/test/analytics-sources.test.ts
@@ -1,0 +1,66 @@
+import * as tap from 'tap';
+import {
+  getIntegrationName,
+  getIntegrationVersion,
+  integrationNameHeader,
+  integrationVersionHeader,
+} from '../src/lib/analytics-sources';
+
+const { test, beforeEach } = tap;
+
+const emptyArgs = [];
+
+beforeEach((done) => {
+  delete process.env[integrationNameHeader];
+  delete process.env[integrationVersionHeader];
+  done();
+});
+
+test('Integration name is empty by default', (t) => {
+  t.equal(getIntegrationName(emptyArgs), '');
+  t.end();
+});
+
+test('Integration name is loaded from envvar', (t) => {
+  process.env[integrationNameHeader] = 'NPM';
+  t.equal(getIntegrationName(emptyArgs), 'NPM');
+
+  process.env[integrationNameHeader] = 'STANDALONE';
+  t.equal(getIntegrationName(emptyArgs), 'STANDALONE');
+  t.end();
+});
+
+test('Integration name is empty when envvar is not recognized', (t) => {
+  process.env[integrationNameHeader] = 'INVALID';
+  t.equal(getIntegrationName(emptyArgs), '');
+  t.end();
+});
+
+test('Integration version is empty by default', (t) => {
+  t.equal(getIntegrationVersion(emptyArgs), '');
+  t.end();
+});
+
+test('Integration version is loaded from envvar', (t) => {
+  process.env[integrationVersionHeader] = '1.2.3';
+  t.equal(getIntegrationVersion(emptyArgs), '1.2.3');
+  t.end();
+});
+
+test('Integration name is loaded and formatted from CLI flag', (t) => {
+  t.equal(getIntegrationName([{ integrationName: 'homebrew' }]), 'HOMEBREW');
+  t.end();
+});
+
+test('Integration name is loaded and validated from CLI flag', (t) => {
+  t.equal(getIntegrationName([{ integrationName: 'invalid' }]), '');
+  t.end();
+});
+
+test('Integration version is loaded from CLI flag', (t) => {
+  t.equal(
+    getIntegrationVersion([{ integrationVersion: '1.2.3-Crystal' }]),
+    '1.2.3-Crystal',
+  );
+  t.end();
+});

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -64,7 +64,12 @@ test('analytics', (t) => {
 
   return analytics({
     command: '__test__',
-    args: [],
+    args: [
+      {
+        integrationName: 'JENKINS',
+        integrationVersion: '1.2.3',
+      },
+    ],
   }).then(() => {
     const body = spy.lastCall.args[0].body.data;
     t.deepEqual(
@@ -80,6 +85,8 @@ test('analytics', (t) => {
         'nodeVersion',
         'standalone',
         'durationMs',
+        'integrationName',
+        'integrationVersion',
       ].sort(),
       'keys as expected',
     );
@@ -115,6 +122,8 @@ test('analytics with args', (t) => {
         'nodeVersion',
         'standalone',
         'durationMs',
+        'integrationName',
+        'integrationVersion',
       ].sort(),
       'keys as expected',
     );
@@ -152,6 +161,8 @@ test('analytics with args and org', (t) => {
         'standalone',
         'durationMs',
         'org',
+        'integrationName',
+        'integrationVersion',
       ].sort(),
       'keys as expected',
     );


### PR DESCRIPTION
This PR adds an integrationName and integrationVersion optional parameters to the Analytics.
  We are collecting Snyk CLI usage in our official integrations

  We distinguish them by either:
  - Setting integrationNameHeader or integrationVersionHeader in environment when CLI is run
  - passing an --integration-name or --integration-version flags on CLI invocation

  Integration name is validated with a list