### PR TITLE
Remove dev-release package publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,6 @@ jobs:
       - checkout
       - setup_remote_docker:
           version: 19.03.13
-      - install_github_cli
       - run:
           name: Install npm@7
           command: |
@@ -332,25 +331,11 @@ jobs:
       - run:
           name: Setup Lerna
           command: sudo npm install -g lerna
-      - update_local_npmrc_linux
       - install_deps
       - generate_help
       - run:
           name: Update package versions
           command: ./release-scripts/update-versions.sh
-      - run:
-          name: Make git ignore changes relating to version updates
-          command: |
-            git update-index --skip-worktree -- ./lerna.json
-            git update-index --skip-worktree -- ./package.json
-            git update-index --skip-worktree -- ./packages/snyk-protect/package.json
-            git update-index --skip-worktree -- ./.npmrc
-      - run:
-          name: Dev Lerna Publish
-          command: |
-            dev_version="1.0.0-dev-${CIRCLE_SHA1}"
-            echo "dev_version: ${dev_version}"
-            lerna publish ${dev_version} --yes --no-push --no-git-tag-version --dist-tag hammertest
       - run:
           name: Install osslsigncode
           command: sudo apt-get install -y osslsigncode
@@ -460,7 +445,6 @@ workflows:
       - dev-release:
           name: Dev Release
           node_version: '14'
-          context: nodejs-app-release
           requires:
             - Regression Test
       - test-windows:


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Removes the publishing of the npm packages from the `dev-release` job in CircleCI.

#### Any background context you want to provide?
Creating too much noise in the versions list on npmjs.
