### PR TITLE
fix: bump nuget plugin to fix diff target monikers

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.23.0",
     "snyk-nodejs-lockfile-parser": "1.28.1",
-    "snyk-nuget-plugin": "1.19.3",
+    "snyk-nuget-plugin": "1.19.4",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.14.1",
     "snyk-python-plugin": "1.18.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

This PR bumps the NuGet plugin to 1.9.4

#### What are the relevant tickets?

https://github.com/snyk/snyk-nuget-plugin/issues/75