### PR TITLE
feat: add init-script argument to CLI for gradle

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -149,6 +149,9 @@ Below are flags that are influencing CLI behavior for specific projects, languag
 
   Default: 300 (5 minutes).
 
+- `--init-script`=<FILE>
+  For projects that contain a gradle initialization script.
+  
 ### .Net & NuGet options
 
 - `--assets-project-name`:

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.17.2",
     "snyk-go-plugin": "1.16.5",
-    "snyk-gradle-plugin": "3.12.5",
+    "snyk-gradle-plugin": "3.13.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
     "snyk-nodejs-lockfile-parser": "1.30.2",

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -212,6 +212,7 @@ export function args(rawArgv: string[]): Args {
     'reachable-vulns',
     'reachable-timeout',
     'reachable-vulns-timeout',
+    'init-script',
     'integration-name',
     'integration-version',
     'prune-repeated-subdependencies',

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -20,6 +20,7 @@ export interface TestOptions {
   failOn?: FailOn;
   reachableVulns?: boolean;
   reachableVulnsTimeout?: number;
+  initScript?: string;
   yarnWorkspaces?: boolean;
   testDepGraphDockerEndpoint?: string | null;
   isDockerUser?: boolean;
@@ -100,6 +101,7 @@ export interface MonitorOptions {
   'app-vulns'?: boolean;
   reachableVulns?: boolean;
   reachableVulnsTimeout?: number;
+  initScript?: string;
   yarnWorkspaces?: boolean;
 }
 
@@ -179,6 +181,7 @@ export type SupportedUserReachableFacingCliArgs =
   | 'reachable-vulns'
   | 'reachable-timeout'
   | 'reachable-vulns-timeout'
+  | 'init-script'
   | 'integration-name'
   | 'integration-version';
 


### PR DESCRIPTION
This PR was submitted by @pwnslinger, this pull request was opened because CircleCI is unable to pull a forked repository. Credit where it's due, this fix was created by @pwnslinger as well.

- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [X] Reviewed by Snyk internal team

#### What does this PR do?

init-script is part of gradle and is used for certain use cases such as private artifact inventories.
This is required for reachability in order to get the classpath required for building the call graph.

#### How should this be manually tested?

Using a gradle project, create a file `init.gradle` for example and run

`snyk test -d --file=./build.gradle --insecure  --severity-threshold=medium --reachable --init-script=init.gradle`

or

`snyk monitor -d --file=./build.gradle --insecure  --severity-threshold=medium --reachable --init-script=init.gradle`

#### Any background context you want to provide?

We need the inner gradle commands of the java call graph builder to succeed in order to retrieve the classpath that allows us to get a call graph from the project.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/FLOW-649