### PR TITLE
fix: check if scanned project does have a callgraph

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -533,10 +533,7 @@ async function assembleLocalPayloads(
         body.depGraph = depGraph;
       }
 
-      if (
-        options.reachableVulns &&
-        (scannedProject.callGraph as CallGraphError).message
-      ) {
+      if (options.reachableVulns && scannedProject.callGraph?.message) {
         const err = scannedProject.callGraph as CallGraphError;
         const analyticsError = err.innerError || err;
         analytics.add('callGraphError', {


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When running with `snyk test --reachable --all-projects` and one of the projects is not supported for reachable vulns
i.e. not maven, we are failing with this error `Cannot read property 'message' of undefined”.`.

This change makes sure that the project does have a call graph.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
