### PR TITLE
fix: Improve error message for scanning an image that doesn't exist

### DIFF
--- a/src/lib/errors/docker-image-not-found-error.ts
+++ b/src/lib/errors/docker-image-not-found-error.ts
@@ -1,0 +1,12 @@
+import { CustomError } from './custom-error';
+
+export class DockerImageNotFoundError extends CustomError {
+  private static ERROR_CODE = 404;
+
+  constructor(image: string) {
+    const message = `Failed to scan image "${image}". Please make sure the image and/or repository exist.`;
+    super(message);
+    this.code = DockerImageNotFoundError.ERROR_CODE;
+    this.userMessage = message;
+  }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -19,6 +19,7 @@ export { OptionMissingErrorError } from './option-missing-error';
 export { ExcludeFlagBadInputError } from './exclude-flag-bad-input';
 export { UnsupportedOptionCombinationError } from './unsupported-option-combination-error';
 export { FeatureNotSupportedByPackageManagerError } from './feature-not-supported-by-package-manager-error';
+export { DockerImageNotFoundError } from './docker-image-not-found-error';
 export {
   NotSupportedIacFileError,
   NotSupportedIacFileErrorMsg,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -27,6 +27,7 @@ import {
   FailedToGetVulnsFromUnavailableResource,
   FailedToRunTestError,
   UnsupportedFeatureFlagError,
+  DockerImageNotFoundError,
 } from '../errors';
 import * as snyk from '../';
 import { isCI } from '../is-ci';
@@ -317,6 +318,13 @@ export async function runTest(
     }
     if (hasFailedToGetVulnerabilities) {
       throw FailedToGetVulnsFromUnavailableResource(root, error.code);
+    }
+    if (
+      getEcosystem(options) === 'docker' &&
+      error.statusCode === 401 &&
+      error.message === 'authentication required'
+    ) {
+      throw new DockerImageNotFoundError(root);
     }
 
     throw new FailedToRunTestError(

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -1873,6 +1873,23 @@ if (!isWindows) {
     );
   });
 
+  test('`monitor doesnotexist --docker`', async (t) => {
+    try {
+      await cli.monitor('doesnotexist', {
+        docker: true,
+        org: 'explicit-org',
+      });
+      t.fail('should have failed');
+    } catch (err) {
+      t.match(
+        err.message,
+        'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist.',
+        'show err message',
+      );
+      t.pass('throws err');
+    }
+  });
+
   test('monitor --json multiple folders', async (t) => {
     chdirWorkspaces('fail-on');
 

--- a/test/acceptance/cli-test/cli-test.docker.spec.ts
+++ b/test/acceptance/cli-test/cli-test.docker.spec.ts
@@ -671,6 +671,22 @@ export const DockerTests: AcceptanceTests = {
       );
       t.end();
     },
+
+    '`test --docker doesnotexist`': (params) => async (t) => {
+      try {
+        await params.cli.test('doesnotexist', {
+          docker: true,
+          org: 'explicit-org',
+        });
+        t.fail('should have thrown');
+      } catch (err) {
+        const msg = err.message;
+        t.match(
+          msg,
+          'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist.',
+        );
+      }
+    },
   },
 };
 


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Converts an internal error into an actionable human readable message. 

#### How should this be manually tested?

* `snyk container monitor doesnotexist`
* `snyk container test doesnotexist`

#### What are the relevant tickets?

* [JIRA: DC-948](https://snyksec.atlassian.net/browse/DC-948)

#### Screenshots

![Screenshot 2020-11-04 at 16 00 44](https://user-images.githubusercontent.com/70949530/98134741-f64c2a80-1eb6-11eb-9a18-738333516ac7.png)
