### PR TITLE
fix: update docker-legacy plugin name to resolve npm@5 issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.1",
     "snyk-cpp-plugin": "2.0.0",
-    "legacy-snyk-docker-plugin": "snyk/snyk-docker-plugin#v3.26.2",
+    "legacy-snyk-docker-plugin": "snyk/snyk-docker-plugin#v3.26.3",
     "snyk-docker-plugin": "4.1.1",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.0",


### PR DESCRIPTION
Possible fix for #1453 - we've pushed a new tag with correct name package name