### PR TITLE
feat: Add impact and resolve fields in sarif output.

### DIFF
--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -222,8 +222,14 @@ export function extractReportingDescriptor(
         text: `${iacTypeToText[issue.type]} ${issue.subType}`,
       },
       help: {
-        text: '',
-        markdown: issue.description,
+        text: `The issue is... \n${issue.iacDescription.issue}\n\n The impact of this is... \n ${issue.iacDescription.impact}\n\n You can resolve this by... \n${issue.iacDescription.resolve}`.replace(
+          /^\s+/g,
+          '',
+        ),
+        markdown: `**The issue is...** \n${issue.iacDescription.issue}\n\n **The impact of this is...** \n ${issue.iacDescription.impact}\n\n **You can resolve this by...** \n${issue.iacDescription.resolve}`.replace(
+          /^\s+/g,
+          '',
+        ),
       },
       defaultConfiguration: {
         level: getIssueLevel(issue.severity),

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -1,4 +1,4 @@
-import { BasicResultData, TestDepGraphMeta, SEVERITY } from './legacy';
+import { BasicResultData, SEVERITY, TestDepGraphMeta } from './legacy';
 
 export interface AnnotatedIacIssue {
   id: string;
@@ -14,6 +14,11 @@ export interface AnnotatedIacIssue {
   name?: string;
   from?: string[];
   lineNumber?: number;
+  iacDescription: {
+    issue: string;
+    impact: string;
+    resolve: string;
+  };
 }
 
 type FILTERED_OUT_FIELDS = 'cloudConfigPath' | 'name' | 'from';

--- a/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
+++ b/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
@@ -281,6 +281,7 @@ export function iacTestSarifAssertions(
 
 function generateDummyIssue(severity): AnnotatedIacIssue {
   return {
+    iacDescription: { issue: '', impact: '', resolve: '' },
     id: 'SNYK-CC-K8S-1',
     title: 'Reducing the admission of containers with dropped capabilities',
     name: 'Reducing the admission of containers with dropped capabilities',
@@ -303,7 +304,7 @@ function generateDummyIssue(severity): AnnotatedIacIssue {
 }
 
 function generateDummyTestData(
-  cloudConfigResults: Array<AnnotatedIacIssue>,
+  cloudConfigResults: AnnotatedIacIssue[],
 ): IacTestResponse {
   return {
     path: '',


### PR DESCRIPTION
CC-517

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
This PR adds the 'resolve' and 'impact' fields in the results of the sarif output in order to give more useful information to the users and show that to the Github Security page (coming from the registry's AnnotatedIssues object).

#### Where should the reviewer start?
Check the two new fields in `iac-output.ts. The resolution is added to the 'help' field and the impact is included in the full description.

#### How should this be manually tested?

- [ ] Run iac test --sarif and see the results

- [ ] Check Github Security

#### Any background context you want to provide?

We are using the reportingDescriptor object, more info on the docs here [Github Security SARIF Docs](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/sarif-support-for-code-scanning#supported-sarif-output-file-properties)

#### What are the relevant tickets?
[Jira CC-517](https://snyksec.atlassian.net/browse/CC-517)

#### Screenshots
**CLI Output:**
<img width="1215" alt="image" src="https://user-images.githubusercontent.com/6989529/102087881-0fc78700-3e12-11eb-8371-53f646282941.png">

**Github Security:**
![image](https://user-images.githubusercontent.com/6989529/102087757-e9a1e700-3e11-11eb-9678-9adc08ba14fc.png)

