### PR TITLE
feat: make reachability wording consistent

### DIFF
--- a/src/cli/commands/test/formatters/format-reachability.ts
+++ b/src/cli/commands/test/formatters/format-reachability.ts
@@ -15,23 +15,27 @@ import {
 } from '../../constants';
 
 const reachabilityLevels: {
-  [key in REACHABILITY]: { color: Function; text: string };
+  [key in REACHABILITY]: { color: Function; text: string; json: string };
 } = {
   [REACHABILITY.FUNCTION]: {
     color: chalk.redBright,
     text: 'Reachable',
+    json: 'reachable',
   },
   [REACHABILITY.PACKAGE]: {
     color: chalk.yellow,
     text: 'Potentially reachable',
+    json: 'potentially-reachable',
   },
   [REACHABILITY.NOT_REACHABLE]: {
     color: chalk.blueBright,
     text: 'Not reachable',
+    json: 'not-reachable',
   },
   [REACHABILITY.NO_INFO]: {
     color: (str) => str,
     text: '',
+    json: 'no-info',
   },
 };
 
@@ -55,6 +59,14 @@ export function getReachabilityText(reachability?: REACHABILITY): string {
   return reachableInfo ? reachableInfo.text : '';
 }
 
+export function getReachabilityJson(reachability?: REACHABILITY): string {
+  if (!reachability) {
+    return '';
+  }
+  const reachableInfo = reachabilityLevels[reachability];
+  return reachableInfo ? reachableInfo.json : '';
+}
+
 export function summariseReachableVulns(
   vulnerabilities: AnnotatedIssue[],
 ): string {
@@ -67,7 +79,6 @@ export function summariseReachableVulns(
       reachableVulnsCount === 1 ? 'vulnerability' : 'vulnerabilities';
     return `In addition, found ${reachableVulnsCount} ${vulnText} with a reachable path.`;
   }
-
   return '';
 }
 

