### PR TITLE
fix: gradle 5.4 Java 11 Dockerfile npm install

### DIFF
--- a/docker/Dockerfile.gradle-5.4_java11
+++ b/docker/Dockerfile.gradle-5.4_java11
@@ -11,8 +11,9 @@ RUN apt-get update && \
   curl -L https://services.gradle.org/distributions/gradle-5.4-bin.zip -o gradle-5.4-bin.zip && \
   unzip gradle-5.4-bin.zip -d /home/node/ && \
   curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-  apt-get install -y nodejs jq npm && \
+  apt-get install -y nodejs jq && \
   node -v && \
+  npm -v && \
   npm install --global snyk snyk-to-html && \
   apt-get autoremove -y && \
   apt-get clean && \


### PR DESCRIPTION


- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When building docker image we see error message:

```
The following packages have unmet dependencies:
 nodejs : Conflicts: npm
 npm : Depends: node-gyp (>= 3.6.2~) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

Removing explicit npm install from 'apt-get install' fixes issue.

Just doing 'apt-get install -y nodejs' will install npm.
