### PR TITLE
fix(build): use node 14 for alpine executable

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -9,10 +9,10 @@ on:
 jobs:
   smoke_test:
     # The type of runner that the job will run on
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm]
         node_version: [8, 10, 12]
         exclude:
@@ -22,16 +22,19 @@ jobs:
             node_version: 10
         include:
           - snyk_install_method: binary
-            os: ubuntu-latest
+            os: ubuntu
             snyk_cli_dl_file: snyk-linux
           - snyk_install_method: binary
-            os: macos-latest
+            os: macos
             snyk_cli_dl_file: snyk-macos
+          - snyk_install_method: alpine-binary
+            os: ubuntu
+            snyk_cli_dl_file: snyk-alpine
 
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1 # Needed for fixtures installation
         with:
           node-version: ${{ matrix.node_version }}
 
@@ -48,8 +51,16 @@ jobs:
         run: |
           npm install
 
+      - name: Run alpine test
+        if: ${{ matrix.snyk_install_method == 'alpine-binary' }}
+        env:
+          SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.SMOKE_TESTS_SNYK_TOKEN }}
+        run: |
+          docker build -t snyk-cli-alpine -f ./test/smoke/alpine/Dockerfile ./test
+          docker run -eCI=1 -eSMOKE_TESTS_SNYK_TOKEN snyk-cli-alpine
+
       - name: Install Snyk with binary - Non-Windows
-        if: ${{ matrix.snyk_install_method == 'binary' && matrix.os != 'windows-latest' }}
+        if: ${{ matrix.snyk_install_method == 'binary' && matrix.os != 'windows' }}
         run: |
           echo "install snyk with binary"
           export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep location | sed s#.*tag/##g | tr -d "\r")
@@ -57,13 +68,12 @@ jobs:
           snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/${{ matrix.snyk_cli_dl_file }}"
           echo "snyk_cli_dl_linux: ${snyk_cli_dl_linux}"
           curl -Lo ./snyk-cli $snyk_cli_dl_linux
-          echo "snyk_cli_dl_linux: ${snyk_cli_dl_linux}"
           chmod -R +x ./snyk-cli
           sudo mv ./snyk-cli /usr/local/bin/snyk
           snyk --version
 
       - name: Install Snyk with binary - Windows
-        if: ${{ matrix.snyk_install_method == 'binary' && matrix.os == 'windows-latest' }}
+        if: ${{ matrix.snyk_install_method == 'binary' && matrix.os == 'windows' }}
         shell: powershell
         run: |
           echo "install snyk with binary"
@@ -71,7 +81,7 @@ jobs:
           sh ./test/smoke/install-snyk-binary-win.sh
 
       - name: Install Shellspec - non-windows
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows' && matrix.snyk_install_method != 'alpine-binary' }}
         run: |
           curl -fsSL https://git.io/shellspec | sh -s -- -y
           sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec
@@ -83,7 +93,7 @@ jobs:
           shellspec --version
 
       - name: Install brew on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos' }}
         # We need "timeout" and "jq" util and we'll use brew to check our brew package as well
         run: |
           /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
@@ -91,26 +101,26 @@ jobs:
           brew install jq
 
       - name: Install scoop on Windows
-        if: ${{ matrix.os == 'windows-latest'}}
+        if: ${{ matrix.os == 'windows'}}
         run: |
           iwr -useb get.scoop.sh | iex
           scoop install jq
 
       - name: Install jq on Ubuntu
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu' && matrix.snyk_install_method != 'alpine-binary'}}
         run: |
           sudo apt-get install jq
 
       - name: Install Shellspec - Windows
         shell: powershell
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows' }}
         run: |
           Get-Host | Select-Object Version
           Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
           sh ./test/smoke/install-shellspec-win.sh
 
       - name: Run shellspec tests - non-Windows
-        if: ${{ matrix.os != 'windows-latest' }}
+        if: ${{ matrix.os != 'windows' && matrix.snyk_install_method != 'alpine-binary'}}
         working-directory: test/smoke
         env:
           SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.SMOKE_TESTS_SNYK_TOKEN }}
@@ -119,7 +129,7 @@ jobs:
           shellspec -f d
 
       - name: Run shellspec tests - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == 'windows' }}
         working-directory: test/smoke
         shell: powershell
         env:

