### PR TITLE
fix: bump python plugin version

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "snyk-nuget-plugin": "1.19.3",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.14.1",
-    "snyk-python-plugin": "1.19.0",
+    "snyk-python-plugin": "1.19.1",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.4.0",
     "snyk-sbt-plugin": "2.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Bump snyk-python-plugin version to include auto-resolving dependencies with underscores to hyphens