### PR TITLE
feat: SARIF format support for IaC and containers

### DIFF
--- a/help/container.txt
+++ b/help/container.txt
@@ -15,10 +15,19 @@ Options:
   --exclude-base-image-vulns .............. Exclude from display base image vulnerabilities.
   --file=<string> ......................... Include the path to the image's Dockerfile for more detailed advice.
   -h, --help
-  --json
   --platform=<string> ..................... For multi-architecture images, specify the platform to test. Options are:
                                             [linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x,
                                             linux/386, linux/arm/v7 orlinux/arm/v6]
+  --json  .................................. Return results in JSON format.
+  --json-file-output=<string>
+                       (test command only)
+                       Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+                       This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+  --sarif ................................. Return results in SARIF format.
+  --sarif-file-output=<string>
+                       (test command only)
+                       Save test output in SARIF format directly to the specified file, regardless of whether or not you use the `--sarif` option.
+                       This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
   --print-deps ............................ Print the dependency tree before sending it for analysis.
   --project-name=<string> ................. Specify a custom Snyk project name.
   --policy-path=<path> .................... Manually pass a path to a snyk policy file.

--- a/help/iac.txt
+++ b/help/iac.txt
@@ -12,6 +12,15 @@ Options:
 
   -h, --help
   --json .................................. Return results in JSON format.
+  --json-file-output=<string>
+                       (test command only)
+                       Save test output in JSON format directly to the specified file, regardless of whether or not you use the `--json` option.
+                       This is especially useful if you want to display the human-readable test output via stdout and at the same time save the JSON format output to a file.
+  --sarif ................................. Return results in SARIF format.
+  --sarif-file-output=<string>
+                       (test command only)
+                       Save test output in SARIF format directly to the specified file, regardless of whether or not you use the `--sarif` option.
+                       This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
   --severity-threshold=<low|medium|high>... Only report issues of provided level or higher.
 
 Examples:

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "@types/needle": "^2.0.4",
     "@types/node": "8.10.59",
     "@types/restify": "^8.4.2",
+    "@types/sarif": "^2.1.2",
     "@types/sinon": "^7.5.0",
     "@types/update-notifier": "^4.1.0",
     "@typescript-eslint/eslint-plugin": "2.18.0",

--- a/src/cli/commands/test/sarif-output.ts
+++ b/src/cli/commands/test/sarif-output.ts
@@ -1,0 +1,93 @@
+import * as sarif from 'sarif';
+
+export function createSarifOutputForContainers(testResult): sarif.Log {
+  const sarifRes: sarif.Log = {
+    version: '2.1.0',
+    runs: [],
+  };
+
+  testResult.forEach((testResult) => {
+    sarifRes.runs.push({
+      tool: getTool(testResult),
+      results: getResults(testResult),
+    });
+  });
+
+  return sarifRes;
+}
+
+export function getTool(testResult): sarif.Tool {
+  const tool: sarif.Tool = {
+    driver: {
+      name: 'Snyk Container',
+      rules: [],
+    },
+  };
+
+  if (!testResult.vulnerabilities) {
+    return tool;
+  }
+
+  const pushedIds = {};
+  tool.driver.rules = testResult.vulnerabilities
+    .map((vuln) => {
+      if (pushedIds[vuln.id]) {
+        return;
+      }
+      const level = vuln.severity === 'high' ? 'error' : 'warning';
+      const cve = vuln['identifiers']['CVE'][0];
+      pushedIds[vuln.id] = true;
+      return {
+        id: vuln.id,
+        shortDescription: {
+          text: `${vuln.severity} severity ${vuln.title} vulnerability in ${vuln.packageName}`,
+        },
+        fullDescription: {
+          text: cve
+            ? `(${cve}) ${vuln.name}@${vuln.version}`
+            : `${vuln.name}@${vuln.version}`,
+        },
+        help: {
+          text: '',
+          markdown: vuln.description,
+        },
+        defaultConfiguration: {
+          level: level,
+        },
+        properties: {
+          tags: ['security', ...vuln.identifiers.CWE],
+        },
+      };
+    })
+    .filter(Boolean);
+  return tool;
+}
+
+export function getResults(testResult): sarif.Result[] {
+  const results: sarif.Result[] = [];
+
+  if (!testResult.vulnerabilities) {
+    return results;
+  }
+  testResult.vulnerabilities.forEach((vuln) => {
+    results.push({
+      ruleId: vuln.id,
+      message: {
+        text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: testResult.displayTargetFile,
+            },
+            region: {
+              startLine: vuln.lineNumber || 1,
+            },
+          },
+        },
+      ],
+    });
+  });
+  return results;
+}

