### PR TITLE
feat: remove yarn2 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "snyk-gradle-plugin": "3.6.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.19.1",
-    "snyk-nodejs-lockfile-parser": "1.27.0",
+    "snyk-nodejs-lockfile-parser": "1.28.0",
     "snyk-nuget-plugin": "1.18.1",
     "snyk-php-plugin": "1.9.0",
     "snyk-policy": "1.14.1",

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -390,49 +390,49 @@ if (!isWindows) {
     }
   });
 
-  test('`monitor yarn v2 project`', async (t) => {
-    const nodeVersion = parseInt(process.version.slice(1).split('.')[0], 10);
-
-    if (nodeVersion < 10) {
-      return t.skip();
-    }
-
-    chdirWorkspaces();
-
-    await cli.monitor('yarn-v2');
-    const req = server.popRequest();
-    t.equal(req.method, 'PUT', 'makes PUT request');
-    t.equal(
-      req.headers['x-snyk-cli-version'],
-      versionNumber,
-      'sends version number',
-    );
-    t.match(req.url, '/monitor/yarn/graph', 'puts at correct url');
-
-    const depGraphJSON = req.body.depGraphJSON;
-    t.ok(depGraphJSON);
-    const lodash = depGraphJSON.pkgs.find((pkg) => pkg.info.name === 'lodash');
-
-    t.ok(lodash, 'dependency');
-    t.notOk(req.body.targetFile, 'doesnt send the targetFile');
-    t.notOk(depGraphJSON.from, 'no "from" array on root');
-    t.notOk(lodash.from, 'no "from" array on dep');
-    if (process.platform === 'win32') {
-      t.true(
-        req.body.targetFileRelativePath.endsWith(
-          '\\test\\acceptance\\workspaces\\yarn-v2\\yarn.lock',
-        ),
-        'matching file path win32',
-      );
-    } else {
-      t.true(
-        req.body.targetFileRelativePath.endsWith(
-          '/test/acceptance/workspaces/yarn-v2/yarn.lock',
-        ),
-        'matching file path',
-      );
-    }
-  });
+  // test('`monitor yarn v2 project`', async (t) => {
+  //   const nodeVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+  //
+  //   if (nodeVersion < 10) {
+  //     return t.skip();
+  //   }
+  //
+  //   chdirWorkspaces();
+  //
+  //   await cli.monitor('yarn-v2');
+  //   const req = server.popRequest();
+  //   t.equal(req.method, 'PUT', 'makes PUT request');
+  //   t.equal(
+  //     req.headers['x-snyk-cli-version'],
+  //     versionNumber,
+  //     'sends version number',
+  //   );
+  //   t.match(req.url, '/monitor/yarn/graph', 'puts at correct url');
+  //
+  //   const depGraphJSON = req.body.depGraphJSON;
+  //   t.ok(depGraphJSON);
+  //   const lodash = depGraphJSON.pkgs.find((pkg) => pkg.info.name === 'lodash');
+  //
+  //   t.ok(lodash, 'dependency');
+  //   t.notOk(req.body.targetFile, 'doesnt send the targetFile');
+  //   t.notOk(depGraphJSON.from, 'no "from" array on root');
+  //   t.notOk(lodash.from, 'no "from" array on dep');
+  //   if (process.platform === 'win32') {
+  //     t.true(
+  //       req.body.targetFileRelativePath.endsWith(
+  //         '\\test\\acceptance\\workspaces\\yarn-v2\\yarn.lock',
+  //       ),
+  //       'matching file path win32',
+  //     );
+  //   } else {
+  //     t.true(
+  //       req.body.targetFileRelativePath.endsWith(
+  //         '/test/acceptance/workspaces/yarn-v2/yarn.lock',
+  //       ),
+  //       'matching file path',
+  //     );
+  //   }
+  // });
 
   test('`monitor yarn-package from within folder`', async (t) => {
     chdirWorkspaces('yarn-package');

--- a/test/acceptance/cli-test/cli-test.yarn-workspaces.spec.ts
+++ b/test/acceptance/cli-test/cli-test.yarn-workspaces.spec.ts
@@ -218,150 +218,150 @@ export const YarnWorkspacesTests: AcceptanceTests = {
       });
       t.equal(policyCount, 2, '2 policies found in a workspace');
     },
