### PR TITLE
fix: use Java call graph builder with long path fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.2",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.23.1",
+    "snyk-mvn-plugin": "2.23.3",
     "snyk-nodejs-lockfile-parser": "1.30.1",
     "snyk-nuget-plugin": "1.19.4",
     "snyk-php-plugin": "1.9.2",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Bumps the version of the maven plugin to include the long path fix for the java call graph builder.

snyk/java-call-graph-builder#38