### PR TITLE
Retry large object stringify without pretty print

### DIFF
--- a/src/cli/commands/test/formatters/format-test-results.ts
+++ b/src/cli/commands/test/formatters/format-test-results.ts
@@ -26,6 +26,7 @@ import { formatDockerBinariesIssues } from './docker';
 import { createSarifOutputForContainers } from '../sarif-output';
 import { createSarifOutputForIac } from '../iac-output';
 import { isNewVuln, isVulnFixable } from '../vuln-helpers';
+import { jsonStringifyLargeObject } from '../../../../lib/json';
 
 export function formatJsonOutput(jsonData) {
   const jsonDataClone = _.cloneDeep(jsonData);
@@ -52,12 +53,10 @@ export function extractDataToSendFromResults(
       : createSarifOutputForIac(results);
   }
 
-  const stringifiedJsonData = JSON.stringify(
+  const stringifiedJsonData = jsonStringifyLargeObject(
     formatJsonOutput(jsonData),
-    null,
-    2,
   );
-  const stringifiedSarifData = JSON.stringify(sarifData, null, 2);
+  const stringifiedSarifData = jsonStringifyLargeObject(sarifData);
 
   const dataToSend = options.sarif ? sarifData : jsonData;
   const stringifiedData = options.sarif

--- a/src/lib/json.ts
+++ b/src/lib/json.ts
@@ -1,0 +1,20 @@
+const debug = require('debug')('snyk-json');
+
+/**
+ * Attempt to json-stringify an object which is potentially very large and might exceed the string limit.
+ * If it does exceed the string limit, try again without pretty-print to hopefully come out below the string limit.
+ * @param obj the object from which you want to get a JSON string
+ */
+export function jsonStringifyLargeObject(obj: any): string {
+  let res = '';
+  try {
+    // first try pretty-print
+    res = JSON.stringify(obj, null, 2);
+    return res;
+  } catch (err) {
+    // if that doesn't work, try non-pretty print
+    debug('JSON.stringify failed - trying again without pretty print', err);
+    res = JSON.stringify(obj);
+    return res;
+  }
+}

--- a/test/json.spec.ts
+++ b/test/json.spec.ts
@@ -1,0 +1,30 @@
+import { jsonStringifyLargeObject } from '../src/lib/json';
+
+describe('jsonStringifyLargeObject', () => {
+  it('works normally with a small object', () => {
+    const smallObject = {
+      name: 'Brian',
+      isGoodBoy: true,
+    };
+    const s = jsonStringifyLargeObject(smallObject);
+    expect(s).toEqual('{\n  "name": "Brian",\n  "isGoodBoy": true\n}');
+  });
+
+  it('fallsback on non-pretty-print on very large object', () => {
+    const largeObject = {
+      name: 'Brian',
+      isGoodBoy: true,
+      type: 'big',
+    };
+    const jsonStringifyMock = jest
+      .spyOn(JSON, 'stringify')
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      .mockImplementationOnce((any) => {
+        throw new Error('fake error to simulate an `Invalid string length`');
+      });
+
+    const s = jsonStringifyLargeObject(largeObject);
+    expect(jsonStringifyMock).toHaveBeenCalledTimes(2);
+    expect(s).toEqual(`{"name":"Brian","isGoodBoy":true,"type":"big"}`);
+  });
+});


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Try/catch the JSON.stringify where we're creating the JSON/SARIF JSON outputs using pretty print and, if we catch an error, try again without pretty-print.

#### Any background context you want to provide?

This is because in very rare cases, we saw calls to JSON.stringify throw an `Invalid string length` error and in some cases we can work around this by outputting raw (non-pretty-printed) JSON rather than pretty-printed JSON.

#### What are the relevant tickets?
HAMMER-214
