### PR TITLE
fix: remove spec requirement

### DIFF
--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -12,7 +12,7 @@ import {
 
 const debug = debugLib('snyk-detect');
 
-const requiredK8SObjectFields = ['apiVersion', 'kind', 'metadata', 'spec'];
+const requiredK8SObjectFields = ['apiVersion', 'kind', 'metadata'];
 
 export function getFileType(filePath: string): string {
   const filePathSplit = filePath.split('.');

--- a/test/fixtures/iac/kubernetes/pod-invalid.yaml
+++ b/test/fixtures/iac/kubernetes/pod-invalid.yaml
@@ -1,4 +1,2 @@
 apiVersion: test
 kind: example
-metadata:
-  name: pod


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR removes the requirement of `spec` to accept yaml files as valid k8s objects

#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

We currently reject yaml files if the `spec` field is not present in k8s object.
This is not valid requirement for all k8s object for example service-account

#### What are the relevant tickets?
[Zendesk](https://snyk.zendesk.com/agent/tickets/7401)

#### Screenshots


#### Additional questions
