### PR TITLE
feat: iac test terraform support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,5 +12,6 @@ src/lib/snyk-test/payload-schema.ts @snyk/cloudconfig
 src/lib/snyk-test/run-iac-test.ts @snyk/cloudconfig
 test/acceptance/cli-test/cli-test.iac-k8s.spec.ts @snyk/cloudconfig
 test/acceptance/cli-test/cli-test.iac-k8s.utils.ts @snyk/cloudconfig
+test/fixtures/iac-terraform/* @snyk/cloudconfig
 src/lib/errors/invalid-iac-file.ts @snyk/cloudconfig
 src/lib/errors/unsupported-options-iac-error.ts @snyk/cloudconfig

--- a/help/iac.txt
+++ b/help/iac.txt
@@ -2,7 +2,7 @@ Usage:
 
   $ snyk iac [command] [options] <path>
 
-Find security issues in your Infrastructure as Code files (currently we support Kubernetes files only).
+Find security issues in your Infrastructure as Code files (currently we support Kubernetes & Terraform files only).
 
 Commands:
 
@@ -26,6 +26,7 @@ Options:
 Examples:
 
   $ snyk iac test /path/to/Kubernetes.yaml
+  $ snyk iac test /path/to/terraform_file.tf
 
 
 For more information see https://support.snyk.io/hc/en-us/categories/360001342678-Infrastructure-as-code

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -150,6 +150,11 @@ function getIssueLevel(severity: SEVERITY): sarif.ReportingConfiguration.level {
   return severity === SEVERITY.HIGH ? 'error' : 'warning';
 }
 
+const iacTypeToText = {
+  k8s: 'Kubernetes',
+  terraform: 'Terraform',
+};
+
 export function mapIacTestResponseToSarifTool(
   iacTestResponse: IacTestResponse,
 ): sarif.Tool {
@@ -172,7 +177,7 @@ export function mapIacTestResponseToSarifTool(
           text: `${upperFirst(iacIssue.severity)} - ${iacIssue.title}`,
         },
         fullDescription: {
-          text: `Kubernetes ${iacIssue.subType}`,
+          text: `${iacTypeToText[iacIssue.type]} ${iacIssue.subType}`,
         },
         help: {
           text: '',
@@ -182,7 +187,7 @@ export function mapIacTestResponseToSarifTool(
           level: getIssueLevel(iacIssue.severity),
         },
         properties: {
-          tags: ['security', `kubernetes/${iacIssue.subType}`],
+          tags: ['security', `${iacIssue.type}/${iacIssue.subType}`],
         },
       });
       pushedIds[iacIssue.id] = true;
@@ -198,7 +203,11 @@ export function mapIacTestResponseToSarifResults(
     (iacIssue: AnnotatedIacIssue) => ({
       ruleId: iacIssue.id,
       message: {
-        text: `This line contains a potential ${iacIssue.severity} severity misconfiguration affacting the Kubernetes ${iacIssue.subType}`,
+        text: `This line contains a potential ${
+          iacIssue.severity
+        } severity misconfiguration affecting the ${
+          iacTypeToText[iacIssue.type]
+        } ${iacIssue.subType}`,
       },
       locations: [
         {

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -53,6 +53,11 @@ import { getEcosystem, testEcosystem } from '../../../lib/ecosystems';
 import { TestLimitReachedError } from '../../../lib/errors';
 import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
 import { createSarifOutputForContainers } from './sarif-output';
+import {
+  IacProjectType,
+  IacProjectTypes,
+  TEST_SUPPORTED_IAC_PROJECTS,
+} from '../../../lib/iac/constants';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -448,7 +453,8 @@ function displayResult(
     return prefix + res.message;
   }
   const issuesText =
-    res.licensesPolicy || projectType === 'k8sconfig'
+    res.licensesPolicy ||
+    TEST_SUPPORTED_IAC_PROJECTS.includes(projectType as IacProjectTypes)
       ? 'issues'
       : 'vulnerabilities';
   let pathOrDepsText = '';
@@ -520,7 +526,9 @@ function displayResult(
     );
   }
 
-  if (res.packageManager === 'k8sconfig') {
+  if (
+    TEST_SUPPORTED_IAC_PROJECTS.includes(res.packageManager as IacProjectType)
+  ) {
     return getIacDisplayedOutput(
       (res as any) as IacTestResponse,
       testedInfoText,

--- a/src/lib/errors/invalid-iac-file.ts
+++ b/src/lib/errors/invalid-iac-file.ts
@@ -34,3 +34,22 @@ export function IllegalIacFileError(atLocations: string[]): CustomError {
   error.userMessage = errorMsg;
   return error;
 }
+
+export function IllegalTerraformFileError(
+  atLocations: string[],
+  reason: string,
+): CustomError {
+  const locationsStr = atLocations.join(', ');
+  const errorMsg =
+    `Illegal Terraform target file ${locationsStr} \nValidation Error Reason: ${reason}` +
+    '.\nPlease see our documentation for supported target files (currently we support Kubernetes files only): ' +
+    chalk.underline(
+      'https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files',
+    ) +
+    ' and make sure you are in the right directory.';
+
+  const error = new CustomError(errorMsg);
+  error.code = 422;
+  error.userMessage = errorMsg;
+  return error;
+}

--- a/src/lib/iac/constants.ts
+++ b/src/lib/iac/constants.ts
@@ -1,0 +1,26 @@
+export type IacProjectTypes = 'k8sconfig' | 'terraformconfig';
+export type IacFileTypes = 'yaml' | 'yml' | 'json' | 'tf';
+
+export enum IacProjectType {
+  K8S = 'k8sconfig',
+  TERRAFORM = 'terraformconfig',
+}
+
+export const TEST_SUPPORTED_IAC_PROJECTS: IacProjectTypes[] = [
+  IacProjectType.K8S,
+  IacProjectType.TERRAFORM,
+];
+
+export const projectTypeByFileType = {
+  yaml: IacProjectType.K8S,
+  yml: IacProjectType.K8S,
+  json: IacProjectType.K8S,
+  tf: IacProjectType.TERRAFORM,
+};
+
+export type IacValidateTerraformResponse = {
+  body?: {
+    isValidTerraformFile: boolean;
+    reason: string;
+  };
+};

--- a/src/lib/iac/iac-projects.ts
+++ b/src/lib/iac/iac-projects.ts
@@ -1,3 +1,0 @@
-export type IacProjectTypes = 'k8sconfig' | 'helmconfig';
-
-export const TEST_SUPPORTED_IAC_PROJECTS: IacProjectTypes[] = ['k8sconfig'];

--- a/src/lib/snyk-test/index.js
+++ b/src/lib/snyk-test/index.js
@@ -4,7 +4,7 @@ const detect = require('../detect');
 const { runTest } = require('./run-test');
 const chalk = require('chalk');
 const pm = require('../package-managers');
-const iacProjects = require('../iac/iac-projects');
+const iacProjects = require('../iac/constants');
 const {
   UnsupportedPackageManagerError,
   NotSupportedIacFileError,
@@ -30,11 +30,11 @@ async function test(root, options, callback) {
   return promise;
 }
 
-function executeTest(root, options) {
+async function executeTest(root, options) {
   try {
     if (!options.allProjects) {
       options.packageManager = options.iac
-        ? detect.isIacProject(root, options)
+        ? await detect.isIacProject(root, options)
         : detect.detectPackageManager(root, options);
     }
     return run(root, options).then((results) => {

--- a/src/lib/snyk-test/payload-schema.ts
+++ b/src/lib/snyk-test/payload-schema.ts
@@ -1,5 +1,5 @@
 //TODO(orka): future - change this file
-import { IacProjectTypes } from '../iac/iac-projects';
+import { IacProjectTypes } from '../iac/constants';
 
 interface Scan {
   type: string;
@@ -9,7 +9,7 @@ interface Scan {
 
 export interface IacFile {
   fileContent: string;
-  fileType: 'yaml' | 'yml' | 'json';
+  fileType: 'yaml' | 'yml' | 'json' | 'tf';
 }
 
 export interface IacScan extends Scan {

--- a/src/lib/snyk-test/run-iac-test.ts
+++ b/src/lib/snyk-test/run-iac-test.ts
@@ -12,6 +12,7 @@ import { Payload } from './types';
 import { IacScan } from './payload-schema';
 import { SEVERITY } from './legacy';
 import * as pathLib from 'path';
+import { projectTypeByFileType, IacFileTypes } from '../iac/constants';
 
 export async function parseIacTestResult(
   res: IacTestResponse,
@@ -52,20 +53,22 @@ export async function assembleIacLocalPayloads(
     : '';
 
   const fileContent = fs.readFileSync(targetFile, 'utf8');
+  const fileType = root.substr(root.lastIndexOf('.') + 1);
+  const projectType = projectTypeByFileType[fileType];
+
   const body: IacScan = {
     data: {
       fileContent,
-      fileType: 'yaml',
+      fileType: fileType as IacFileTypes,
     },
     targetFile: root,
-    type: 'k8sconfig',
+    type: projectType,
     //TODO(orka): future - support policy
     policy: '',
     targetFileRelativePath: `${targetFileRelativePath}`, // Forcing string
     originalProjectName: path.basename(path.dirname(targetFile)),
     projectNameOverride: options.projectName,
   };
-
   const payload: Payload = {
     method: 'POST',
     url: config.API + (options.vulnEndpoint || '/test-iac'),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,5 @@
 import { SupportedPackageManagers } from './package-managers';
-import { IacProjectTypes } from './iac/iac-projects';
+import { IacProjectTypes } from './iac/constants';
 import { legacyCommon as legacyApi } from '@snyk/cli-interface';
 import { SEVERITY } from './snyk-test/legacy';
 import { FailOn } from './snyk-test/common';

--- a/test/acceptance/cli-test/cli-test.iac-k8s.utils.ts
+++ b/test/acceptance/cli-test/cli-test.iac-k8s.utils.ts
@@ -225,7 +225,7 @@ export function iacTestSarifAssertions(
     const expectedIssue = expectedResults.infrastructureAsCodeIssues[i];
     t.deepEqual(sarifIssue.ruleId, expectedIssue.id, 'issue id is ok');
 
-    const messageText = `This line contains a potential ${expectedIssue.severity} severity misconfiguration affacting the Kubernetes ${expectedIssue.subType}`;
+    const messageText = `This line contains a potential ${expectedIssue.severity} severity misconfiguration affecting the Kubernetes ${expectedIssue.subType}`;
     t.deepEqual(sarifIssue.message.text, messageText, 'issue message is ok');
     t.deepEqual(
       sarifIssue.locations![0].physicalLocation!.region!.startLine,

--- a/test/fixtures/iac-terraform/sg_open_ssh.tf
+++ b/test/fixtures/iac-terraform/sg_open_ssh.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/fixtures/iac-terraform/sg_open_ssh_invalid_go_templates.tf
+++ b/test/fixtures/iac-terraform/sg_open_ssh_invalid_go_templates.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+  {{ Disallowed usage of Go Templates! }}
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/fixtures/iac-terraform/sg_open_ssh_invalid_hcl2.tf
+++ b/test/fixtures/iac-terraform/sg_open_ssh_invalid_hcl2.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress 
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/smoke/alpine/Dockerfile
+++ b/test/smoke/alpine/Dockerfile
@@ -3,6 +3,7 @@ FROM shellspec/shellspec:latest
 COPY ./smoke/ /snyk/smoke/
 COPY ./fixtures/basic-npm/ /snyk/fixtures/basic-npm/
 COPY ./fixtures/empty/ /snyk/fixtures/empty/
+COPY ./fixtures/iac-terraform/ /snyk/fixtures/iac-terraform/ 
 
 RUN shellspec --version
 RUN apk add curl jq libgcc libstdc++

--- a/test/smoke/spec/snyk_test_iac_spec.sh
+++ b/test/smoke/spec/snyk_test_iac_spec.sh
@@ -1,0 +1,72 @@
+#shellcheck shell=sh
+
+Describe "Snyk iac test command"
+  Before snyk_login
+  After snyk_logout
+  Describe "terraform single file scan"
+    It "finds issues in terraform file"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh.tf
+      The status should be failure # issues found
+      The output should include "Testing ../fixtures/iac-terraform/sg_open_ssh.tf..."
+      # Outputs issues   
+      The output should include "Infrastructure as code issues:"
+      The output should include "✗ Security Group allows open ingress [Medium Severity] [SNYK-CC-TF-1] in Security Group"
+      The output should include "introduced by resource > aws_security_group[allow_ssh] > ingress"
+      
+      # Outputs Summary
+      The output should include "Organization:"
+      The output should include "Type:              Terraform"
+      The output should include "Target file:       ../fixtures/iac-terraform/sg_open_ssh.tf"
+      The output should include "Project name:      iac-terraform"
+      The output should include "Open source:       no"
+      The output should include "Project path:      ../fixtures/iac-terraform/sg_open_ssh.tf"
+      The output should include "Tested ../fixtures/iac-terraform/sg_open_ssh.tf for known issues, found 1 issues"
+    End
+
+    It "filters out issues when using severity threshold"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh.tf --severity-threshold=high
+      The status should be success # no issues found
+      The output should include "Testing ../fixtures/iac-terraform/sg_open_ssh.tf..."
+      # Outputs issues   
+      The output should include "Infrastructure as code issues:"
+      
+      # Outputs Summary
+      The output should include "Organization:"
+      The output should include "Type:              Terraform"
+      The output should include "Target file:       ../fixtures/iac-terraform/sg_open_ssh.tf"
+      The output should include "Project name:      iac-terraform"
+      The output should include "Open source:       no"
+      The output should include "Project path:      ../fixtures/iac-terraform/sg_open_ssh.tf"
+      The output should include "Tested ../fixtures/iac-terraform/sg_open_ssh.tf for known issues, found 0 issues"
+    End
+
+    It "outputs an error for invalid hcl2 tf files"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh_invalid_hcl2.tf
+      The status should be failure
+      The output should include "Illegal Terraform target file ../fixtures/iac-terraform/sg_open_ssh_invalid_hcl2.tf"
+      The output should include "Validation Error Reason: Invalid HCL2 Format."
+    End
+
+    It "outputs an error for invalid tf files with go templates"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh_invalid_go_templates.tf
+      The status should be failure
+      The output should include "Illegal Terraform target file ../fixtures/iac-terraform/sg_open_ssh_invalid_go_templates.tf"
+      The output should include "Validation Error Reason: Go Template placeholders found in Terraform file."
+    End
+
+    It "outputs the expected text when running with --sarif flag"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh.tf --sarif
+      The status should be failure
+      The output should include '"id": "SNYK-CC-TF-1",'
+      The output should include '"ruleId": "SNYK-CC-TF-1",'
+    End
+
+    It "outputs the expected text when running with --json flag"
+      When run snyk iac test ../fixtures/iac-terraform/sg_open_ssh.tf --json
+      The status should be failure
+      The output should include '"id": "SNYK-CC-TF-1",'
+      The output should include '"packageManager": "terraformconfig",'
+      The result of function check_valid_json should be success
+    End
+  End
+End


### PR DESCRIPTION
#### What does this PR do?
This PR adds the following:
- a validation request to Registry to a new endpoint in order to validate Terraform files before passing them to the `iac-test` endpoint in registry.
- Support across the CLI IaC command for Terraform Project types.
- Regression Smoke tests with ShellSpec for the main Use-Cases for TF files.

Todo:
- [x] Update Public Documentation.

#### How should this be manually tested?
`snyk iac test someTerraformFile.tf`

#### Screenshots
![image](https://user-images.githubusercontent.com/43777855/93470391-82e85c80-f8fa-11ea-84e4-5ea770208737.png)
![image](https://user-images.githubusercontent.com/43777855/93470421-90054b80-f8fa-11ea-9390-f7ab0dc286bd.png)
![image](https://user-images.githubusercontent.com/43777855/93470445-9a274a00-f8fa-11ea-8d6c-1b04de6ea2be.png)

