### PR TITLE
test(smoke): scenario where root user installing Snyk

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -47,6 +47,8 @@ jobs:
           - snyk_install_method: alpine-binary
             os: ubuntu
             snyk_cli_dl_file: snyk-alpine
+          - snyk_install_method: npm-root-user
+            os: ubuntu
 
     steps:
       - uses: actions/checkout@v2
@@ -84,6 +86,14 @@ jobs:
         run: |
           docker build -t snyk-cli-alpine -f ./test/smoke/alpine/Dockerfile ./test
           docker run -eCI=1 -eSMOKE_TESTS_SNYK_TOKEN snyk-cli-alpine
+
+      - name: Run npm test with Root user
+        if: ${{ matrix.snyk_install_method == 'npm-root-user' }}
+        env:
+          SMOKE_TESTS_SNYK_TOKEN: ${{ secrets.SMOKE_TESTS_SNYK_TOKEN }}
+        run: |
+          docker build -t snyk-docker-root -f ./test/smoke/docker-root/Dockerfile ./test
+          docker run -eCI=1 -eSMOKE_TESTS_SNYK_TOKEN snyk-docker-root
 
       - name: Install Snyk with binary - Non-Windows
         if: ${{ matrix.snyk_install_method == 'binary' && matrix.os != 'windows' }}
@@ -138,7 +148,7 @@ jobs:
           scoop install jq
 
       - name: Install jq on Ubuntu
-        if: ${{ matrix.os == 'ubuntu' && matrix.snyk_install_method != 'alpine-binary'}}
+        if: ${{ matrix.os == 'ubuntu' && matrix.snyk_install_method != 'alpine-binary' && matrix.snyk_install_method != 'npm-root-user' }}
         run: |
           sudo apt-get install jq
 
@@ -151,7 +161,7 @@ jobs:
           sh ./test/smoke/install-shellspec-win.sh
 
       - name: Run shellspec tests - non-Windows
-        if: ${{ matrix.os != 'windows' && matrix.snyk_install_method != 'alpine-binary'}}
+        if: ${{ matrix.os != 'windows' && matrix.snyk_install_method != 'alpine-binary' && matrix.snyk_install_method != 'npm-root-user'  }}
         working-directory: test/smoke
         shell: bash -l {0} # run bash with --login flag to load .bash_profile that's used by yarn install method
         env:

--- a/test/smoke/docker-root/Dockerfile
+++ b/test/smoke/docker-root/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:12
+
+COPY ./smoke/ /snyk/smoke/
+COPY ./fixtures/ /snyk/fixtures/
+
+RUN apt-get update && apt-get install -y curl jq
+RUN curl -fsSL https://git.io/shellspec | sh -s -- --yes
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /snyk/smoke/
+
+ENTRYPOINT [ "./docker-root/entrypoint.sh" ]

--- a/test/smoke/docker-root/entrypoint.sh
+++ b/test/smoke/docker-root/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+echo "Install Snyk CLI with npm"
+npm install snyk -g
+snyk --version
+
+export EXPECTED_SNYK_VERSION=$(snyk --version)
+
+shellspec -f d


### PR DESCRIPTION
This PR introduces:

New docker container for Smoke Tests, that runs CLI install as root, replicating the issue from https://github.com/snyk/snyk/issues/1453

<img width="673" alt="Screenshot 2020-11-03 at 17 16 49" src="https://user-images.githubusercontent.com/1788727/98011610-5fb93400-1df8-11eb-8d5a-7790972e9907.png">