### PR TITLE
fix: snyk auth command

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -173,7 +173,7 @@ export enum SupportedCliCommands {
   version = 'version',
   help = 'help',
   // config = 'config', // TODO: cleanup `$ snyk config` parsing logic before adding it here
-  auth = 'auth',
+  // auth = 'auth', // TODO: auth does not support argv._ at the moment
   test = 'test',
   monitor = 'monitor',
   protect = 'protect',


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Commenting out from SupportedCliCommands enum as it doesn't support argv._ yet.

#### How should this be manually tested?

snyk auth

#### Any background context you want to provide?

Breaking CLI auth command since v1.370.0