### PR TITLE
Update Smoke tests workflow

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -13,6 +13,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ${{ matrix.os }}-latest
     strategy:
+      fail-fast: false # we care about other platforms and channels building
       matrix:
         os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm]

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,12 +17,14 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm]
-        node_version: [8, 10, 12]
+        node_version: [8, 10, 12, 14]
         exclude:
           - snyk_install_method: binary
             node_version: 8
           - snyk_install_method: binary
             node_version: 10
+          - snyk_install_method: binary
+            node_version: 12
         include:
           - snyk_install_method: binary
             os: ubuntu

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm]
-        node_version: [8, 10, 12, 14]
+        node_version: [8, 10, 12, 14, 15]
         exclude:
           - snyk_install_method: binary
             node_version: 8
@@ -25,6 +25,8 @@ jobs:
             node_version: 10
           - snyk_install_method: binary
             node_version: 12
+          - snyk_install_method: binary
+            node_version: 15
         include:
           - snyk_install_method: binary
             os: ubuntu

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -19,6 +19,7 @@ jobs:
         snyk_install_method: [binary, npm]
         node_version: [8, 10, 12, 14, 15]
         exclude:
+          # For binary, use only the Node 14
           - snyk_install_method: binary
             node_version: 8
           - snyk_install_method: binary
@@ -34,6 +35,9 @@ jobs:
           - snyk_install_method: binary
             os: macos
             snyk_cli_dl_file: snyk-macos
+          # Homebrew installation
+          - snyk_install_method: brew
+            os: macos
           - snyk_install_method: alpine-binary
             os: ubuntu
             snyk_cli_dl_file: snyk-alpine
@@ -105,6 +109,12 @@ jobs:
         run: |
           brew install coreutils
           brew install jq
+
+      - name: Install Snyk CLI with homebrew on macOS
+        if: ${{ matrix.snyk_install_method == 'brew' }}
+        run: |
+          brew tap snyk/tap
+          brew install snyk
 
       - name: Install scoop on Windows
         if: ${{ matrix.os == 'windows'}}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -16,9 +16,15 @@ jobs:
       fail-fast: false # we care about other platforms and channels building
       matrix:
         os: [ubuntu, macos, windows]
-        snyk_install_method: [binary, npm]
+        snyk_install_method: [binary, npm, yarn]
         node_version: [8, 10, 12, 14, 15]
         exclude:
+          # Skip yarn for Node 8 for now (see https://github.com/snyk/snyk/issues/1270)
+          - snyk_install_method: yarn
+            node_version: 8
+          # Skip yarn for Windows, as it's a bit crazy to get it working in CI environment. Unless we see evidence we need it, I'd avoid it
+          - snyk_install_method: yarn
+            os: windows
           # For binary, use only the Node 14
           - snyk_install_method: binary
             node_version: 8
@@ -56,6 +62,15 @@ jobs:
           node -v
           echo "install snyk with npm"
           npm install -g snyk
+
+      - name: Install Snyk with Yarn globally
+        if: ${{ matrix.snyk_install_method == 'yarn' }}
+        run: |
+          npm install yarn -g
+          echo "Yarn global path"
+          yarn global bin
+          echo 'export PATH="$PATH:$(yarn global bin)"' >> ~/.bash_profile
+          yarn global add snyk
 
       - name: npm install for fixture project
         working-directory: test/fixtures/basic-npm
@@ -138,6 +153,7 @@ jobs:
       - name: Run shellspec tests - non-Windows
         if: ${{ matrix.os != 'windows' && matrix.snyk_install_method != 'alpine-binary'}}
         working-directory: test/smoke
+        shell: bash -l {0} # run bash with --login flag to load .bash_profile that's used by yarn install method
         env:
           SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.SMOKE_TESTS_SNYK_TOKEN }}
         run: |

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -95,11 +95,10 @@ jobs:
           which shellspec
           shellspec --version
 
-      - name: Install brew on macOS
+      - name: Install test utilities with homebrew on macOS
         if: ${{ matrix.os == 'macos' }}
         # We need "timeout" and "jq" util and we'll use brew to check our brew package as well
         run: |
-          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
           brew install coreutils
           brew install jq
 

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,7 +1,7 @@
 const { danger, warn, fail, message } = require('danger');
 
 const MAX_COMMIT_MESSAGE_LENGTH = 72;
-const SMOKE_TEST_BRANCH = 'feat/smoke-test';
+const SMOKE_TEST_BRANCH = 'smoke/';
 const SMOKE_TEST_WORKFLOW_FILE_PATH = '.github/workflows/smoke-tests.yml';
 
 if (danger.github && danger.github.pr) {
@@ -55,11 +55,15 @@ if (danger.github && danger.github.pr) {
     const inTestFolder = f.startsWith('test/');
     const inLegacyAcceptanceTestsFolder = f.includes('test/acceptance/');
     const testFilenameLooksLikeJest = f.includes('.spec.ts');
-    return inTestFolder && !inLegacyAcceptanceTestsFolder && !testFilenameLooksLikeJest;
+    return (
+      inTestFolder &&
+      !inLegacyAcceptanceTestsFolder &&
+      !testFilenameLooksLikeJest
+    );
   });
 
   if (newTestFiles.length) {
-    const joinedFileList = newTestFiles.map(f => '- `' + f + '`').join("\n");
+    const joinedFileList = newTestFiles.map((f) => '- `' + f + '`').join('\n');
     const msg = `Looks like you added a new Tap test. Consider making it a Jest test instead. See files like \`test/*.spec.ts\` for examples. Files found:\n${joinedFileList}`;
     warn(msg);
   }
@@ -70,11 +74,13 @@ if (danger.github && danger.github.pr) {
     danger.git.created_files.some((f) => f.startsWith('test/smoke/')) ||
     danger.git.modified_files.includes(SMOKE_TEST_WORKFLOW_FILE_PATH);
 
-  const isOnSmokeTestBranch = danger.github.pr.head.ref === SMOKE_TEST_BRANCH;
+  const isOnSmokeTestBranch = danger.github.pr.head.ref.startsWith(
+    SMOKE_TEST_BRANCH,
+  );
 
   if (modifiedSmokeTest && !isOnSmokeTestBranch) {
     message(
-      `You are modifying something in test/smoke directory, yet you are not on the branch ${SMOKE_TEST_BRANCH}. You can rename your branch to ${SMOKE_TEST_BRANCH} and Smoke tests will trigger for this PR.`,
+      `You are modifying something in test/smoke directory, yet you are not on the branch starting with ${SMOKE_TEST_BRANCH}. You can prefix your branch with ${SMOKE_TEST_BRANCH} and Smoke tests will trigger for this PR.`,
     );
   }
 }

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -61,9 +61,9 @@ _Note: Alpine image is not copying/mounting everything, so you might need to add
 
 - [x] Alpine binary
 - [ ] Docker: current images can't output a clear stderr, because of an extraneous --json flag. Also released version is currently lagging behind the latest GitHub tag by a few hours
-- [ ] yarn installation (see https://github.com/snyk/snyk/issues/1270)
+- [x] yarn installation
 - [ ] scoop package
-- [ ] homebrew
+- [x] homebrew
 
 ## Current workarounds and limitations
 


### PR DESCRIPTION
- add new node versions
- disable fail-fast strategy
- use homebrew that's already installed
- test homebrew installation
- test yarn installation