--- a/src/cli/commands/test/formatters/format-test-results.ts
+++ b/src/cli/commands/test/formatters/format-test-results.ts
@@ -1,0 +1,291 @@
+import { Options, OutputDataTypes, TestOptions } from '../../../../lib/types';
+import {
+  getReachabilityJson,
+  summariseReachableVulns,
+} from './format-reachability';
+import {
+  GroupedVuln,
+  SEVERITY,
+  TestResult,
+  VulnMetaData,
+} from '../../../../lib/snyk-test/legacy';
+import chalk from 'chalk';
+import {
+  SupportedPackageManagers,
+  WIZARD_SUPPORTED_PACKAGE_MANAGERS,
+} from '../../../../lib/package-managers';
+import * as config from '../../../../lib/config';
+import * as _ from 'lodash';
+import * as analytics from '../../../../lib/analytics';
+import {
+  formatIssuesWithRemediation,
+  getSeverityValue,
+} from './remediation-based-format-issues';
+import { formatIssues } from './legacy-format-issue';
+import { formatDockerBinariesIssues } from './docker';
+import { isNewVuln, isVulnFixable } from '../vuln-helpers';
+import { createSarifOutputForContainers } from '../sarif-output';
+import { createSarifOutputForIac } from '../iac-output';
+
+export function formatJsonOutput(jsonData) {
+  const jsonDataClone = _.cloneDeep(jsonData);
+
+  if (jsonDataClone.vulnerabilities) {
+    jsonDataClone.vulnerabilities.forEach((vuln) => {
+      if (vuln.reachability) {
+        vuln.reachability = getReachabilityJson(vuln.reachability);
+      }
+    });
+  }
+  return jsonDataClone;
+}
+
+export function extractDataToSendFromResults(
+  results,
+  jsonData,
+  options: Options,
+): OutputDataTypes {
+  let sarifData = {};
+  if (options.sarif || options['sarif-file-output']) {
+    sarifData = !options.iac
+      ? createSarifOutputForContainers(results)
+      : createSarifOutputForIac(results);
+  }
+
+  const stringifiedJsonData = JSON.stringify(
+    formatJsonOutput(jsonData),
+    null,
+    2,
+  );
+
+  const stringifiedSarifData = JSON.stringify(sarifData, null, 2);
+
+  const dataToSend = options.sarif ? sarifData : jsonData;
+  const stringifiedData = options.sarif
+    ? stringifiedSarifData
+    : stringifiedJsonData;
+
+  return {
+    stdout: dataToSend,
+    stringifiedData,
+    stringifiedJsonData,
+    stringifiedSarifData,
+  };
+}
+
+export function createErrorMappedResultsForJsonOutput(results) {
+  const errorMappedResults = results.map((result) => {
+    // add json for when thrown exception
+    if (result instanceof Error) {
+      return {
+        ok: false,
+        error: result.message,
+        path: (result as any).path,
+      };
+    }
+    return result;
+  });
+
+  return errorMappedResults;
+}
+
+export function getDisplayedOutput(
+  res: TestResult,
+  options: Options & TestOptions,
+  testedInfoText: string,
+  localPackageTest: any,
+  projectType: string,
+  meta: string,
+  prefix: string,
+  multiProjAdvice: string,
+  dockerAdvice: string,
+  dockerCTA: string,
+): string {
+  const vulnCount = res.vulnerabilities && res.vulnerabilities.length;
+  const singleVulnText = res.licensesPolicy ? 'issue' : 'vulnerability';
+  const multipleVulnsText = res.licensesPolicy ? 'issues' : 'vulnerabilities';
+
+  // Text will look like so:
+  // 'found 232 vulnerabilities, 404 vulnerable paths.'
+  let vulnCountText =
+    `found ${res.uniqueCount} ` +
+    (res.uniqueCount === 1 ? singleVulnText : multipleVulnsText);
+
+  // Docker is currently not supported as num of paths is inaccurate due to trimming of paths to reduce size.
+  if (options.showVulnPaths && !options.docker) {
+    vulnCountText += `, ${vulnCount} vulnerable `;
+
+    if (vulnCount === 1) {
+      vulnCountText += 'path.';
+    } else {
+      vulnCountText += 'paths.';
+    }
+  } else {
+    vulnCountText += '.';
+  }
+
+  const reachableVulnsText =
+    options.reachableVulns && vulnCount > 0
+      ? ` ${summariseReachableVulns(res.vulnerabilities)}`
+      : '';
+
+  const summary =
+    testedInfoText +
+    ', ' +
+    chalk.red.bold(vulnCountText) +
+    chalk.blue.bold(reachableVulnsText);
+  let wizardAdvice = '';
+
+  if (
+    localPackageTest &&
+    WIZARD_SUPPORTED_PACKAGE_MANAGERS.includes(
+      projectType as SupportedPackageManagers,
+    )
+  ) {
+    wizardAdvice = chalk.bold.green(
+      '\n\nRun `snyk wizard` to address these issues.',
+    );
+  }
+  const dockerSuggestion = getDockerSuggestionText(options, config);
+
+  const vulns = res.vulnerabilities || [];
+  const groupedVulns: GroupedVuln[] = groupVulnerabilities(vulns);
+  const sortedGroupedVulns = _.orderBy(
+    groupedVulns,
+    ['metadata.severityValue', 'metadata.name'],
+    ['asc', 'desc'],
+  );
+  const filteredSortedGroupedVulns = sortedGroupedVulns.filter(
+    (vuln) => vuln.metadata.packageManager !== 'upstream',
+  );
+  const binariesSortedGroupedVulns = sortedGroupedVulns.filter(
+    (vuln) => vuln.metadata.packageManager === 'upstream',
+  );
+
+  let groupedVulnInfoOutput;
+  if (res.remediation) {
+    analytics.add('actionableRemediation', true);
+    groupedVulnInfoOutput = formatIssuesWithRemediation(
+      filteredSortedGroupedVulns,
+      res.remediation,
+      options,
+    );
+  } else {
+    analytics.add('actionableRemediation', false);
+    groupedVulnInfoOutput = filteredSortedGroupedVulns.map((vuln) =>
+      formatIssues(vuln, options),
+    );
+  }
+
+  const groupedDockerBinariesVulnInfoOutput =
+    res.docker && binariesSortedGroupedVulns.length
+      ? formatDockerBinariesIssues(
+          binariesSortedGroupedVulns,
+          res.docker.binariesVulns,
+          options,
+        )
+      : [];
+
+  let body =
+    groupedVulnInfoOutput.join('\n\n') +
+    '\n\n' +
+    groupedDockerBinariesVulnInfoOutput.join('\n\n') +
+    '\n\n' +
+    meta;
+
+  if (res.remediation) {
+    body = summary + body + wizardAdvice;
+  } else {
+    body = body + '\n\n' + summary + wizardAdvice;
+  }
+
+  const ignoredIssues = '';
+  // const dockerCTA = dockerUserCTA(options);
+  return (
+    prefix +
+    body +
+    multiProjAdvice +
+    ignoredIssues +
+    dockerAdvice +
+    dockerSuggestion +
+    dockerCTA
+  );
+}
+
+function getDockerSuggestionText(options, config): string {
+  if (!options.docker || options.isDockerUser) {
+    return '';
+  }
+
+  let dockerSuggestion = '';
+  if (config && config.disableSuggestions !== 'true') {
+    const optOutSuggestions =
+      '\n\nTo remove this message in the future, please run `snyk config set disableSuggestions=true`';
+    if (!options.file) {
+      dockerSuggestion +=
+        chalk.bold.white(
+          '\n\nPro tip: use `--file` option to get base image remediation advice.' +
+            `\nExample: $ snyk test --docker ${options.path} --file=path/to/Dockerfile`,
+        ) + optOutSuggestions;
+    } else if (!options['exclude-base-image-vulns']) {
+      dockerSuggestion +=
+        chalk.bold.white(
+          '\n\nPro tip: use `--exclude-base-image-vulns` to exclude from display Docker base image vulnerabilities.',
+        ) + optOutSuggestions;
+    }
+  }
+  return dockerSuggestion;
+}
+
+function groupVulnerabilities(vulns): GroupedVuln[] {
+  return vulns.reduce((map, curr) => {
+    if (!map[curr.id]) {
+      map[curr.id] = {};
+      map[curr.id].list = [];
+      map[curr.id].metadata = metadataForVuln(curr);
+      map[curr.id].isIgnored = false;
+      map[curr.id].isPatched = false;
+      // Extra added fields for ease of handling
+      map[curr.id].title = curr.title;
+      map[curr.id].note = curr.note;
+      map[curr.id].severity = curr.severity as SEVERITY;
+      map[curr.id].originalSeverity = curr.originalSeverity as SEVERITY;
+      map[curr.id].isNew = isNewVuln(curr);
+      map[curr.id].name = curr.name;
+      map[curr.id].version = curr.version;
+      map[curr.id].fixedIn = curr.fixedIn;
+      map[curr.id].dockerfileInstruction = curr.dockerfileInstruction;
+      map[curr.id].dockerBaseImage = curr.dockerBaseImage;
+      map[curr.id].nearestFixedInVersion = curr.nearestFixedInVersion;
+      map[curr.id].legalInstructionsArray = curr.legalInstructionsArray;
+      map[curr.id].reachability = curr.reachability;
+    }
+
+    map[curr.id].list.push(curr);
+    if (!map[curr.id].isFixable) {
+      map[curr.id].isFixable = isVulnFixable(curr);
+    }
+
+    if (!map[curr.id].note) {
+      map[curr.id].note = !!curr.note;
+    }
+
+    return map;
+  }, {});
+}
+
+function metadataForVuln(vuln): VulnMetaData {
+  return {
+    id: vuln.id,
+    title: vuln.title,
+    description: vuln.description,
+    type: vuln.type,
+    name: vuln.name,
+    info: vuln.info,
+    severity: vuln.severity,
+    severityValue: getSeverityValue(vuln.severity),
+    isNew: isNewVuln(vuln),
+    version: vuln.version,
+    packageManager: vuln.packageManager,
+  };
+}

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -1,3 +1,9 @@
+import {
+  createErrorMappedResultsForJsonOutput,
+  extractDataToSendFromResults,
+  getDisplayedOutput,
+} from './formatters/format-test-results';
+
 export = test;
 
 import * as _ from 'lodash';