-    'test --yarn-workspaces --detection-depth=5 --strict-out-of-sync=false (yarn v2)': (
-      params,
-      utils,
-    ) => async (t) => {
-      // Yarn workspaces for Yarn 2 is only supported on Node 10+
-      if (nodeVersion < 10) {
-        return t.skip();
-      }
-      utils.chdirWorkspaces();
-      const result = await params.cli.test('yarn-workspaces-v2', {
-        yarnWorkspaces: true,
-        detectionDepth: 5,
-        strictOutOfSync: false,
-      });
-      const loadPlugin = sinon.spy(params.plugins, 'loadPlugin');
-      // the parser is used directly
-      t.ok(loadPlugin.withArgs('yarn').notCalled, 'skips load plugin');
-      t.teardown(() => {
-        loadPlugin.restore();
-      });
-      t.match(
-        result.getDisplayResults(),
-        '✓ Tested 1 dependencies for known vulnerabilities, no vulnerable paths found.',
-        'correctly showing dep number',
-      );
-      t.match(result.getDisplayResults(), 'Package manager:   yarn\n');
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      package.json',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      tomatoes',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      apples',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Tested 3 projects, no vulnerable paths were found.',
-        'no vulnerable paths found as both policies detected and applied.',
-      );
-    },
-    'test --yarn-workspaces --detection-depth=5 multiple workspaces found': (
-      params,
-      utils,
-    ) => async (t) => {
-      // Yarn workspaces for Yarn 2 is only supported on Node 10+
-      if (nodeVersion < 10) {
-        return t.skip();
-      }
-      utils.chdirWorkspaces();
-      const result = await params.cli.test({
-        yarnWorkspaces: true,
-        detectionDepth: 5,
-        strictOutOfSync: false,
-      });
-      const loadPlugin = sinon.spy(params.plugins, 'loadPlugin');
-      // the parser is used directly
-      t.ok(loadPlugin.withArgs('yarn').notCalled, 'skips load plugin');
-      t.teardown(() => {
-        loadPlugin.restore();
-      });
-      t.match(
-        result.getDisplayResults(),
-        '✓ Tested 1 dependencies for known vulnerabilities, no vulnerable paths found.',
-        'correctly showing dep number',
-      );
-      t.match(result.getDisplayResults(), 'Package manager:   yarn\n');
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      package.json',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      tomatoes',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Project name:      apples',
-        'yarn project in output',
-      );
-      t.match(
-        result.getDisplayResults(),
-        'Tested 9 projects, no vulnerable paths were found.',
-        'Tested 9 projects',
-      );
-      let policyCount = 0;
-      const applesWorkspace =
-        process.platform === 'win32'
-          ? '\\apples\\package.json'
-          : 'apples/package.json';
-      const tomatoesWorkspace =
-        process.platform === 'win32'
-          ? '\\tomatoes\\package.json'
-          : 'tomatoes/package.json';
-      const rootWorkspace =
-        process.platform === 'win32'
-          ? '\\yarn-workspaces\\package.json'
-          : 'yarn-workspaces/package.json';
-
-      params.server.popRequests(6).forEach((req) => {
-        t.equal(req.method, 'POST', 'makes POST request');
-        t.equal(
-          req.headers['x-snyk-cli-version'],
-          params.versionNumber,
-          'sends version number',
-        );
-        t.match(req.url, '/api/v1/test-dep-graph', 'posts to correct url');
-        t.ok(req.body.depGraph, 'body contains depGraph');
-        if (req.body.targetFileRelativePath.endsWith(applesWorkspace)) {
-          t.match(
-            req.body.policy,
-            'npm:node-uuid:20160328',
-            'policy is as expected',
-          );
-          t.ok(req.body.policy, 'body contains policy');
-          policyCount += 1;
-        } else if (
-          req.body.targetFileRelativePath.endsWith(tomatoesWorkspace)
-        ) {
-          t.notOk(req.body.policy, 'body does not contain policy');
-        } else if (req.body.targetFileRelativePath.endsWith(rootWorkspace)) {
-          t.match(
-            req.body.policy,
-            'npm:node-uuid:20111130',
-            'policy is as expected',
-          );
-          t.ok(req.body.policy, 'body contains policy');
-          policyCount += 1;
-        }
-        t.equal(
-          req.body.depGraph.pkgManager.name,
-          'yarn',
-          'depGraph has package manager',
-        );
-      });
-      t.equal(policyCount, 3, '3 policies found in a workspace');
-    },
+    // 'test --yarn-workspaces --detection-depth=5 --strict-out-of-sync=false (yarn v2)': (
+    //   params,
+    //   utils,
+    // ) => async (t) => {
+    //   // Yarn workspaces for Yarn 2 is only supported on Node 10+
+    //   if (nodeVersion < 10) {
+    //     return t.skip();
+    //   }
+    //   utils.chdirWorkspaces();
+    //   const result = await params.cli.test('yarn-workspaces-v2', {
+    //     yarnWorkspaces: true,
+    //     detectionDepth: 5,
+    //     strictOutOfSync: false,
+    //   });
+    //   const loadPlugin = sinon.spy(params.plugins, 'loadPlugin');
+    //   // the parser is used directly
+    //   t.ok(loadPlugin.withArgs('yarn').notCalled, 'skips load plugin');
+    //   t.teardown(() => {
+    //     loadPlugin.restore();
+    //   });
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     '✓ Tested 1 dependencies for known vulnerabilities, no vulnerable paths found.',
+    //     'correctly showing dep number',
+    //   );
+    //   t.match(result.getDisplayResults(), 'Package manager:   yarn\n');
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      package.json',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      tomatoes',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      apples',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Tested 3 projects, no vulnerable paths were found.',
+    //     'no vulnerable paths found as both policies detected and applied.',
+    //   );
+    // },
+    // 'test --yarn-workspaces --detection-depth=5 multiple workspaces found': (
+    //   params,
+    //   utils,
+    // ) => async (t) => {
+    //   // Yarn workspaces for Yarn 2 is only supported on Node 10+
+    //   if (nodeVersion < 10) {
+    //     return t.skip();
+    //   }
+    //   utils.chdirWorkspaces();
+    //   const result = await params.cli.test({
+    //     yarnWorkspaces: true,
+    //     detectionDepth: 5,
+    //     strictOutOfSync: false,
+    //   });
+    //   const loadPlugin = sinon.spy(params.plugins, 'loadPlugin');
+    //   // the parser is used directly
+    //   t.ok(loadPlugin.withArgs('yarn').notCalled, 'skips load plugin');
+    //   t.teardown(() => {
+    //     loadPlugin.restore();
+    //   });
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     '✓ Tested 1 dependencies for known vulnerabilities, no vulnerable paths found.',
+    //     'correctly showing dep number',
+    //   );
+    //   t.match(result.getDisplayResults(), 'Package manager:   yarn\n');
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      package.json',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      tomatoes',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Project name:      apples',
+    //     'yarn project in output',
+    //   );
+    //   t.match(
+    //     result.getDisplayResults(),
+    //     'Tested 9 projects, no vulnerable paths were found.',
+    //     'Tested 9 projects',
+    //   );
+    //   let policyCount = 0;
+    //   const applesWorkspace =
+    //     process.platform === 'win32'
+    //       ? '\\apples\\package.json'
+    //       : 'apples/package.json';
+    //   const tomatoesWorkspace =
+    //     process.platform === 'win32'
+    //       ? '\\tomatoes\\package.json'
+    //       : 'tomatoes/package.json';
+    //   const rootWorkspace =
+    //     process.platform === 'win32'
+    //       ? '\\yarn-workspaces\\package.json'
+    //       : 'yarn-workspaces/package.json';
+    //
+    //   params.server.popRequests(6).forEach((req) => {
+    //     t.equal(req.method, 'POST', 'makes POST request');
+    //     t.equal(
+    //       req.headers['x-snyk-cli-version'],
+    //       params.versionNumber,
+    //       'sends version number',
+    //     );
+    //     t.match(req.url, '/api/v1/test-dep-graph', 'posts to correct url');
+    //     t.ok(req.body.depGraph, 'body contains depGraph');
+    //     if (req.body.targetFileRelativePath.endsWith(applesWorkspace)) {
+    //       t.match(
+    //         req.body.policy,
+    //         'npm:node-uuid:20160328',
+    //         'policy is as expected',
+    //       );
+    //       t.ok(req.body.policy, 'body contains policy');
+    //       policyCount += 1;
+    //     } else if (
+    //       req.body.targetFileRelativePath.endsWith(tomatoesWorkspace)
+    //     ) {
+    //       t.notOk(req.body.policy, 'body does not contain policy');
+    //     } else if (req.body.targetFileRelativePath.endsWith(rootWorkspace)) {
+    //       t.match(
+    //         req.body.policy,
+    //         'npm:node-uuid:20111130',
+    //         'policy is as expected',
+    //       );
+    //       t.ok(req.body.policy, 'body contains policy');
+    //       policyCount += 1;
+    //     }
+    //     t.equal(
+    //       req.body.depGraph.pkgManager.name,
+    //       'yarn',
+    //       'depGraph has package manager',
+    //     );
+    //   });
+    //   t.equal(policyCount, 3, '3 policies found in a workspace');
+    // },
   },
 };

