### PR TITLE
Warn on new tap tests with dangerjs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -51,6 +51,19 @@ if (danger.github && danger.github.pr) {
     );
   }
 
+  const newTestFiles = danger.git.created_files.filter((f) => {
+    const inTestFolder = f.startsWith('test/');
+    const inLegacyAcceptanceTestsFolder = f.includes('test/acceptance/');
+    const testFilenameLooksLikeJest = f.includes('.spec.ts');
+    return inTestFolder && !inLegacyAcceptanceTestsFolder && !testFilenameLooksLikeJest;
+  });
+
+  if (newTestFiles) {
+    const joinedFileList = newTestFiles.map(f => '- `' + f + '`').join("\n");
+    const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files like \`test/*.spec.ts\` for examples. Files found:\n${joinedFileList}`;
+    warn(msg);
+  }
+
   // Smoke test modification check
   const modifiedSmokeTest =
     danger.git.modified_files.some((f) => f.startsWith('test/smoke/')) ||


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Warns if you create a new Tap test file and suggests making anew Jest test file instead.

#### Any background context you want to provide?
We want people to stop making new Tap tests and make Jest tests instead.
This won't warn if you're adding a new test to an existing Tap test file.
