### PR TITLE
refactor: circle-ci jvm unix using sdkman install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,10 @@ commands:
           root: .
           paths:
             - dist/
+  install_gradle_windows:
+    description: Install gradle
+    steps:
+      - run: choco install gradle
   install_maven_windows:
     description: Install maven
     steps:
@@ -44,19 +48,39 @@ commands:
     description: Install SBT
     steps:
       - run: choco install sbt
+  install_sdkman_unix:
+    description: Install SDKMAN
+    steps:
+      - run:
+          name: Installing SDKMAN
+          command: |
+            curl -s "https://get.sdkman.io?rcupdate=false" | bash
+            echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
+            source $BASH_ENV
+  install_jdk_unix:
+    description: Install JDK
+    steps:
+      - run:
+          name: Installing JDK
+          command: sdk install java $(sdk list java | grep -o -m1 "11\.[0-9\.]\+hs-adpt")
+  install_gradle_unix:
+    description: Install gradle
+    steps:
+      - run:
+          name: Installing Gradle
+          command: sdk install gradle 6.4.1
   install_maven_unix:
     description: Install maven
     steps:
-      - run: sudo apt update
-      - run: sudo apt install -y maven
+      - run:
+          name: Installing maven
+          command: sdk install maven 3.6.3
   install_sbt_unix:
     description: Install SBT
     steps:
-      - run: sudo apt install apt-transport-https ca-certificates
-      - run: echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list
-      - run: curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | sudo apt-key add
-      - run: sudo apt update
-      - run: sudo apt install -y sbt
+      - run: 
+          name: Installing sbt
+          command: sdk install sbt 1.3.12
   install_node_npm:
     description: Install correct Node version
     parameters:
@@ -135,6 +159,7 @@ jobs:
     <<: *windows_defaults
     steps:
       - run: git config --global core.autocrlf false
+      - install_gradle_windows
       - install_maven_windows
       - install_sbt_windows
       - install_node_npm:
@@ -160,6 +185,9 @@ jobs:
     docker:
       - image: circleci/node:<< parameters.node_version >>
     steps:
+      - install_sdkman_unix
+      - install_jdk_unix
+      - install_gradle_unix
       - install_maven_unix
       - install_sbt_unix
       - show_node_version


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Gives a standard approach to install JVM ecosystems for unix (maven, gradle and sbt) by Using SDKMAN, 
and introduces `install_gradle_unix` & `install_gradle_windows`