### PR TITLE
feat: Allow environment variables to override config values

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -52,7 +52,7 @@ if (!config.org && org) {
 // invalid (non-numeric) value will fallback to the default
 const timeout = userConfig.get('timeout');
 if (!config.timeout) {
-  config.timeout = +timeout ? +timeout : DEFAULT_TIMEOUT;
+  config.timeout = timeout && +timeout ? +timeout : DEFAULT_TIMEOUT;
 }
 
 // this is a bit of an assumption that our web site origin is the same

--- a/src/lib/user-config.ts
+++ b/src/lib/user-config.ts
@@ -1,3 +1,16 @@
 const Configstore = require('configstore');
 const pkg = require(__dirname + '/../../package.json');
-export const config = new Configstore(pkg.name);
+
+class ConfigStoreWithEnvironmentVariables extends Configstore {
+  constructor(id, defaults = undefined, options = {}) {
+    super(id, defaults, options);
+  }
+
+  public get(key: string): string | undefined {
+    const envKey = `SNYK_CFG_${key.replace(/-/g, '_').toUpperCase()}`;
+    const envValue = process.env[envKey];
+    return super.has(key) && !envValue ? String(super.get(key)) : envValue;
+  }
+}
+
+export const config = new ConfigStoreWithEnvironmentVariables(pkg.name);


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adding a wrapper around configstore to allow environment variables to override config values.

#### How should this be manually tested?
You can run the following to disable suggestions:
```
$ SNYK_CFG_DISABLESUGGESTIONS=true snyk test
```

#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/DC-881

#### Screenshots


#### Additional questions
