### PR TITLE
fix: don't fail on request's big payload

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -83,7 +83,11 @@ export = function makeRequest(
           payload.timeout = config.timeout * 1000; // s -> ms
         }
 
-        debug('request payload: ', JSON.stringify(payload));
+        try {
+          debug('request payload: ', JSON.stringify(payload));
+        } catch (e) {
+          debug('request payload is too big to log', e);
+        }
 
         const method = (
           payload.method || 'get'


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Today we're serialising the request's payload to debug it. this fails when the payload is too be (see ticket https://snyk.zendesk.com/agent/tickets/6712).
This will skip and log another message in this scenario.