### PR TITLE
chore(build): don’t rely on dynamic names from pkg

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,9 +7,24 @@
       "cmd": "echo '' > dist/STANDALONE"
     },
     {
-      "//": "build the alpine, macos, linux and windows binaries",
+      "//": "build the Alpine executable",
       "path": "@semantic-release/exec",
-      "cmd": "pkg . -t node14-alpine-x64,node12-linux-x64,node12-macos-x64,node12-win-x64"
+      "cmd": "pkg . -t node14-alpine-x64 -o snyk-alpine"
+    },
+    {
+      "//": "build the Linux executable",
+      "path": "@semantic-release/exec",
+      "cmd": "pkg . -t node12-linux-x64 -o snyk-linux"
+    },
+    {
+      "//": "build the macOS executable",
+      "path": "@semantic-release/exec",
+      "cmd": "pkg . -t node12-macos-x64 -o snyk-macos"
+    },
+    {
+      "//": "build the windows executable",
+      "path": "@semantic-release/exec",
+      "cmd": "pkg . -t node12-win-x64 -o snyk-win.exe"
     },
     {
       "//": "build docker package",


### PR DESCRIPTION
Follow up to #1337 - this PR makes it that we don't rely on automatic naming from `pkg`.
Since we've had to diverge Node 12 and 14 version, autogenerated names specified Node version as well:
 
<img width="538" alt="Screenshot 2020-08-17 at 19 31 53" src="https://user-images.githubusercontent.com/1788727/90425606-50133480-e0c0-11ea-9237-5533af8ec608.png">

`pkg` mentions in `--help` that `--output`may be used with a template string, but it seems like it's not implemented, so I broke the command into multiple `pkg` calls with a specified filename