### PR TITLE
feat: add default created date to ignores

### DIFF
--- a/src/cli/commands/ignore.ts
+++ b/src/cli/commands/ignore.ts
@@ -69,6 +69,7 @@ function ignore(options): Promise<MethodResult> {
               '*': {
                 reason: options.reason,
                 expires: options.expiry,
+                created: new Date(),
               },
             },
           ];

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -1,5 +1,6 @@
 import * as util from 'util';
-import * as _ from 'lodash';
+import * as get from 'lodash.get';
+import * as isObject from 'lodash.isobject';
 import { test } from 'tap';
 import * as ciChecker from '../../src/lib/is-ci';
 import * as dockerChecker from '../../src/lib/is-docker';
@@ -16,12 +17,12 @@ type Ignore = {
     reason: string;
     expires: Date;
     created?: Date;
-  }
-}
+  };
+};
 
 type Policy = {
   [id: string]: Ignore[];
-}
+};
 
 const port = process.env.PORT || process.env.SNYK_PORT || '12345';
 
@@ -314,7 +315,7 @@ test('snyk ignore - default options', async (t) => {
       new Date().getTime(),
       'created date is the current date',
     );
-  clock.restore();
+    clock.restore();
   } catch (e) {
     t.fail(e, 'ignore should succeed');
   }
@@ -363,7 +364,7 @@ test('monitor --json', async (t) => {
     const response = await cli.monitor(undefined, { json: true });
     const res = JSON.parse(response);
 
-    if (_.isObject(res)) {
+    if (isObject(res)) {
       t.pass('monitor outputted JSON');
     } else {
       t.fail('Failed parsing monitor JSON output');
@@ -372,7 +373,7 @@ test('monitor --json', async (t) => {
     const keyList = ['packageManager', 'manageUrl'];
 
     keyList.forEach((k) => {
-      !_.get(res, k) ? t.fail(k + 'not found') : t.pass(k + ' found');
+      !get(res, k) ? t.fail(k + 'not found') : t.pass(k + ' found');
     });
   } catch (error) {
     t.fail(error);
@@ -387,7 +388,7 @@ test('monitor --json no supported target files', async (t) => {
   } catch (error) {
     const jsonResponse = error.json;
 
-    if (_.isObject(jsonResponse)) {
+    if (isObject(jsonResponse)) {
       t.pass('monitor outputted JSON');
     } else {
       t.fail('Failed parsing monitor JSON output');
@@ -397,7 +398,7 @@ test('monitor --json no supported target files', async (t) => {
     t.equals(jsonResponse.ok, false, 'result is an error');
 
     keyList.forEach((k) => {
-      t.ok(_.get(jsonResponse, k, null), `${k} present`);
+      t.ok(get(jsonResponse, k, null), `${k} present`);
     });
   }
 });


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

In all the time we’ve had ignores in the CLI, we’ve never set a created date of the current timestamp to them, which is counter to what we do in the UI/API.

Now is the time to change that.

#### Where should the reviewer start?

Pull this down and build it locally.

#### How should this be manually tested?

- Find a monitored project which has issues
- Find an issue and run ignore, e.g `snyk-dev ignore --id=npm:qs:20140806`
- Monitor the project
- Call the aggregated issues endpoint for the project to see that the created date is in the returned ignore object on the issue, `http://[host]/api/v1/org/orgId/project/projectId/aggregated-issues`