### PR TITLE
feat: allow usage of -q or --quiet

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "prepare": "npm run build",
     "test:common": "npm run check-tests && npm run lint && node --require ts-node/register src/cli test --org=snyk",
     "test:acceptance": "tap test/acceptance/**/*.test.* test/acceptance/*.test.* -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
+    "a": "tap test/acceptance/cli-test/cli-test.acceptance.test.ts -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
     "test:acceptance-windows": "tap test/acceptance/**/*.test.* -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
     "test:system": "tap test/system/*.test.* -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
     "test:jest": "jest",

--- a/src/lib/print-deps.ts
+++ b/src/lib/print-deps.ts
@@ -21,15 +21,19 @@ export async function maybePrintDepGraph(
   } else {
     if (options['print-deps']) {
       if (options.json) {
-        console.log(
-          '--print-deps --json option not yet supported for large projects. Displaying graph json output instead',
-        );
+        if (!options.quiet) {
+          console.log(
+            '--print-deps --json option not yet supported for large projects. Displaying graph json output instead',
+          );
+        }
         // TODO @boost: add as output graphviz 'dot' file to visualize?
         console.log(JSON.stringify(depGraph.toJSON(), null, 2));
       } else {
-        console.log(
-          '--print-deps option not yet supported for large projects. Try with --json.',
-        );
+        if (!options.quiet) {
+          console.log(
+            '--print-deps option not yet supported for large projects. Try with --json.',
+          );
+        }
       }
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface Options {
   'app-vulns'?: boolean;
   debug?: boolean;
   sarif?: boolean;
+  quiet: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -100,6 +101,7 @@ export interface MonitorOptions {
   reachableVulns?: boolean;
   reachableVulnsTimeout?: number;
   yarnWorkspaces?: boolean;
+  quiet?: boolean;
 }
 
 export interface MonitorMeta {

--- a/test/acceptance.spec.ts
+++ b/test/acceptance.spec.ts
@@ -1,0 +1,60 @@
+import { fakeServer } from './acceptance/fake-server';
+import * as cli from './../src/cli/commands';
+
+async function createFakeServer() {
+  const port = (process.env.PORT = process.env.SNYK_PORT = '12345');
+  const BASE_API = '/api/v1';
+  process.env.SNYK_API = 'http://localhost:' + port + BASE_API;
+  process.env.SNYK_HOST = 'http://localhost:' + port;
+  process.env.LOG_LEVEL = '0';
+  const apiKey = '123456789';
+  const server = fakeServer(BASE_API, apiKey);
+  let key = await cli.config('get', 'api');
+  const oldkey = key;
+  key = await cli.config('get', 'endpoint');
+  const oldendpoint = key;
+  await new Promise((resolve) => server.listen(port, resolve));
+  await cli.config('set', 'api=' + apiKey);
+  await cli.config('unset', 'endpoint');
+  return {
+    server,
+    async teardown() {
+      delete process.env.SNYK_API;
+      delete process.env.SNYK_HOST;
+      delete process.env.SNYK_PORT;
+      await new Promise((resolve) => server.close(resolve));
+      let teardownKey = 'set';
+      let value = 'api=' + oldkey;
+      if (!oldkey) {
+        teardownKey = 'unset';
+        value = 'api';
+      }
+      await cli.config(teardownKey, value);
+      if (oldendpoint) {
+        await cli.config('endpoint', oldendpoint);
+      }
+    },
+  };
+}
+
+describe('Acceptance suite', () => {
+  let globalTeardown;
+  let globalServer;
+  beforeAll(async () => {
+    const { server, teardown } = await createFakeServer();
+    globalServer = server;
+    globalTeardown = teardown;
+  });
+
+  afterAll(async () => await globalTeardown());
+
+  test('print-deps suite', async () => {
+    const response = await cli.test('print-deps', {
+      'quiet': true,
+      'json': true,
+      'print-deps': true,
+    });
+    console.log(response);
+    expect(response).toEqual(2);
+  });
+});

--- a/test/acceptance/workspaces/print-deps/expected-graph.json
+++ b/test/acceptance/workspaces/print-deps/expected-graph.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": "1.2.0",
+  "pkgManager": {
+    "name": "gomodules"
+  },
+  "pkgs": [
+    {
+      "id": "github.com/kr/text@v0.1.0",
+      "info": {
+        "name": "github.com/kr/text",
+        "version": "v0.1.0"
+      }
+    },
+    {
+      "id": "gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+      "info": {
+        "name": "gopkg.in/check.v1",
+        "version": "v0.0.0-20161208181325-20d25e280405"
+      }
+    }
+  ],
+  "graph": {
+    "rootNodeId": "root-node",
+    "nodes": [
+      {
+        "nodeId": "root-node",
+        "pkgId": "github.com/kr/text@v0.1.0",
+        "deps": [
+          {
+            "nodeId": "gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405"
+          }
+        ]
+      },
+      {
+        "nodeId": "gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+        "pkgId": "gopkg.in/check.v1@v0.0.0-20161208181325-20d25e280405",
+        "deps": []
+      }
+    ]
+  }
+}

--- a/test/acceptance/workspaces/print-deps/package-lock.json
+++ b/test/acceptance/workspaces/print-deps/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "npm-package",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    }
+  }
+}

--- a/test/acceptance/workspaces/print-deps/package.json
+++ b/test/acceptance/workspaces/print-deps/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "npm-package",
+  "version": "1.0.0",
+  "description": "Simple NPM package",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "snyk",
+  "license": "ISC",
+  "dependencies": {
+    "debug": "2.2.0"
+  },
+  "devDependencies": {
+    "object-assign": "4.1.1"
+  }
+}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
We would like to allow the usage of `-q` (== `--quiet`) as a cli flag in order to allow users to ignore warnings; A classic example will be the print-deps warning for large graphs/trees;
