### PR TITLE
fix: incorrect header sent for Docker Desktop requests

### DIFF
--- a/src/lib/api-token.ts
+++ b/src/lib/api-token.ts
@@ -19,3 +19,11 @@ export function apiTokenExists() {
   }
   return configured;
 }
+
+export function authHeaderWithApiTokenOrDockerJWT() {
+  const dockerToken = getDockerToken();
+  if (dockerToken) {
+    return 'bearer ' + dockerToken;
+  }
+  return 'token ' + api();
+}

--- a/src/lib/snyk-test/assemble-payloads.ts
+++ b/src/lib/snyk-test/assemble-payloads.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-import * as snyk from '../';
 import * as config from '../config';
 import { isCI } from '../is-ci';
 import { getPlugin } from '../ecosystems';
@@ -9,6 +8,7 @@ import { Payload } from './types';
 import { assembleQueryString } from './common';
 import spinner = require('../spinner');
 import { findAndLoadPolicyForScanResult } from '../ecosystems/policy';
+import { authHeaderWithApiTokenOrDockerJWT } from '../../lib/api-token';
 
 export async function assembleEcosystemPayloads(
   ecosystem: Ecosystem,
@@ -58,7 +58,7 @@ export async function assembleEcosystemPayloads(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: 'token ' + snyk.api,
+          authorization: authHeaderWithApiTokenOrDockerJWT(),
         },
         body: {
           scanResult,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -67,7 +67,7 @@ import {
 import { CallGraphError, CallGraph } from '@snyk/cli-interface/legacy/common';
 import * as alerts from '../alerts';
 import { abridgeErrorMessage } from '../error-format';
-import { getDockerToken } from '../api-token';
+import { authHeaderWithApiTokenOrDockerJWT } from '../api-token';
 import { getEcosystem } from '../ecosystems';
 import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
@@ -751,7 +751,7 @@ async function assembleLocalPayloads(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: getAuthHeader(),
+          authorization: authHeaderWithApiTokenOrDockerJWT(),
         },
         qs: common.assembleQueryString(options),
         body,
@@ -801,14 +801,6 @@ function addPackageAnalytics(name: string, version: string): void {
   analytics.add('packageName', name);
   analytics.add('packageVersion', version);
   analytics.add('package', name + '@' + version);
-}
-
-function getAuthHeader() {
-  const dockerToken = getDockerToken();
-  if (dockerToken) {
-    return 'bearer ' + dockerToken;
-  }
-  return 'token ' + snyk.api;
 }
 
 function countUniqueVulns(vulns: AnnotatedIssue[]): number {

--- a/test/acceptance/docker-token.test.ts
+++ b/test/acceptance/docker-token.test.ts
@@ -76,9 +76,18 @@ test('`snyk test` with docker flag - docker token and no api key', async (t) => 
       docker: true,
     });
     const req = server.popRequest();
+    t.match(
+      req.headers.authorization,
+      'bearer docker-jwt-token',
+      'sends correct authorization header',
+    );
     t.equal(req.method, 'POST', 'makes POST request');
     t.match(req.url, 'docker-jwt/test-dependencies', 'posts to correct url');
   } catch (err) {
+    if (err.code === 401) {
+      t.fail('did not send correct autorization header');
+      t.end();
+    }
     t.fail('did not expect exception to be thrown ' + err);
   }
 });

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -125,6 +125,13 @@ export function fakeServer(root, apikey) {
   });
 
   server.post(root + '/docker-jwt/test-dependencies', (req, res, next) => {
+    if (
+      req.headers.authorization &&
+      !req.headers.authorization.includes('bearer')
+    ) {
+      res.send(401);
+    }
+
     res.send({
       result: {
         issues: [],


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixing an issue where incorrect auth header was sent to the docker-jwt endpoint and improving test coverage in that area.