--- a/test/acceptance/cli-test/cli-test.yarn.spec.ts
+++ b/test/acceptance/cli-test/cli-test.yarn.spec.ts
@@ -316,30 +316,30 @@ export const YarnTests: AcceptanceTests = {
         'depGraph looks fine',
       );
     },
-    '`test` on a yarn v2 package': (params, utils) => async (t) => {
-      const nodeVersion = parseInt(process.version.slice(1).split('.')[0], 10);
-
-      if (nodeVersion < 10) {
-        return t.skip();
-      }
-
-      utils.chdirWorkspaces('yarn-v2');
-      await params.cli.test();
-      const req = params.server.popRequest();
-      t.equal(req.method, 'POST', 'makes POST request');
-      t.equal(
-        req.headers['x-snyk-cli-version'],
-        params.versionNumber,
-        'sends version number',
-      );
-      t.match(req.url, '/test-dep-graph', 'posts to correct url');
-      t.match(req.body.targetFile, undefined, 'target is undefined');
-      const depGraph = req.body.depGraph;
-      t.same(
-        depGraph.pkgs.map((p) => p.id).sort(),
-        ['yarn-v2@1.0.0', 'lodash@4.17.0'].sort(),
-        'depGraph looks fine',
-      );
-    },
+    // '`test` on a yarn v2 package': (params, utils) => async (t) => {
+    //   const nodeVersion = parseInt(process.version.slice(1).split('.')[0], 10);
+    //
+    //   if (nodeVersion < 10) {
+    //     return t.skip();
+    //   }
+    //
+    //   utils.chdirWorkspaces('yarn-v2');
+    //   await params.cli.test();
+    //   const req = params.server.popRequest();
+    //   t.equal(req.method, 'POST', 'makes POST request');
+    //   t.equal(
+    //     req.headers['x-snyk-cli-version'],
+    //     params.versionNumber,
+    //     'sends version number',
+    //   );
+    //   t.match(req.url, '/test-dep-graph', 'posts to correct url');
+    //   t.match(req.body.targetFile, undefined, 'target is undefined');
+    //   const depGraph = req.body.depGraph;
+    //   t.same(
+    //     depGraph.pkgs.map((p) => p.id).sort(),
+    //     ['yarn-v2@1.0.0', 'lodash@4.17.0'].sort(),
+    //     'depGraph looks fine',
+    //   );
+    // },
   },
 };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Yarn2 requires node>10. We still have users on node8 using yarn and ever since we added yarn2 they are no longer able to add snyk to their projects.

Since snyk still supports node8, we must unfortunately remove our support for yarn2.

Node8 support will be dropped in the near future, after which we can reinstate yarn2 support.
In the meantime, users can pin the version 1.387.0 to retain yarn 2 support

See relevant issue: snyk/snyk#1270