### PR TITLE
Pass integration name and version to UTM parameters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,14 @@
         "--node-arg=-r",
         "--node-arg=ts-node/register"
       ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "console": "integratedTerminal",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${relativeFile}"]
     }
   ]
 }

--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -7,6 +7,7 @@ import { Spinner } from 'cli-spinner';
 import * as snyk from '../../../lib';
 import { verifyAPI } from './is-authed';
 import { isCI } from '../../../lib/is-ci';
+import { args as argsLib } from '../../args';
 import * as config from '../../../lib/config';
 import request = require('../../../lib/request');
 import { CustomError } from '../../../lib/errors';
@@ -37,7 +38,9 @@ async function webAuth(via: AuthCliCommands) {
 
   let urlStr = authUrl + '/login?token=' + token;
 
-  const utmParams = getQueryParamsAsString();
+  // It's not optimal, but I have to parse args again here. Alternative is reworking everything about how we parse args
+  const args = [argsLib(process.argv).options];
+  const utmParams = getQueryParamsAsString(args);
   if (utmParams) {
     urlStr += '&' + utmParams;
   }

--- a/src/lib/analytics-sources.ts
+++ b/src/lib/analytics-sources.ts
@@ -10,6 +10,7 @@
 
 const debug = require('debug')('snyk');
 import * as fs from 'fs';
+import { ArgsOptions } from '../cli/args';
 
 export const INTEGRATION_NAME_HEADER = 'SNYK_INTEGRATION_NAME';
 export const INTEGRATION_VERSION_HEADER = 'SNYK_INTEGRATION_VERSION';
@@ -48,8 +49,7 @@ enum TrackedIntegration {
   NETLIFY_PLUGIN = 'NETLIFY_PLUGIN',
 }
 
-// TODO: propagate these to the UTM params
-export const getIntegrationName = (args: Array<any>): string => {
+export const getIntegrationName = (args: ArgsOptions[]): string => {
   const maybeScoop = isScoop() ? 'SCOOP' : '';
   const integrationName = String(
     args[0]?.integrationName || // Integration details passed through CLI flag
@@ -64,7 +64,7 @@ export const getIntegrationName = (args: Array<any>): string => {
   return '';
 };
 
-export const getIntegrationVersion = (args): string => {
+export const getIntegrationVersion = (args: ArgsOptions[]): string => {
   // Integration details passed through CLI flag
   const integrationVersion = String(
     args[0]?.integrationVersion ||

--- a/src/lib/query-strings.ts
+++ b/src/lib/query-strings.ts
@@ -1,22 +1,33 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import * as url from 'url';
 import * as os from 'os';
+import { ArgsOptions } from './../cli/args';
 import { isDocker } from './is-docker';
+import { getIntegrationName, getIntegrationVersion } from './analytics-sources';
 
-export function getQueryParamsAsString(): string {
-  const SNYK_UTM_MEDIUM = process.env.SNYK_UTM_MEDIUM || 'cli';
-  const SNYK_UTM_SOURCE = process.env.SNYK_UTM_SOURCE || 'cli';
-  const SNYK_UTM_CAMPAIGN = process.env.SNYK_UTM_CAMPAIGN || 'cli';
+export function getQueryParamsAsString(args: ArgsOptions[]): string {
+  const utm_source = process.env.SNYK_UTM_SOURCE || 'cli';
+  const utm_medium = process.env.SNYK_UTM_MEDIUM || 'cli';
+  const utm_campaign =
+    process.env.SNYK_UTM_CAMPAIGN || getIntegrationName(args) || 'cli';
+  const utm_campaign_content =
+    process.env.SNYK_UTM_CAMPAIGN_CONTENT || getIntegrationVersion(args);
   const osType = os.type()?.toLowerCase();
   const docker = isDocker().toString();
 
-  /* eslint-disable @typescript-eslint/camelcase */
   const queryParams = new url.URLSearchParams({
-    utm_medium: SNYK_UTM_MEDIUM,
-    utm_source: SNYK_UTM_SOURCE,
-    utm_campaign: SNYK_UTM_CAMPAIGN,
+    utm_medium,
+    utm_source,
+    utm_campaign,
+    utm_campaign_content,
     os: osType,
     docker,
   });
-  /* eslint-enable @typescript-eslint/camelcase */
+
+  // It may not be set and URLSearchParams won't filter out undefined values
+  if (!utm_campaign_content) {
+    queryParams.delete('utm_campaign_content');
+  }
+
   return queryParams.toString();
 }

--- a/test/analytics-sources.spec.ts
+++ b/test/analytics-sources.spec.ts
@@ -8,6 +8,10 @@ import {
 } from '../src/lib/analytics-sources';
 
 const emptyArgs = [];
+const defaultArgsParams = {
+  _: [],
+  _doubleDashArgs: [],
+};
 
 beforeEach(() => {
   delete process.env[INTEGRATION_NAME_HEADER];
@@ -62,13 +66,19 @@ describe('analytics-sources - getIntegrationName', () => {
   });
 
   it('integration name is loaded and formatted from CLI flag', () => {
-    expect(getIntegrationName([{ integrationName: 'homebrew' }])).toBe(
-      'HOMEBREW',
-    );
+    expect(
+      getIntegrationName([
+        { integrationName: 'homebrew', ...defaultArgsParams },
+      ]),
+    ).toBe('HOMEBREW');
   });
 
   it('integration name is loaded and validated from CLI flag', () => {
-    expect(getIntegrationName([{ integrationName: 'invalid' }])).toBe('');
+    expect(
+      getIntegrationName([
+        { integrationName: 'invalid', ...defaultArgsParams },
+      ]),
+    ).toBe('');
   });
 
   it('integration name SCOOP when snyk is installed with scoop', () => {
@@ -95,7 +105,9 @@ describe('analytics-sources - getIntegrationVersion', () => {
 
   it('integration version is loaded from CLI flag', () => {
     expect(
-      getIntegrationVersion([{ integrationVersion: '1.2.3-Crystal' }]),
+      getIntegrationVersion([
+        { integrationVersion: '1.2.3-Crystal', ...defaultArgsParams },
+      ]),
     ).toBe('1.2.3-Crystal');
   });
 });

--- a/test/query-strings.spec.ts
+++ b/test/query-strings.spec.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/camelcase */
+import * as url from 'url';
+import { getQueryParamsAsString } from '../src/lib/query-strings';
+
+describe('Query strings', () => {
+  it('returns a string', () => {
+    expect(typeof getQueryParamsAsString([])).toBe('string');
+  });
+
+  it("returns a string that's a valid URL query string", () => {
+    // Object.fromEntries is not available for Node 8 and 10. Testing this in latest Node is enough
+    if (Object.fromEntries) {
+      expect(
+        Object.fromEntries(new url.URLSearchParams(getQueryParamsAsString([]))),
+      ).toStrictEqual({
+        utm_medium: 'cli',
+        utm_source: 'cli',
+        utm_campaign: 'cli',
+        os: expect.any(String),
+        docker: expect.any(String),
+      });
+    }
+  });
+
+  it('uses integration name and version', () => {
+    process.env.SNYK_INTEGRATION_NAME = 'NPM';
+    process.env.SNYK_INTEGRATION_VERSION = '1.2.3';
+
+    // Object.fromEntries is not available for Node 8 and 10. Testing this in latest Node is enough
+    if (Object.fromEntries) {
+      expect(
+        Object.fromEntries(new url.URLSearchParams(getQueryParamsAsString([]))),
+      ).toStrictEqual({
+        utm_source: 'cli',
+        utm_medium: 'cli',
+        utm_campaign: 'NPM',
+        utm_campaign_content: '1.2.3',
+        os: expect.any(String),
+        docker: expect.any(String),
+      });
+    }
+
+    delete process.env.SNYK_INTEGRATION_NAME;
+    delete process.env.SNYK_INTEGRATION_VERSION;
+  });
+});


### PR DESCRIPTION
This PR propagates integration names to the UTM parameters used for `$ snyk auth` command.

You can check the logic https://github.com/snyk/snyk/pull/1432/files#diff-a66b785903d0b694ec783784733b20a3, but in general it will result in this:

- UTM_MEDIUM = 'cli' 
- UTM_SOURCE = 'cli'
- UTM_CAMPAIGN = integrationName https://github.com/snyk/snyk/blob/master/src/lib/analytics-sources.ts#L14 e.g. `JENKINS` 
- UTM_CAMPAIGN_CONTENT = integrationVersion e.g. `2.12.1`

HAMMER-117