### PR TITLE
test: Fix a flaky test

### DIFF
--- a/test/metrics.spec.ts
+++ b/test/metrics.spec.ts
@@ -49,12 +49,15 @@ describe('TimerMetricInstance', () => {
     expect(tmi.getValue()).toBeUndefined;
   });
 
-  it('can time things', async () => {
+  it('can time things with sufficient accuracy', async () => {
     const tmi = new TimerMetricInstance('timer/network_time');
     tmi.start();
     await sleep(10);
     tmi.stop();
-    expect(tmi.getValue()).toBeGreaterThan(9);
+    // Sleep() is backed by setTimeout(), and some Node runtimes might execute setTimeout callback before the specified
+    // delay, meaning that tmi.getValue() will occasionally return `9` at this point. An extra ms leeway in this
+    // assertion works round the issue. https://github.com/nodejs/node/issues/10154
+    expect(tmi.getValue()).toBeGreaterThanOrEqual(9);
   });
 
   it('.start() / .stop() logs start/top and improper use warnings if you try to start/stop it again after stopping it', async () => {


### PR DESCRIPTION
In the modified test file, sleep() is backed by setTimeout(), and some Node runtimes might execute setTimeout callback before the specified delay, meaning that tmi.getValue() will occasionally return `9`. This produces a flaky test, eg https://app.circleci.com/pipelines/github/snyk/snyk/3074/workflows/f11955a8-5ffc-450a-94be-387dfdfc55a8/jobs/17080. An extra ms leeway in the assertion works round the issue. https://github.com/nodejs/node/issues/10154.

Test name updated to reflect that the timer's accuracy does not have single-digit precision

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team
