### PR TITLE
feat: paths always shown where available

### DIFF
--- a/src/cli/commands/test/formatters/remediation-based-format-issues.ts
+++ b/src/cli/commands/test/formatters/remediation-based-format-issues.ts
@@ -467,10 +467,11 @@ export function formatIssue(
   }
 
   let introducedBy = '';
+
   if (
     testOptions.showVulnPaths === 'some' &&
     paths &&
-    paths.find((p) => p.length > 2)
+    paths.find((p) => p.length > 1)
   ) {
     // In this mode, we show only one path by default, for compactness
     const pathStr = printPath(paths[0]);
@@ -493,6 +494,7 @@ export function formatIssue(
       )} other path(s)`;
     }
   }
+
   const reachableVia = formatReachablePaths(
     sampleReachablePaths,
     MAX_REACHABLE_PATHS,

--- a/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
+++ b/test/acceptance/workspaces/pip-app-transitive-vuln/cli-output-actionable-remediation.txt
@@ -8,7 +8,9 @@ Issues to fix by upgrading dependencies:
 
   Upgrade flask to 1.0 to fix
   ✗ Improper Input Validation [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-42185] in flask@0.12.2
+    introduced by flask@0.12.2
   ✗ Denial of Service (DOS) [High Severity][http://localhost:12345/vuln/SNYK-PYTHON-FLASK-451637] in flask@0.12.2
+    introduced by flask@0.12.2
 
   Pin Jinja2 to 2.10.1 to fix
   ✗ Sandbox Escape [Medium Severity][http://localhost:12345/vuln/SNYK-PYTHON-JINJA2-174126] in Jinja2@2.9.6


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Currently paths for top-level dependencies that have a vuln are only shown if the `all` flag is passed to `--show-vulnerable-paths`. This can be a bit confusing and some people don't understand why they're not seeing an "introduced by:" line for these top-level deps (e.g. if you have a direct dependency of `adm-zip@0.4.7`)

This PR changes that so that whenever a path is available it will also be shown when the default of `some` is used for `show-vulnerable-paths`