### PR TITLE
fix: support globs pattern in yarn workspaces definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "graphlib": "^2.1.8",
     "inquirer": "^7.3.3",
     "lodash": "^4.17.20",
+    "micromatch": "4.0.2",
     "needle": "2.5.0",
     "open": "^7.0.3",
     "os-name": "^3.0.0",

--- a/test/acceptance/cli-test/cli-test.yarn-workspaces.spec.ts
+++ b/test/acceptance/cli-test/cli-test.yarn-workspaces.spec.ts
@@ -98,7 +98,12 @@ export const YarnWorkspacesTests: AcceptanceTests = {
       );
       t.match(
         result.getDisplayResults(),
-        'Tested 3 projects, no vulnerable paths were found.',
+        'Project name:      apple-lib',
+        'yarn project in output',
+      );
+      t.match(
+        result.getDisplayResults(),
+        'Tested 4 projects, no vulnerable paths were found.',
         'no vulnerable paths found as both policies detected and applied.',
       );
       let policyCount = 0;
@@ -115,7 +120,7 @@ export const YarnWorkspacesTests: AcceptanceTests = {
           ? '\\yarn-workspaces\\package.json'
           : 'yarn-workspaces/package.json';
 
-      params.server.popRequests(3).forEach((req) => {
+      params.server.popRequests(4).forEach((req) => {
         t.equal(req.method, 'POST', 'makes POST request');
         t.equal(
           req.headers['x-snyk-cli-version'],

--- a/test/acceptance/workspaces/yarn-workspaces/libs/apple-lib/package.json
+++ b/test/acceptance/workspaces/yarn-workspaces/libs/apple-lib/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "apple-lib",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "main": "./src/index.js",
+  "scripts": {
+    "precommit": "lint-staged"
+  },
+  "dependencies": {
+    "node-uuid": "1.3.0"
+  }
+}

--- a/test/acceptance/workspaces/yarn-workspaces/package.json
+++ b/test/acceptance/workspaces/yarn-workspaces/package.json
@@ -1,7 +1,8 @@
 {
   "private": true,
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "libs/**/*"
   ],
   "resolutions": {
     "node-fetch": "^2.3.0"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Yarn workspaces patterns also support *globs* pattern, update the matching to cover this too.
> The workspaces field is an array containing the paths to each workspace. Since it might be tedious to keep track of each of them, this field also accepts glob patterns! For example, Babel reference all of their packages through a single packages/* directive.
https://classic.yarnpkg.com/en/docs/workspaces/

Also added a failing test to show a deep globs pattern in workspaces definitions was not supported until the fix
