### PR TITLE
Cleaner Smoke test output

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,7 +2,7 @@ name: Smoke Tests
 
 on:
   push:
-    branches: [feat/smoke-test]
+    branches: [feat/smoke-test, smoke/**]
   release:
     types: [published]
   schedule:

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -37,12 +37,12 @@ if (danger.github && danger.github.pr) {
   }
 
   // Forgotten tests check
-  const modifiedTest = danger.git.modified_files.some((f) =>
-    f.startsWith('test/'),
-  );
-  const modifiedSrc = danger.git.modified_files.some((f) =>
-    f.startsWith('src/'),
-  );
+  const modifiedTest =
+    danger.git.modified_files.some((f) => f.startsWith('test/')) ||
+    danger.git.created_files.some((f) => f.startsWith('test/'));
+  const modifiedSrc =
+    danger.git.modified_files.some((f) => f.startsWith('src/')) ||
+    danger.git.created_files.some((f) => f.startsWith('src/'));
 
   if (modifiedSrc && !modifiedTest) {
     // TODO: let's be careful about wording here. Maybe including Contributing guidelines and project goals document here
@@ -54,6 +54,7 @@ if (danger.github && danger.github.pr) {
   // Smoke test modification check
   const modifiedSmokeTest =
     danger.git.modified_files.some((f) => f.startsWith('test/smoke/')) ||
+    danger.git.created_files.some((f) => f.startsWith('test/smoke/')) ||
     danger.git.modified_files.includes(SMOKE_TEST_WORKFLOW_FILE_PATH);
 
   const isOnSmokeTestBranch = danger.github.pr.head.ref === SMOKE_TEST_BRANCH;

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -15,7 +15,7 @@ Smoke tests should be fast. Ideally tests only things that could break when CLI 
 
 Before you start adding specs, those files are bash scripts, it's recommended to have a [ShellCheck](https://www.shellcheck.net) installed and running in your IDE. See [Shellspec reference](https://github.com/shellspec/shellspec/blob/master/docs/references.md#expectation) for available commands.
 
-It's recommended to have a branch named `feat/smoke-test`, as [this branch will run the GitHub Action](https://github.com/snyk/snyk/blob/f35f39e96ef7aa69b22a846315dda015b12a4564/.github/workflows/smoke-tests.yml#L3-L5).
+It's recommended to have a branch named `smoke/_SOMETHING_`, as [this branch will run the GitHub Action](https://github.com/snyk/snyk/blob/f35f39e96ef7aa69b22a846315dda015b12a4564/.github/workflows/smoke-tests.yml#L3-L5).
 
 To run these tests locally:
 

--- a/test/smoke/alpine/Dockerfile
+++ b/test/smoke/alpine/Dockerfile
@@ -1,9 +1,7 @@
 FROM shellspec/shellspec:latest
 
 COPY ./smoke/ /snyk/smoke/
-COPY ./fixtures/basic-npm/ /snyk/fixtures/basic-npm/
-COPY ./fixtures/empty/ /snyk/fixtures/empty/
-COPY ./fixtures/iac/ /snyk/fixtures/iac/ 
+COPY ./fixtures/ /snyk/fixtures/
 
 RUN shellspec --version
 RUN apk add curl jq libgcc libstdc++

--- a/test/smoke/spec/snyk_auth_spec.sh
+++ b/test/smoke/spec/snyk_auth_spec.sh
@@ -17,7 +17,10 @@ Describe "Snyk CLI Authorization"
 
     It "fails when run without token set"
       # Alpine can't open browser, misses xdg-open utility and errors out
-      is_alpine() { grep "Alpine Linux" < /etc/os-release; }
+      is_alpine() {
+        grep "Alpine Linux" /etc/os-release > /dev/null 2>&1
+        return $?
+      }
       Skip if "function returns success" is_alpine
 
       # Using timeout to not wait for browser confirmation

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -6,11 +6,11 @@ print_snyk_config() {
 }
 
 snyk_login() {
-  snyk auth "${SMOKE_TESTS_SNYK_TOKEN}"
+  snyk auth "${SMOKE_TESTS_SNYK_TOKEN}" > /dev/null 2>&1
 }
 
 snyk_logout() {
-  snyk config clear
+  snyk config clear > /dev/null 2>&1
 }
 
 verify_login_url() {


### PR DESCRIPTION
This PR clears the output of Smoke test commands, by silencing some before/after hooks. And fixes an issue on Windows.

### Before

<img width="609" alt="Screenshot 2020-09-30 at 13 55 53" src="https://user-images.githubusercontent.com/1788727/94682132-cc866d80-0324-11eb-87bd-5fcb28b513d0.png">

### After

<img width="577" alt="Screenshot 2020-09-30 at 13 56 28" src="https://user-images.githubusercontent.com/1788727/94682166-d7410280-0324-11eb-976d-e9433e73b412.png">
