### PR TITLE
fix: log filtered out files instead of all

### DIFF
--- a/src/lib/find-files.ts
+++ b/src/lib/find-files.ts
@@ -97,7 +97,7 @@ export async function find(
       debug(
         `Filtered out ${filteredOutFiles.length}/${
           foundAll.length
-        } files: ${foundAll.join(', ')}`,
+        } files: ${filteredOutFiles.join(', ')}`,
       );
     }
     return { files: filterForDefaultManifests(found), allFilesFound: foundAll };


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Only log the filtered out files when we show debug log: `Filtered out 4/26 files....`, issue seen in https://github.com/snyk/snyk/issues/1563

## Before
```
  snyk:find-files File does not seem to exist, skipping:  broken-symlink +0ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json +22ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json +3ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json +0ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock +0ms
  snyk:find-files Filtered out 3/22 files: /Users/lili/www/snyk/snyk/test/fixtures/basic-npm/package.json, /Users/lili/www/snyk/snyk/test/fixtures/deduped-dep/package.json, /Users/lili/www/snyk/snyk/test/fixtures/demo-os/package.json, /Users/lili/www/snyk/snyk/test/fixtures/dev-deps-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/four-spaces/package.json, /Users/lili/www/snyk/snyk/test/fixtures/gradle-prune-repeated-deps/build.gradle, /Users/lili/www/snyk/snyk/test/fixtures/hbs-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/no-deps/package.json, /Users/lili/www/snyk/snyk/test/fixtures/openapi-node/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-SC-1472/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-mean-io/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock, /Users/lili/www/snyk/snyk/test/fixtures/qs-package/package.json, /Users/lili/www/snyk/snyk/test/fixtures/semver-patch-fail/package.json, /Users/lili/www/snyk/snyk/test/fixtures/uglify-package/package.json +7ms
  snyk:find-files Filtered out 4/25 files: /Users/lili/www/snyk/snyk/test/acceptance/workspaces/package.json, /Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json, /Users/lili/www/snyk/snyk/test/cli-alert/package.json, /Users/lili/www/snyk/snyk/test/fixtures/basic-npm/package.json, /Users/lili/www/snyk/snyk/test/fixtures/deduped-dep/package.json, /Users/lili/www/snyk/snyk/test/fixtures/demo-os/package.json, /Users/lili/www/snyk/snyk/test/fixtures/dev-deps-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/four-spaces/package.json, /Users/lili/www/snyk/snyk/test/fixtures/gradle-prune-repeated-deps/build.gradle, /Users/lili/www/snyk/snyk/test/fixtures/hbs-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/no-deps/package.json, /Users/lili/www/snyk/snyk/test/fixtures/openapi-node/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-SC-1472/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-mean-io/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock, /Users/lili/www/snyk/snyk/test/fixtures/qs-package/package.json, /Users/lili/www/snyk/snyk/test/fixtures/semver-patch-fail/package.json, /Users/lili/www/snyk/snyk/test/fixtures/uglify-package/package.json +2ms
  snyk:find-files Filtered out 4/26 files: /Users/lili/www/snyk/snyk/package.json, /Users/lili/www/snyk/snyk/test/acceptance/workspaces/package.json, /Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json, /Users/lili/www/snyk/snyk/test/cli-alert/package.json, /Users/lili/www/snyk/snyk/test/fixtures/basic-npm/package.json, /Users/lili/www/snyk/snyk/test/fixtures/deduped-dep/package.json, /Users/lili/www/snyk/snyk/test/fixtures/demo-os/package.json, /Users/lili/www/snyk/snyk/test/fixtures/dev-deps-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/four-spaces/package.json, /Users/lili/www/snyk/snyk/test/fixtures/gradle-prune-repeated-deps/build.gradle, /Users/lili/www/snyk/snyk/test/fixtures/hbs-demo/package.json, /Users/lili/www/snyk/snyk/test/fixtures/no-deps/package.json, /Users/lili/www/snyk/snyk/test/fixtures/openapi-node/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-SC-1472/package.json, /Users/lili/www/snyk/snyk/test/fixtures/pkg-mean-io/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock, /Users/lili/www/snyk/snyk/test/fixtures/qs-package/package.json, /Users/lili/www/snyk/snyk/test/fixtures/semver-patch-fail/package.json, /Users/lili/www/snyk/snyk/test/fixtures/uglify-package/package.json +0ms
  snyk-test auto detect manifest files, found 22 [
  '/Users/lili/www/snyk/snyk/package.json',
  '/Users/lili/www/snyk/snyk/test/acceptance/workspaces/package.json',
  '/Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/basic-npm/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/deduped-dep/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/demo-os/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/dev-deps-demo/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/four-spaces/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/gradle-prune-repeated-deps/build.gradle',
  '/Users/lili/www/snyk/snyk/test/fixtures/hbs-demo/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/no-deps/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/openapi-node/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/package-sans-name/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/pkg-SC-1472/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/pkg-mean-io/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock',
  '/Users/lili/www/snyk/snyk/test/fixtures/qs-package/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/semver-patch-fail/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/uglify-package/package.json'
] +0ms
```
## Now

```
  snyk:find-files File does not seem to exist, skipping:  broken-symlink +0ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json +42ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json +2ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json +1ms
  snyk:find-files Encountered multiple node lockfiles files, defaulting to /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock +0ms
  snyk:find-files Filtered out 3/22 files: /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json +8ms
  snyk:find-files Filtered out 4/25 files: /Users/lili/www/snyk/snyk/test/cli-alert/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json +1ms
  snyk:find-files Filtered out 4/26 files: /Users/lili/www/snyk/snyk/test/cli-alert/package.json, /Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package.json, /Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/package.json +1ms
  snyk-test auto detect manifest files, found 22 [
  '/Users/lili/www/snyk/snyk/package.json',
  '/Users/lili/www/snyk/snyk/test/acceptance/workspaces/package.json',
  '/Users/lili/www/snyk/snyk/test/cli-alert/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/basic-npm/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/deduped-dep/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/demo-os/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/dev-deps-demo/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/four-spaces/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/gradle-prune-repeated-deps/build.gradle',
  '/Users/lili/www/snyk/snyk/test/fixtures/hbs-demo/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/no-deps/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/openapi-node/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/package-sans-name/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/package-sans-name-lockfile/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/pkg-SC-1472/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/pkg-mean-io/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect-semver-patch/package-lock.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/protect-via-snyk/yarn.lock',
  '/Users/lili/www/snyk/snyk/test/fixtures/qs-package/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/semver-patch-fail/package.json',
  '/Users/lili/www/snyk/snyk/test/fixtures/uglify-package/package.json'
] +0ms

```