### PR TITLE
fix: restore analytics for tracking Docker/container calls

### DIFF
--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -112,6 +112,9 @@ function prepareEcosystemResponseForParsing(
   const targetFile = payloadBody?.identity?.targetFile || options.file;
   const platform = payloadBody?.identity?.args?.platform;
 
+  analytics.add('depGraph', !!depGraph);
+  analytics.add('isDocker', !!options.docker);
+
   return {
     depGraph,
     dockerfilePackages,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Restore analytics for tracking Docker/container calls.

#### Any background context you want to provide?

[Slack thread where it was first reported](https://snyk.slack.com/archives/CFVCSBXN0/p1604590163176000?thread_ts=1604586579.175300&cid=CFVCSBXN0)
