### PR TITLE
feat: use snyk-gradle-plugin@3.6.2 that sends back project targetFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "snyk-cpp-plugin": "1.4.1",
     "snyk-docker-plugin": "3.18.1",
     "snyk-go-plugin": "1.16.0",
-    "snyk-gradle-plugin": "3.5.1",
+    "snyk-gradle-plugin": "3.6.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.19.1",
     "snyk-nodejs-lockfile-parser": "1.27.0",

--- a/src/lib/plugins/get-deps-from-plugin.ts
+++ b/src/lib/plugins/get-deps-from-plugin.ts
@@ -149,7 +149,7 @@ export function warnSomeGradleManifestsNotScanned(
   );
 
   if (diff.length > 0) {
-    return `✗ ${diff.length}/${detectedGradleFiles.length} detected Gradle manifests did not return dependencies.\nThey may have errored or were not included as part of a multi-project build. You may need to scan them individually with --file=path/to/file. Run with \`-d\` for more info.`;
+    return `✗ ${diff.length}/${detectedGradleFiles.length} detected Gradle manifests did not return dependencies. They may have errored or were not included as part of a multi-project build. You may need to scan them individually with --file=path/to/file. Run with \`-d\` for more info.`;
   }
   return null;
 }

--- a/test/acceptance/cli-test/cli-test.all-projects.spec.ts
+++ b/test/acceptance/cli-test/cli-test.all-projects.spec.ts
@@ -92,7 +92,7 @@ export const AllProjectsTests: AcceptanceTests = {
       );
       t.same(
         stdoutMessages,
-        '✗ 1/3 detected Gradle manifests did not return dependencies.\n' +
+        '✗ 1/3 detected Gradle manifests did not return dependencies. ' +
           'They may have errored or were not included as part of a multi-project build. You may need to scan them individually with --file=path/to/file. Run with `-d` for more info.',
       );
       stubbedConsole.restore();


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Use latest gradle plugin that sends scanned project targetFile as meta