### PR TITLE
Set integration name for Homebrew installs

### DIFF
--- a/test/analytics-sources.spec.ts
+++ b/test/analytics-sources.spec.ts
@@ -4,8 +4,12 @@ import {
   INTEGRATION_NAME_HEADER,
   INTEGRATION_VERSION_HEADER,
   isScoop,
+  isHomebrew,
+  validateHomebrew,
   validateScoopManifestFile,
 } from '../src/lib/analytics-sources';
+
+import * as fs from 'fs';
 
 const emptyArgs = [];
 const defaultArgsParams = {
@@ -21,16 +25,13 @@ beforeEach(() => {
 describe('analytics-sources - scoop detection', () => {
   it('detects if snyk is installed via scoop', () => {
     const originalExecPath = process.execPath;
-    try {
-      process.execPath =
-        process.cwd() + '/test/fixtures/scoop/good-manifest/snyk-win.exe';
-      expect(isScoop()).toBe(true);
+    process.execPath =
+      process.cwd() + '/test/fixtures/scoop/good-manifest/snyk-win.exe';
+    expect(isScoop()).toBe(true);
 
-      process.execPath = '/test/fixtures/scoop/bad-manifest/snyk-win.exe';
-      expect(isScoop()).toBe(false);
-    } finally {
-      process.execPath = originalExecPath;
-    }
+    process.execPath = '/test/fixtures/scoop/bad-manifest/snyk-win.exe';
+    expect(isScoop()).toBe(false);
+    process.execPath = originalExecPath;
   });
 
   it('validates scoop manifest file', () => {
@@ -44,6 +45,51 @@ describe('analytics-sources - scoop detection', () => {
 
     snykExecPath = process.cwd() + '/test/fixtures/scoop/no-exist/snyk-win.exe';
     expect(validateScoopManifestFile(snykExecPath)).toBe(false);
+  });
+});
+
+describe('analytics-sources - Homebrew detection', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('detects if snyk is installed via Homebrew', () => {
+    const originalExecPath = process.execPath;
+    process.execPath = process.cwd() + '/usr/local/Cellar/snyk/v1.413.2/bin';
+    const fileExistsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    expect(isHomebrew()).toBe(true);
+    expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+    process.execPath = originalExecPath;
+  });
+
+  it('returns false if formula not in Homebrew path', () => {
+    const originalExecPath = process.execPath;
+    process.execPath =
+      process.cwd() + '/usr/local/some-other-location/snyk/v1.413.2/bin';
+    const fileExistsSpy = jest.spyOn(fs, 'existsSync');
+    expect(isHomebrew()).toBe(false);
+    expect(fileExistsSpy).not.toHaveBeenCalled();
+    process.execPath = originalExecPath;
+  });
+
+  it('returns false if formula files does not exist', () => {
+    const originalExecPath = process.execPath;
+    process.execPath = process.cwd() + '/usr/local/Cellar/snyk/v1.413.2/bin';
+    const fileExistsSpy = jest.spyOn(fs, 'existsSync').mockReturnValue(false);
+    expect(isHomebrew()).toBe(false);
+    expect(fileExistsSpy).toHaveBeenCalledTimes(1);
+    process.execPath = originalExecPath;
+  });
+
+  it('validates Homebrew formula file exists', () => {
+    let snykExecPath =
+      process.cwd() + '/test/fixtures/homebrew/Cellar/snyk/vX/bin/snyk'; // relies on fixture at /test/fixtures/homebrew/Cellar/vX/.brew/snyk.rb
+    expect(validateHomebrew(snykExecPath)).toBe(true);
+
+    snykExecPath =
+      process.cwd() +
+      '/test/fixtures/homebrew/no-exist/Cellar/snyk/vX/bin/snyk';
+    expect(validateHomebrew(snykExecPath)).toBe(false);
   });
 });
 
@@ -83,13 +129,18 @@ describe('analytics-sources - getIntegrationName', () => {
 
   it('integration name SCOOP when snyk is installed with scoop', () => {
     const originalExecPath = process.execPath;
-    try {
-      process.execPath =
-        process.cwd() + '/test/fixtures/scoop/good-manifest/snyk-win.exe';
-      expect(getIntegrationName(emptyArgs)).toBe('SCOOP');
-    } finally {
-      process.execPath = originalExecPath;
-    }
+    process.execPath =
+      process.cwd() + '/test/fixtures/scoop/good-manifest/snyk-win.exe';
+    expect(getIntegrationName(emptyArgs)).toBe('SCOOP');
+    process.execPath = originalExecPath;
+  });
+
+  it('integration name HOMEBREW when snyk is installed with Homebrew', () => {
+    const originalExecPath = process.execPath;
+    process.execPath =
+      process.cwd() + '/test/fixtures/homebrew/Cellar/snyk/vX/bin/snyk'; // relies on fixture at /test/fixtures/homebrew/Cellar/vX/.brew/snyk.rb
+    expect(getIntegrationName(emptyArgs)).toBe('HOMEBREW');
+    process.execPath = originalExecPath;
   });
 });
 

--- a/test/fixtures/homebrew/Cellar/snyk/vX/.brew/snyk.rb
+++ b/test/fixtures/homebrew/Cellar/snyk/vX/.brew/snyk.rb
@@ -1,0 +1,1 @@
+# fake Formula file


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Adds the integration name`HOMEBREW` when the running CLI instances is installed with Homebrew.

#### What are the relevant tickets?
HAMMER-135