### PR TITLE
fix: scanning lock due of unresolved deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.13.1",
     "snyk-go-plugin": "1.16.4",
-    "snyk-gradle-plugin": "3.12.0",
+    "snyk-gradle-plugin": "3.12.1",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.1",
     "snyk-nodejs-lockfile-parser": "1.30.1",


### PR DESCRIPTION
This pr changes comes from https://github.com/snyk/snyk-gradle-plugin/pull/161

- Renamed snykConf to projectConfigs, to improve the readability

- Created configsSuccessfullyResolved method that confirms if
  configs sets as canBeResolved=true, can be really resolved or not.

  If there is an error now, while resolving configs set as
  canBeResolved=true, we are no longer blocking the scanning. We ignore
  those configs whose depGraph cannot be computed and move forward with the
  scanning process since it's not a snyk issue but a given gradle project
  resolution config caused by bad config or 3rd party gradle dependencies bad behaving.

By going into `test/fixtures/successful-scan-with-unresolved-custom-configs/build.gradle` and running `gradle -q dependencies` you will see the following message (pic below)

This fixture emulates issue gradle/gradle#6854, **where gradle cannot resolve incremental analysis configurations**.

<img width="638" alt="Screen Shot 2021-01-31 at 18 54 04" src="https://user-images.githubusercontent.com/40601533/106393164-d369dd80-63f5-11eb-9335-bcc1716b890a.png">

What does **FAILED** means? Means any dependency belonging to these configuratios failed to be resolved (compute depGraph)

Continue reading about failed resolution in Gradle Docs.. https://docs.gradle.org/current/userguide/viewing_debugging_dependencies.html#example_rendering_the_dependency_report_for_a_custom_configuration
