### PR TITLE
chore: update help docs to remove gradle exclusion.

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -29,7 +29,6 @@ Options:
 
   --all-projects ..... (test & monitor commands only)
                        Auto detect all projects in working directory.
-                       Note gradle is not supported, use --all-sub-projects instead.
   --detection-depth=<number>
                        (test & monitor commands only)
                        Use with --all-projects or --yarn-workspaces to indicate how many sub-directories to search.


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Update help text for `--all-projects` to remove the note about gradle not being supported