--- a/src/cli/commands/types.ts
+++ b/src/cli/commands/types.ts
@@ -17,15 +17,26 @@ export class CommandResult {
 
 export abstract class TestCommandResult extends CommandResult {
   protected jsonResult = '';
+  protected sarifResult = '';
+
   public getJsonResult(): string {
     return this.jsonResult;
+  }
+
+  public getSarifResult(): string {
+    return this.sarifResult;
   }
 
   public static createHumanReadableTestCommandResult(
     humanReadableResult: string,
     jsonResult: string,
+    sarifResult?: string,
   ): HumanReadableTestCommandResult {
-    return new HumanReadableTestCommandResult(humanReadableResult, jsonResult);
+    return new HumanReadableTestCommandResult(
+      humanReadableResult,
+      jsonResult,
+      sarifResult,
+    );
   }
 
   public static createJsonTestCommandResult(
@@ -37,14 +48,26 @@ export abstract class TestCommandResult extends CommandResult {
 
 class HumanReadableTestCommandResult extends TestCommandResult {
   protected jsonResult = '';
+  protected sarifResult = '';
 
-  constructor(humanReadableResult: string, jsonResult: string) {
+  constructor(
+    humanReadableResult: string,
+    jsonResult: string,
+    sarifResult?: string,
+  ) {
     super(humanReadableResult);
     this.jsonResult = jsonResult;
+    if (sarifResult) {
+      this.sarifResult = sarifResult;
+    }
   }
 
   public getJsonResult(): string {
     return this.jsonResult;
+  }
+
+  public getSarifResult(): string {
+    return this.sarifResult;
   }
 }
 

--- a/src/lib/errors/empty-sarif-output-error.ts
+++ b/src/lib/errors/empty-sarif-output-error.ts
@@ -1,0 +1,13 @@
+import { CustomError } from './custom-error';
+
+export class SarifFileOutputEmptyError extends CustomError {
+  private static ERROR_CODE = 422;
+  private static ERROR_MESSAGE =
+    'Empty --sarif-file-output argument. Did you mean --file=path/to/output-file.json ?';
+
+  constructor() {
+    super(SarifFileOutputEmptyError.ERROR_MESSAGE);
+    this.code = SarifFileOutputEmptyError.ERROR_CODE;
+    this.userMessage = SarifFileOutputEmptyError.ERROR_MESSAGE;
+  }
+}

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -13,6 +13,7 @@ export interface AnnotatedIacIssue {
   // Legacy fields from Registry, unused.
   name?: string;
   from?: string[];
+  lineNumber?: number;
 }
 
 type FILTERED_OUT_FIELDS = 'cloudConfigPath' | 'name' | 'from';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -74,6 +74,7 @@ export interface Options {
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
   debug?: boolean;
+  sarif?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -136,6 +137,13 @@ export interface SpinnerOptions {
   label?: string;
   unref?: any;
   cleanup?: any;
+}
+
+export interface OutputDataTypes {
+  stdout: any;
+  stringifiedData: string;
+  stringifiedJsonData: string;
+  stringifiedSarifData: string;
 }
 
 export type SupportedProjectTypes = IacProjectTypes | SupportedPackageManagers;

--- a/test/acceptance/cli-test/cli-test.iac-k8s.spec.ts
+++ b/test/acceptance/cli-test/cli-test.iac-k8s.spec.ts
@@ -2,10 +2,13 @@ import * as _ from 'lodash';
 import {
   iacTest,
   iacTestJson,
+  iacTestSarif,
   iacErrorTest,
   iacTestMetaAssertions,
   iacTestJsonAssertions,
+  iacTestSarifAssertions,
   iacTestResponseFixturesByThreshold,
+  iacTestSarifFileOutput,
 } from './cli-test.iac-k8s.utils';
 import { CommandResult } from '../../../src/cli/commands/types';
 
@@ -20,19 +23,6 @@ import { AcceptanceTests } from './cli-test.acceptance.test';
 export const IacK8sTests: AcceptanceTests = {
   language: 'Iac (Kubernetes)',
   tests: {
-    '`iac test multi-file.yaml --json - no issues`': (params, utils) => async (
-      t,
-    ) => {
-      utils.chdirWorkspaces();
-      const commandResult: CommandResult = await params.cli.test(
-        'iac-kubernetes/multi-file.yaml',
-        {
-          iac: true,
-        },
-      );
-      const res: any = JSON.parse((commandResult as any).jsonResult);
-      iacTestJsonAssertions(t, res, null, false);
-    },
     '`iac test multi.yaml - no issues`': (params, utils) => async (t) => {
       utils.chdirWorkspaces();
 
@@ -140,6 +130,23 @@ export const IacK8sTests: AcceptanceTests = {
       utils,
     ) => async (t) => await iacTest(t, utils, params, 'high', 1),
 
+    '`iac test multi-file.yaml --json - no issues`': (params, utils) => async (
+      t,
+    ) => {
+      utils.chdirWorkspaces();
+      let testableObject;
+      try {
+        await params.cli.test('iac-kubernetes/multi-file.yaml', {
+          iac: true,
+          json: true,
+        });
+        t.fail('should have thrown');
+      } catch (error) {
+        testableObject = error;
+      }
+      const res: any = JSON.parse(testableObject.message);
+      iacTestJsonAssertions(t, res, null, false);
+    },
     '`iac test multi-file.yaml --severity-threshold=low --json`': (
       params,
       utils,
@@ -154,5 +161,42 @@ export const IacK8sTests: AcceptanceTests = {
       params,
       utils,
     ) => async (t) => await iacTestJson(t, utils, params, 'high'),
+
+    '`iac test multi-file.yaml --sarif - no issues`': (params, utils) => async (
+      t,
+    ) => {
+      utils.chdirWorkspaces();
+      let testableObject;
+      try {
+        await params.cli.test('iac-kubernetes/multi-file.yaml', {
+          iac: true,
+          sarif: true,
+        });
+        t.fail('should have thrown');
+      } catch (error) {
+        testableObject = error;
+      }
+      const res: any = JSON.parse(testableObject.message);
+      iacTestSarifAssertions(t, res, null, false);
+    },
+    '`iac test multi-file.yaml --severity-threshold=low --sarif`': (
+      params,
+      utils,
+    ) => async (t) => await iacTestSarif(t, utils, params, 'low'),
+
+    '`iac test multi-file.yaml --severity-threshold=medium --sarif`': (
+      params,
+      utils,
+    ) => async (t) => await iacTestSarif(t, utils, params, 'medium'),
+
+    '`iac test multi-file.yaml --severity-threshold=high --sarif`': (
+      params,
+      utils,
+    ) => async (t) => await iacTestSarif(t, utils, params, 'high'),
+
+    '`iac test multi-file.yaml --severity-threshold=high --sarif --sarif-file-output=test.json`': (
+      params,
+      utils,
+    ) => async (t) => await iacTestSarifFileOutput(t, utils, params, 'high'),
   },
 };

--- a/test/acceptance/fixtures/docker/sarif-container-result.json
+++ b/test/acceptance/fixtures/docker/sarif-container-result.json
@@ -1,0 +1,59 @@
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "Snyk Container",
+          "rules": [
+            {
+              "id": "SNYK-LINUX-BZIP2-106947",
+              "shortDescription": {
+                "text": "low severity Denial of Service (DoS) vulnerability in bzip2"
+              },
+              "fullDescription": {
+                "text": "(CVE-2016-3189) bzip2/libbz2-1.0@1.0.6-8.1"
+              },
+              "help": {
+                "text": "",
+                "markdown": "## Overview\nUse-after-free vulnerability in bzip2recover in bzip2 1.0.6 allows remote attackers to cause a denial of service (crash) via a crafted bzip2 file, related to block ends set to before the start of the block.\n\n## References\n- [GENTOO](https://security.gentoo.org/glsa/201708-08)\n- [CONFIRM](https://bugzilla.redhat.com/show_bug.cgi?id=1319648)\n- [SECTRACK](http://www.securitytracker.com/id/1036132)\n- [BID](http://www.securityfocus.com/bid/91297)\n- [CONFIRM](http://www.oracle.com/technetwork/topics/security/bulletinjul2016-3090568.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2016/06/20/1)\n"
+              },
+              "defaultConfiguration": { "level": "warning" },
+              "properties": { "tags": ["security"] }
+            }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "SNYK-LINUX-BZIP2-106947",
+          "message": {
+            "text": "This file introduces a vulnerable bzip2 package with a low severity vulnerability."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {},
+                "region": { "startLine": 1 }
+              }
+            }
+          ]
+        },
+        {
+          "ruleId": "SNYK-LINUX-BZIP2-106947",
+          "message": {
+            "text": "This file introduces a vulnerable bzip2 package with a low severity vulnerability."
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {},
+                "region": { "startLine": 1 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Introduces SARIF support for both containers and IaC.
Support for `--sarif` flag to output SARIF to stdout.
Support for `--sarif-file-output` to save SARIF results to specified file.

#### How should this be manually tested?
`snyk container test alpine --file=Dockerfile --sarif --sarif-output-file=test-container-sarif.json`
`snyk iac test file.yaml --sarif --sarif-file-output=test-iac-sarif.json`
