### PR TITLE
fix: Added filtering history entries with no "created_by"

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0-rc.2",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.17.2",
+    "snyk-docker-plugin": "4.17.3",
     "snyk-go-plugin": "1.16.5",
     "snyk-gradle-plugin": "3.13.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
For docker archives we extract auto detected user instructions from the image config. Some of the entries are missing "created_by" so we were throwing an error.
