### PR TITLE
fix: bump python plugin version to include multiple fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "snyk-nuget-plugin": "1.20.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.14.1",
-    "snyk-python-plugin": "1.19.2",
+    "snyk-python-plugin": "1.19.3",
     "snyk-resolve": "1.0.1",
     "snyk-resolve-deps": "4.7.2",
     "snyk-sbt-plugin": "2.11.0",


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Bumps the python plugin to include the following fixes:
- Stop parser from trying to look up packages not propagated to the lockfile (wheel, distributed, pip,  setuptools)
- Stop parser from failing when failing to locate dependency in lockfile and instead log a warning. This could be because of python requirements allowing it in the manifest but not actually installing it and adding a lockfile entry or because of how Poetry treats the use of underscores and hyphens when installing packages
- Reversed PR that introduced swapping underscores in manifest for hyphens in lockfile. This was due to a misunderstanding of how Poetry worked and is remediated by the above.

#### What are the relevant tickets?
[LOKI-174](https://snyksec.atlassian.net/browse/LOKI-174)
[LOKI-175](https://snyksec.atlassian.net/browse/LOKI-175)
[LOKI-187](https://snyksec.atlassian.net/browse/LOKI-187)