### PR TITLE
Fix dangerfile tap test detection

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -58,7 +58,7 @@ if (danger.github && danger.github.pr) {
     return inTestFolder && !inLegacyAcceptanceTestsFolder && !testFilenameLooksLikeJest;
   });
 
-  if (newTestFiles) {
+  if (newTestFiles.length) {
     const joinedFileList = newTestFiles.map(f => '- `' + f + '`').join("\n");
     const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files like \`test/*.spec.ts\` for examples. Files found:\n${joinedFileList}`;
     warn(msg);


### PR DESCRIPTION
We are getting false positives because `!![] => true`, so you need to check for the actual array length because `!!0 => false`