### PR TITLE
fix: iac k8s validation helm file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@ src/lib/snyk-test/iac-test-result.ts @snyk/cloudconfig
 src/lib/snyk-test/payload-schema.ts @snyk/cloudconfig
 src/lib/snyk-test/run-iac-test.ts @snyk/cloudconfig
 test/acceptance/cli-test/iac/ @snyk/cloudconfig
+test/acceptance/workspaces/helmconfig @snyk/cloudconfig
+test/acceptance/workspaces/iac-kubernetes @snyk/cloudconfig
 test/fixtures/iac/ @snyk/cloudconfig
 test/smoke/spec/iac/ @snyk/cloudconfig
 src/lib/errors/invalid-iac-file.ts @snyk/cloudconfig

--- a/package.json
+++ b/package.json
@@ -101,7 +101,8 @@
     "tempfile": "^2.0.0",
     "update-notifier": "^4.1.0",
     "uuid": "^3.3.2",
-    "wrap-ansi": "^5.1.0"
+    "wrap-ansi": "^5.1.0",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@types/agent-base": "^4.2.1",

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -25,4 +25,5 @@ export {
   NotSupportedIacFileErrorMsg,
   IllegalIacFileErrorMsg,
   NotSupportedIacAllProjects,
+  InvalidYamlFileErrorMsg,
 } from './invalid-iac-file';

--- a/src/lib/errors/invalid-iac-file.ts
+++ b/src/lib/errors/invalid-iac-file.ts
@@ -25,6 +25,18 @@ export function IllegalIacFileErrorMsg(fileName: string): string {
   );
 }
 
+export function InvalidYamlFileErrorMsg(fileName: string): string {
+  return (
+    'Invalid YAML format in file ' +
+    fileName +
+    '.\nFor Helm template files you might use `Helm install` command and run `snyk iac test` with the generated files.' +
+    '.\nPlease see our documentation for supported target files (currently we support Kubernetes files only): ' +
+    chalk.underline(
+      'https://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool',
+    )
+  );
+}
+
 export function NotSupportedIacFileError(fileName: string): CustomError {
   const errorMsg = NotSupportedIacFileErrorMsg(fileName);
   const error = new CustomError(errorMsg);

--- a/test/acceptance/cli-args.test.ts
+++ b/test/acceptance/cli-args.test.ts
@@ -128,6 +128,25 @@ test('snyk test command should fail when iac file is not supported', (t) => {
     },
   );
 });
+
+test('snyk test command should fail when iac invalid yaml file is not supported', (t) => {
+  t.plan(1);
+  exec(
+    `node ${main} iac test ./test/acceptance/workspaces/helmconfig/templates/cluster-role-binding.yaml`,
+    (err, stdout) => {
+      if (err) {
+        console.log('CLI stdout: ', stdout);
+        throw err;
+      }
+      t.match(
+        stdout.trim(),
+        'Invalid YAML format in file cluster-role-binding.yaml.',
+        'correct error output',
+      );
+    },
+  );
+});
+
 test('`test multiple paths with --project-name=NAME`', (t) => {
   t.plan(1);
   exec(`node ${main} test pathA pathB --project-name=NAME`, (err, stdout) => {

--- a/test/acceptance/workspaces/helmconfig/templates/cluster-role-binding.yaml
+++ b/test/acceptance/workspaces/helmconfig/templates/cluster-role-binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "app.fullname" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "app.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "service-account.name" . }}
+    namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
This PR fixes the fact the for k8s files `iac test` is not doing helm validation and fail on internal error instead of showing a proper message that indicates this file type is not supported.

#### Any background context you want to provide?
As part of an investigation that happens in Cloud Config team, we understood that in the UI we have validation for Helm files as part of the k8s file scanning, while in the CLI there is no such validation.
This PR align between those