### PR TITLE
fix: Error output for mismatched options

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -105,7 +105,10 @@ async function handleError(args, error) {
   if (args.options.debug && !args.options.json) {
     const output = vulnsFound ? error.message : error.stack;
     console.log(output);
-  } else if (args.options.json) {
+  } else if (
+    args.options.json &&
+    !(error instanceof UnsupportedOptionCombinationError)
+  ) {
     console.log(stripAnsi(error.json || error.stack));
   } else {
     if (!args.options.quiet) {

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -454,8 +454,8 @@ test(
 );
 
 test('flags not allowed with --sarif', (t) => {
-  t.plan(1);
-  exec(`node ${main} test --sarif --json`, (err, stdout) => {
+  t.plan(4);
+  exec(`node ${main} test iac --sarif --json`, (err, stdout) => {
     if (err) {
       console.log('CLI stdout: ', stdout);
       throw err;
@@ -464,6 +464,30 @@ test('flags not allowed with --sarif', (t) => {
       stdout.trim(),
       new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
         .userMessage,
+      'Display unsupported combination error message (iac)',
+    );
+    t.equal(
+      stdout.trim().split('\n').length,
+      1,
+      'Error message should not include stacktrace (iac)',
+    );
+  });
+
+  exec(`node ${main} test container --sarif --json`, (err, stdout) => {
+    if (err) {
+      console.log('CLI stdout: ', stdout);
+      throw err;
+    }
+    t.match(
+      stdout.trim(),
+      new UnsupportedOptionCombinationError(['test', 'sarif', 'json'])
+        .userMessage,
+      'Display unsupported combination error message (container)',
+    );
+    t.equal(
+      stdout.trim().split('\n').length,
+      1,
+      'Error message should not include stacktrace (container)',
     );
   });
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Currently when running:

```
% snyk iac test --sarif --json # or
% snyk container test --sarif --json
```

We output the error stack to the terminal (due to the `--json` flag):

```
UnsupportedOptionCombinationError: The following option combination is not currently supported: test + sarif + json
    at validateUnsupportedSarifCombinations (/Users/$USER/.nvm/versions/node/v12.19.0/lib/node_modules/snyk/src/cli/index.ts:383:11)
    at main (/Users/$USER/.nvm/versions/node/v12.19.0/lib/node_modules/snyk/src/cli/index.ts:265:5)
    at Object.<anonymous> (/Users/$USER/.nvm/versions/node/v12.19.0/lib/node_modules/snyk/src/cli/index.ts:293:13)
    at Module._compile (internal/modules/cjs/loader.js:1015:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1035:10)
    at Module.load (internal/modules/cjs/loader.js:879:32)
    at Function.Module._load (internal/modules/cjs/loader.js:724:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47
```

This PR changes this behaviour to output the user friendly error message.

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/47144/100074323-80443f00-2e36-11eb-97ba-16c22878b2d0.png">

I've also updated the integration tests to verify that the stack trace is not included in the output.

Fixes [CC-401]

#### Where should the reviewer start?

Start and finish in src/cli/index.ts

#### How should this be manually tested?

Generate a local build (`npm run build`) and run:

```
node ./dist/cli/index.js container test --json --sarif
```


[CC-401]: https://snyksec.atlassian.net/browse/CC-401