### PR TITLE
fix: correct credential auth failure error text

### DIFF
--- a/src/lib/errors/docker-image-not-found-error.ts
+++ b/src/lib/errors/docker-image-not-found-error.ts
@@ -4,7 +4,7 @@ export class DockerImageNotFoundError extends CustomError {
   private static ERROR_CODE = 404;
 
   constructor(image: string) {
-    const message = `Failed to scan image "${image}". Please make sure the image and/or repository exist.`;
+    const message = `Failed to scan image "${image}". Please make sure the image and/or repository exist, and that you are using the correct credentials.`;
     super(message);
     this.code = DockerImageNotFoundError.ERROR_CODE;
     this.userMessage = message;

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -325,7 +325,10 @@ export async function runTest(
     if (
       getEcosystem(options) === 'docker' &&
       error.statusCode === 401 &&
-      error.message === 'authentication required'
+      [
+        'authentication required',
+        '{"details":"incorrect username or password"}\n',
+      ].includes(error.message)
     ) {
       throw new DockerImageNotFoundError(root);
     }

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -1883,7 +1883,7 @@ if (!isWindows) {
     } catch (err) {
       t.match(
         err.message,
-        'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist.',
+        'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist, and that you are using the correct credentials.',
         'show err message',
       );
       t.pass('throws err');

--- a/test/acceptance/cli-test/cli-test.docker.spec.ts
+++ b/test/acceptance/cli-test/cli-test.docker.spec.ts
@@ -683,7 +683,7 @@ export const DockerTests: AcceptanceTests = {
         const msg = err.message;
         t.match(
           msg,
-          'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist.',
+          'Failed to scan image "doesnotexist". Please make sure the image and/or repository exist, and that you are using the correct credentials.',
         );
       }
     },


### PR DESCRIPTION

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Container registries can return an error which we don't currently catch as a Docker one, resulting in user getting shown JSON in the terminal. This fixes that by replacing it with a human-readable message, as well as clarifying that the same error can also result from bad credentials


#### How should this be manually tested?
Example commands are in #run-1041-demo

#### Any background context you want to provide?
https://snyk.slack.com/archives/C01EXBHKVML/p1605797706005400?thread_ts=1605797655.004700&cid=C01EXBHKVML

#### What are the relevant tickets?
[RUN-1041]

#### Screenshots
https://snyk.slack.com/archives/C01EXBHKVML/p1605868316000300


[RUN-1041]: https://snyksec.atlassian.net/browse/RUN-1041