### PR TITLE
feat: monitor dependencies with new ecosystem plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.1",
     "snyk-cpp-plugin": "2.0.0",
-    "snyk-docker-plugin": "3.24.0",
+    "snyk-docker-plugin": "snyk/snyk-docker-plugin#feat/v4/scan-interface",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.6.3",
     "snyk-module": "3.1.0",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -7,7 +7,6 @@ import {
   SupportedCliCommands,
   SupportedUserReachableFacingCliArgs,
 } from '../lib/types';
-import { getContainerImageSavePath } from '../lib/container';
 
 export declare interface Global extends NodeJS.Global {
   ignoreUnknownCA: boolean;
@@ -170,13 +169,6 @@ export function args(rawArgv: string[]): Args {
     // if we failed to find a command, then default to an error
     method = require('../lib/errors/legacy-errors');
     argv._.push(command);
-  }
-
-  // TODO: Once experimental flag became default this block should be
-  // moved to inside the parseModes function for container mode
-  const imageSavePath = getContainerImageSavePath();
-  if (imageSavePath) {
-    argv['imageSavePath'] = imageSavePath;
   }
 
   if (command in SupportedCliCommands) {

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -37,6 +37,11 @@ import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import { getContributors } from '../../../lib/monitor/dev-count-analysis';
 import { FailedToRunTestError, MonitorError } from '../../../lib/errors';
 import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
+import {
+  getEcosystem,
+  getFormattedMonitorOutput,
+  monitorEcosystem,
+} from '../../../lib/ecosystems';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 const debug = Debug('snyk');
@@ -93,6 +98,24 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     } catch (err) {
       debug('error getting repo contributors', err);
     }
+  }
+
+  const ecosystem = getEcosystem(options);
+  if (ecosystem) {
+    const commandResult = await monitorEcosystem(
+      ecosystem,
+      args as string[],
+      options,
+    );
+
+    const [monitorResults, monitorErrors] = commandResult;
+
+    return await getFormattedMonitorOutput(
+      results,
+      monitorResults,
+      monitorErrors,
+      options,
+    );
   }
 
   // Part 1: every argument is a scan target; process them sequentially

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -1,4 +1,5 @@
 import * as abbrev from 'abbrev';
