### PR TITLE
chore: remove unused gemfile detection

### DIFF
--- a/src/lib/plugins/rubygems/inspectors/gemfile.ts
+++ b/src/lib/plugins/rubygems/inspectors/gemfile.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Files, tryGetSpec } from './try-get-spec';
+import { tryGetSpec } from './try-get-spec';
 import { Spec } from './index';
 
 const pattern = /^Gemfile(\.lock)*$/;
@@ -11,7 +11,6 @@ export function canHandle(file: string): boolean {
 export async function gatherSpecs(root: string, target: string): Promise<Spec> {
   const targetName = path.basename(target);
   const targetDir = path.dirname(target);
-  const files: Files = {};
 
   const gemfileLock = await tryGetSpec(
     root,
@@ -19,23 +18,15 @@ export async function gatherSpecs(root: string, target: string): Promise<Spec> {
   );
 
   if (gemfileLock) {
-    files.gemfileLock = gemfileLock;
+    return {
+      packageName: path.basename(root),
+      targetFile: path.join(targetDir, targetName),
+      files: { gemfileLock },
+    };
   } else {
     throw new Error(
       "Missing Gemfile.lock file: we can't test " +
         'without dependencies.\nPlease run `bundle install` first.',
     );
   }
-
-  const gemfile = await tryGetSpec(root, path.join(targetDir, 'Gemfile'));
-
-  if (gemfile) {
-    files.gemfile = gemfile;
-  }
-
-  return {
-    packageName: path.basename(root),
-    targetFile: path.join(targetDir, targetName),
-    files,
-  };
 }

--- a/src/lib/plugins/rubygems/inspectors/gemspec.ts
+++ b/src/lib/plugins/rubygems/inspectors/gemspec.ts
@@ -30,12 +30,6 @@ export async function gatherSpecs(root: string, target: string): Promise<Spec> {
     files.gemfileLock = gemfileLock;
   }
 
-  const gemfile = await tryGetSpec(root, path.join(targetDir, 'Gemfile'));
-
-  if (gemfile) {
-    files.gemfile = gemfile;
-  }
-
   return {
     packageName: path.basename(root),
     targetFile: path.join(targetDir, targetName),

--- a/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
+++ b/src/lib/plugins/rubygems/inspectors/try-get-spec.ts
@@ -8,7 +8,6 @@ interface File {
 
 export interface Files {
   gemfileLock?: File;
-  gemfile?: File;
   gemspec?: File;
 }
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Removes code in rubygems plugin that is unused around locating Gemfile - this file is not being used anywhere in the code unless there is no lockfile, in which case it will be detected as the what is called the `gemfileLock`

this is prep work for https://github.com/snyk/snyk/pull/1345