### PR TITLE
fix: Bumping sdp to 3.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
     "snyk-cpp-plugin": "1.4.0",
-    "snyk-docker-plugin": "3.17.0",
+    "snyk-docker-plugin": "3.18.1",
     "snyk-go-plugin": "1.16.0",
     "snyk-gradle-plugin": "3.5.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Bumping `snyk-docker-plugin` to 3.18.1
Fixing issue #1363 - calling `map` on undefined object.
