### PR TITLE
fix: gracefully handle broken symlinks when using --all-projects

### DIFF
--- a/src/lib/find-files.ts
+++ b/src/lib/find-files.ts
@@ -68,14 +68,16 @@ export async function find(
     } else {
       levelsDeep--;
     }
-    const fileStats = await getStats(path);
-    if (fileStats.isDirectory()) {
-      const files = await findInDirectory(path, ignore, filter, levelsDeep);
-      found.push(...files);
-    } else if (fileStats.isFile()) {
-      const fileFound = findFile(path, filter);
-      if (fileFound) {
-        found.push(fileFound);
+    if (fs.existsSync(path)) {
+      const fileStats = await getStats(path);
+      if (fileStats.isDirectory()) {
+        const files = await findInDirectory(path, ignore, filter, levelsDeep);
+        found.push(...files);
+      } else if (fileStats.isFile()) {
+        const fileFound = findFile(path, filter);
+        if (fileFound) {
+          found.push(fileFound);
+        }
       }
     }
     return filterForDefaultManifests(found);

--- a/test/fixtures/find-files/broken-symlink
+++ b/test/fixtures/find-files/broken-symlink
@@ -1,0 +1,1 @@
+/path-that-does-not-exist


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an edge case when using "snyk test --all-projects" in a project that contains a broken symlink. (Currently it fails catastrophically.)

#### Where should the reviewer start?

Small change to src/lib/find-files.ts

#### How should this be manually tested?

$ ln -s /path-that-does-not-exist broken-symlink
$ node dist/cli/index.js test --all-projects

#### Any background context you want to provide?
Closing and cherry-picked here: https://github.com/snyk/snyk/pull/1329