### PR TITLE
fix: gradle graceful resolvable configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.13.1",
     "snyk-go-plugin": "1.16.4",
-    "snyk-gradle-plugin": "3.12.2",
+    "snyk-gradle-plugin": "3.12.3",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.1",
     "snyk-nodejs-lockfile-parser": "1.30.1",


### PR DESCRIPTION
making configsSuccessfullyResolved more graceful, when at least a single
dependency available in a config failed e.g. 1/5, we immediately were
considering the config not resolvable and filtering it out.
By using configuration.resolvedConfiguration.firstLevelModuleDependencies;
We no longer try to locate and download files as we were doing with
configuration.resolve. With the new approach we just ask for the instances
available for each direct dependency of the configuration that matches the given spec.
Continue reading https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ResolvedConfiguration.html

https://github.com/snyk/snyk-gradle-plugin/releases/tag/v3.12.3

