### PR TITLE
refactor: remove project from iac help

### DIFF
--- a/help/iac.txt
+++ b/help/iac.txt
@@ -12,7 +12,6 @@ Options:
 
   -h, --help
   --json .................................. Return results in JSON format.
-  --project-name=<string> ................. Specify a custom Snyk project name.
   --severity-threshold=<low|medium|high>... Only report issues of provided level or higher.
 
 Examples:


### PR DESCRIPTION
#### What does this PR do?
This PR removes the `--project-name=` details from the `snyk iac` help output.

Ticket: https://snyksec.atlassian.net/browse/CC-281

### Screenshots
#### After:
```
Usage:

  $ snyk iac [command] [options] <path>

Find security issues in your Infrastructure as Code files.

Commands:

  test ............... Test for any known issue.

Options:

  -h, --help
  --json .................................. Return results in JSON format.
  --severity-threshold=<low|medium|high>... Only report issues of provided level or higher.

Examples:

  $ snyk iac test /path/to/Kubernetes.yaml


For more information see https://support.snyk.io/hc/en-us/categories/360001342678-Infrastructure-as-code
```

#### Before:
```
Usage:

  $ snyk iac [command] [options] <path>

Find security issues in your Infrastructure as Code files.

Commands:

  test ............... Test for any known issue.

Options:

  -h, --help
  --json .................................. Return results in JSON format.
  --project-name=<string> ................. Specify a custom Snyk project name.
  --severity-threshold=<low|medium|high>... Only report issues of provided level or higher.

Examples:

  $ snyk iac test /path/to/Kubernetes.yaml


For more information see https://support.snyk.io/hc/en-us/categories/360001342678-Infrastructure-as-code
```