### PR TITLE
fix: Group issues should also group names

### DIFF
--- a/src/cli/commands/test/formatters/format-test-results.ts
+++ b/src/cli/commands/test/formatters/format-test-results.ts
@@ -38,6 +38,7 @@ export function formatJsonOutput(jsonData, options: Options) {
         any
       > => {
         vuln.from = [vuln.from].concat(acc[vuln.id]?.from || []);
+        vuln.name = [vuln.name].concat(acc[vuln.id]?.name || []);
         acc[vuln.id] = vuln;
         return acc;
       }, {}),

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -254,7 +254,11 @@ async function main() {
         '--group-issues is currently not supported for Snyk IaC.',
       ]);
     }
-    if (args.options['group-issues'] && !args.options['json']) {
+    if (
+      args.options['group-issues'] &&
+      !args.options['json'] &&
+      !args.options['json-file-output']
+    ) {
       throw new UnsupportedOptionCombinationError([
         'JSON output is required to use --group-issues, try adding --json.',
       ]);

--- a/test/fixtures/basic-apk/jsonDataGrouped.json
+++ b/test/fixtures/basic-apk/jsonDataGrouped.json
@@ -103,7 +103,21 @@
       "upgradePath": [],
       "isUpgradable": false,
       "isPatchable": false,
-      "name": "musl/musl-utils",
+      "name": [
+        "musl/musl-utils",
+        "musl/musl-utils",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl",
+        "musl/musl"
+      ],
       "version": "1.1.24-r9",
       "nearestFixedInVersion": "1.1.24-r10"
     }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Small fix for the `--group-issues` flag. We should also group the name attribute along with the from attribute.

#### Screenshots

![image](https://user-images.githubusercontent.com/49239888/101046435-f3595e00-3578-11eb-8497-4c8c1b4d7634.png)