--- a/.releaserc
+++ b/.releaserc
@@ -9,7 +9,7 @@
     {
       "//": "build the alpine, macos, linux and windows binaries",
       "path": "@semantic-release/exec",
-      "cmd": "pkg . -t node12-alpine-x64,node12-linux-x64,node12-macos-x64,node12-win-x64"
+      "cmd": "pkg . -t node14-alpine-x64,node12-linux-x64,node12-macos-x64,node12-win-x64"
     },
     {
       "//": "build docker package",

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -29,6 +29,10 @@ CI=1 SMOKE_TESTS_SNYK_TOKEN=$SNYK_API_TOKEN shellspec -f d
 
 ## TODO
 
+### Wishlist
+
+- [ ] be able to run against PR
+
 ### Missing scenarios
 
 - [x] basics: version, help, config
@@ -41,7 +45,15 @@ CI=1 SMOKE_TESTS_SNYK_TOKEN=$SNYK_API_TOKEN shellspec -f d
 
 ### Missing environments
 
-- [ ] Alpine binary
+- [x] Alpine binary
 - [ ] Docker: current images can't output a clear stderr, because of an extraneous --json flag. Also released version is currently lagging behind the latest GitHub tag by a few hours
 - [ ] yarn installation (see https://github.com/snyk/snyk/issues/1270)
 - [ ] scoop package
+- [ ] homebrew
+
+## Current workarounds and limitations
+
+### Alpine
+
+- Needs to run in a Docker container because GitHub Actions don't support Alpine as a host OS. Using shellspec container, as it's based on alpine and ready to run the tests.
+- Need to skip a test that normally tries to open browser for login, but that fails horribly on Alpine.

--- a/test/smoke/alpine/Dockerfile
+++ b/test/smoke/alpine/Dockerfile
@@ -1,0 +1,11 @@
+FROM shellspec/shellspec:latest
+
+COPY ./smoke/ /snyk/smoke/
+COPY ./fixtures/basic-npm/ /snyk/fixtures/basic-npm/
+
+RUN shellspec --version
+RUN apk add curl jq libgcc libstdc++
+
+WORKDIR /snyk/smoke/
+
+ENTRYPOINT [ "./alpine/entrypoint.sh" ]

--- a/test/smoke/alpine/entrypoint.sh
+++ b/test/smoke/alpine/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+echo "install snyk with binary"
+export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep location | sed s#.*tag/##g | tr -d "\r")
+echo "latest_version: ${latest_version}"
+snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-alpine"
+curl -Lo ./snyk-cli $snyk_cli_dl_linux
+chmod -R +x ./snyk-cli
+mv ./snyk-cli /usr/local/bin/snyk
+snyk --version
+export EXPECTED_SNYK_VERSION=$(snyk --version)
+
+shellspec -f d

--- a/test/smoke/spec/snyk_auth_spec.sh
+++ b/test/smoke/spec/snyk_auth_spec.sh
@@ -16,6 +16,10 @@ Describe "Snyk CLI Authorization"
     After restore_is_ci_flags
 
     It "fails when run without token set"
+      # Alpine can't open browser, misses xdg-open utility and errors out
+      is_alpine() { grep "Alpine Linux" < /etc/os-release; }
+      Skip if "function returns success" is_alpine
+
       # Using timeout to not wait for browser confirmation
       When run timeout 5 snyk auth
       The output should include "Now redirecting you to our auth page, go ahead and log in,"

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -54,7 +54,6 @@ Describe "Snyk test command"
     It "won't output to stderr when one project fails and json flag is set"
       When run snyk_test_json_all
       The status should be failure # issues found
-      The output should include '"error": "package' # we expect some error
       The stderr should equal ""
       The result of function check_valid_json should be success
     End


### PR DESCRIPTION
Currently our CLI Alpine executable based on Node v12 is throwing segfault errors.

This PR introduces an Alpine docker container that runs shellspec tests for our CLI.

Smoke tests are passing with the latest working version using Node v14. They will fail in this PR, until we release a new version with v14:
<img width="801" alt="Screenshot 2020-08-17 at 18 16 08" src="https://user-images.githubusercontent.com/1788727/90418677-bcd50180-e0b5-11ea-9588-42bfa67da000.png">
