### PR TITLE
feat: container command correctly handles DOCKER_HOST

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.1",
     "snyk-cpp-plugin": "2.0.0",
-    "snyk-docker-plugin": "4.1.1",
+    "snyk-docker-plugin": "4.6.1",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an issue with the Bitbucket integration related to using DOCKER_HOST and also some use-cases where users want to provide an external Docker host.

#### Any background context you want to provide?

https://github.com/snyk/snyk-docker-plugin/pull/286
[Slack thread](https://snyk.slack.com/archives/C85H8Q12Q/p1603379479306300)
[Slack thread](https://snyk.slack.com/archives/C0127HWU0E7/p1603180034133800)
