### PR TITLE
Resolve type annotation changes required to enable `composite` in tsconfig

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -52,7 +52,7 @@ const EXIT_CODES = {
 async function runCommand(args: Args) {
   const commandResult = await args.method(...args.options._);
 
-  const res = analytics({
+  const res = analytics.addDataAndSend({
     args: args.options._,
     command: args.command,
     org: args.options.org,
@@ -156,7 +156,7 @@ async function handleError(args, error) {
     analytics.add('command', args.command);
   }
 
-  const res = analytics({
+  const res = analytics.addDataAndSend({
     args: args.options._,
     command,
     org: args.options.org,

--- a/src/lib/protect/apply-patch.js
+++ b/src/lib/protect/apply-patch.js
@@ -7,7 +7,7 @@ const path = require('path');
 const fs = require('fs');
 const uuid = require('uuid/v4');
 const semver = require('semver');
-const errorAnalytics = require('../analytics').single;
+const errorAnalytics = require('../analytics').postAnalytics;
 
 function applyPatch(patchFileName, vuln, live, patchUrl) {
   let cwd = vuln.source;

--- a/src/lib/request/index.ts
+++ b/src/lib/request/index.ts
@@ -1,12 +1,13 @@
 import request = require('./request');
 import alerts = require('../alerts');
 import { MetricsCollector } from '../metrics';
+import * as needle from 'needle';
 
 // A hybrid async function: both returns a promise and takes a callback
 export = async (
   payload: any,
   callback?: (err: Error | null, res?, body?) => void,
-) => {
+): Promise<void | { res: needle.NeedleResponse; body: any }> => {
   const totalNetworkTimeTimer = MetricsCollector.NETWORK_TIME.createInstance();
   totalNetworkTimeTimer.start();
   try {

--- a/src/lib/user-config.ts
+++ b/src/lib/user-config.ts
@@ -1,7 +1,7 @@
 const Configstore = require('configstore');
 const pkg = require(__dirname + '/../../package.json');
 
-class ConfigStoreWithEnvironmentVariables extends Configstore {
+export class ConfigStoreWithEnvironmentVariables extends Configstore {
   constructor(id, defaults = undefined, options = {}) {
     super(id, defaults, options);
   }

--- a/test/analytics.spec.ts
+++ b/test/analytics.spec.ts
@@ -4,7 +4,7 @@ describe('Analytics basic testing', () => {
   it('Has all analytics arguments', async () => {
     analytics.add('foo', 'bar');
     const data = { args: [], command: '__test__' };
-    const res = await analytics(data);
+    const res = await analytics.addDataAndSend(data);
     if (!res) {
       throw 'analytics creation failed!';
     }
@@ -34,7 +34,7 @@ describe('Analytics basic testing', () => {
   it('Has all analytics arguments when org is specified', async () => {
     analytics.add('foo', 'bar');
     const data = { args: [], command: '__test__', org: '__snyk__' };
-    const res = await analytics(data);
+    const res = await analytics.addDataAndSend(data);
     if (!res) {
       throw 'analytics creation failed!';
     }
@@ -68,7 +68,7 @@ describe('Analytics basic testing', () => {
       args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
       command: '__test__',
     };
-    const res = await analytics(data);
+    const res = await analytics.addDataAndSend(data);
     if (!res) {
       throw 'analytics creation failed!';
     }
@@ -102,7 +102,7 @@ describe('Analytics basic testing', () => {
       command: '__test__',
       org: '__snyk__',
     };
-    const res = await analytics(data);
+    const res = await analytics.addDataAndSend(data);
     if (!res) {
       throw 'analytics creation failed!';
     }
@@ -137,7 +137,7 @@ describe('Analytics basic testing', () => {
       command: '__test__',
       org: '__snyk__',
     };
-    const res = await analytics(data);
+    const res = await analytics.addDataAndSend(data);
     if (!res) {
       throw 'analytics creation failed!';
     }

--- a/test/analytics.test.ts
+++ b/test/analytics.test.ts
@@ -50,7 +50,7 @@ test('analytics disabled', (t) => {
     './request': spy,
   });
 
-  return analytics().then(() => {
+  return analytics.addDataAndSend().then(() => {
     t.equal(spy.called, false, 'the request should not have been made');
   });
 });
@@ -63,42 +63,44 @@ test('analytics', (t) => {
 
   analytics.add('foo', 'bar');
 
-  return analytics({
-    command: '__test__',
-    args: [
-      {
-        integrationName: 'JENKINS',
-        integrationVersion: '1.2.3',
-      },
-    ],
-  }).then(() => {
-    const body = spy.lastCall.args[0].body.data;
-    t.deepEqual(
-      Object.keys(body).sort(),
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-      'keys as expected',
-    );
+  return analytics
+    .addDataAndSend({
+      command: '__test__',
+      args: [
+        {
+          integrationName: 'JENKINS',
+          integrationVersion: '1.2.3',
+        },
+      ],
+    })
+    .then(() => {
+      const body = spy.lastCall.args[0].body.data;
+      t.deepEqual(
+        Object.keys(body).sort(),
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+        'keys as expected',
+      );
 
-    const queryString = spy.lastCall.args[0].qs;
-    t.deepEqual(queryString, undefined, 'query string is empty');
-  });
+      const queryString = spy.lastCall.args[0].qs;
+      t.deepEqual(queryString, undefined, 'query string is empty');
+    });
 });
 
 test('analytics with args', (t) => {
@@ -109,37 +111,39 @@ test('analytics with args', (t) => {
 
   analytics.add('foo', 'bar');
 
-  return analytics({
-    command: '__test__',
-    args: [],
-  }).then(() => {
-    const body = spy.lastCall.args[0].body.data;
-    t.deepEqual(
-      Object.keys(body).sort(),
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-      'keys as expected',
-    );
+  return analytics
+    .addDataAndSend({
+      command: '__test__',
+      args: [],
+    })
+    .then(() => {
+      const body = spy.lastCall.args[0].body.data;
+      t.deepEqual(
+        Object.keys(body).sort(),
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+        'keys as expected',
+      );
 
-    const queryString = spy.lastCall.args[0].qs;
-    t.deepEqual(queryString, undefined, 'query string is empty');
-  });
+      const queryString = spy.lastCall.args[0].qs;
+      t.deepEqual(queryString, undefined, 'query string is empty');
+    });
 });
 
 test('analytics with args and org', (t) => {
@@ -150,43 +154,45 @@ test('analytics with args and org', (t) => {
 
   analytics.add('foo', 'bar');
 
-  return analytics({
-    command: '__test__',
-    args: [],
-    org: 'snyk',
-  }).then(() => {
-    const body = spy.lastCall.args[0].body.data;
-    t.deepEqual(
-      Object.keys(body).sort(),
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'org',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-      'keys as expected',
-    );
+  return analytics
+    .addDataAndSend({
+      command: '__test__',
+      args: [],
+      org: 'snyk',
+    })
+    .then(() => {
+      const body = spy.lastCall.args[0].body.data;
+      t.deepEqual(
+        Object.keys(body).sort(),
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'org',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+        'keys as expected',
+      );
 
-    const queryString = spy.lastCall.args[0].qs;
-    t.deepEqual(
-      queryString,
-      { org: 'snyk' },
-      'query string has the expected values',
-    );
-  });
+      const queryString = spy.lastCall.args[0].qs;
+      t.deepEqual(
+        queryString,
+        { org: 'snyk' },
+        'query string has the expected values',
+      );
+    });
 });
 
 test('analytics npm version capture', (t) => {
@@ -197,23 +203,25 @@ test('analytics npm version capture', (t) => {
 
   analytics.add('foo', 'bar');
 
-  return analytics({
-    command: '__test__',
-    args: [],
-  }).then(() => {
-    const body = spy.lastCall.args[0].body.data;
-    if (body.environment.npmVersion === undefined) {
-      t.ok(
-        semver.valid(body.environment.npmVersion) === null,
-        'captured npm version is not valid as expected',
-      );
-    } else {
-      t.ok(
-        semver.valid(body.environment.npmVersion) !== null,
-        'captured npm version is valid',
-      );
-    }
-  });
+  return analytics
+    .addDataAndSend({
+      command: '__test__',
+      args: [],
+    })
+    .then(() => {
+      const body = spy.lastCall.args[0].body.data;
+      if (body.environment.npmVersion === undefined) {
+        t.ok(
+          semver.valid(body.environment.npmVersion) === null,
+          'captured npm version is not valid as expected',
+        );
+      } else {
+        t.ok(
+          semver.valid(body.environment.npmVersion) !== null,
+          'captured npm version is valid',
+        );
+      }
+    });
 });
 
 test('bad command', (t) => {


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Fixes some typing issues that are needed for the upcoming modular CLI init PR (https://github.com/snyk/snyk/pull/1564).

#### Any background context you want to provide?
For the modular CLI init / monorepo PR, we will be turning on `"composite": true` in the tsconfig which requires certain typing things be addressed beforehand.

Why not just do this as part of the aforementioned PR (https://github.com/snyk/snyk/pull/1564)? Because that PR is going to touch a lot of things and I would prefer to keep that PR as small as reasonably possible and since this is just about improving some typing (and refactoring analytics into TypeScript) I think it is best kept on its own.

#### What are the relevant tickets?
HAMMER-237
