### PR TITLE
Track Snyk-CLI docker usage

### DIFF
--- a/docker/Dockerfile.docker
+++ b/docker/Dockerfile.docker
@@ -22,6 +22,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION docker
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.gradle-2.8
+++ b/docker/Dockerfile.gradle-2.8
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION gradle-2.8
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.gradle-4.4
+++ b/docker/Dockerfile.gradle-4.4
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION gradle-4.4
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.gradle-5.4
+++ b/docker/Dockerfile.gradle-5.4
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION gradle-5.4
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.maven-3.5.4
+++ b/docker/Dockerfile.maven-3.5.4
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 ADD docker-entrypoint.sh .
 ADD snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION maven-3.5.4
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.maven-3.6.3
+++ b/docker/Dockerfile.maven-3.6.3
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 ADD docker-entrypoint.sh .
 ADD snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION maven-3.6.3
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.maven-3.6.3_java11
+++ b/docker/Dockerfile.maven-3.6.3_java11
@@ -28,6 +28,9 @@ ENV PROJECT_PATH /project
 ADD docker-entrypoint.sh .
 ADD snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION maven-3.6.3_java11
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.npm_ruby
+++ b/docker/Dockerfile.npm_ruby
@@ -19,9 +19,13 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+# This image is currently being used for nuget, composer and ruby
+# If we see a tons of usage, we can split the analytics
+ENV SNYK_INTEGRATION_VERSION npm
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`
 # Override with `docker run ... snyk/snyk-cli <command> <args>`
 CMD ["test"]
-

--- a/docker/Dockerfile.python-2
+++ b/docker/Dockerfile.python-2
@@ -25,9 +25,11 @@ COPY docker-python-entrypoint.sh .
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION python-2
+
 ENTRYPOINT ["./docker-python-entrypoint.sh"]
 
 # Default command is `snyk test`
 # Override with `docker run ... snyk/snyk-cli <command> <args>`
 CMD ["test"]
-

--- a/docker/Dockerfile.python-3
+++ b/docker/Dockerfile.python-3
@@ -25,9 +25,11 @@ COPY docker-python-entrypoint.sh .
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION python-3
+
 ENTRYPOINT ["./docker-python-entrypoint.sh"]
 
 # Default command is `snyk test`
 # Override with `docker run ... snyk/snyk-cli <command> <args>`
 CMD ["test"]
-

--- a/docker/Dockerfile.sbt-0.13.16
+++ b/docker/Dockerfile.sbt-0.13.16
@@ -38,6 +38,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION sbt-0.13.16
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`

--- a/docker/Dockerfile.sbt-1.0.4
+++ b/docker/Dockerfile.sbt-1.0.4
@@ -37,6 +37,9 @@ ENV PROJECT_PATH /project
 COPY docker-entrypoint.sh .
 COPY snyk_report.css .
 
+ENV SNYK_INTEGRATION_NAME DOCKER_SNYK_CLI
+ENV SNYK_INTEGRATION_VERSION sbt-1.0.4
+
 ENTRYPOINT ["./docker-entrypoint.sh"]
 
 # Default command is `snyk test`


### PR DESCRIPTION
Following https://github.com/snyk/snyk/pull/1304

This will allow us to see usage for a specific published docker image (~tag)
At the same time, you can overwrite these envvars during runtime with `-eSNYK_INTEGRATION_NAME`

<sub><img src="https://user-images.githubusercontent.com/4775299/87437657-e7332b00-c5ee-11ea-958d-589dfb19d72c.png" alt=" " width="10" height="9"> Mention [stepsize] in a comment if you'd like to report some technical debt. See examples [here](https://app.stepsize.com/api/demo-pr-redirect).</sub>