### PR TITLE
chore: Log node 8 deprecation msg from analytics

### DIFF
--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -127,6 +127,17 @@ export function postAnalytics(
           ? queryStringParams
           : undefined;
 
+      // Log node 8 deprecation message
+      if (
+        !data.command.includes('--json') &&
+        data.nodeVersion.startsWith('v8')
+      ) {
+        console.error(
+          'Node.js 8 reached End Of Life on December 31, 2019 and the Snyk CLI will stop supporting it in the near future. ' +
+            '\nPlease consider upgrading your runtime version to Node 10 or higher in order to get Snyk CLI updates.',
+        );
+      }
+
       return request({
         body: {
           data: data,


### PR DESCRIPTION
#### What does this PR do?
Log a Node 8 deprecation message from analytics only if --json flag isn't in use.
This means the message will be logged **for every CLI command**.

#### Any background context you want to provide?
Node 8 has reached end of life a year ago. The number of users using Node 8 is still high, and prevents us from stopping to support it.

