### PR TITLE
fix: avoid ansi escape codes in non-tty and no color output

### DIFF
--- a/src/cli/commands/help.ts
+++ b/src/cli/commands/help.ts
@@ -1,7 +1,16 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import stripAnsi from 'strip-ansi';
 
 const DEFAULT_HELP = 'snyk';
+
+function readHelpFile(filename: string): string {
+  const file = fs.readFileSync(filename, 'utf8');
+  if (typeof process.env.NO_COLOR !== 'undefined' || !process.stdout.isTTY) {
+    return stripAnsi(file);
+  }
+  return file;
+}
 
 export = async function help(item: string | boolean) {
   if (!item || item === true || typeof item !== 'string' || item === 'help') {
@@ -18,13 +27,13 @@ export = async function help(item: string | boolean) {
       '../../../help/commands-txt',
       item === DEFAULT_HELP ? DEFAULT_HELP + '.txt' : `snyk-${item}.txt`,
     );
-    return fs.readFileSync(filename, 'utf8');
+    return readHelpFile(filename);
   } catch (error) {
     const filename = path.resolve(
       __dirname,
       '../../../help/commands-txt',
       DEFAULT_HELP + '.txt',
     );
-    return fs.readFileSync(filename, 'utf8');
+    return readHelpFile(filename);
   }
 };

--- a/test/smoke/spec/snyk_basic_spec.sh
+++ b/test/smoke/spec/snyk_basic_spec.sh
@@ -87,6 +87,30 @@ Describe "Snyk CLI basics"
       # TODO: unusable with our current docker issues
       The stderr should equal ""
     End
+
+    Describe "prints help info without ascii escape sequences"
+      It "has NO_COLOR set"
+        snyk_help_no_color() {
+          NO_COLOR='' snyk help
+        }
+
+        When run snyk_help_no_color
+        The output should not include "[1mN"
+        The output should not include "[0m"
+        The output should not include "[4mC"
+      End
+
+      It "is not tty"
+        snyk_help_no_tty() {
+          snyk help | cat
+        }
+
+        When run snyk_help_no_tty
+        The output should not include "[1mN"
+        The output should not include "[0m"
+        The output should not include "[4mC"
+      End
+    End
   End
 
   Describe "snyk config"


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

When the terminal doesn't support colour (either NO_COLOR env variable or not TTY as detected by NodeJS), it will remove every ANSI escape code when printing the `help` output. This avoids printing them in plain text and obfuscating the help text.

#### Where should the reviewer start?

Only a few files to check.

#### How should this be manually tested?

Run `snyk help | cat` will print ANSI codes in plain text before this change. After it should print plain unformatted text.

#### Any background context you want to provide?

Originally noticed in some Powershell sessions.

#### What are the relevant tickets?

None.

#### Screenshots

None.

#### Additional questions

`strip-ansi` is a part of `chalk` so it's not added as a direct dependency, but as best practice, maybe it should be as we use it directly?