### PR TITLE
fix: align PRUNE_DEPS_THRESHOLD with internal value

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,6 +1,6 @@
 {
   "API": "https://snyk.io/api/v1",
   "devDeps": false,
-  "PRUNE_DEPS_THRESHOLD": 40000,
+  "PRUNE_DEPS_THRESHOLD": 20000,
   "MAX_PATH_COUNT": 1500000
 }


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Aligns the threshold for pruning dependencies with our internal value of 20,000