### PR TITLE
feat: add `-p` as alias for `--prune-repeated-subdependencies`

### DIFF
--- a/help/help.txt
+++ b/help/help.txt
@@ -66,7 +66,7 @@ Options:
   -v, --version ...... The CLI version.
   --print-deps ....... (test and monitor commands only)
                        Print the dependency tree before sending it for analysis.
-  --prune-repeated-subdependencies
+  -p, --prune-repeated-subdependencies
                        (test and monitor command only)
                        Prune dependency trees, removing duplicate sub-dependencies.
                        Will still find all vulnerabilities, but potentially not all

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -26,6 +26,7 @@ const alias = abbrev(
 );
 alias.d = 'debug'; // always make `-d` debug
 alias.t = 'test';
+alias.p = 'prune-repeated-subdependencies';
 
 // The -d flag enables printing the messages for predefined namespaces.
 // Additional ones can be specified (comma-separated) in the DEBUG environment variable.
@@ -202,6 +203,7 @@ export function args(rawArgv: string[]): Args {
     'reachable-vulns-timeout',
     'integration-name',
     'integration-version',
+    'prune-repeated-subdependencies',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -304,7 +304,7 @@ function generateMonitorMeta(options, packageManager?): MonitorMeta {
     'policy-path': options['policy-path'],
     'project-name': options['project-name'] || config.PROJECT_NAME,
     isDocker: !!options.docker,
-    prune: !!options['prune-repeated-subdependencies'],
+    prune: !!options.pruneRepeatedSubdependencies,
     'experimental-dep-graph': !!options['experimental-dep-graph'],
     'remote-repo-url': options['remote-repo-url'],
   };

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -521,7 +521,7 @@ async function assembleLocalPayloads(
           });
         }
 
-        const pruneIsRequired = options['prune-repeated-subdependencies'];
+        const pruneIsRequired = options.pruneRepeatedSubdependencies;
 
         if (packageManager) {
           depGraph = await pruneGraph(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,7 +15,7 @@ export type ShowVulnPaths = 'none' | 'some' | 'all';
 export interface TestOptions {
   traverseNodeModules: boolean;
   interactive: boolean;
-  'prune-repeated-subdependencies'?: boolean;
+  pruneRepeatedSubdependencies?: boolean;
   showVulnPaths: ShowVulnPaths;
   failOn?: FailOn;
   reachableVulns?: boolean;
@@ -87,7 +87,7 @@ export interface MonitorOptions {
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
-  'prune-repeated-subdependencies'?: boolean;
+  pruneRepeatedSubdependencies?: boolean;
   // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
   experimental?: boolean;
   // Used with the Docker plugin only. Allows application scanning.

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -240,7 +240,7 @@ if (!isWindows) {
     chdirWorkspaces();
 
     await cli.monitor('npm-package-pruneable', {
-      'prune-repeated-subdependencies': true,
+      pruneRepeatedSubdependencies: true,
     });
     const req = server.popRequest();
     t.equal(req.method, 'PUT', 'makes PUT request');
@@ -271,7 +271,7 @@ if (!isWindows) {
     chdirWorkspaces();
 
     await cli.monitor('npm-package-pruneable', {
-      'prune-repeated-subdependencies': true,
+      pruneRepeatedSubdependencies: true,
       'experimental-dep-graph': true,
     });
     const req = server.popRequest();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Using the full form is a mouthfull & hard to spell specially when debugging! Allow a simpler alternative as well.
- add alias -p for --prune-repeated-subdependencies
- convert `prune-repeated-subdependencies` internally to camel case

<img width="954" alt="Screen Shot 2020-08-17 at 17 52 47" src="https://user-images.githubusercontent.com/2911613/90422217-77630500-e0b2-11ea-9969-431f77c09862.png">