@@ -13,51 +19,34 @@ import {
   ShowVulnPaths,
   SupportedProjectTypes,
   TestOptions,
-  OutputDataTypes,
 } from '../../../lib/types';
 import { isLocalFolder } from '../../../lib/detect';
 import { MethodArgs } from '../../args';
 import { TestCommandResult } from '../../commands/types';
-import {
-  GroupedVuln,
-  LegacyVulnApiResult,
-  SEVERITY,
-  TestResult,
-  VulnMetaData,
-} from '../../../lib/snyk-test/legacy';
+import { LegacyVulnApiResult, TestResult } from '../../../lib/snyk-test/legacy';
 import {
   IacTestResponse,
   mapIacTestResult,
 } from '../../../lib/snyk-test/iac-test-result';
-import {
-  SupportedPackageManagers,
-  WIZARD_SUPPORTED_PACKAGE_MANAGERS,
-} from '../../../lib/package-managers';
 
-import * as analytics from '../../../lib/analytics';
 import { FailOnError } from '../../../lib/errors/fail-on-error.ts';
 import {
   dockerRemediationForDisplay,
-  formatDockerBinariesIssues,
-  formatIssues,
-  formatIssuesWithRemediation,
   formatTestMeta,
-  getSeverityValue,
   summariseErrorResults,
-  summariseReachableVulns,
   summariseVulnerableResults,
 } from './formatters';
 import * as utils from './utils';
-import { getIacDisplayedOutput, createSarifOutputForIac } from './iac-output';
+import { getIacDisplayedOutput } from './iac-output';
 import { getEcosystem, testEcosystem } from '../../../lib/ecosystems';
 import { TestLimitReachedError } from '../../../lib/errors';
 import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
-import { createSarifOutputForContainers } from './sarif-output';
 import {
   IacProjectType,
   IacProjectTypes,
   TEST_SUPPORTED_IAC_PROJECTS,
 } from '../../../lib/iac/constants';
+import { hasFixes, hasPatches, hasUpgrades } from './vuln-helpers';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -88,9 +77,7 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
   // org fallback to config unless specified
   options.org = options.org || config.org;
 
