### PR TITLE
fix: smoke tests’ snyk binary download

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -99,11 +99,9 @@ jobs:
         if: ${{ matrix.snyk_install_method == 'binary' && matrix.os != 'windows' }}
         run: |
           echo "install snyk with binary"
-          export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
-          echo "latest_version: ${latest_version}"
-          snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/${{ matrix.snyk_cli_dl_file }}"
-          echo "snyk_cli_dl_linux: ${snyk_cli_dl_linux}"
-          curl -Lo ./snyk-cli $snyk_cli_dl_linux
+          snyk_cli_dl=$(curl https://api.github.com/repos/snyk/snyk/releases/latest | jq --raw-output '(.assets[])? | select(.name == "${{ matrix.snyk_cli_dl_file }}") | .browser_download_url')
+          echo "snyk_cli_dl: ${snyk_cli_dl}"
+          curl -Lo ./snyk-cli $snyk_cli_dl
           chmod -R +x ./snyk-cli
           sudo mv ./snyk-cli /usr/local/bin/snyk
           snyk --version

--- a/test/smoke/alpine/entrypoint.sh
+++ b/test/smoke/alpine/entrypoint.sh
@@ -1,10 +1,9 @@
 #!/bin/sh
 
 echo "install snyk with binary"
-export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
-echo "latest_version: ${latest_version}"
-snyk_cli_dl_linux="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-alpine"
-curl -Lo ./snyk-cli $snyk_cli_dl_linux
+snyk_cli_dl=$(curl https://api.github.com/repos/snyk/snyk/releases/latest | jq --raw-output '(.assets[])? | select(.name == "snyk-alpine") | .browser_download_url')
+echo "snyk_cli_dl: ${snyk_cli_dl}"
+curl -Lo ./snyk-cli $snyk_cli_dl
 chmod -R +x ./snyk-cli
 mv ./snyk-cli /usr/local/bin/snyk
 snyk --version

--- a/test/smoke/install-snyk-binary-win.sh
+++ b/test/smoke/install-snyk-binary-win.sh
@@ -1,8 +1,5 @@
 echo "install-snyk-binary-win.sh"
-
-export latest_version=$(curl -Is "https://github.com/snyk/snyk/releases/latest" | grep -i location | sed s#.*tag/##g | tr -d "\r")
-echo "latest_version: ${latest_version}"
-snyk_cli_dl="https://github.com/snyk/snyk/releases/download/${latest_version}/snyk-win.exe"
+snyk_cli_dl=$(curl https://api.github.com/repos/snyk/snyk/releases/latest | jq --raw-output '(.assets[])? | select(.name == "snyk-win.exe") | .browser_download_url')
 echo "snyk_cli_dl: ${snyk_cli_dl}"
 curl -Lo ./snyk-cli.exe $snyk_cli_dl
 ./snyk-cli.exe --version


### PR DESCRIPTION
Fix smoke tests' Snyk binary download and installation.

- [✅ ] Ready for review
- [✅ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [✅ ] Reviewed by Snyk internal team

