### PR TITLE
feat: adding cta for docker users

### DIFF
--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -23,3 +23,4 @@ export {
   NotSupportedIacFileError,
   IllegalIacFileError,
 } from './invalid-iac-file';
+export { TestLimitReachedError } from './test-limit-reached-error';

--- a/src/lib/errors/test-limit-reached-error.ts
+++ b/src/lib/errors/test-limit-reached-error.ts
@@ -1,0 +1,12 @@
+import { CustomError } from './custom-error';
+
+export function TestLimitReachedError(
+  errorMessage = 'Test limit reached!',
+  errorCode = 429,
+) {
+  const error = new CustomError(errorMessage);
+  error.code = errorCode;
+  error.strCode = 'TEST_LIMIT_REACHED';
+  error.userMessage = errorMessage;
+  return error;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface TestOptions {
   reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;
   testDepGraphDockerEndpoint?: string | null;
+  isDockerUser?: boolean;
 }
 
 export interface WizardOptions {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adding a CTA if a test is made without an API key and with a Docker JWT. 
There are 2 cases - 
* Scan successful
![image](https://user-images.githubusercontent.com/7031854/90753599-7a900800-e2e1-11ea-9c89-707825e5deae.png)
![image](https://user-images.githubusercontent.com/7031854/90753654-87acf700-e2e1-11ea-8c2d-c86e229781fb.png)

* Scan not successful - the user has reached the free test limit
![image](https://user-images.githubusercontent.com/7031854/90753425-43b9f200-e2e1-11ea-84ef-b43be4dba155.png)

#### How should this be manually tested?

Need to setup the env locally with JWT auth enabled and with a valid token.
In any `snyk test` where the API key doesn't exist and the `SNYK_DOCKER_TOKEN` env var is set, the CTA should be displayed. 
