### PR TITLE
fix: remove extraneous logging field

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -154,8 +154,6 @@ async function monitor(...args0: MethodArgs): Promise<any> {
       await spinner(analyzingDepsSpinnerLabel);
 
       // Scan the project dependencies via a plugin
-
-      analytics.add('pluginOptions', options);
       debug('getDepsFromPlugin ...');
 
       // each plugin will be asked to scan once per path


### PR DESCRIPTION
We log this `pluginOptions` field only in the `monitor` command. Since we are not using it in `test`, we shouldn't keep it here either.