### PR TITLE
fix: bump docker plugin to explicity append latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0-rc.2",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.12.0",
+    "snyk-docker-plugin": "4.13.1",
     "snyk-go-plugin": "1.16.2",
     "snyk-gradle-plugin": "3.11.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
when no tag is provided when scanning container images
the plugin will now always append latest tag

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes an issue where the user has multiple images from the same repo - not all docker commands implicitly append `latest` tag when none is received.
In this version `latest` will always be appended if not present.

