### PR TITLE
chore: fix smoke test action yaml

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -3,7 +3,6 @@ name: Smoke Tests
 on:
   push:
     branches: [feat/smoke-test]
-on:
   release:
     types: [published]
   schedule:


### PR DESCRIPTION
There was a yaml lint error, and I missed the action failing

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>