### PR TITLE
fix: add full file path to output file for iac scan

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -181,6 +181,7 @@ export interface BaseImageRemediationAdvice {
 export interface TestResult extends LegacyVulnApiResult {
   targetFile?: string;
   projectName?: string;
+  targetFilePath?: string;
   displayTargetFile?: string; // used for display only
   foundProjectCount?: number;
 }

--- a/src/lib/snyk-test/run-iac-test.ts
+++ b/src/lib/snyk-test/run-iac-test.ts
@@ -17,6 +17,7 @@ import { projectTypeByFileType, IacFileTypes } from '../iac/constants';
 export async function parseIacTestResult(
   res: IacTestResponse,
   targetFile: string | undefined,
+  targetFileRelativePath: string | undefined,
   projectName: any,
   severityThreshold?: SEVERITY,
   //TODO(orka): future - return a proper type
@@ -38,6 +39,7 @@ export async function parseIacTestResult(
     policy: meta.policy,
     isPrivate: !meta.isPublic,
     severityThreshold,
+    targetFilePath: targetFileRelativePath,
   };
 }
 

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -250,6 +250,7 @@ async function sendAndParseResults(
           return await parseIacTestResult(
             res,
             iacScan.targetFile,
+            iacScan.targetFileRelativePath,
             projectName,
             options.severityThreshold,
           );


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Today, when running IaC scan with `--json-file-output`, the JSON does not contain the tested file full path.
This PR added the relevant field to the JSON.

#### How should this be manually tested?
` node dist/cli/index.js iac test <folder>  --json-file-output=output.json` 

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
