### PR TITLE
test: CLI alert: add PD_ROUTING_KEY env variable

### DIFF
--- a/.github/workflows/cli-alert.yml
+++ b/.github/workflows/cli-alert.yml
@@ -19,3 +19,4 @@ jobs:
         env:
           USER_GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          PD_ROUTING_KEY: ${{ secrets.PD_ROUTING_KEY }}


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Small fix to add PagerDuty routing key as environment variable, so that CLI alerts workflow works properly
