### PR TITLE
chore(smoke): handle uppercase header in release downloader

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -99,7 +99,7 @@ jobs:
         if: ${{ matrix.snyk_install_method == 'binary' && matrix.os != 'windows' }}
         run: |
           echo "install snyk with binary"
-          export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep location | sed s#.*tag/##g | tr -d "\r")
+          export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
           echo "latest_version: ${latest_version}"
           snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/${{ matrix.snyk_cli_dl_file }}"
           echo "snyk_cli_dl_linux: ${snyk_cli_dl_linux}"

--- a/test/smoke/alpine/entrypoint.sh
+++ b/test/smoke/alpine/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "install snyk with binary"
-export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep location | sed s#.*tag/##g | tr -d "\r")
+export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
 echo "latest_version: ${latest_version}"
 snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-alpine"
 curl -Lo ./snyk-cli $snyk_cli_dl_linux

--- a/test/smoke/install-snyk-binary-win.sh
+++ b/test/smoke/install-snyk-binary-win.sh
@@ -1,6 +1,6 @@
 echo "install-snyk-binary-win.sh"
 
-export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep location | sed s#.*tag/##g | tr -d "\r")
+export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
 echo "latest_version: ${latest_version}"
 snyk_cli_dl="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-win.exe"
 echo "snyk_cli_dl: ${snyk_cli_dl}"


### PR DESCRIPTION
Seems like GitHub changed capitalization of the `Location` header in the HTTP response for `https://github.com/snyk/snyk/releases/latest`

Added case insensitive `-i` flag to the grep command