### PR TITLE
fix: align integration naming for JetBrains IDEs

### DIFF
--- a/src/lib/analytics-sources.ts
+++ b/src/lib/analytics-sources.ts
@@ -25,7 +25,7 @@ enum TrackedIntegration {
   DOCKER_SNYK = 'DOCKER_SNYK', // docker snyk/snyk
 
   // IDE plugins - tracked by passing flag or envvar on CLI invocation
-  INTELLIJ = 'INTELLIJ',
+  JETBRAINS_IDE = 'JETBRAINS_IDE',
   ECLIPSE = 'ECLIPSE',
   VS_CODE_VULN_COST = 'VS_CODE_VULN_COST',
 


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Use `JETBRAINS_IDE` as integration name for all IntelliJ based IDEs from JetBrains.
