### PR TITLE
fix: more than one line with jsondeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.13.1",
     "snyk-go-plugin": "1.16.4",
-    "snyk-gradle-plugin": "3.12.1",
+    "snyk-gradle-plugin": "3.12.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.1",
     "snyk-nodejs-lockfile-parser": "1.30.1",


### PR DESCRIPTION
swallowing unresolvable configs error msg in order to prevent mass spam in
script output while scanning projects with large graph output to prevent parse errors...


snyk/snyk-gradle-plugin#162