### PR TITLE
feat: Bump docker plugin to enable env var auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0-rc.2",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.7.4",
+    "snyk-docker-plugin": "4.9.0",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.10.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
Setting SNYK_REGISTRY_USERNAME and/or SNYK_REGISTRY_PASSWORD environment variables allows these credentials to be used to log in to remote registries. The existing --username and --password flags, if present, take precedence

Documentation updates to follow in a separate PR

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team


