### PR TITLE
test: convert flaky tests to jest & increase timeout

### DIFF
--- a/test/acceptance/workspaces/no-vulns/package.json
+++ b/test/acceptance/workspaces/no-vulns/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "no-vulns",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}

--- a/test/analytics.spec.ts
+++ b/test/analytics.spec.ts
@@ -1,150 +1,171 @@
 const analytics = require('../src/lib/analytics');
 
+const testTimeout = 50000;
 describe('Analytics basic testing', () => {
-  it('Has all analytics arguments', async () => {
-    analytics.add('foo', 'bar');
-    const data = { args: [], command: '__test__' };
-    const res = await analytics.addDataAndSend(data);
-    if (!res) {
-      throw 'analytics creation failed!';
-    }
-    const keys = Object.keys(data).sort();
-    expect(keys).toEqual(
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-    );
-  });
+  it(
+    'Has all analytics arguments',
+    async () => {
+      analytics.add('foo', 'bar');
+      const data = { args: [], command: '__test__' };
+      const res = await analytics.addDataAndSend(data);
+      if (!res) {
+        throw 'analytics creation failed!';
+      }
+      const keys = Object.keys(data).sort();
+      expect(keys).toEqual(
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+      );
+    },
+    testTimeout,
+  );
 
-  it('Has all analytics arguments when org is specified', async () => {
-    analytics.add('foo', 'bar');
-    const data = { args: [], command: '__test__', org: '__snyk__' };
-    const res = await analytics.addDataAndSend(data);
-    if (!res) {
-      throw 'analytics creation failed!';
-    }
-    const keys = Object.keys(data).sort();
-    expect(keys).toEqual(
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'org',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-    );
-  });
+  it(
+    'Has all analytics arguments when org is specified',
+    async () => {
+      analytics.add('foo', 'bar');
+      const data = { args: [], command: '__test__', org: '__snyk__' };
+      const res = await analytics.addDataAndSend(data);
+      if (!res) {
+        throw 'analytics creation failed!';
+      }
+      const keys = Object.keys(data).sort();
+      expect(keys).toEqual(
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'org',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+      );
+    },
+    testTimeout,
+  );
 
-  it('Has all analytics arguments when args are given', async () => {
-    analytics.add('foo', 'bar');
-    const data = {
-      args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
-      command: '__test__',
-    };
-    const res = await analytics.addDataAndSend(data);
-    if (!res) {
-      throw 'analytics creation failed!';
-    }
-    const keys = Object.keys(data).sort();
-    expect(keys).toEqual(
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-    );
-  });
+  it(
+    'Has all analytics arguments when args are given',
+    async () => {
+      analytics.add('foo', 'bar');
+      const data = {
+        args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
+        command: '__test__',
+      };
+      const res = await analytics.addDataAndSend(data);
+      if (!res) {
+        throw 'analytics creation failed!';
+      }
+      const keys = Object.keys(data).sort();
+      expect(keys).toEqual(
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+      );
+    },
+    testTimeout,
+  );
 
-  it('Has all analytics arguments when org is specified and args are given', async () => {
-    analytics.add('foo', 'bar');
-    const data = {
-      args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
-      command: '__test__',
-      org: '__snyk__',
-    };
-    const res = await analytics.addDataAndSend(data);
-    if (!res) {
-      throw 'analytics creation failed!';
-    }
-    const keys = Object.keys(data).sort();
-    expect(keys).toEqual(
-      [
-        'command',
-        'os',
-        'version',
-        'id',
-        'ci',
-        'environment',
-        'metadata',
-        'metrics',
-        'args',
-        'nodeVersion',
-        'standalone',
-        'durationMs',
-        'org',
-        'integrationName',
-        'integrationVersion',
-        'integrationEnvironment',
-        'integrationEnvironmentVersion',
-      ].sort(),
-    );
-  });
+  it(
+    'Has all analytics arguments when org is specified and args are given',
+    async () => {
+      analytics.add('foo', 'bar');
+      const data = {
+        args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
+        command: '__test__',
+        org: '__snyk__',
+      };
+      const res = await analytics.addDataAndSend(data);
+      if (!res) {
+        throw 'analytics creation failed!';
+      }
+      const keys = Object.keys(data).sort();
+      expect(keys).toEqual(
+        [
+          'command',
+          'os',
+          'version',
+          'id',
+          'ci',
+          'environment',
+          'metadata',
+          'metrics',
+          'args',
+          'nodeVersion',
+          'standalone',
+          'durationMs',
+          'org',
+          'integrationName',
+          'integrationVersion',
+          'integrationEnvironment',
+          'integrationEnvironmentVersion',
+        ].sort(),
+      );
+    },
+    testTimeout,
+  );
 
-  it('Has analytics given values', async () => {
-    analytics.add('foo', 'bar');
-    const data = {
-      args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
-      command: '__test__',
-      org: '__snyk__',
-    };
-    const res = await analytics.addDataAndSend(data);
-    if (!res) {
-      throw 'analytics creation failed!';
-    }
-    const vals = Object.values(data);
-    expect(vals).toContain('__test__');
-    expect(vals).toContain('__snyk__');
-    expect(vals).toContain('JENKINS');
-    expect(vals).toContain('1.2.3');
-  });
+  it(
+    'Has analytics given values',
+    async () => {
+      analytics.add('foo', 'bar');
+      const data = {
+        args: [{ integrationName: 'JENKINS', integrationVersion: '1.2.3' }],
+        command: '__test__',
+        org: '__snyk__',
+      };
+      const res = await analytics.addDataAndSend(data);
+      if (!res) {
+        throw 'analytics creation failed!';
+      }
+      const vals = Object.values(data);
+      expect(vals).toContain('__test__');
+      expect(vals).toContain('__snyk__');
+      expect(vals).toContain('JENKINS');
+      expect(vals).toContain('1.2.3');
+    },
+    testTimeout,
+  );
 });

