### PR TITLE
fix: move custom API endpoint warning message to stderr

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -30,7 +30,7 @@ if (endpoint && endpoint !== config.API) {
   if (!parsedEndpoint || !parsedEndpoint.protocol || !parsedEndpoint.host) {
     throw new InvalidEndpointConfigError();
   }
-  console.info(
+  console.warn(
     'Using a custom API endpoint from `snyk config` (tip: it should contain path to `/api`):',
     endpoint,
   );


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Changes the output stream for the "Using a custom API endpoint..." warning message from stdout to stderr.

#### Where should the reviewer start?

src/lib/config.ts: line 33

#### How should this be manually tested?

test with `snyk-to-html` using

```bash
$ snyk test --json | snyk-to-html
```

#### Any background context you want to provide?

This message currently outputs to stdout, which when running snyk with `--json`, breaks tools like `snyk-to-html` that require valid json input

#### What are the relevant tickets?

N/A

#### Screenshots

Before change:
![image](https://user-images.githubusercontent.com/59919895/90185296-1c60a380-dd7c-11ea-9401-b26b6bbe6f6f.png)

After change:
![image](https://user-images.githubusercontent.com/59919895/90185329-2d111980-dd7c-11ea-9ac3-4df71d19d314.png)


### Additional questions
I didn't find an existing test for this, so would be happy to add one with your guidance.