-  // making `show-vulnerable-paths` 'some' by default.
-  const svpSupplied = (options['show-vulnerable-paths'] || '').toLowerCase();
-  options.showVulnPaths = showVulnPathsMapping[svpSupplied] || 'some';
+  defaultShowVulnerablePathsToSome(options);
 
   if (
     options.severityThreshold &&
@@ -137,35 +124,7 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
     const testOpts = _.cloneDeep(options);
     testOpts.path = path;
     testOpts.projectName = testOpts['project-name'];
-
-    let res: (TestResult | TestResult[]) | Error;
-
-    try {
-      res = await snyk.test(path, testOpts);
-    } catch (error) {
-      // Possible error cases:
-      // - the test found some vulns. `error.message` is a
-      // JSON-stringified
-      //   test result.
-      // - the flow failed, `error` is a real Error object.
-      // - the flow failed, `error` is a number or string
-      // describing the problem.
-      //
-      // To standardise this, make sure we use the best _object_ to
-      // describe the error.
-
-      if (error instanceof Error) {
-        res = error;
-      } else if (typeof error !== 'object') {
-        res = new Error(error);
-      } else {
-        try {
-          res = JSON.parse(error.message);
-        } catch (unused) {
-          res = error;
-        }
-      }
-    }
+    const res = await runSnykTestOnPath(path, testOpts);
 
     // Not all test results are arrays in order to be backwards compatible
     // with scripts that use a callback with test. Coerce results/errors to be arrays
@@ -349,20 +308,44 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
   );
 }
 
