### PR TITLE
chore: add help for new --project-name-prefix flag

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -139,6 +139,9 @@ Below are flags that are influencing CLI behavior for specific projects, languag
 - `--packages-folder`:
   Custom path to packages folder
 
+- `--project-name-prefix`=<PREFIX_STRING>:
+  When monitoring a .NET project, use this flag to add a custom prefix to the name of files inside a project along with any desired separators, e.g. `snyk monitor --file=my-project.sln --project-name-prefix=my-group/`. This is useful when you have multiple projects with the same name in other sln files.
+
 ### npm options
 
 - `--strict-out-of-sync`=true|false:

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.1",
     "snyk-nodejs-lockfile-parser": "1.30.1",
-    "snyk-nuget-plugin": "1.19.4",
+    "snyk-nuget-plugin": "1.20.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.14.1",
     "snyk-python-plugin": "1.19.2",

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -303,3 +303,60 @@ test('test command line "container test --help" should display help for mode', (
   );
   t.end();
 });
+
+test('test command line "snyk monitor --project-name-prefix" should add a property on options', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'monitor',
+    '--project-name-prefix=my-prefix/',
+  ];
+  const result = args(cliArgs);
+  t.equal(
+    result.options['project-name-prefix'],
+    'my-prefix/',
+    'expected options[project-name-prefix] to equal expected value',
+  );
+  t.end();
+});
+
+test('test command line "snyk monitor --packages-folder" should add a property on options', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'monitor',
+    '--packages-folder=/path/to/folder',
+  ];
+  const result = args(cliArgs);
+  t.equal(
+    result.options['packagesFolder'], // this option is camel-cased in src/cli/args.ts
+    '/path/to/folder',
+    'expected options[packagesFolder] to equal expected value',
+  );
+  t.end();
+});
+
+test('test command line "snyk monitor --assets-project-name" should add a property on options', (t) => {
+  const cliArgsWithFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'monitor',
+    '--assets-project-name',
+  ];
+  const resultWithFlag = args(cliArgsWithFlag);
+  t.ok(
+    resultWithFlag.options['assets-project-name'],
+    'expected options[assets-project-name] to be true',
+  );
+  const cliArgsWithoutFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'monitor',
+  ];
+  const resultWithoutFlag = args(cliArgsWithoutFlag);
+  t.notOk(
+    resultWithoutFlag.options['assets-project-name'],
+    'expected options[assets-project-name] to be false',
+  );
+  t.end();
+});


### PR DESCRIPTION
Adds help text for new `--project-name-prefix` flag added to the Nuget plugin. Also added tests for all Nuget-specific CLI args: `--project-name-prefix`, `--assets-project-name` and `--packages-folder`

- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team
