### PR TITLE
fix: pin transitives for Node 8 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/cli-interface": "2.8.1",
-    "@snyk/dep-graph": "1.18.3",
+    "@snyk/dep-graph": "1.19.3",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "2.1.9-patch",
     "@snyk/inquirer": "6.2.2-patch",
@@ -109,7 +109,7 @@
     "@typescript-eslint/parser": "^2.0.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.1.0",
-    "madge": "^3.4.4",
+    "madge": "3.4.4",
     "nock": "^10.0.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Pin transitives as they have moved on to requireing Node.js 10 >.