### PR TITLE
feat: use policy testing scan results

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,7 @@ export interface Options {
   debug?: boolean;
   sarif?: boolean;
   'group-issues'?: boolean;
+  'ignore-policy'?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/ecosystems-test-cpp.spec.ts
+++ b/test/ecosystems-test-cpp.spec.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as ecosystems from '../src/lib/ecosystems';
 import * as ecosystemsTypes from '../src/lib/ecosystems/types';
 import * as request from '../src/lib/request/promise';
+import * as snykPolicyLib from 'snyk-policy';
 
 import { TestCommandResult } from '../src/cli/commands/types';
 const osName = require('os-name');
@@ -13,35 +14,21 @@ const isWindows =
     .toLowerCase()
     .indexOf('windows') === 0;
 
-describe('testEcosystem - cpp', () => {
-  const fixturePath = path.join(__dirname, 'fixtures', 'cpp-project');
+describe('test ecosystem - cpp', () => {
   const cwd = process.cwd();
 
-  function readFixture(filename: string) {
+  function readFixture(fixturePath: string, filename: string) {
     if (isWindows) {
       filename = filename.replace('.txt', '-windows.txt');
     }
-
     const filePath = path.join(fixturePath, filename);
     return fs.readFileSync(filePath, 'utf-8');
   }
 
-  function readJsonFixture(filename: string) {
-    const contents = readFixture(filename);
+  function readJsonFixture(fixturePath: string, filename: string) {
+    const contents = readFixture(fixturePath, filename);
     return JSON.parse(contents);
   }
-
-  const displayTxt = readFixture('display.txt');
-  const debugDisplayTxt = readFixture('debug-display.txt');
-  const errorTxt = readFixture('error.txt');
-  const testResult = readJsonFixture(
-    'testResults.json',
-  ) as ecosystemsTypes.TestResult;
-  const stringifyTestResults = JSON.stringify([testResult], null, 2);
-
-  beforeAll(() => {
-    process.chdir(fixturePath);
-  });
 
   afterEach(() => {
     jest.resetAllMocks();
@@ -51,157 +38,290 @@ describe('testEcosystem - cpp', () => {
     process.chdir(cwd);
   });
 
-  it('should return human readable result when no json option given', async () => {
-    const makeRequestSpy = jest
-      .spyOn(request, 'makeRequest')
-      .mockResolvedValue({ result: testResult });
-    const expected = TestCommandResult.createHumanReadableTestCommandResult(
-      displayTxt,
-      stringifyTestResults,
-    );
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
+  describe('cpp-project fixture', () => {
+    const fixturePath = path.join(__dirname, 'fixtures', 'cpp-project');
+    const displayTxt = readFixture(fixturePath, 'display.txt');
+    const debugDisplayTxt = readFixture(fixturePath, 'debug-display.txt');
+    const errorTxt = readFixture(fixturePath, 'error.txt');
+    const testResult = readJsonFixture(
+      fixturePath,
+      'testResults.json',
+    ) as ecosystemsTypes.TestResult;
+    const stringifyTestResults = JSON.stringify([testResult], null, 2);
+
+    beforeAll(() => {
+      process.chdir(fixturePath);
     });
-    expect(makeRequestSpy.mock.calls[0][0]).toEqual({
-      body: {
-        scanResult: {
-          facts: [
-            {
-              type: 'cpp-fingerprints',
-              data: [
-                {
-                  filePath: 'add.cpp',
-                  hash: '52d1b046047db9ea0c581cafd4c68fe5',
-                },
-                {
-                  filePath: 'add.h',
-                  hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
-                },
-                {
-                  filePath: 'main.cpp',
-                  hash: 'ad3365b3370ef6b1c3e778f875055f19',
-                },
-              ],
+
+    it('should return human readable result when no json option given', async () => {
+      const makeRequestSpy = jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ result: testResult });
+      const expected = TestCommandResult.createHumanReadableTestCommandResult(
+        displayTxt,
+        stringifyTestResults,
+      );
+      const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+        path: '',
+      });
+      expect(makeRequestSpy.mock.calls[0][0]).toEqual({
+        body: {
+          scanResult: {
+            facts: [
+              {
+                type: 'cpp-fingerprints',
+                data: [
+                  {
+                    filePath: 'add.cpp',
+                    hash: '52d1b046047db9ea0c581cafd4c68fe5',
+                  },
+                  {
+                    filePath: 'add.h',
+                    hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+                  },
+                  {
+                    filePath: 'main.cpp',
+                    hash: 'ad3365b3370ef6b1c3e778f875055f19',
+                  },
+                ],
+              },
+            ],
+            identity: {
+              type: 'cpp',
             },
-          ],
-          identity: {
-            type: 'cpp',
-          },
-          name: expect.any(String),
-          target: {
-            branch: expect.any(String),
-            remoteUrl: expect.any(String),
+            name: expect.any(String),
+            target: {
+              branch: expect.any(String),
+              remoteUrl: expect.any(String),
+            },
           },
         },
-      },
-      headers: {
-        authorization: expect.stringContaining('token'),
-        'x-is-ci': expect.any(Boolean),
-      },
-      json: true,
-      method: 'POST',
-      url: expect.stringContaining('/test-dependencies'),
-      qs: expect.any(Object),
+        headers: {
+          authorization: expect.stringContaining('token'),
+          'x-is-ci': expect.any(Boolean),
+        },
+        json: true,
+        method: 'POST',
+        url: expect.stringContaining('/test-dependencies'),
+        qs: expect.any(Object),
+      });
+      expect(actual).toEqual(expected);
     });
-    expect(actual).toEqual(expected);
-  });
 
-  it('should return json result when json option', async () => {
-    const makeRequestSpy = jest
-      .spyOn(request, 'makeRequest')
-      .mockResolvedValue({ result: testResult });
-    const expected = TestCommandResult.createJsonTestCommandResult(
-      stringifyTestResults,
-    );
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
-      json: true,
-    });
-    expect(makeRequestSpy.mock.calls[0][0]).toEqual({
-      body: {
-        scanResult: {
-          facts: [
-            {
-              type: 'cpp-fingerprints',
-              data: [
-                {
-                  filePath: 'add.cpp',
-                  hash: '52d1b046047db9ea0c581cafd4c68fe5',
-                },
-                {
-                  filePath: 'add.h',
-                  hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
-                },
-                {
-                  filePath: 'main.cpp',
-                  hash: 'ad3365b3370ef6b1c3e778f875055f19',
-                },
-              ],
+    it('should return json result when json option', async () => {
+      const makeRequestSpy = jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ result: testResult });
+      const expected = TestCommandResult.createJsonTestCommandResult(
+        stringifyTestResults,
+      );
+      const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+        path: '',
+        json: true,
+      });
+      expect(makeRequestSpy.mock.calls[0][0]).toEqual({
+        body: {
+          scanResult: {
+            facts: [
+              {
+                type: 'cpp-fingerprints',
+                data: [
+                  {
+                    filePath: 'add.cpp',
+                    hash: '52d1b046047db9ea0c581cafd4c68fe5',
+                  },
+                  {
+                    filePath: 'add.h',
+                    hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+                  },
+                  {
+                    filePath: 'main.cpp',
+                    hash: 'ad3365b3370ef6b1c3e778f875055f19',
+                  },
+                ],
+              },
+            ],
+            identity: {
+              type: 'cpp',
             },
-          ],
-          identity: {
-            type: 'cpp',
-          },
-          name: expect.any(String),
-          target: {
-            branch: expect.any(String),
-            remoteUrl: expect.any(String),
+            name: expect.any(String),
+            target: {
+              branch: expect.any(String),
+              remoteUrl: expect.any(String),
+            },
           },
         },
-      },
-      headers: {
-        authorization: expect.stringContaining('token'),
-        'x-is-ci': expect.any(Boolean),
-      },
-      json: true,
-      method: 'POST',
-      url: expect.stringContaining('/test-dependencies'),
-      qs: expect.any(Object),
+        headers: {
+          authorization: expect.stringContaining('token'),
+          'x-is-ci': expect.any(Boolean),
+        },
+        json: true,
+        method: 'POST',
+        url: expect.stringContaining('/test-dependencies'),
+        qs: expect.any(Object),
+      });
+      expect(actual).toEqual(expected);
     });
-    expect(actual).toEqual(expected);
-  });
 
-  it('should return fingerprints when debug option is set', async () => {
-    const mock = jest
-      .spyOn(request, 'makeRequest')
-      .mockResolvedValue({ result: testResult });
-    const expected = TestCommandResult.createHumanReadableTestCommandResult(
-      debugDisplayTxt,
-      stringifyTestResults,
+    it('should return fingerprints when debug option is set', async () => {
+      const makeRequestSpy = jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ result: testResult });
+      const expected = TestCommandResult.createHumanReadableTestCommandResult(
+        debugDisplayTxt,
+        stringifyTestResults,
+      );
+      const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+        path: '',
+        debug: true,
+      });
+      expect(makeRequestSpy).toHaveBeenCalled();
+      expect(actual).toEqual(expected);
+    });
+
+    it('should throw error when response code is not 200', async () => {
+      const error = { code: 401, message: 'Invalid auth token' };
+      jest.spyOn(request, 'makeRequest').mockRejectedValue(error);
+      const expected = new Error(error.message);
+      expect.assertions(1);
+      try {
+        await ecosystems.testEcosystem('cpp', ['.'], {
+          path: '',
+        });
+      } catch (error) {
+        expect(error).toEqual(expected);
+      }
+    });
+
+    it('should return error when there was a problem testing dependencies', async () => {
+      jest
+        .spyOn(request, 'makeRequest')
+        .mockRejectedValue('Something went wrong');
+      const expected = TestCommandResult.createHumanReadableTestCommandResult(
+        errorTxt,
+        '[]',
+      );
+      const actual = await ecosystems.testEcosystem('cpp', ['.'], {
+        path: '',
+      });
+      expect(actual).toEqual(expected);
+    });
+  });
+  describe('cpp-project-with-policy fixture', () => {
+    const fixturePath = path.join(
+      __dirname,
+      'fixtures',
+      'cpp-project-with-policy',
     );
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
-      debug: true,
-    });
-    expect(mock).toHaveBeenCalled();
-    expect(actual).toEqual(expected);
-  });
+    const policyFile = readFixture(fixturePath, '.snyk');
 
-  it('should throw error when response code is not 200', async () => {
-    const error = { code: 401, message: 'Invalid auth token' };
-    jest.spyOn(request, 'makeRequest').mockRejectedValue(error);
-    const expected = new Error(error.message);
-    expect.assertions(1);
-    try {
+    beforeAll(() => {
+      process.chdir(fixturePath);
+    });
+
+    it('should send policy when .snyk found locally', async () => {
+      const makeRequestSpy = jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ result: {} });
       await ecosystems.testEcosystem('cpp', ['.'], {
         path: '',
       });
-    } catch (error) {
-      expect(error).toEqual(expected);
-    }
-  });
-
-  it('should return error when there was a problem testing dependencies', async () => {
-    jest
-      .spyOn(request, 'makeRequest')
-      .mockRejectedValue('Something went wrong');
-    const expected = TestCommandResult.createHumanReadableTestCommandResult(
-      errorTxt,
-      '[]',
-    );
-    const actual = await ecosystems.testEcosystem('cpp', ['.'], {
-      path: '',
+      expect(makeRequestSpy.mock.calls[0][0]).toEqual({
+        body: {
+          scanResult: {
+            facts: [
+              {
+                type: 'cpp-fingerprints',
+                data: [
+                  {
+                    filePath: 'add.cpp',
+                    hash: '52d1b046047db9ea0c581cafd4c68fe5',
+                  },
+                  {
+                    filePath: 'add.h',
+                    hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+                  },
+                  {
+                    filePath: 'main.cpp',
+                    hash: 'ad3365b3370ef6b1c3e778f875055f19',
+                  },
+                ],
+              },
+            ],
+            identity: {
+              type: 'cpp',
+            },
+            name: expect.any(String),
+            policy: policyFile,
+            target: {
+              branch: expect.any(String),
+              remoteUrl: expect.any(String),
+            },
+          },
+        },
+        headers: {
+          authorization: expect.stringContaining('token'),
+          'x-is-ci': expect.any(Boolean),
+        },
+        json: true,
+        method: 'POST',
+        url: expect.stringContaining('/test-dependencies'),
+        qs: expect.any(Object),
+      });
     });
-    expect(actual).toEqual(expected);
+    it('should not send policy when ignore-policy option set', async () => {
+      const makeRequestSpy = jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ result: {} });
+      await ecosystems.testEcosystem('cpp', ['.'], {
+        path: '',
+        'ignore-policy': true,
+      });
+      expect(makeRequestSpy.mock.calls[0][0]).toEqual({
+        body: {
+          scanResult: {
+            facts: [
+              {
+                type: 'cpp-fingerprints',
+                data: [
+                  {
+                    filePath: 'add.cpp',
+                    hash: '52d1b046047db9ea0c581cafd4c68fe5',
+                  },
+                  {
+                    filePath: 'add.h',
+                    hash: 'aeca71a6e39f99a24ecf4c088eee9cb8',
+                  },
+                  {
+                    filePath: 'main.cpp',
+                    hash: 'ad3365b3370ef6b1c3e778f875055f19',
+                  },
+                ],
+              },
+            ],
+            identity: {
+              type: 'cpp',
+            },
+            name: expect.any(String),
+            policy: (await snykPolicyLib.create()).toString(), // policy replaced with empty one
+            target: {
+              branch: expect.any(String),
+              remoteUrl: expect.any(String),
+            },
+          },
+        },
+        headers: {
+          authorization: expect.stringContaining('token'),
+          'x-is-ci': expect.any(Boolean),
+        },
+        json: true,
+        method: 'POST',
+        url: expect.stringContaining('/test-dependencies'),
+        qs: {
+          org: null,
+          ignorePolicy: true,
+        },
+      });
+    });
   });
 });

--- a/test/fixtures/cpp-project-with-policy/.snyk
+++ b/test/fixtures/cpp-project-with-policy/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.14.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-VULN-PKG-123:
+    - '*':
+        reason: None Given
+        expires: 2100-01-01T00:00:00.000Z
+patch: {}

--- a/test/fixtures/cpp-project-with-policy/add.cpp
+++ b/test/fixtures/cpp-project-with-policy/add.cpp
@@ -1,0 +1,4 @@
+int add(int x, int y)
+{
+  return x + y;
+}

--- a/test/fixtures/cpp-project-with-policy/add.h
+++ b/test/fixtures/cpp-project-with-policy/add.h
@@ -1,0 +1,1 @@
+int add(int x, int y);

--- a/test/fixtures/cpp-project-with-policy/main.cpp
+++ b/test/fixtures/cpp-project-with-policy/main.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+#include "add.h"
+
+int main() {
+  std::cout << "The sum of 3 and 4 is " << add(3, 4) << '\n';
+  return 0;
+}


### PR DESCRIPTION


- [X] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
If the CLI plugin does not provide a policy, default to searching for a
.snyk file in the scan result path, and use that if found.

#### How should this be manually tested?
`snyk ignore` to create a `.snyk` policy file, then `snyk source test` or `snyk source monitor` to ensure the policy is being used.

