### PR TITLE
refactor: iac test docs

### DIFF
--- a/src/lib/errors/invalid-iac-file.ts
+++ b/src/lib/errors/invalid-iac-file.ts
@@ -5,7 +5,7 @@ export function NotSupportedIacFileErrorMsg(fileName: string): string {
   return (
     'Not supported infrastructure as code target files in ' +
     fileName +
-    '.\nPlease see our documentation for supported target files (currently we support Kubernetes files only): ' +
+    '.\nPlease see our documentation for supported target files: ' +
     chalk.underline(
       'https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files',
     ) +
@@ -17,7 +17,7 @@ export function IllegalIacFileErrorMsg(fileName: string): string {
   return (
     'Illegal infrastructure as code target file ' +
     fileName +
-    '.\nPlease see our documentation for supported target files (currently we support Kubernetes files only): ' +
+    '.\nPlease see our documentation for supported target files: ' +
     chalk.underline(
       'https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files',
     ) +
@@ -55,9 +55,9 @@ export function IllegalTerraformFileError(
   const locationsStr = atLocations.join(', ');
   const errorMsg =
     `Illegal Terraform target file ${locationsStr} \nValidation Error Reason: ${reason}` +
-    '.\nPlease see our documentation for supported target files (currently we support Kubernetes files only): ' +
+    '.\nPlease see our documentation for supported target files: ' +
     chalk.underline(
-      'https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files',
+      'https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool',
     ) +
     ' and make sure you are in the right directory.';
 

--- a/test/smoke/spec/iac/snyk_test_directory_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_directory_spec.sh
@@ -25,17 +25,11 @@ Describe "Snyk iac test command"
 
       The output should include "Tested sg_open_ssh.tf for known issues, found"
 
-      # Invalid File testing - Go Template
-      The output should include "Testing sg_open_ssh_invalid_go_templates.tf..."
-      The output should include "Illegal Terraform target file sg_open_ssh_invalid_go_templates.tf "
-      The output should include "Validation Error Reason: Go Template placeholders found in Terraform file."
-      The output should include "Please see our documentation for supported target files (currently we support Kubernetes files only): https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files and make sure you are in the right directory."
-
       # Invalid File testing - HCL2 Format
       The output should include "Testing sg_open_ssh_invalid_hcl2.tf..."
       The output should include "Illegal Terraform target file sg_open_ssh_invalid_hcl2.tf"
       The output should include "Validation Error Reason: Invalid HCL2 Format."
-      The output should include "Please see our documentation for supported target files (currently we support Kubernetes files only): https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files and make sure you are in the right directory."
+      The output should include "Please see our documentation for supported target files: https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool and make sure you are in the right directory."
     End
 
     It "filters out issues when using severity threshold"
@@ -55,17 +49,11 @@ Describe "Snyk iac test command"
 
       The output should include "Tested sg_open_ssh.tf for known issues, found"
 
-      # Invalid File testing - Go Template
-      The output should include "Testing sg_open_ssh_invalid_go_templates.tf..."
-      The output should include "Illegal Terraform target file sg_open_ssh_invalid_go_templates.tf "
-      The output should include "Validation Error Reason: Go Template placeholders found in Terraform file."
-      The output should include "Please see our documentation for supported target files (currently we support Kubernetes files only): https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files and make sure you are in the right directory."
-
       # Invalid File testing - HCL2 Format
       The output should include "Testing sg_open_ssh_invalid_hcl2.tf..."
       The output should include "Illegal Terraform target file sg_open_ssh_invalid_hcl2.tf"
       The output should include "Validation Error Reason: Invalid HCL2 Format."
-      The output should include "Please see our documentation for supported target files (currently we support Kubernetes files only): https://support.snyk.io/hc/en-us/articles/360006368877-Scan-and-fix-security-issues-in-your-Kubernetes-configuration-files and make sure you are in the right directory."
+      The output should include "Please see our documentation for supported target files: https://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool and make sure you are in the right directory."
     End
 
     It "outputs the expected text when running with --sarif flag"

--- a/test/smoke/spec/iac/snyk_test_terraform_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_terraform_spec.sh
@@ -48,13 +48,6 @@ Describe "Snyk iac test command"
       The output should include "Validation Error Reason: Invalid HCL2 Format."
     End
 
-    It "outputs an error for invalid tf files with go templates"
-      When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh_invalid_go_templates.tf
-      The status should be failure
-      The output should include "Illegal Terraform target file sg_open_ssh_invalid_go_templates.tf"
-      The output should include "Validation Error Reason: Go Template placeholders found in Terraform file."
-    End
-
     It "outputs the expected text when running with --sarif flag"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf --sarif
       The status should be failure


### PR DESCRIPTION
#### What does this PR do?
Fixes wrong error message output for `iac test` and removes tests that will break soon due to backend change.

We have a wider ticket for doing an overhaul on our documentation and error messages, this mainly quickly fixes a wrong error message that claims that we support only Kubernetes.