### PR TITLE
feat: [RUN-1197] Fail 'snyk container' if '--platform' unsupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.1",
     "snyk-cpp-plugin": "2.0.0",
-    "snyk-docker-plugin": "3.23.0",
+    "snyk-docker-plugin": "3.24.0",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.6.3",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
We support the '--platform' flag only when Docker experimental features enabled, throwing a user friendly error otherwise.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/RUN-1197
