### PR TITLE
Update snyk iac cli to issue parallel requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "needle": "2.5.0",
     "open": "^7.0.3",
     "os-name": "^3.0.0",
+    "promise-queue": "^2.2.5",
     "proxy-agent": "^3.1.1",
     "proxy-from-env": "^1.0.0",
     "semver": "^6.0.0",

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -112,13 +112,14 @@ export = function makeRequest(
         const proxyUri = getProxyForUrl(url);
         if (proxyUri) {
           snykDebug('using proxy:', proxyUri);
+          // proxyAgent type is an EventEmitter and not an http Agent
           options.agent = (new ProxyAgent(proxyUri) as unknown) as http.Agent;
         } else {
           snykDebug('not using proxy');
         }
 
         if (global.ignoreUnknownCA) {
-          debug('Using insecure mode (ignore unkown certificate authority)');
+          debug('Using insecure mode (ignore unknown certificate authority)');
           options.rejectUnauthorized = false;
         }
 

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -8,6 +8,7 @@ import { getProxyForUrl } from 'proxy-from-env';
 import * as ProxyAgent from 'proxy-agent';
 import * as analytics from '../analytics';
 import { Agent } from 'http';
+import * as https from 'https';
 import { Global } from '../../cli/args';
 import { Payload } from './types';
 import { getVersion } from '../version';
@@ -93,7 +94,7 @@ export = function makeRequest(
           url = url + '?' + querystring.stringify(payload.qs);
           delete payload.qs;
         }
-
+        const agent = new https.Agent({ keepAlive: true, maxSockets: 10 });
         const options: needle.NeedleOptions = {
           json: payload.json,
           headers: payload.headers,
@@ -101,6 +102,7 @@ export = function makeRequest(
           // eslint-disable-next-line @typescript-eslint/camelcase
           follow_max: 5,
           family: payload.family,
+          agent,
         };
 
         const proxyUri = getProxyForUrl(url);

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -8,7 +8,6 @@ import { getProxyForUrl } from 'proxy-from-env';
 import * as ProxyAgent from 'proxy-agent';
 import * as analytics from '../analytics';
 import { Agent } from 'http';
-import * as https from 'https';
 import { Global } from '../../cli/args';
 import { Payload } from './types';
 import { getVersion } from '../version';
@@ -94,7 +93,7 @@ export = function makeRequest(
           url = url + '?' + querystring.stringify(payload.qs);
           delete payload.qs;
         }
-        const agent = new https.Agent({ keepAlive: true, maxSockets: 10 });
+
         const options: needle.NeedleOptions = {
           json: payload.json,
           headers: payload.headers,
@@ -102,7 +101,6 @@ export = function makeRequest(
           // eslint-disable-next-line @typescript-eslint/camelcase
           follow_max: 5,
           family: payload.family,
-          agent,
         };
 
         const proxyUri = getProxyForUrl(url);

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -234,7 +234,7 @@ async function sendAndParseResults(
   if (options.iac) {
     const maxConcurrent = 25;
     const queue = new Queue(maxConcurrent);
-    const iacResults: Array<Promise<TestResult>> = [];
+    const iacResults: Promise<TestResult>[] = [];
 
     await spinner.clear<void>(spinnerLbl)();
     await spinner(spinnerLbl);

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -4,7 +4,6 @@ import * as proxyquire from 'proxyquire';
 import * as needle from 'needle';
 import { Global } from '../src/cli/args';
 import * as http from 'http';
-import * as https from 'https';
 
 declare const global: Global;
 

--- a/test/request.test.ts
+++ b/test/request.test.ts
@@ -3,6 +3,8 @@ import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
 import * as needle from 'needle';
 import { Global } from '../src/cli/args';
+import * as http from 'http';
+import * as https from 'https';
 
 declare const global: Global;
 
@@ -49,7 +51,7 @@ test('request calls needle as expected and returns status code and body', (t) =>
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -86,7 +88,7 @@ test('request to localhost calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -124,7 +126,7 @@ test('request with timeout calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 100000, // provided
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -165,7 +167,7 @@ test('request with query string calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -203,7 +205,7 @@ test('request with json calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: false, // provided
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -244,7 +246,7 @@ test('request with custom header calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -377,7 +379,7 @@ test('request with no proxy calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when no proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: undefined, // should not be set when not use insecure mode
           }),
           sinon.match.func, // callback function
@@ -415,7 +417,7 @@ test('request with insecure calls needle as expected', (t) => {
             follow_max: 5, // default
             timeout: 300000, // default
             json: undefined, // default
-            agent: undefined, // should not be set when not using proxy
+            agent: sinon.match.instanceOf(http.Agent),
             rejectUnauthorized: false, // should be false when insecure mode enabled
           }),
           sinon.match.func, // callback function


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Currently for a call to snyk iac test our CLI process makes the following sequential requests to our backend API:
- One request per file to validate each Terraform file in the directory tree (or provided via arguments)
- One request pre file to test each matching IaC file in the directory tree (or provided via arguments)

1. As part of cloud-config's work on making tthe cli more performant, we are changing the requests above to **run in parallel.** Various tests were made to determine how this affects the timings, with results showing an average decrease of 8m30s. This is a small win which makes the cli run much faster.
2. In order not to throttle the system in the case of a big number of files being tested, we also introduced two small changes. By default, HTTP connections close after each request. The keepAlive property will allow a persistent connection. For rate limiting, a queue was implemented for both detecting the iac files and testing them. 

The results look very promising. From the original 10m22sec when run locally, it went down to 1min4s with a queue.

This is a table with some tests. It was run against cloud-config-goof, which contains 249 IaC files.

_Tested 247 projects, 201 contained issues. Failed to test 4 projects._

The goal of these experiments was to see what the "optimal" number of concurrent requests is for our case.
- The "before" run is by running it locally without any changes from the master branch. 
- The "after" run is by running it locally against the proposed changes.

***table to be updated asap***
Scenario | user | system | cpu | Total
-- | -- | -- | -- | --
Before | 14.32s | 36.63s | 8% | 10m28s18ms
After: |  
with promises running in parallel | 12.00s | 31.08s | 52% | 1m22s71ms
with promises running in parallel & Queue | 28.00s | 84.08s | 92% | 1m12s71ms
with  rest && https.agent {keepAlive: true} | 14.49s | 43.21s | 51% | 1m52s74ms

#### How should this be manually tested?
- Run the code on the master branch:
`time node snyk iac test`
- Then go to this branch and run `time node ~/snyk-repos/snyk/dist/cli iac test` .
Note the 'total' time in the end. It should have been improved.

#### Any background context you want to provide?
There were [more performance improvements](https://snyksec.atlassian.net/jira/software/projects/CC/boards/93?selectedIssue=CC-519) done on the cloud-config-policy-engine where a new endpoint and a feature flag were added. 
As part of the current task, we also use those changes in combination. 
To do this, we needed to enable the _iacEvaluatePolicyEndpoint_ flag in the local snyk admin area when running locally. 

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-594