### PR TITLE
fix: container test should not run app vulns scan by default

### DIFF
--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -19,7 +19,6 @@ const modes: Record<string, ModeData> = {
     config: (args): [] => {
       args['docker'] = true;
       args['experimental'] = true;
-      args['app-vulns'] = args.json ? false : true;
 
       return args;
     },

--- a/test/modes.spec.ts
+++ b/test/modes.spec.ts
@@ -118,7 +118,6 @@ describe('when have a valid mode and command', () => {
       _: [],
       docker: true,
       experimental: true,
-      'app-vulns': true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -160,37 +159,11 @@ describe('when have a valid mode, command and exists a command alias', () => {
       _: [],
       docker: true,
       experimental: true,
-      'app-vulns': true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
     const cliArgs = {
       _: ['t'],
-      'package-manager': 'pip',
-    };
-
-    const command = parseMode(cliCommand, cliArgs);
-
-    expect(command).toBe(expectedCommand);
-    expect(cliArgs).toEqual(expectedArgs);
-    expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
-  });
-
-  it('"container test" should set docker option and not app-vulns and test command', () => {
-    const expectedCommand = 't';
-    const expectedArgs = {
-      _: [],
-      json: true,
-      docker: true,
-      experimental: true,
-      'app-vulns': false,
-      'package-manager': 'pip',
-    };
-    const cliCommand = 'container';
-    const cliArgs = {
-      _: ['t'],
-      json: true,
       'package-manager': 'pip',
     };
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

removes containers test default `--app-vulns` scan

#### How should this be manually tested?

* `snyk container test mladkau/snykin`

#### Any background context you want to provide?

[Slack Thread](https://snyk.slack.com/archives/CDSMEJ29E/p1601447472250500?thread_ts=1601396580.226500&cid=CDSMEJ29E)

#### What are the relevant tickets?

[DC-852](https://snyksec.atlassian.net/browse/DC-852)

