### PR TITLE
feat: add url link to supported pkg mngrs for  --reachable

### DIFF
--- a/src/lib/errors/feature-not-supported-by-package-manager-error.ts
+++ b/src/lib/errors/feature-not-supported-by-package-manager-error.ts
@@ -2,10 +2,14 @@ import { CustomError } from './custom-error';
 import { SupportedPackageManagers } from '../package-managers';
 
 export class FeatureNotSupportedByPackageManagerError extends CustomError {
-  constructor(feature: string, packageManager: SupportedPackageManagers) {
+  constructor(
+    feature: string,
+    packageManager: SupportedPackageManagers,
+    additionalUserHelp = '',
+  ) {
     super(`Unsupported package manager ${packageManager} for ${feature}.`);
     this.code = 422;
 
-    this.userMessage = `'${feature}' is not supported for package manager '${packageManager}'.`;
+    this.userMessage = `'${feature}' is not supported for package manager '${packageManager}'. ${additionalUserHelp}`;
   }
 }

--- a/src/lib/reachable-vulns.ts
+++ b/src/lib/reachable-vulns.ts
@@ -43,6 +43,7 @@ export async function validatePayload(
     throw new FeatureNotSupportedByPackageManagerError(
       'Reachable vulns',
       packageManager,
+      `For a list of supported package managers go to https://support.snyk.io/hc/en-us/articles/360010554837-Reachable-Vulnerabilities`,
     );
   }
   const reachableVulnsSupportedRes = await isFeatureFlagSupportedForOrg(

--- a/test/acceptance/cli-reachable-vulns.test.ts
+++ b/test/acceptance/cli-reachable-vulns.test.ts
@@ -56,7 +56,7 @@ test('test vulnerable project with --reachable-vulns not supported package manag
     t.equal(err.code, 422, 'should throw exception');
     t.equal(
       err.userMessage,
-      `'Reachable vulns' is not supported for package manager 'npm'.`,
+      `'Reachable vulns' is not supported for package manager 'npm'. For a list of supported package managers go to https://support.snyk.io/hc/en-us/articles/360010554837-Reachable-Vulnerabilities`,
       'correct user message',
     );
   }
@@ -72,7 +72,7 @@ test('monitor vulnerable project with --reachable-vulns not supported package ma
   } catch (err) {
     t.match(
       err.message,
-      `'Reachable vulns' is not supported for package manager 'gradle'.`,
+      `'Reachable vulns' is not supported for package manager 'gradle'. For a list of supported package managers go to https://support.snyk.io/hc/en-us/articles/360010554837-Reachable-Vulnerabilities`,
     );
   }
 });

--- a/test/dev-count-analysis.spec.ts
+++ b/test/dev-count-analysis.spec.ts
@@ -1,7 +1,8 @@
 import { getContributors } from '../src/lib/monitor/dev-count-analysis';
 
+//TODO (Hammer): Correct flaky test
 describe('cli dev count via git log analysis', () => {
-  it('returns contributors', async () => {
+  it.skip('returns contributors', async () => {
     const contributors = await getContributors({
       endDate: new Date(1590174610000),
       periodDays: 10,

--- a/test/reachable-vulns.test.ts
+++ b/test/reachable-vulns.test.ts
@@ -169,7 +169,7 @@ test('validatePayload - not supported package manager', async (t) => {
   const pkgManagers = Object.keys(SUPPORTED_PACKAGE_MANAGER_NAME);
   const mavenIndex = pkgManagers.indexOf('maven');
   pkgManagers.splice(mavenIndex, 1); // remove maven as it's supported
-  t.plan(pkgManagers.length * 2);
+  t.plan(pkgManagers.length * 3);
 
   for (const pkgManager of pkgManagers) {
     try {
@@ -183,6 +183,11 @@ test('validatePayload - not supported package manager', async (t) => {
       t.equal(
         err.message,
         `Unsupported package manager ${pkgManager} for Reachable vulns.`,
+        'correct error message',
+      );
+      t.equal(
+        err.userMessage,
+        `'Reachable vulns' is not supported for package manager '${pkgManager}'. For a list of supported package managers go to https://support.snyk.io/hc/en-us/articles/360010554837-Reachable-Vulnerabilities`,
         'correct error message',
       );
       t.equal(err.code, 422, 'correct error code');


### PR DESCRIPTION
- [ x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When a developer tries to run the Reachable Vulnerability feature (snyk test --reachable) for a non-supported package manager, we want to direct them to a web page where they can view which package managers we do support this feature.

#### Where should the reviewer start?
I would advise starting test test/reachable-vulns.test.ts line 168. You can see the expected message on line 190.

#### How should this be manually tested?
run a local build with parameters `test --reachable`
Output should be:
'Reachable vulns' is not supported for package manager 'npm'. For a list of supported package managers go to https://support.snyk.io/hc/en-us/articles/360010554837-Reachable-Vulnerabilities
Unless you're testing with another package manager, then the package manager name will be different

#### Any background context you want to provide?
Change provides more context to developer about which package managers Reachable Vulnerabilities works for.
Note test/dev-count-analysis.spec.ts was disabled with agreement from Jeff McLean.

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/projects/FLOW/boards/96?selectedIssue=FLOW-401

#### Screenshots
<img width="1366" alt="Screenshot 2020-09-24 at 11 35 34" src="https://user-images.githubusercontent.com/245346/94295189-c70dd980-ff58-11ea-93ed-920a1d1fc338.png">

#### Additional questions
NOT breaking change
NO db migration