### PR TITLE
feat: Show auto detected user instructions in 'container test' output

### DIFF
--- a/src/cli/commands/test/formatters/legacy-format-issue.ts
+++ b/src/cli/commands/test/formatters/legacy-format-issue.ts
@@ -136,11 +136,12 @@ export function titleCaseText(text) {
 
 function dockerfileInstructionText(vuln) {
   if (vuln.dockerfileInstruction) {
-    return `\n  Introduced in your Dockerfile by '${vuln.dockerfileInstruction}'`;
+    JSON.stringify(vuln.dockerfileInstruction);
+    return `\n  Image layer: '${vuln.dockerfileInstruction}'`;
   }
 
   if (vuln.dockerBaseImage) {
-    return `\n  Introduced by your base image (${vuln.dockerBaseImage})`;
+    return `\n  Image layer: Introduced by your base image (${vuln.dockerBaseImage})`;
   }
 
   return '';

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -104,10 +104,13 @@ function prepareEcosystemResponseForParsing(
     depGraphData !== undefined
       ? depGraphLib.createFromJSON(depGraphData)
       : undefined;
-  const dockerfileAnalysisFact = payloadBody?.facts.find(
-    (fact) => fact.type === 'dockerfileAnalysis',
+  const imageUserInstructions = payloadBody?.facts.find(
+    (fact) =>
+      fact.type === 'dockerfileAnalysis' ||
+      fact.type === 'autoDetectedUserInstructions',
   );
-  const dockerfilePackages = dockerfileAnalysisFact?.data?.dockerfilePackages;
+
+  const dockerfilePackages = imageUserInstructions?.data?.dockerfilePackages;
   const projectName = payloadBody?.name || depGraph?.rootPkg.name;
   const packageManager = payloadBody?.identity?.type as SupportedProjectTypes;
   const targetFile = payloadBody?.identity?.targetFile || options.file;


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Updated 'container test' Dockerfile instructions to "Image layer:" to be consistent with what we show in the UI.
Added showing auto detected instructions if Dockerfile not present.

#### Where should the reviewer start?



#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CAP-149

#### `container test` json output

```
✗ Low severity vulnerability found in bzip2/libbz2-1.0
  Description: Denial of Service (DoS)
  Info: http://localhost:12346/vuln/SNYK-LINUX-BZIP2-106947
  Introduced through: bzip2/libbz2-1.0@1.0.6-8.1, apt/libapt-pkg5.0@1.6.3ubuntu0.1
  From: bzip2/libbz2-1.0@1.0.6-8.1
  From: apt/libapt-pkg5.0@1.6.3ubuntu0.1 > bzip2/libbz2-1.0@1.0.6-8.1
  Image layer: 'RUN test instruction'
```