### PR TITLE
feat: handle empty package.json dependencies better

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -36,6 +36,7 @@ const DEBUG_DEFAULT_NAMESPACES = [
   'snyk:find-files',
   'snyk:run-test',
   'snyk:prune',
+  'snyk-nodejs-plugin',
   'snyk-gradle-plugin',
   'snyk-sbt-plugin',
   'snyk-mvn-plugin',

--- a/src/lib/get-file-contents.ts
+++ b/src/lib/get-file-contents.ts
@@ -6,7 +6,7 @@ export function getFileContents(
   fileName: string,
 ): {
   content: string;
-  name: string;
+  fileName: string;
 } {
   const fullPath = path.resolve(root, fileName);
   if (!fs.existsSync(fullPath)) {
@@ -17,6 +17,6 @@ export function getFileContents(
   const content = fs.readFileSync(fullPath, 'utf-8');
   return {
     content,
-    name: fileName,
+    fileName,
   };
 }

--- a/src/lib/get-file-contents.ts
+++ b/src/lib/get-file-contents.ts
@@ -1,0 +1,22 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+export function getFileContents(
+  root: string,
+  fileName: string,
+): {
+  content: string;
+  name: string;
+} {
+  const fullPath = path.resolve(root, fileName);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(
+      'Manifest ' + fileName + ' not found at location: ' + fileName,
+    );
+  }
+  const content = fs.readFileSync(fullPath, 'utf-8');
+  return {
+    content,
+    name: fileName,
+  };
+}

--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -1,21 +1,62 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as resolveNodeDeps from 'snyk-resolve-deps';
+import * as baseDebug from 'debug';
+import * as _ from '@snyk/lodash';
 
 import * as spinner from '../../spinner';
 import * as analytics from '../../analytics';
 import { Options } from '../types';
+import { getFileContents } from '../../get-file-contents';
+
+const debug = baseDebug('snyk-nodejs-plugin');
 
 export async function parse(
   root: string,
   targetFile: string,
   options: Options,
 ): Promise<resolveNodeDeps.PackageExpanded> {
+  if (targetFile.endsWith('yarn.lock')) {
+    options.file =
+      options.file && options.file.replace('yarn.lock', 'package.json');
+  }
+
+  // package-lock.json falls back to package.json (used in wizard code)
+  if (targetFile.endsWith('package-lock.json')) {
+    options.file =
+      options.file && options.file.replace('package-lock.json', 'package.json');
+  }
+  // check if there any dependencies
+  const packageJsonFileName = path.resolve(root, options.file!);
+  const packageManager = options.packageManager || 'npm';
+
+  try {
+    const packageJson = JSON.parse(
+      getFileContents(root, packageJsonFileName).content,
+    );
+    let dependencies = packageJson.dependencies;
+    if (options.dev) {
+      dependencies = { ...dependencies, ...packageJson.devDependencies };
+    }
+    if (_.isEmpty(dependencies)) {
+      return new Promise((resolve) =>
+        resolve({
+          name: packageJson.name,
+          dependencies: {},
+          version: packageJson.version,
+        }),
+      );
+    }
+  } catch (e) {
+    debug(`Failed to read ${packageJsonFileName}: Error: ${e}`);
+    throw new Error(
+      `Failed to read ${packageJsonFileName}. Error: ${e.message}`,
+    );
+  }
   const nodeModulesPath = path.join(
     path.dirname(path.resolve(root, targetFile)),
     'node_modules',
   );
-  const packageManager = options.packageManager || 'npm';
 
   if (!fs.existsSync(nodeModulesPath)) {
     // throw a custom error
@@ -36,17 +77,6 @@ export async function parse(
   try {
     await spinner.clear<void>(resolveModuleSpinnerLabel)();
     await spinner(resolveModuleSpinnerLabel);
-    if (targetFile.endsWith('yarn.lock')) {
-      options.file =
-        options.file && options.file.replace('yarn.lock', 'package.json');
-    }
-
-    // package-lock.json falls back to package.json (used in wizard code)
-    if (targetFile.endsWith('package-lock.json')) {
-      options.file =
-        options.file &&
-        options.file.replace('package-lock.json', 'package.json');
-    }
     return resolveNodeDeps(
       root,
       Object.assign({}, options, { noFromArrays: true }),

--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -89,7 +89,7 @@ export async function processYarnWorkspaces(
       );
       const project: ScannedProjectCustom = {
         packageManager: 'yarn',
-        targetFile: path.relative(root, packageJson.name),
+        targetFile: path.relative(root, packageJson.fileName),
         depTree: res as any,
         plugin: {
           name: 'snyk-nodejs-lockfile-parser',
@@ -110,7 +110,7 @@ interface YarnWorkspacesMap {
 
 export function getWorkspacesMap(file: {
   content: string;
-  name: string;
+  fileName: string;
 }): YarnWorkspacesMap {
   const yarnWorkspacesMap = {};
   if (!file) {
@@ -123,7 +123,7 @@ export function getWorkspacesMap(file: {
     );
 
     if (rootFileWorkspacesDefinitions && rootFileWorkspacesDefinitions.length) {
-      yarnWorkspacesMap[file.name] = {
+      yarnWorkspacesMap[file.fileName] = {
         workspaces: rootFileWorkspacesDefinitions,
       };
     }

--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -3,7 +3,6 @@ import * as pathUtil from 'path';
 import * as _ from '@snyk/lodash';
 
 const debug = baseDebug('snyk:yarn-workspaces');
-import * as fs from 'fs';
 import * as lockFileParser from 'snyk-nodejs-lockfile-parser';
 import * as path from 'path';
 import { NoSupportedManifestsFoundError } from '../../errors';
@@ -11,6 +10,7 @@ import {
   MultiProjectResultCustom,
   ScannedProjectCustom,
 } from '../get-multi-plugin-result';
+import { getFileContents } from '../../get-file-contents';
 
 export async function processYarnWorkspaces(
   root: string,
@@ -100,26 +100,6 @@ export async function processYarnWorkspaces(
     }
   }
   return result;
-}
-
-function getFileContents(
-  root: string,
-  fileName: string,
-): {
-  content: string;
-  name: string;
-} {
-  const fullPath = path.resolve(root, fileName);
-  if (!fs.existsSync(fullPath)) {
-    throw new Error(
-      'Manifest ' + fileName + ' not found at location: ' + fileName,
-    );
-  }
-  const content = fs.readFileSync(fullPath, 'utf-8');
-  return {
-    content,
-    name: fileName,
-  };
 }
 
 interface YarnWorkspacesMap {

--- a/test/fixtures/npm/no-dependencies/package.json
+++ b/test/fixtures/npm/no-dependencies/package.json
@@ -8,8 +8,5 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
-  "dependencies": {
-    "debug": "3.6.7"
-  }
+  "license": "ISC"
 }

--- a/test/missing-node-modules.test.ts
+++ b/test/missing-node-modules.test.ts
@@ -1,9 +1,10 @@
 import * as tap from 'tap';
-const { test } = tap;
 import * as fs from 'fs';
+import { getWorkspaceJSON } from './acceptance/workspace-helper';
+import { fakeServer } from './acceptance/fake-server';
 
+const { test } = tap;
 const apiKey = '123456789';
-const notAuthorizedApiKey = 'notAuthorized';
 const port = process.env.PORT || process.env.SNYK_PORT || '12345';
 let oldkey;
 let oldendpoint;
@@ -13,13 +14,17 @@ process.env.SNYK_HOST = 'http://localhost:' + port;
 
 const baseDir = __dirname + '/fixtures/';
 
-// tslint:disable-next-line:no-var-requires
-const server = require('./cli-server')(BASE_API, apiKey, notAuthorizedApiKey);
+const server = fakeServer(BASE_API, apiKey);
 
 // ensure this is required *after* the demo server, since this will
 // configure our fake configuration too
 import * as cli from '../src/cli/commands';
 
+const noVulnsResult = getWorkspaceJSON(
+  'fail-on',
+  'no-vulns',
+  'vulns-result.json',
+);
 test('setup', (t) => {
   t.plan(3);
   cli.config('get', 'api').then((key) => {
@@ -52,6 +57,54 @@ test('throws when missing node_modules', async (t) => {
     t.fail('should have thrown');
   } catch (e) {
     t.matches(e.message, /Missing node_modules folder/);
+  }
+});
+
+test('does not throw when missing node_modules & package.json has no dependencies', async (t) => {
+  t.plan(1);
+  server.setNextResponse(noVulnsResult);
+
+  const dir = baseDir + 'npm/no-dependencies';
+  // ensure node_modules does not exist
+  try {
+    fs.rmdirSync(dir + '/node_modules');
+  } catch (err) {
+    // ignore
+  }
+  // test
+  try {
+    const res = await cli.test(dir);
+    t.match(
+      res.getDisplayResults(),
+      'for known issues, no vulnerable paths found.',
+      'res is correct',
+    );
+  } catch (e) {
+    t.fail('should have passed', e);
+  }
+});
+
+test('does not throw when missing node_modules & package.json has no dependencies (with --dev)', async (t) => {
+  t.plan(1);
+  server.setNextResponse(noVulnsResult);
+
+  const dir = baseDir + 'npm/no-dependencies';
+  // ensure node_modules does not exist
+  try {
+    fs.rmdirSync(dir + '/node_modules');
+  } catch (err) {
+    // ignore
+  }
+  // test
+  try {
+    const res = await cli.test(dir, { dev: true });
+    t.match(
+      res.getDisplayResults(),
+      'for known issues, no vulnerable paths found.',
+      'res is correct',
+    );
+  } catch (e) {
+    t.fail('should have passed', e);
   }
 });
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
If the package.json has no `dependencies` property defined then assume no deps and do not throw and error that `node_modules` are needed.

Example **package.json**:
```
{
  "name": "subpkg",
  "version": "1.0.0",
  "description": "",
  "main": "index.js",
  "scripts": {
    "test": "echo \"Error: no test specified\" && exit 1"
  },
  "author": "",
  "license": "ISC"
}
```

Some lerna projects may have many sub packages that have no dependencies and scanning them with `--all-projects` skips the local packages & throws an error.


#### Additional questions
**Before**
<img width="1152" alt="Screen Shot 2020-08-28 at 16 58 09" src="https://user-images.githubusercontent.com/2911613/91588181-afd6ce80-e94f-11ea-8a61-f0f577320b4e.png">
**After**
<img width="1208" alt="Screen Shot 2020-08-28 at 16 57 10" src="https://user-images.githubusercontent.com/2911613/91588189-b2392880-e94f-11ea-8a7b-901c6a37d264.png">
