### PR TITLE
feat: Adding '--platform' flag to 'snyk container' commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.0",
     "snyk-cpp-plugin": "1.4.1",
-    "snyk-docker-plugin": "3.18.1",
+    "snyk-docker-plugin": "3.19.0",
     "snyk-go-plugin": "1.16.0",
     "snyk-gradle-plugin": "3.6.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We're adding 'arm' architecture support to the cli scanning. Firstly the 'platform' flag is supported if docker available locally and experimental features configured.

We support `docker buildx` format of the `platform` flag, so it's familiar to the user, eg. `linux/arm64/v8`

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1146
