### PR TITLE
fix: handle broken symlinks (attempt 2)

### DIFF
--- a/src/lib/find-files.ts
+++ b/src/lib/find-files.ts
@@ -105,6 +105,7 @@ async function findInDirectory(
   const files = await readDirectory(path);
   const toFind = files
     .filter((file) => !ignore.includes(file))
+    .filter((file) => fs.existsSync(pathLib.resolve(path, file)))
     .map((file) => {
       const resolvedPath = pathLib.resolve(path, file);
       return find(resolvedPath, ignore, filter, levelsDeep);

--- a/test/fixtures/find-files/broken-symlink
+++ b/test/fixtures/find-files/broken-symlink
@@ -1,0 +1,1 @@
+/path-that-does-not-exist


### PR DESCRIPTION
- [X] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an edge case when using "snyk test --all-projects" in a project that contains a broken symlink. (Currently it fails catastrophically.)

#### Where should the reviewer start?

Small change to src/lib/find-files.ts

#### How should this be manually tested?

$ ln -s /path-that-does-not-exist broken-symlink
$ node dist/cli/index.js test --all-projects

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
