### PR TITLE
fix: test dependencies scan result type

### DIFF
--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -1,0 +1,18 @@
+import request = require('./index');
+
+export async function makeRequest<T>(payload: any): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request(payload, (error, res, body) => {
+      if (error) {
+        return reject(error);
+      }
+      if (res.statusCode !== 200) {
+        return reject({
+          code: res.statusCode,
+          message: body?.message,
+        });
+      }
+      resolve(body);
+    });
+  });
+}

--- a/test/ecosystems.spec.ts
+++ b/test/ecosystems.spec.ts
@@ -1,13 +1,14 @@
-import { Options } from '../src/lib/types';
-import * as cppPlugin from 'snyk-cpp-plugin';
-import * as path from 'path';
 import * as fs from 'fs';
+import * as path from 'path';
+import * as cppPlugin from 'snyk-cpp-plugin';
 import * as ecosystems from '../src/lib/ecosystems';
+import * as request from '../src/lib/request/promise';
+import { Options } from '../src/lib/types';
 import { TestCommandResult } from '../src/cli/commands/types';
 
 describe('ecosystems', () => {
   describe('getPlugin', () => {
-    it('should return c++ plugin when cpp ecosystem is given', () => {
+    it('should return cpp plugin when cpp ecosystem is given', () => {
       const actual = ecosystems.getPlugin('cpp');
       const expected = cppPlugin;
       expect(actual).toBe(expected);
@@ -21,7 +22,7 @@ describe('ecosystems', () => {
   });
 
   describe('getEcosystem', () => {
-    it('should return c++ ecosystem when options source is true', () => {
+    it('should return cpp ecosystem when options source is true', () => {
       const options: Options = {
         source: true,
         path: '',
@@ -30,91 +31,108 @@ describe('ecosystems', () => {
       const expected = 'cpp';
       expect(actual).toBe(expected);
     });
-  });
-
-  it('should return null when options source is false', () => {
-    const options: Options = {
-      source: false,
-      path: '',
-    };
-    const actual = ecosystems.getEcosystem(options);
-    const expected = null;
-    expect(actual).toBe(expected);
-  });
-});
-
-describe('testEcosystem', () => {
-  const fixturePath = path.join(__dirname, 'fixtures', 'cpp-project');
-  const cwd = process.cwd();
-
-  function readFixture(filename: string) {
-    const filePath = path.join(fixturePath, filename);
-    return fs.readFileSync(filePath, 'utf-8');
-  }
-
-  beforeAll(() => {
-    process.chdir(fixturePath);
-  });
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-  });
-
-  afterAll(() => {
-    process.chdir(cwd);
-  });
-
-  it('should return human readable result when no json option given', async () => {
-    const display = readFixture('display.txt');
-    const testResults = readFixture('testResults.json');
-    const stringifiedData = JSON.stringify(JSON.parse(testResults), null, 2);
-    const expected = TestCommandResult.createHumanReadableTestCommandResult(
-      display,
-      stringifiedData,
-    );
-
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], { path: '' });
-    expect(actual).toEqual(expected);
-  });
-
-  it('should return json result when json option', async () => {
-    const testResults = readFixture('testResults.json');
-    const stringifiedData = JSON.stringify(JSON.parse(testResults), null, 2);
-    const expected = TestCommandResult.createJsonTestCommandResult(
-      stringifiedData,
-    );
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
-      json: true,
-    });
-    expect(actual).toEqual(expected);
-  });
-
-  it('should throw error when response code is not 200', async () => {
-    const expected = { code: 401, message: 'Invalid auth token' };
-    jest.spyOn(ecosystems, 'testEcosystem').mockRejectedValue(expected);
-    expect.assertions(1);
-    try {
-      await ecosystems.testEcosystem('cpp', ['.'], {
+    it('should return null when options source is false', () => {
+      const options: Options = {
+        source: false,
         path: '',
-      });
-    } catch (error) {
-      expect(error).toEqual(expected);
-    }
+      };
+      const actual = ecosystems.getEcosystem(options);
+      const expected = null;
+      expect(actual).toBe(expected);
+    });
   });
 
-  it.skip('should return error when there was a problem testing dependencies', async () => {
-    //@boost: TODO finish up my implementation
-    // const makeRequestSpy = jest
-    //   .spyOn(ecosystems, 'makeRequest')
-    //   .mockRejectedValue('Something went wrong');
-    // const ecosystemDisplaySpy = jest.spyOn(cppPlugin, 'display');
-    const commandResult = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
-      json: true,
+  describe('testEcosystem', () => {
+    describe('cpp', () => {
+      const fixturePath = path.join(__dirname, 'fixtures', 'cpp-project');
+      const cwd = process.cwd();
+
+      function readFixture(filename: string) {
+        const filePath = path.join(fixturePath, filename);
+        return fs.readFileSync(filePath, 'utf-8');
+      }
+
+      function readJsonFixture(filename: string) {
+        const contents = readFixture(filename);
+        return JSON.parse(contents);
+      }
+
+      const displayTxt = readFixture('display.txt');
+      const errorTxt = readFixture('error.txt');
+      const testResult = readJsonFixture(
+        'testResults.json',
+      ) as ecosystems.TestResult;
+      const stringifyTestResults = JSON.stringify([testResult], null, 2);
+
+      beforeAll(() => {
+        process.chdir(fixturePath);
+      });
+
+      afterEach(() => {
+        jest.resetAllMocks();
+      });
+
+      afterAll(() => {
+        process.chdir(cwd);
+      });
+
+      it('should return human readable result when no json option given', async () => {
+        const mock = jest
+          .spyOn(request, 'makeRequest')
+          .mockResolvedValue(testResult);
+        const expected = TestCommandResult.createHumanReadableTestCommandResult(
+          displayTxt,
+          stringifyTestResults,
+        );
+        const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+          path: '',
+        });
+        expect(mock).toHaveBeenCalled();
+        expect(actual).toEqual(expected);
+      });
+
+      it('should return json result when json option', async () => {
+        const mock = jest
+          .spyOn(request, 'makeRequest')
+          .mockResolvedValue(testResult);
+        const expected = TestCommandResult.createJsonTestCommandResult(
+          stringifyTestResults,
+        );
+        const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+          path: '',
+          json: true,
+        });
+        expect(mock).toHaveBeenCalled();
+        expect(actual).toEqual(expected);
+      });
+
+      it('should throw error when response code is not 200', async () => {
+        const error = { code: 401, message: 'Invalid auth token' };
+        jest.spyOn(request, 'makeRequest').mockRejectedValue(error);
+        const expected = new Error(error.message);
+        expect.assertions(1);
+        try {
+          await ecosystems.testEcosystem('cpp', ['.'], {
+            path: '',
+          });
+        } catch (error) {
+          expect(error).toEqual(expected);
+        }
+      });
+
+      it('should return error when there was a problem testing dependencies', async () => {
+        jest
+          .spyOn(request, 'makeRequest')
+          .mockRejectedValue('Something went wrong');
+        const expected = TestCommandResult.createHumanReadableTestCommandResult(
+          errorTxt,
+          '[]',
+        );
+        const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+          path: '',
+        });
+        expect(actual).toEqual(expected);
+      });
     });
-    console.log(commandResult);
-    expect(commandResult).toEqual('');
-    // expect(ecosystemDisplaySpy).toHaveBeenCalledWith({});
   });
 });

--- a/test/fixtures/cpp-project/display.txt
+++ b/test/fixtures/cpp-project/display.txt
@@ -4,6 +4,12 @@ Dependency Fingerprints
 aeca71a6e39f99a24ecf4c088eee9cb8 add.h
 ad3365b3370ef6b1c3e778f875055f19 main.cpp
 
+Dependencies
+------------
+add@1.2.3
+
 Issues
 ------
-Tested 0 dependencies for known issues, found 0 issues.
+Tested 1 dependency for known issues, found 1 issue.
+
+✗ Cross-site Scripting (XSS) [medium severity][https://snyk.io/vuln/cpp:add:20161130] in add@1.2.3

--- a/test/fixtures/cpp-project/error.txt
+++ b/test/fixtures/cpp-project/error.txt
@@ -1,0 +1,10 @@
+Dependency Fingerprints
+-----------------------
+52d1b046047db9ea0c581cafd4c68fe5 add.cpp
+aeca71a6e39f99a24ecf4c088eee9cb8 add.h
+ad3365b3370ef6b1c3e778f875055f19 main.cpp
+
+
+Errors
+------
+Could not test dependencies in .

--- a/test/fixtures/cpp-project/testResults.json
+++ b/test/fixtures/cpp-project/testResults.json
@@ -1,120 +1,63 @@
-[
-  {
-    "result": {
-      "affectedPkgs": {},
-      "issuesData": {}
-    },
-    "meta": {
-      "isPrivate": true,
-      "isLicensesEnabled": true,
-      "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
-      "ignoreSettings": null,
-      "org": "snyk",
-      "licensesPolicy": {
-        "severities": {},
-        "orgLicenseRules": {
-          "AGPL-1.0": {
-            "licenseType": "AGPL-1.0",
-            "severity": "high",
-            "instructions": ""
-          },
-          "AGPL-3.0": {
-            "licenseType": "AGPL-3.0",
-            "severity": "high",
-            "instructions": ""
-          },
-          "Artistic-1.0": {
-            "licenseType": "Artistic-1.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "Artistic-2.0": {
-            "licenseType": "Artistic-2.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "CDDL-1.0": {
-            "licenseType": "CDDL-1.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "CPOL-1.02": {
-            "licenseType": "CPOL-1.02",
-            "severity": "high",
-            "instructions": ""
-          },
-          "GPL-2.0": {
-            "licenseType": "GPL-2.0",
-            "severity": "high",
-            "instructions": ""
-          },
-          "GPL-3.0": {
-            "licenseType": "GPL-3.0",
-            "severity": "high",
-            "instructions": ""
-          },
-          "LGPL-2.0": {
-            "licenseType": "LGPL-2.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "LGPL-2.1": {
-            "licenseType": "LGPL-2.1",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "LGPL-3.0": {
-            "licenseType": "LGPL-3.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "MPL-1.1": {
-            "licenseType": "MPL-1.1",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "MPL-2.0": {
-            "licenseType": "MPL-2.0",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "MS-RL": {
-            "licenseType": "MS-RL",
-            "severity": "medium",
-            "instructions": ""
-          },
-          "SimPL-2.0": {
-            "licenseType": "SimPL-2.0",
-            "severity": "high",
-            "instructions": ""
-          }
-        }
-      }
-    },
-    "depGraph": {
-      "schemaVersion": "1.2.0",
-      "pkgManager": {
-        "name": "cpp"
+{
+  "affectedPkgs": {
+    "add@1.2.3": {
+      "pkg": {
+        "name": "add",
+        "version": "1.2.3"
       },
-      "pkgs": [
-        {
-          "id": "_root@0.0.0",
-          "info": {
-            "name": "_root",
-            "version": "0.0.0"
-          }
+      "issues": {
+        "cpp:add:20161130": {
+          "issueId": "cpp:add:20161130"
         }
-      ],
-      "graph": {
-        "rootNodeId": "root-node",
-        "nodes": [
-          {
-            "nodeId": "root-node",
-            "pkgId": "_root@0.0.0",
-            "deps": []
-          }
-        ]
       }
     }
+  },
+  "issuesData": {
+    "cpp:add:20161130": {
+      "id": "cpp:add:20161130",
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)"
+    }
+  },
+  "depGraph": {
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "cpp"
+    },
+    "pkgs": [
+      {
+        "id": "app@1.0.0",
+        "info": {
+          "name": "app",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "add@1.2.3",
+        "info": {
+          "name": "add",
+          "version": "1.2.3"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "app@1.0.0",
+          "deps": [
+            {
+              "nodeId": "add@1.2.3"
+            }
+          ]
+        },
+        {
+          "nodeId": "add@1.2.3",
+          "pkgId": "add@1.2.3",
+          "deps": []
+        }
+      ]
+    }
   }
-]
+}


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Use scan result type when making request to test dependencies.
Split out makeRequest to it's own file so that it can be mocked.

#### How should this be manually tested?

snyk source test
