### PR TITLE
fix: correct classpath extraction for reachable vulns on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.22.0",
+    "snyk-mvn-plugin": "2.23.0",
     "snyk-nodejs-lockfile-parser": "1.28.1",
     "snyk-nuget-plugin": "1.19.3",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Sets that right command for maven to get the classpath for the
correct repo.

For more info go to:
https://github.com/snyk/java-call-graph-builder/pull/36

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
