### PR TITLE
feat: add tracking for netlify plugin as source

### DIFF
--- a/src/lib/analytics-sources.ts
+++ b/src/lib/analytics-sources.ts
@@ -39,6 +39,10 @@ enum TrackedIntegration {
 
   // Partner integrations - tracked by passing envvar on CLI invocation
   DOCKER_DESKTOP = 'DOCKER_DESKTOP',
+
+  // DevRel integrations and plugins
+  // Netlify plugin: https://github.com/snyk-labs/netlify-plugin-snyk
+  NETLIFY_PLUGIN = 'NETLIFY_PLUGIN',
 }
 
 // TODO: propagate these to the UTM params


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Adds an expected environment variable for the Netlify plugin as a source for tracking Snyk CLI analytics usage

#### Where should the reviewer start?
Here, and then view the associated update for the plugin here: https://github.com/snyk-labs/netlify-plugin-snyk/pull/5
