### PR TITLE
fix: annotate deps with Dockerfile instruction that introduced them

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "semver": "^6.0.0",
     "snyk-config": "3.1.1",
     "snyk-cpp-plugin": "2.0.0",
-    "snyk-docker-plugin": "4.6.2",
+    "snyk-docker-plugin": "4.6.3",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes a regression where dependencies were not annotated with the Dockerfile instruction that introduced them.