-function createErrorMappedResultsForJsonOutput(results) {
-  const errorMappedResults = results.map((result) => {
-    // add json for when thrown exception
-    if (result instanceof Error) {
-      return {
-        ok: false,
-        error: result.message,
-        path: (result as any).path,
-      };
-    }
-    return result;
-  });
+function defaultShowVulnerablePathsToSome(options) {
+  const svpSupplied = (options['show-vulnerable-paths'] || '').toLowerCase();
+  options.showVulnPaths = showVulnPathsMapping[svpSupplied] || 'some';
+}
 
-  return errorMappedResults;
+async function runSnykTestOnPath(
+  path: string,
+  testOpts: Options & TestOptions,
+) {
+  let res: (TestResult | TestResult[]) | Error;
+
+  try {
+    res = await snyk.test(path, testOpts);
+  } catch (error) {
+    // Possible error cases:
+    // - the test found some vulns. `error.message` is a
+    // JSON-stringified
+    //   test result.
+    // - the flow failed, `error` is a real Error object.
+    // - the flow failed, `error` is a number or string
+    // describing the problem.
+    //
+    // To standardise this, make sure we use the best _object_ to
+    // describe the error.
+
+    if (error instanceof Error) {
+      res = error;
+    } else if (typeof error !== 'object') {
+      res = new Error(error);
+    } else {
+      try {
+        res = JSON.parse(error.message);
+      } catch (unused) {
+        res = error;
+      }
+    }
+  }
+  return res;
 }
 
 function shouldFail(vulnerableResults: any[], failOn: FailOn) {
@@ -378,58 +361,6 @@ function shouldFail(vulnerableResults: any[], failOn: FailOn) {
   }
   // should fail by default when there are vulnerable results
   return vulnerableResults.length > 0;
-}
-
-function isFixable(testResult: any): boolean {
-  return isUpgradable(testResult) || isPatchable(testResult);
-}
-
-function hasFixes(testResults: any[]): boolean {
-  return testResults.some(isFixable);
-}
-
-function isUpgradable(testResult: any): boolean {
-  if (testResult.remediation) {
-    const {
-      remediation: { upgrade = {}, pin = {} },
-    } = testResult;
-    return Object.keys(upgrade).length > 0 || Object.keys(pin).length > 0;
-  }
-  // if remediation is not available, fallback on vuln properties
-  const { vulnerabilities = {} } = testResult;
-  return vulnerabilities.some(isVulnUpgradable);
-}
-
-function hasUpgrades(testResults: any[]): boolean {
-  return testResults.some(isUpgradable);
-}
-
-function isPatchable(testResult: any): boolean {
-  if (testResult.remediation) {
-    const {
-      remediation: { patch = {} },
-    } = testResult;
-    return Object.keys(patch).length > 0;
-  }
-  // if remediation is not available, fallback on vuln properties
-  const { vulnerabilities = {} } = testResult;
-  return vulnerabilities.some(isVulnPatchable);
-}
-
-function hasPatches(testResults: any[]): boolean {
-  return testResults.some(isPatchable);
-}
-
-function isVulnUpgradable(vuln) {
-  return vuln.isUpgradable || vuln.isPinnable;
-}
-
-function isVulnPatchable(vuln) {
-  return vuln.isPatchable;
-}
-
-function isVulnFixable(vuln) {
-  return isVulnUpgradable(vuln) || isVulnPatchable(vuln);
 }
 
 function displayResult(
@@ -490,6 +421,8 @@ function displayResult(
     );
   }
 
+  const dockerCTA = dockerUserCTA(options);
+
   // OK  => no vulns found, return
   if (res.ok && res.vulnerabilities.length === 0) {
     const vulnPathsText = options.showVulnPaths
@@ -513,7 +446,6 @@ function displayResult(
       ? '\n\nTip: Snyk only tests production dependencies by default. You can try re-running with the `--dev` flag.'
       : '';
 
-    const dockerCTA = dockerUserCTA(options);
     return (
       prefix +
       meta +
@@ -549,128 +481,7 @@ function displayResult(
     prefix,
     multiProjAdvice,
     dockerAdvice,
-  );
-}
-
-function getDisplayedOutput(
-  res: TestResult,
-  options: Options & TestOptions,
-  testedInfoText: string,
-  localPackageTest: any,
-  projectType: string,
-  meta: string,
-  prefix: string,
-  multiProjAdvice: string,
-  dockerAdvice: string,
-): string {
-  const vulnCount = res.vulnerabilities && res.vulnerabilities.length;
-  const singleVulnText = res.licensesPolicy ? 'issue' : 'vulnerability';
-  const multipleVulnsText = res.licensesPolicy ? 'issues' : 'vulnerabilities';
-
-  // Text will look like so:
-  // 'found 232 vulnerabilities, 404 vulnerable paths.'
-  let vulnCountText =
-    `found ${res.uniqueCount} ` +
-    (res.uniqueCount === 1 ? singleVulnText : multipleVulnsText);
-
-  // Docker is currently not supported as num of paths is inaccurate due to trimming of paths to reduce size.
-  if (options.showVulnPaths && !options.docker) {
-    vulnCountText += `, ${vulnCount} vulnerable `;
-
-    if (vulnCount === 1) {
-      vulnCountText += 'path.';
-    } else {
-      vulnCountText += 'paths.';
-    }
-  } else {
-    vulnCountText += '.';
-  }
-
-  const reachableVulnsText =
-    options.reachableVulns && vulnCount > 0
-      ? ` ${summariseReachableVulns(res.vulnerabilities)}`
-      : '';
-
-  const summary =
-    testedInfoText +
-    ', ' +
-    chalk.red.bold(vulnCountText) +
-    chalk.blue.bold(reachableVulnsText);
-  let wizardAdvice = '';
-
-  if (
-    localPackageTest &&
-    WIZARD_SUPPORTED_PACKAGE_MANAGERS.includes(
-      projectType as SupportedPackageManagers,
-    )
-  ) {
-    wizardAdvice = chalk.bold.green(
-      '\n\nRun `snyk wizard` to address these issues.',
-    );
-  }
-  const dockerSuggestion = getDockerSuggestionText(options, config);
-
-  const vulns = res.vulnerabilities || [];
-  const groupedVulns: GroupedVuln[] = groupVulnerabilities(vulns);
-  const sortedGroupedVulns = _.orderBy(
-    groupedVulns,
-    ['metadata.severityValue', 'metadata.name'],
-    ['asc', 'desc'],
-  );
-  const filteredSortedGroupedVulns = sortedGroupedVulns.filter(
-    (vuln) => vuln.metadata.packageManager !== 'upstream',
-  );
-  const binariesSortedGroupedVulns = sortedGroupedVulns.filter(
-    (vuln) => vuln.metadata.packageManager === 'upstream',
-  );
-
-  let groupedVulnInfoOutput;
-  if (res.remediation) {
-    analytics.add('actionableRemediation', true);
-    groupedVulnInfoOutput = formatIssuesWithRemediation(
-      filteredSortedGroupedVulns,
-      res.remediation,
-      options,
-    );
-  } else {
-    analytics.add('actionableRemediation', false);
-    groupedVulnInfoOutput = filteredSortedGroupedVulns.map((vuln) =>
-      formatIssues(vuln, options),
-    );
-  }
-
-  const groupedDockerBinariesVulnInfoOutput =
-    res.docker && binariesSortedGroupedVulns.length
-      ? formatDockerBinariesIssues(
-          binariesSortedGroupedVulns,
-          res.docker.binariesVulns,
-          options,
-        )
-      : [];
-
-  let body =
-    groupedVulnInfoOutput.join('\n\n') +
-    '\n\n' +
-    groupedDockerBinariesVulnInfoOutput.join('\n\n') +
-    '\n\n' +
-    meta;
-
-  if (res.remediation) {
-    body = summary + body + wizardAdvice;
-  } else {
-    body = body + '\n\n' + summary + wizardAdvice;
-  }
-
-  const ignoredIssues = '';
-  const dockerCTA = dockerUserCTA(options);
-  return (
-    prefix +
-    body +
-    multiProjAdvice +
-    ignoredIssues +
-    dockerAdvice +
-    dockerSuggestion +
-    dockerCTA
+    dockerCTA,
   );
 }
 
@@ -682,121 +493,9 @@ function validateFailOn(arg: FailOn) {
   return Object.keys(FAIL_ON).includes(arg);
 }
 
-function groupVulnerabilities(vulns): GroupedVuln[] {
-  return vulns.reduce((map, curr) => {
-    if (!map[curr.id]) {
-      map[curr.id] = {};
-      map[curr.id].list = [];
-      map[curr.id].metadata = metadataForVuln(curr);
-      map[curr.id].isIgnored = false;
-      map[curr.id].isPatched = false;
-      // Extra added fields for ease of handling
-      map[curr.id].title = curr.title;
-      map[curr.id].note = curr.note;
-      map[curr.id].severity = curr.severity as SEVERITY;
-      map[curr.id].originalSeverity = curr.originalSeverity as SEVERITY;
-      map[curr.id].isNew = isNewVuln(curr);
-      map[curr.id].name = curr.name;
-      map[curr.id].version = curr.version;
-      map[curr.id].fixedIn = curr.fixedIn;
-      map[curr.id].dockerfileInstruction = curr.dockerfileInstruction;
-      map[curr.id].dockerBaseImage = curr.dockerBaseImage;
-      map[curr.id].nearestFixedInVersion = curr.nearestFixedInVersion;
-      map[curr.id].legalInstructionsArray = curr.legalInstructionsArray;
-      map[curr.id].reachability = curr.reachability;
-    }
-
-    map[curr.id].list.push(curr);
-    if (!map[curr.id].isFixable) {
-      map[curr.id].isFixable = isVulnFixable(curr);
-    }
-
-    if (!map[curr.id].note) {
-      map[curr.id].note = !!curr.note;
-    }
-
-    return map;
-  }, {});
-}
-// check if vuln was published in the last month
-function isNewVuln(vuln) {
-  const MONTH = 30 * 24 * 60 * 60 * 1000;
-  const publicationTime = new Date(vuln.publicationTime).getTime();
-  return publicationTime > Date.now() - MONTH;
-}
-
-function metadataForVuln(vuln): VulnMetaData {
-  return {
-    id: vuln.id,
-    title: vuln.title,
-    description: vuln.description,
-    type: vuln.type,
-    name: vuln.name,
-    info: vuln.info,
-    severity: vuln.severity,
-    severityValue: getSeverityValue(vuln.severity),
-    isNew: isNewVuln(vuln),
-    version: vuln.version,
-    packageManager: vuln.packageManager,
-  };
-}
-
-function getDockerSuggestionText(options, config): string {
-  if (!options.docker || options.isDockerUser) {
-    return '';
-  }
-
-  let dockerSuggestion = '';
-  if (config && config.disableSuggestions !== 'true') {
-    const optOutSuggestions =
-      '\n\nTo remove this message in the future, please run `snyk config set disableSuggestions=true`';
-    if (!options.file) {
-      dockerSuggestion +=
-        chalk.bold.white(
-          '\n\nPro tip: use `--file` option to get base image remediation advice.' +
-            `\nExample: $ snyk test --docker ${options.path} --file=path/to/Dockerfile`,
-        ) + optOutSuggestions;
-    } else if (!options['exclude-base-image-vulns']) {
-      dockerSuggestion +=
-        chalk.bold.white(
-          '\n\nPro tip: use `--exclude-base-image-vulns` to exclude from display Docker base image vulnerabilities.',
-        ) + optOutSuggestions;
-    }
-  }
-  return dockerSuggestion;
-}
-
 function dockerUserCTA(options) {
   if (options.isDockerUser) {
     return '\n\nFor more free scans that keep your images secure, sign up to Snyk at https://dockr.ly/3ePqVcp';
   }
   return '';
-}
-
-function extractDataToSendFromResults(
-  results,
-  jsonData,
-  options: Options,
-): OutputDataTypes {
-  let sarifData = {};
-  if (options.sarif || options['sarif-file-output']) {
-    sarifData = !options.iac
-      ? createSarifOutputForContainers(results)
-      : createSarifOutputForIac(results);
-  }
-
-  const stringifiedJsonData = JSON.stringify(jsonData, null, 2);
-  const stringifiedSarifData = JSON.stringify(sarifData, null, 2);
-
-  const dataToSend = options.sarif ? sarifData : jsonData;
-  const stringifiedData = options.sarif
-    ? stringifiedSarifData
-    : stringifiedJsonData;
-
-  return {
-    stdout: dataToSend,
-    stringifiedData,
-    stringifiedJsonData,
-    stringifiedSarifData,
-  };
 }

--- a/src/cli/commands/test/vuln-helpers.ts
+++ b/src/cli/commands/test/vuln-helpers.ts
@@ -1,0 +1,58 @@
+// check if vuln was published in the last month
+export function isNewVuln(vuln) {
+  const MONTH = 30 * 24 * 60 * 60 * 1000;
+  const publicationTime = new Date(vuln.publicationTime).getTime();
+  return publicationTime > Date.now() - MONTH;
+}
+
+export function isFixable(testResult: any): boolean {
+  return isUpgradable(testResult) || isPatchable(testResult);
+}
+
+export function hasFixes(testResults: any[]): boolean {
+  return testResults.some(isFixable);
+}
+
+export function isUpgradable(testResult: any): boolean {
+  if (testResult.remediation) {
+    const {
+      remediation: { upgrade = {}, pin = {} },
+    } = testResult;
+    return Object.keys(upgrade).length > 0 || Object.keys(pin).length > 0;
+  }
+  // if remediation is not available, fallback on vuln properties
+  const { vulnerabilities = {} } = testResult;
+  return vulnerabilities.some(isVulnUpgradable);
+}
+
+export function hasUpgrades(testResults: any[]): boolean {
+  return testResults.some(isUpgradable);
+}
+
+export function isPatchable(testResult: any): boolean {
+  if (testResult.remediation) {
+    const {
+      remediation: { patch = {} },
+    } = testResult;
+    return Object.keys(patch).length > 0;
+  }
+  // if remediation is not available, fallback on vuln properties
+  const { vulnerabilities = {} } = testResult;
+  return vulnerabilities.some(isVulnPatchable);
+}
+
+export function hasPatches(testResults: any[]): boolean {
+  return testResults.some(isPatchable);
+}
+
+export function isVulnUpgradable(vuln) {
+  return vuln.isUpgradable || vuln.isPinnable;
+}
+
+export function isVulnPatchable(vuln) {
+  return vuln.isPatchable;
+}
+
+export function isVulnFixable(vuln) {
+  return isVulnUpgradable(vuln) || isVulnPatchable(vuln);
+}

--- a/test/acceptance/display-test-results.test.ts
+++ b/test/acceptance/display-test-results.test.ts
@@ -117,6 +117,42 @@ test('test reachability info is displayed', async (t) => {
   t.end();
 });
 
+test('test info is displayed when reachability with json flag', async (t) => {
+  chdirWorkspaces();
+  const stubbedResponse = JSON.parse(
+    fs.readFileSync(
+      __dirname +
+        '/workspaces/reachable-vulns/maven/test-dep-graph-response-reachable.json',
+      'utf8',
+    ),
+  );
+  const snykTestStub = sinon.stub(snyk, 'test').returns(stubbedResponse);
+  try {
+    await cli.test('maven-app', {
+      reachableVulns: true,
+      json: true,
+    });
+  } catch (error) {
+    let { message } = error;
+    message = JSON.parse(message);
+
+    const reachabilities = message.vulnerabilities.map(
+      (vuln) => vuln.reachability,
+    );
+
+    t.deepEqual(reachabilities, [
+      'potentially-reachable',
+      'no-info',
+      'reachable',
+    ]);
+    const resType = error.constructor.name;
+    t.equal(resType, 'Error');
+  }
+
+  snykTestStub.restore();
+  t.end();
+});
+
 test('`test npm-package-with-severity-override` show original severity upgrade', async (t) => {
   chdirWorkspaces();
   const stubbedResponse = JSON.parse(
@@ -185,7 +221,7 @@ test('`test npm-package-with-severity-override` show original severity no remedi
     const { message } = error;
     t.match(
       message,
-      `Low severity (originally Medium) vulnerability found in node-uuid`,
+      'Low severity (originally Medium) vulnerability found in node-uuid',
     );
   }
 

--- a/test/acceptance/workspaces/reachable-vulns/maven/test-dep-graph-response-reachable.json
+++ b/test/acceptance/workspaces/reachable-vulns/maven/test-dep-graph-response-reachable.json
@@ -1,0 +1,194 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": ["Package level Reachability"],
+      "cvssScore": 5.6,
+      "description": "Package level Reachability",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": ["1.4.11", "1.5.6", "1.6.3", "1.7.1"],
+      "functions": [],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/file.js",
+            "functionName": "theFunctionName"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-PACAKGE-12345",
+      "identifiers": {
+        "CVE": ["CVE-2014-0472"],
+        "CWE": ["CWE-94"]
+      },
+      "language": "java",
+      "modificationTime": "2019-07-11T13:26:49.758445Z",
+      "moduleName": "package-name",
+      "packageManager": "maven",
+      "packageName": "package-name",
+      "patches": [],
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "reachability": "package",
+      "references": [
+        {
+          "title": "Vulnerability Description",
+          "url": "https://www.url.com/page.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": ["[,1.4.11)", "[1.5,1.5.6)", "[1.6,1.6.3)", "[1.7,1.7.1)"]
+      },
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "from": ["root@0.0.0", "package-name@1.6.1"],
+      "upgradePath": [],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "package-name",
+      "version": "1.6.1"
+    },
+    {
+      "CVSSv3": "CVSS:56565656",
+      "alternativeIds": [],
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": ["No Info on Reachability"],
+      "cvssScore": 5.6,
+      "description": "No Info on Reachability",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": ["1.4.11", "1.5.6", "1.6.3", "1.7.1"],
+      "functions": [],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/file.js",
+            "functionName": "theFunctionName"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-PACAKGE-987765",
+      "identifiers": {
+        "CVE": ["CVE-2014-0472"],
+        "CWE": ["CWE-94"]
+      },
+      "language": "java",
+      "modificationTime": "2019-07-11T13:26:49.758445Z",
+      "moduleName": "package-name",
+      "packageManager": "maven",
+      "packageName": "package-name",
+      "patches": [],
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "reachability": "no-info",
+      "references": [
+        {
+          "title": "Vulnerability Description",
+          "url": "https://www.url.com/page.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": ["[,1.4.11)", "[1.5,1.5.6)", "[1.6,1.6.3)", "[1.7,1.7.1)"]
+      },
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "from": ["root@0.0.0", "package-name@1.6.1"],
+      "upgradePath": [],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "package-name",
+      "version": "1.6.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-04-13T12:32:00Z",
+      "credit": ["Function level Reachability"],
+      "cvssScore": 5.6,
+      "description": "Function level Reachability",
+      "disclosureTime": "2014-04-23T12:32:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": ["1.4.11", "1.5.6", "1.6.3", "1.7.1"],
+      "functions": [],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "lib/file.js",
+            "functionName": "theFunctionName"
+          },
+          "version": [
+            "<0.0.19"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-PACAKGE-1029384",
+      "identifiers": {
+        "CVE": ["CVE-2014-0472"],
+        "CWE": ["CWE-94"]
+      },
+      "language": "java",
+      "modificationTime": "2019-07-11T13:26:49.758445Z",
+      "moduleName": "package-name",
+      "packageManager": "maven",
+      "packageName": "package-name",
+      "patches": [],
+      "publicationTime": "2014-04-23T12:32:00Z",
+      "reachability": "function",
+      "references": [
+        {
+          "title": "Vulnerability Description",
+          "url": "https://www.url.com/page.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": ["[,1.4.11)", "[1.5,1.5.6)", "[1.6,1.6.3)", "[1.7,1.7.1)"]
+      },
+      "severity": "medium",
+      "title": "Arbitrary Code Execution",
+      "from": ["root@0.0.0", "package-name@1.6.1"],
+      "upgradePath": [],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "package-name",
+      "version": "1.6.1"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 1,
+  "org": "reachable vulns org",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+  },
+  "packageManager": "maven",
+  "ignoreSettings": null,
+  "summary": "30 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [],
+    "upgrade": {
+      "package-name@1.6.1": {
+        "upgradeTo": "package-name@1.6.3",
+        "vulns": ["SNYK-JAVA-PACAKGE-12345"],
+        "isTransitive": false
+      }
+    },
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 30
+}


### PR DESCRIPTION
At the moment, when using the CLI with test --reachability --json, the output shows reachability as function / package/ no info. This change makes this to more friendly / easier to understand: reachable/ potentially-reachable / no-info. It includes the creation of two classes to remove some of the context out of the large index.ts file.

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Pr changes the words used to indicate the level of Reachability when displaying the data in Json format. It also includes two new classes to  remove some functionality from the main command logic.

#### Where should the reviewer start?
format-reachability.ts contains the word changes. 
function -> reachable
package -> potentially-reachable
no-info -> no-info (stays the same)

display-test-results.test.ts tests for these conversions using file, test-dep-graph-response-reachable.json, as it contains an example of each of the three states.

vuln-helpers.ts was pulled from test/index.ts - it holds all utility functions for vulnerabilities.
format-test-results.ts was pulled from test/index.ts - it is a collection of functions that handle formatting the output of the Test command.

#### How should this be manually tested?
Run local snyk with `test --reachable --json` on a relevant project eg https://github.com/snyk123/Semaforo (needs to be a java project)

#### Any background context you want to provide?
We wanted to update the wording to be consistent with the front end (and as the code was being worked on, did some clean up as well).

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/projects/FLOW/boards/96?selectedIssue=FLOW-433

#### Screenshots
<img width="452" alt="Screenshot 2020-10-14 at 10 17 05" src="https://user-images.githubusercontent.com/245346/95969314-73c7d200-0e06-11eb-90f5-4405536b8f26.png">

#### Additional questions