--- a/test/cli-json-file-output.spec.ts
+++ b/test/cli-json-file-output.spec.ts
@@ -1,0 +1,138 @@
+import { exec } from 'child_process';
+import { sep, join } from 'path';
+import { readFileSync, unlinkSync, rmdirSync, mkdirSync, existsSync } from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+
+const osName = require('os-name');
+
+const main = './dist/cli/index.js'.replace(/\//g, sep);
+const testTimeout = 40000;
+const isWindows =
+  osName()
+    .toLowerCase()
+    .indexOf('windows') === 0;
+describe('test --json-file-output ', () => {
+  const noVulnsProjectPath = join(
+    __dirname,
+    '/acceptance',
+    'workspaces',
+    'no-vulns',
+  );
+  it(
+    '`can save JSON output to file while sending human readable output to stdout`',
+    async (done) => {
+      return exec(
+        `node ${main} test ${noVulnsProjectPath} --json-file-output=snyk-direct-json-test-output.json`,
+        async (err, stdout) => {
+          if (err) {
+            throw err;
+          }
+          // give file a little time to be finished to be written
+          await new Promise((r) => setTimeout(r, 3000));
+          expect(stdout).toMatch('Organization:');
+          const outputFileContents = readFileSync(
+            'snyk-direct-json-test-output.json',
+            'utf-8',
+          );
+          unlinkSync('./snyk-direct-json-test-output.json');
+          const jsonObj = JSON.parse(outputFileContents);
+          const okValue = jsonObj.ok as boolean;
+          expect(okValue).toBeTruthy();
+          done();
+        },
+      );
+    },
+    testTimeout,
+  );
+
+  it(
+    '`test --json-file-output produces same JSON output as normal JSON output to stdout`',
+    (done) => {
+      return exec(
+        `node ${main} test ${noVulnsProjectPath} --json --json-file-output=snyk-direct-json-test-output.json`,
+        async (err, stdout) => {
+          if (err) {
+            throw err;
+          }
+          // give file a little time to be finished to be written
+          await new Promise((r) => setTimeout(r, 3000));
+          const stdoutJson = stdout;
+          const outputFileContents = readFileSync(
+            'snyk-direct-json-test-output.json',
+            'utf-8',
+          );
+          unlinkSync('./snyk-direct-json-test-output.json');
+          expect(stdoutJson).toEqual(outputFileContents);
+          done();
+        },
+      );
+    },
+    testTimeout,
+  );
+
+  it(
+    '`test --json-file-output can handle a relative path`',
+    (done) => {
+      // if 'test-output' doesn't exist, created it
+      if (!existsSync('test-output')) {
+        mkdirSync('test-output');
+      }
+
+      const tempFolder = uuidv4();
+      const outputPath = `test-output/${tempFolder}/snyk-direct-json-test-output.json`;
+
+      exec(
+        `node ${main} test ${noVulnsProjectPath} --json --json-file-output=${outputPath}`,
+        async (err, stdout) => {
+          if (err) {
+            throw err;
+          }
+          // give file a little time to be finished to be written
+          await new Promise((r) => setTimeout(r, 3000));
+          const stdoutJson = stdout;
+          const outputFileContents = readFileSync(outputPath, 'utf-8');
+          unlinkSync(outputPath);
+          rmdirSync(`test-output/${tempFolder}`);
+          expect(stdoutJson).toEqual(outputFileContents);
+          done();
+        },
+      );
+    },
+    testTimeout,
+  );
+
+  if (isWindows) {
+    test(
+      '`test --json-file-output can handle an absolute path`',
+      () => {
+        // if 'test-output' doesn't exist, created it
+        if (!existsSync('test-output')) {
+          mkdirSync('test-output');
+        }
+
+        const tempFolder = uuidv4();
+        const outputPath = join(
+          process.cwd(),
+          `test-output/${tempFolder}/snyk-direct-json-test-output.json`,
+        );
+
+        exec(
+          `node ${main} test ${noVulnsProjectPath} --json --json-file-output=${outputPath}`,
+          async (err, stdout) => {
+            if (err) {
+              throw err;
+            }
+            // give file a little time to be finished to be written
+            await new Promise((r) => setTimeout(r, 3000));
+            const stdoutJson = stdout;
+            const outputFileContents = readFileSync(outputPath, 'utf-8');
+            unlinkSync(outputPath);
+            rmdirSync(`test-output/${tempFolder}`);
+            expect(stdoutJson).toEqual(outputFileContents);
+          },
+        );
+      },
+      testTimeout,
+    );
+  }
+});

--- a/test/dev-count-analysis.spec.ts
+++ b/test/dev-count-analysis.spec.ts
@@ -7,6 +7,7 @@ import {
   hashData,
 } from '../src/lib/monitor/dev-count-analysis';
 
+const testTimeout = 30000;
 describe('cli dev count via git log analysis', () => {
   let expectedContributorUserIds: string[] = [];
   let expectedMergeOnlyUserIds: string[] = [];
@@ -53,30 +54,38 @@ describe('cli dev count via git log analysis', () => {
     );
   });
 
-  it('returns contributors', async () => {
-    const contributors = await getContributors({
-      endDate: new Date(1590174610000),
-      periodDays: 10,
-      repoPath: process.cwd(),
-    });
-    const contributorUserIds = contributors.map((c) => c.userId);
-    expect(contributorUserIds.sort()).toEqual(
-      expectedContributorUserIds.sort(),
-    );
-  });
+  it(
+    'returns contributors',
+    async () => {
+      const contributors = await getContributors({
+        endDate: new Date(1590174610000),
+        periodDays: 10,
+        repoPath: process.cwd(),
+      });
+      const contributorUserIds = contributors.map((c) => c.userId);
+      expect(contributorUserIds.sort()).toEqual(
+        expectedContributorUserIds.sort(),
+      );
+    },
+    testTimeout,
+  );
 
-  it('does not include contributors who have only merged pull requests', async () => {
-    const contributors = await getContributors({
-      endDate: new Date(1590174610000),
-      periodDays: 10,
-      repoPath: process.cwd(),
-    });
-    const contributorUserIds = contributors.map((c) => c.userId);
+  it(
+    'does not include contributors who have only merged pull requests',
+    async () => {
+      const contributors = await getContributors({
+        endDate: new Date(1590174610000),
+        periodDays: 10,
+        repoPath: process.cwd(),
+      });
+      const contributorUserIds = contributors.map((c) => c.userId);
 
-    // make sure none of uniqueEmailsContainingOnlyMergeCommits are in contributorUserIds
-    const legitUserIdsWhichAreAlsoInMergeOnlyUserIds = expectedMergeOnlyUserIds.filter(
-      (user) => contributorUserIds.includes(user),
-    );
-    expect(legitUserIdsWhichAreAlsoInMergeOnlyUserIds).toHaveLength(0);
-  });
+      // make sure none of uniqueEmailsContainingOnlyMergeCommits are in contributorUserIds
+      const legitUserIdsWhichAreAlsoInMergeOnlyUserIds = expectedMergeOnlyUserIds.filter(
+        (user) => contributorUserIds.includes(user),
+      );
+      expect(legitUserIdsWhichAreAlsoInMergeOnlyUserIds).toHaveLength(0);
+    },
+    testTimeout,
+  );
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Convert some flaky tests to jest from tap
Increase timeout for analytics tests
Use a smaller fixture with a lockfile for a slow test `test/monitor-target.spec.ts` that was running on `node_modules`