+import { getContainerImageSavePath } from '../lib/container';
 import { UnsupportedOptionCombinationError, CustomError } from '../lib/errors';
 
 interface ModeData {
@@ -18,9 +19,7 @@ const modes: Record<string, ModeData> = {
     allowedCommands: ['test', 'monitor'],
     config: (args): [] => {
       args['docker'] = true;
-      args['experimental'] = true;
-      args['app-vulns'] = args.json ? false : true;
-
+      args['imageSavePath'] = getContainerImageSavePath();
       return args;
     },
   },

--- a/src/lib/ecosystems-plugins.ts
+++ b/src/lib/ecosystems-plugins.ts
@@ -1,0 +1,82 @@
+import * as cppPlugin from 'snyk-cpp-plugin';
+import * as dockerPlugin from 'snyk-docker-plugin';
+import { DepGraphData } from '@snyk/dep-graph';
+import { Options } from './types';
+
+export interface Issue {
+  pkgName: string;
+  pkgVersion?: string;
+  issueId: string;
+  fixInfo: {
+    nearestFixedInVersion?: string;
+  };
+}
+
+export interface IssuesData {
+  [issueId: string]: {
+    id: string;
+    severity: string;
+    title: string;
+  };
+}
+
+export interface TestResult {
+  issues: Issue[];
+  issuesData: IssuesData;
+  depGraphData: DepGraphData;
+}
+
+export interface PluginResponse {
+  scanResults: ScanResult[];
+}
+
+export interface GitTarget {
+  remoteUrl: string;
+  branch: string;
+}
+
+export interface ContainerTarget {
+  image: string;
+}
+
+export interface ScanResult {
+  identity: Identity;
+  facts: Facts[];
+  name?: string;
+  policy?: string;
+  target?: GitTarget | ContainerTarget;
+}
+
+export interface Identity {
+  type: string;
+  targetFile?: string;
+  args?: { [key: string]: string };
+}
+
+export interface Facts {
+  type: string;
+  data: any;
+}
+
+export interface EcosystemPlugin {
+  scan: (options: Options) => Promise<PluginResponse>;
+  display: (
+    scanResults: ScanResult[],
+    testResults: TestResult[],
+    errors: string[],
+    options: Options,
+  ) => Promise<string>;
+}
+
+export type Ecosystem = 'cpp' | 'docker';
+
+const EcosystemPlugins: {
+  readonly [ecosystem in Ecosystem]: EcosystemPlugin;
+} = {
+  cpp: cppPlugin,
+  docker: dockerPlugin as any,
+};
+
+export function getPlugin(ecosystem: Ecosystem): EcosystemPlugin {
+  return EcosystemPlugins[ecosystem];
+}

--- a/src/lib/ecosystems.ts
+++ b/src/lib/ecosystems.ts
@@ -1,93 +1,63 @@
-import * as cppPlugin from 'snyk-cpp-plugin';
-import { DepGraphData } from '@snyk/dep-graph';
+import { InspectResult } from '@snyk/cli-interface/legacy/plugin';
+import chalk from 'chalk';
+
 import * as snyk from './index';
 import * as config from './config';
 import { isCI } from './is-ci';
 import { makeRequest } from './request/promise';
-import { Options } from './types';
+import { MonitorResult, Options } from './types';
 import { TestCommandResult } from '../cli/commands/types';
 import * as spinner from '../lib/spinner';
+import { formatMonitorOutput } from '../cli/commands/monitor/formatters/format-monitor-response';
+import { GoodResult, BadResult } from '../cli/commands/monitor/types';
+import { MonitorError } from './errors';
+import { getExtraProjectCount } from './plugins/get-extra-project-count';
+import {
+  Ecosystem,
+  getPlugin,
+  ScanResult,
+  TestResult,
+} from './ecosystems-plugins';
 
-export interface PluginResponse {
-  scanResults: ScanResult[];
+const SEPARATOR = '\n-------------------------------------------------------\n';
+
+export interface EcosystemMonitorError {
+  error: string;
+  path: string;
+  scanResult: ScanResult;
 }
 
-export interface GitTarget {
-  remoteUrl: string;
-  branch: string;
+export interface MonitorDependenciesResponse {
+  ok: boolean;
+  org: string;
+  id: string;
+  isMonitored: boolean;
+  licensesPolicy: any;
+  uri: string;
+  trialStarted: boolean;
+  path: string;
+  projectName: string;
 }
 
-export interface ContainerTarget {
-  image: string;
+export interface EcosystemMonitorResult extends MonitorDependenciesResponse {
+  scanResult: ScanResult;
 }
 
-export interface ScanResult {
-  identity: Identity;
-  facts: Facts[];
-  name?: string;
+export interface MonitorDependenciesRequest {
+  scanResult: ScanResult;
+
+  /** If provided, overrides the default project name (usually equivalent to the root package). */
+  projectName?: string;
   policy?: string;
-  target?: GitTarget | ContainerTarget;
-}
-
-export interface Identity {
-  type: string;
-  targetFile?: string;
-  args?: { [key: string]: string };
-}
-
-export interface Facts {
-  type: string;
-  data: any;
-}
-
-export interface Issue {
-  pkgName: string;
-  pkgVersion?: string;
-  issueId: string;
-  fixInfo: {
-    nearestFixedInVersion?: string;
-  };
-}
-
-export interface IssuesData {
-  [issueId: string]: {
-    id: string;
-    severity: string;
-    title: string;
-  };
-}
-
-export interface TestResult {
-  issues: Issue[];
-  issuesData: IssuesData;
-  depGraphData: DepGraphData;
-}
-
-export interface EcosystemPlugin {
-  scan: (options: Options) => Promise<PluginResponse>;
-  display: (
-    scanResults: ScanResult[],
-    testResults: TestResult[],
-    errors: string[],
-    options: Options,
-  ) => Promise<string>;
-}
-
-export type Ecosystem = 'cpp';
-
-const EcosystemPlugins: {
-  readonly [ecosystem in Ecosystem]: EcosystemPlugin;
-} = {
-  cpp: cppPlugin,
-};
-
-export function getPlugin(ecosystem: Ecosystem): EcosystemPlugin {
-  return EcosystemPlugins[ecosystem];
+  method?: 'cli';
 }
 
 export function getEcosystem(options: Options): Ecosystem | null {
   if (options.source) {
     return 'cpp';
+  }
+  if (options.docker) {
+    return 'docker';
   }
   return null;
 }
@@ -157,4 +127,150 @@ export async function testDependencies(scans: {
   }
   spinner.clearAll();
   return [results, errors];
+}
+
+export async function monitorEcosystem(
+  ecosystem: Ecosystem,
+  paths: string[],
+  options: Options,
+): Promise<[EcosystemMonitorResult[], EcosystemMonitorError[]]> {
+  const plugin = getPlugin(ecosystem);
+  const scanResultsByPath: { [dir: string]: ScanResult[] } = {};
+  for (const path of paths) {
+    await spinner(`Analyzing dependencies in ${path}`);
+    options.path = path;
+    const pluginResponse = await plugin.scan(options);
+    scanResultsByPath[path] = pluginResponse.scanResults;
+  }
+  const [monitorResults, errors] = await monitorDependencies(
+    scanResultsByPath,
+    options,
+  );
+  return [monitorResults, errors];
+}
+
+function generateMonitorDependenciesRequest(
+  scanResult: ScanResult,
+  options: Options,
+): MonitorDependenciesRequest {
+  return {
+    scanResult,
+    method: 'cli',
+    projectName: options['project-name'] || config.PROJECT_NAME || undefined,
+  };
+}
+
+export async function monitorDependencies(
+  scans: {
+    [dir: string]: ScanResult[];
+  },
+  options: Options,
+): Promise<[EcosystemMonitorResult[], EcosystemMonitorError[]]> {
+  const results: EcosystemMonitorResult[] = [];
+  const errors: EcosystemMonitorError[] = [];
+  for (const [path, scanResults] of Object.entries(scans)) {
+    await spinner(`Monitoring dependencies in ${path}`);
+    for (const scanResult of scanResults) {
+      const monitorDependenciesRequest = generateMonitorDependenciesRequest(
+        scanResult,
+        options,
+      );
+
+      monitorDependenciesRequest.scanResult.facts = monitorDependenciesRequest.scanResult.facts.filter(
+        (fact) => fact.type !== 'imageOsReleasePrettyName',
+      );
+
+      const payload = {
+        method: 'PUT',
+        url: `${config.API}/monitor-dependencies`,
+        json: true,
+        headers: {
+          'x-is-ci': isCI(),
+          authorization: 'token ' + snyk.api,
+        },
+        body: monitorDependenciesRequest,
+      };
+      try {
+        const response = await makeRequest<MonitorDependenciesResponse>(
+          payload,
+        );
+        results.push({
+          ...response,
+          path,
+          scanResult,
+        });
+      } catch (error) {
+        if (error.code >= 400 && error.code < 500) {
+          throw new Error(error.message);
+        }
+        errors.push({
+          error: 'Could not monitor dependencies in ' + path,
+          path,
+          scanResult,
+        });
+      }
+    }
+  }
+  spinner.clearAll();
+  return [results, errors];
+}
+
+export async function getFormattedMonitorOutput(
+  results: Array<GoodResult | BadResult>,
+  monitorResults: EcosystemMonitorResult[],
+  errors: EcosystemMonitorError[],
+  options: Options,
+): Promise<string> {
+  for (const monitorResult of monitorResults) {
+    const monOutput = formatMonitorOutput(
+      monitorResult.scanResult.identity.type,
+      monitorResult as MonitorResult,
+      options,
+      monitorResult.projectName,
+      await getExtraProjectCount(
+        monitorResult.path,
+        options,
+        // TODO: Fix to pass the old "inspectResult.plugin.meta.allSubProjectNames", which ecosystem uses this?
+        {} as InspectResult,
+      ),
+    );
+    results.push({
+      ok: true,
+      data: monOutput,
+      path: monitorResult.path,
+      projectName: monitorResult.id,
+    });
+  }
+  for (const monitorError of errors) {
+    results.push({
+      ok: false,
+      data: new MonitorError(500, monitorError),
+      path: monitorError.path,
+    });
+  }
+
+  const outputString = results
+    .map((res) => {
+      if (res.ok) {
+        return res.data;
+      }
+
+      const errorMessage =
+        res.data && res.data.userMessage
+          ? chalk.bold.red(res.data.userMessage)
+          : res.data
+          ? res.data.message
+          : 'Unknown error occurred.';
+
+      return (
+        chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') + errorMessage
+      );
+    })
+    .join('\n' + SEPARATOR);
+
+  if (results.every((res) => res.ok)) {
+    return outputString;
+  }
+
+  throw new Error(outputString);
 }

--- a/src/lib/plugins/get-single-plugin-result.ts
+++ b/src/lib/plugins/get-single-plugin-result.ts
@@ -8,7 +8,7 @@ export async function getSinglePluginResult(
   options: Options & (TestOptions | MonitorOptions),
   targetFile?: string,
 ): Promise<pluginApi.InspectResult> {
-  const plugin = plugins.loadPlugin(options.packageManager, options);
+  const plugin = plugins.loadPlugin(options.packageManager);
   const moduleInfo = ModuleInfo(plugin, options.policy);
   const inspectRes: pluginApi.InspectResult = await moduleInfo.inspect(
     root,

--- a/src/lib/plugins/index.ts
+++ b/src/lib/plugins/index.ts
@@ -1,4 +1,3 @@
-import * as dockerPlugin from 'snyk-docker-plugin';
 import * as rubygemsPlugin from './rubygems';
 import * as mvnPlugin from 'snyk-mvn-plugin';
 import * as gradlePlugin from 'snyk-gradle-plugin';
@@ -15,12 +14,7 @@ import { UnsupportedPackageManagerError } from '../errors';
 
 export function loadPlugin(
   packageManager: SupportedPackageManagers | undefined,
-  options: types.Options = {},
 ): types.Plugin {
-  if (options.docker) {
-    return dockerPlugin;
-  }
-
   switch (packageManager) {
     case 'npm': {
       return nodejsPlugin;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -45,6 +45,7 @@ export interface Options {
   org?: string | null;
   path: string;
   docker?: boolean;
+  container?: boolean; // Container Ecosystem Support
   iac?: boolean;
   source?: boolean; // C/C++ Ecosystem Support
   file?: string;
@@ -69,10 +70,6 @@ export interface Options {
   detectionDepth?: number;
   exclude?: string;
   strictOutOfSync?: boolean;
-  // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
-  experimental?: boolean;
-  // Used with the Docker plugin only. Allows application scanning.
-  'app-vulns'?: boolean;
   debug?: boolean;
   sarif?: boolean;
 }
@@ -92,10 +89,6 @@ export interface MonitorOptions {
   allProjects?: boolean;
   // An experimental flag to allow monitoring of bigtrees (with degraded deps info and remediation advice).
   pruneRepeatedSubdependencies?: boolean;
-  // Used with the Docker plugin only. Allows requesting some experimental/unofficial features.
-  experimental?: boolean;
-  // Used with the Docker plugin only. Allows application scanning.
-  'app-vulns'?: boolean;
   reachableVulns?: boolean;
   reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;

--- a/test/acceptance/cli-test/cli-test.docker.spec.ts
+++ b/test/acceptance/cli-test/cli-test.docker.spec.ts
@@ -52,9 +52,7 @@ export const DockerTests: AcceptanceTests = {
       );
     },
 
-    '`test docker-archive:foo.tar --docker --experimental`': (params) => async (
-      t,
-    ) => {
+    '`test docker-archive:foo.tar --docker`': (params) => async (t) => {
       const spyPlugin = stubDockerPluginResponse(
         params.plugins,
         {
@@ -68,8 +66,7 @@ export const DockerTests: AcceptanceTests = {
 
       await params.cli.test('docker-archive:foo.tar', {
         docker: true,
-        org: 'experimental-org',
-        experimental: true,
+        org: 'container-org',
       });
       const req = params.server.popRequest();
       t.equal(req.method, 'POST', 'makes POST request');
@@ -89,12 +86,11 @@ export const DockerTests: AcceptanceTests = {
             args: null,
             file: null,
             docker: true,
-            org: 'experimental-org',
+            org: 'container-org',
             projectName: null,
             packageManager: null,
             path: 'docker-archive:foo.tar',
             showVulnPaths: 'some',
-            experimental: true,
           },
         ],
         'calls docker plugin with expected arguments',

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -191,6 +191,15 @@ export function fakeServer(root, apikey) {
     return next();
   });
 
+  server.put(root + '/monitor-dependencies', (req, res, next) => {
+    res.send({
+      id: 'monitor',
+      uri: `${req.params.registry}/some/project-id`,
+      isMonitored: true,
+    });
+    return next();
+  });
+
   server.put(root + '/monitor/:registry', (req, res, next) => {
     res.send({
       id: 'monitor',

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -161,7 +161,6 @@ test('test command line "container test"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
-  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -174,7 +173,6 @@ test('test command line "container monitor"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
-  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -187,7 +185,6 @@ test('test command line "container protect"', (t) => {
   ];
   const result = args(cliArgs);
   t.notOk(result.options.docker);
-  t.notOk(result.options.experimental);
   t.end();
 });
 

--- a/test/ecosystems.spec.ts
+++ b/test/ecosystems.spec.ts
@@ -37,6 +37,15 @@ describe('ecosystems', () => {
       const expected = 'cpp';
       expect(actual).toBe(expected);
     });
+    it('should return docker ecosystem when options docker is true', () => {
+      const options: Options = {
+        docker: true,
+        path: '',
+      };
+      const actual = ecosystems.getEcosystem(options);
+      const expected = 'docker';
+      expect(actual).toBe(expected);
+    });
     it('should return null when options source is false', () => {
       const options: Options = {
         source: false,

--- a/test/modes.spec.ts
+++ b/test/modes.spec.ts
@@ -117,8 +117,6 @@ describe('when have a valid mode and command', () => {
     const expectedArgs = {
       _: [],
       docker: true,
-      experimental: true,
-      'app-vulns': true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -132,7 +130,6 @@ describe('when have a valid mode and command', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
   });
 
   it('"source test" should set source option and test command', () => {
@@ -159,8 +156,6 @@ describe('when have a valid mode, command and exists a command alias', () => {
     const expectedArgs = {
       _: [],
       docker: true,
-      experimental: true,
-      'app-vulns': true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -174,17 +169,14 @@ describe('when have a valid mode, command and exists a command alias', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
   });
 
-  it('"container test" should set docker option and not app-vulns and test command', () => {
+  it('"container test" should set docker option and test command', () => {
     const expectedCommand = 't';
     const expectedArgs = {
       _: [],
       json: true,
       docker: true,
-      experimental: true,
-      'app-vulns': false,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -199,7 +191,6 @@ describe('when have a valid mode, command and exists a command alias', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
   });
 });
 
@@ -221,7 +212,6 @@ describe('when have a valid mode and not allowed command', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeFalsy();
-    expect(cliArgs['experimental']).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
- [ ] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Adds support for the new `monitor` flow used by the ecosystems plugin format ([#project-envelope](https://snyk.slack.com/archives/C01342FUD53)).

#### Any background context you want to provide?

This currently uses a spike branch for `snyk-docker-plugin`, we still need to release a new version of the plugin and only then we can merge this PR.

#### What are the relevant tickets?

[Jira ticket RUN-1181](https://snyksec.atlassian.net/browse/RUN-1181)
