### PR TITLE
fix(test): consider presence of fixedIn field as fixableVuln

### DIFF
--- a/src/cli/commands/test/vuln-helpers.ts
+++ b/src/cli/commands/test/vuln-helpers.ts
@@ -46,7 +46,7 @@ export function hasPatches(testResults: any[]): boolean {
 }
 
 export function isVulnUpgradable(vuln) {
-  return vuln.isUpgradable || vuln.isPinnable;
+  return vuln.isUpgradable || vuln.isPinnable || (vuln.fixedIn || []).length;
 }
 
 export function isVulnPatchable(vuln) {


### PR DESCRIPTION
This extends the `isVulnUpgradable` check to consider `fixedIn` array. 
Should resolve the issue with `--fail-on` flag - currently option `all` won't consider vulns where we know `fixedIn`, but don't have any `upgradePath`.