### PR TITLE
feat: Don't open browser auth if inside container

### DIFF
--- a/src/cli/commands/auth/index.ts
+++ b/src/cli/commands/auth/index.ts
@@ -7,6 +7,7 @@ import { Spinner } from 'cli-spinner';
 import * as snyk from '../../../lib';
 import { verifyAPI } from './is-authed';
 import { isCI } from '../../../lib/is-ci';
+import { isDocker } from '../../../lib/is-docker';
 import { args as argsLib } from '../../args';
 import * as config from '../../../lib/config';
 import request = require('../../../lib/request');
@@ -25,7 +26,7 @@ const debug = Debug('snyk-auth');
 let attemptsLeft = 0;
 
 function resetAttempts() {
-  attemptsLeft = 30;
+  attemptsLeft = isDocker() ? 60 : 30;
 }
 
 type AuthCliCommands = 'wizard' | 'ignore';
@@ -50,16 +51,9 @@ async function webAuth(via: AuthCliCommands) {
     urlStr += '&redirectUri=' + Buffer.from(redirects[via]).toString('base64');
   }
 
-  const msg =
-    '\nNow redirecting you to our auth page, go ahead and log in,\n' +
-    "and once the auth is complete, return to this prompt and you'll\n" +
-    "be ready to start using snyk.\n\nIf you can't wait use this url:\n" +
-    urlStr +
-    '\n';
-
   // suppress this message in CI
   if (!isCI()) {
-    console.log(msg);
+    console.log(browserAuthPrompt(isDocker(), urlStr));
   } else {
     return Promise.reject(MisconfiguredAuthInCI());
   }
@@ -70,9 +64,11 @@ async function webAuth(via: AuthCliCommands) {
 
   try {
     spinner.start();
-    await setTimeout(() => {
-      open(urlStr);
-    }, 0);
+    if (!isDocker()) {
+      await setTimeout(() => {
+        open(urlStr);
+      }, 0);
+    }
 
     return await testAuthComplete(token, ipFamily);
   } finally {
@@ -188,5 +184,25 @@ async function getIpFamily(): Promise<6 | undefined> {
     return family;
   } catch (e) {
     return undefined;
+  }
+}
+
+function browserAuthPrompt(isDocker: boolean, urlStr: string): string {
+  if (isDocker) {
+    return (
+      '\nTo authenticate your account, open the below URL in your browser.\n' +
+      'After your authentication is complete, return to this prompt to ' +
+      'start using Snyk.\n\n' +
+      urlStr +
+      '\n'
+    );
+  } else {
+    return (
+      '\nNow redirecting you to our auth page, go ahead and log in,\n' +
+      "and once the auth is complete, return to this prompt and you'll\n" +
+      "be ready to start using snyk.\n\nIf you can't wait use this url:\n" +
+      urlStr +
+      '\n'
+    );
   }
 }

--- a/test/smoke/spec/snyk_auth_spec.sh
+++ b/test/smoke/spec/snyk_auth_spec.sh
@@ -25,7 +25,7 @@ Describe "Snyk CLI Authorization"
 
       # Using timeout to not wait for browser confirmation
       When run timeout 5 snyk auth
-      The output should include "Now redirecting you to our auth page, go ahead and log in,"
+      The output should include "To authenticate your account, open the below URL in your browser."
       The result of function verify_login_url should include "snyk.io/login?token=" # URL found
       The status should be failure
       # TODO: unusable with our current docker issues

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -2,6 +2,7 @@ import * as util from 'util';
 import * as _ from 'lodash';
 import { test } from 'tap';
 import * as ciChecker from '../../src/lib/is-ci';
+import * as dockerChecker from '../../src/lib/is-docker';
 import { makeTmpDirectory, silenceLog } from '../utils';
 import * as sinon from 'sinon';
 import * as proxyquire from 'proxyquire';
@@ -101,6 +102,8 @@ test('auth with no args', async (t) => {
   const auth = proxyquire('../../src/cli/commands/auth', { open });
   // stub CI check (ensure returns false for system test)
   const ciStub = sinon.stub(ciChecker, 'isCI').returns(false);
+  // ensure this works on circleCI as when running outside of a container
+  const dockerStub = sinon.stub(dockerChecker, 'isDocker').returns(false);
   // disable console.log
   const enableLog = silenceLog();
   try {
@@ -117,6 +120,7 @@ test('auth with no args', async (t) => {
       'opens login with token param',
     );
     ciStub.restore();
+    dockerStub.restore();
   } catch (e) {
     t.threw(e);
   }
@@ -130,6 +134,8 @@ test('auth with UTMs in environment variables', async (t) => {
   const auth = proxyquire('../../src/cli/commands/auth', { open });
   // stub CI check (ensure returns false for system test)
   const ciStub = sinon.stub(ciChecker, 'isCI').returns(false);
+  // ensure this works on circleCI as when running outside of a container
+  const dockerStub = sinon.stub(dockerChecker, 'isDocker').returns(false);
 
   // read data from console.log
   let stdoutMessages = '';
@@ -161,6 +167,7 @@ test('auth with UTMs in environment variables', async (t) => {
     delete process.env.SNYK_UTM_CAMPAIGN;
     // clean up stubs
     ciStub.restore();
+    dockerStub.restore();
 
     // restore original console.log
     console.log = origConsoleLog;


### PR DESCRIPTION
#### What does this PR do?

Allows running auth command when inside a docker container by:
* not trying to open a browser via xdg open (breaks if not present or in container)
* providing a better auth prompt/message
* doubling the auth timeout period, so users have more time open browser
  manually

This makes it possible to use auth command via "docker scan" on soon to be released scan plugin for docker linux.

#### How should this be manually tested?

Run "snyk auth" inside a container.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-1077