### PR TITLE
fix: allow indicative messages for CLI users

### DIFF
--- a/src/lib/errors/non-existing-package-error.ts
+++ b/src/lib/errors/non-existing-package-error.ts
@@ -1,0 +1,12 @@
+import { CustomError } from './custom-error';
+
+export class NonExistingPackageError extends CustomError {
+  private static ERROR_CODE = 404;
+  private static ERROR_MESSAGE = "Couldn't find the requested package";
+
+  constructor() {
+    super(NonExistingPackageError.ERROR_MESSAGE);
+    this.code = NonExistingPackageError.ERROR_CODE;
+    this.userMessage = NonExistingPackageError.ERROR_MESSAGE;
+  }
+}

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -72,6 +72,7 @@ import { authHeaderWithApiTokenOrDockerJWT } from '../api-token';
 import { getEcosystem } from '../ecosystems';
 import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
+import { NonExistingPackageError } from '../errors/non-existing-package-error';
 
 const debug = debugModule('snyk:run-test');
 
@@ -465,6 +466,10 @@ function handleTestHttpErrorResponse(res, body) {
     case 401:
     case 403:
       err = AuthFailedError(userMessage, statusCode);
+      err.innerError = body.stack;
+      break;
+    case 404:
+      err = new NonExistingPackageError();
       err.innerError = body.stack;
       break;
     case 405:

--- a/test/acceptance/cli-test/cli-test.generic.spec.ts
+++ b/test/acceptance/cli-test/cli-test.generic.spec.ts
@@ -40,7 +40,7 @@ export const GenericTests: AcceptanceTests = {
       } catch (err) {
         t.equal(
           err.userMessage,
-          'cli error message',
+          "Couldn't find the requested package",
           'got correct err message',
         );
       }
@@ -58,7 +58,7 @@ export const GenericTests: AcceptanceTests = {
       } catch (err) {
         t.equal(
           err.userMessage,
-          'cli error message',
+          "Couldn't find the requested package",
           'got correct err message',
         );
       }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Allow users to see a 404 message for non-existing packages