### PR TITLE
fix: remove file flag from IaC help

### DIFF
--- a/help/iac.txt
+++ b/help/iac.txt
@@ -1,6 +1,6 @@
 Usage:
 
-  $ snyk iac [command] [options] --file=<path>
+  $ snyk iac [command] [options] <path>
 
 Find security issues in your Infrastructure as Code files.
 
@@ -17,7 +17,7 @@ Options:
 
 Examples:
 
-  $ snyk iac test --file=/path/to/Kubernetes.yaml
+  $ snyk iac test /path/to/Kubernetes.yaml
 
 
 For more information see https://support.snyk.io/hc/en-us/categories/360001342678-Infrastructure-as-code


### PR DESCRIPTION
- [x] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Remove `file` flag from IaC help file