### PR TITLE
test: iac local exec new unit tests - part 1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,6 +17,7 @@ test/smoke/spec/iac/ @snyk/cloudconfig
 test/smoke/.iac-data/ @snyk/cloudconfig
 test/fixtures/sast/ @snyk/sast-team
 test/snyk-code-test.spec.ts @snyk/sast-team
+test/iac-unit-tests/ @snyk/cloudconfig
 src/lib/errors/invalid-iac-file.ts @snyk/cloudconfig
 src/lib/errors/unsupported-options-iac-error.ts @snyk/cloudconfig
 help/commands-docs/iac-examples.md @snyk/cloudconfig

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,10 @@ module.exports = {
   testMatch: [
     '<rootDir>/test/*.spec.ts',
     '<rootDir>\\test\\*.spec.ts', // for Windows
+    '<rootDir>/test/iac-unit-tests/*.spec.ts',
+    '<rootDir>\\test\\*.spec.ts', // for Windows,
+    '<rootDir>\\test\\iac-unit-tests\\*.spec.ts', // for Windows
+    '<rootDir>/packages/**/test/*.spec.ts',
     '<rootDir>/packages/**/test/**/*.spec.ts',
     '<rootDir>\\packages\\**\\test\\**\\*.spec.ts,' // for Windows
   ],

--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "lodash.countby": "^4.6.0",
     "lodash.every": "^4.6.0",
     "madge": "^3.4.4",
+    "mock-fs": "^4.13.0",
     "nock": "^10.0.6",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",

--- a/test/iac-unit-tests/file-loader.fixtures.ts
+++ b/test/iac-unit-tests/file-loader.fixtures.ts
@@ -1,0 +1,42 @@
+import * as path from 'path';
+
+const fileContent = 'dont-care';
+const mixedDirectory = path.join(__dirname, '/mixed');
+
+export const k8sDirectory = path.join(__dirname, '/kubernetes/files');
+export const emptyDirectory = path.join(__dirname, '/empty-dir');
+export const k8sFileStub = {
+  fileContent,
+  filePath: path.join(k8sDirectory, 'k8s.yaml'),
+  fileType: 'yaml',
+};
+
+export const anotherK8sFileStub = {
+  ...k8sFileStub,
+  filePath: path.join(k8sDirectory, 'pod.yaml'),
+};
+
+export const terraformDirectory = path.join(__dirname, '/terraform/files');
+
+export const terraformFileStub = {
+  fileContent,
+  filePath: path.join(terraformDirectory, 'main.tf'),
+  fileType: 'tf',
+};
+
+export const anotherTerraformFileStub = {
+  ...terraformFileStub,
+  filePath: path.join(terraformDirectory, 'modules.tf'),
+};
+
+export const nonIacFileStub = {
+  fileContent,
+  filePath: path.join(mixedDirectory, 'this_shouldnt_load.sh'),
+  fileType: 'sh',
+};
+
+export const anotherNonIacFileStub = {
+  fileContent,
+  filePath: path.join(mixedDirectory, 'this_also_shouldnt_load.js'),
+  fileType: 'js',
+};

--- a/test/iac-unit-tests/file-loader.spec.ts
+++ b/test/iac-unit-tests/file-loader.spec.ts
@@ -1,0 +1,113 @@
+const mockFs = require('mock-fs');
+import { loadFiles } from '../../src/cli/commands/test/iac-local-execution/file-loader';
+import {
+  k8sFileStub,
+  anotherK8sFileStub,
+  terraformFileStub,
+  anotherTerraformFileStub,
+  nonIacFileStub,
+  anotherNonIacFileStub,
+  k8sDirectory,
+  terraformDirectory,
+  emptyDirectory,
+} from './file-loader.fixtures';
+
+describe('loadFiles', () => {
+  afterEach(mockFs.restore);
+
+  describe('single file path', () => {
+    describe('with a k8s file', () => {
+      it('returns an array with a single file', async () => {
+        mockFs({ [k8sFileStub.filePath]: k8sFileStub.fileContent });
+        const loadedFiles = await loadFiles(k8sFileStub.filePath);
+        expect(loadedFiles).toContainEqual(k8sFileStub);
+      });
+    });
+
+    describe('with a terraform file', () => {
+      it('returns an array with a single file', async () => {
+        mockFs({ [terraformFileStub.filePath]: terraformFileStub.fileContent });
+        const loadedFiles = await loadFiles(terraformFileStub.filePath);
+        expect(loadedFiles).toContainEqual(terraformFileStub);
+      });
+    });
+
+    describe('with a non iac file', () => {
+      it('throws an error', async () => {
+        mockFs({ [nonIacFileStub.filePath]: nonIacFileStub.fileContent });
+        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
+          "Couldn't find valid IaC files",
+        );
+      });
+    });
+  });
+
+  describe('directory path', () => {
+    describe('with kubernetes files', () => {
+      it('returns an array of files', async () => {
+        mockFs({
+          [k8sFileStub.filePath]: k8sFileStub.fileContent,
+          [anotherK8sFileStub.filePath]: anotherK8sFileStub.fileContent,
+        });
+
+        const loadedFiles = await loadFiles(k8sDirectory);
+        expect(loadedFiles).toEqual([k8sFileStub, anotherK8sFileStub]);
+      });
+    });
+
+    describe('with terraform files', () => {
+      it('returns an array of files', async () => {
+        mockFs({
+          [terraformFileStub.filePath]: terraformFileStub.fileContent,
+          [anotherTerraformFileStub.filePath]:
+            anotherTerraformFileStub.fileContent,
+        });
+
+        const loadedFiles = await loadFiles(terraformDirectory);
+        expect(loadedFiles).toEqual([
+          terraformFileStub,
+          anotherTerraformFileStub,
+        ]);
+      });
+    });
+
+    describe('with no files', () => {
+      it('throws an error', async () => {
+        mockFs({
+          [emptyDirectory]: {},
+        });
+
+        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
+          "Couldn't find valid IaC files",
+        );
+      });
+    });
+
+    describe('with a mix of iac files and others', () => {
+      it('returns only the valid iac files', async () => {
+        mockFs({
+          [nonIacFileStub.filePath]: nonIacFileStub.fileContent,
+          [anotherNonIacFileStub.filePath]: anotherNonIacFileStub.fileContent,
+          [k8sFileStub.filePath]: k8sFileStub.fileContent,
+          [anotherK8sFileStub.filePath]: anotherK8sFileStub.fileContent,
+          [terraformFileStub.filePath]: terraformFileStub.fileContent,
+          [anotherTerraformFileStub.filePath]:
+            anotherTerraformFileStub.fileContent,
+        });
+
+        const loadedFiles = await loadFiles('./');
+        expect(loadedFiles).toEqual([
+          k8sFileStub,
+          anotherK8sFileStub,
+          terraformFileStub,
+          anotherTerraformFileStub,
+        ]);
+
+        expect(loadedFiles).not.toContain([
+          nonIacFileStub,
+          anotherNonIacFileStub,
+        ]);
+      });
+    });
+  });
+});

--- a/test/iac-unit-tests/file-parser.fixtures.ts
+++ b/test/iac-unit-tests/file-parser.fixtures.ts
@@ -1,0 +1,117 @@
+import {
+  EngineType,
+  IacFileData,
+  IacFileParsed,
+} from '../../src/cli/commands/test/iac-local-execution/types';
+
+const kubernetesFileContent = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+spec:
+  containers:
+    - name: whatever
+      securityContext:
+        privileged: true 
+
+`;
+
+export const kubernetesFileDataStub: IacFileData = {
+  fileContent: kubernetesFileContent,
+  filePath: 'dont-care',
+  fileType: 'yml',
+};
+
+const kubernetesInvalidFileContent = `
+apiVersionXYZ: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+spec:
+  containers:
+    - name: whatever
+      securityContext:
+        privileged: true 
+`;
+
+export const invalidK8sFileDataStub: IacFileData = {
+  fileContent: kubernetesInvalidFileContent,
+  filePath: 'dont-care',
+  fileType: 'yml',
+};
+
+export const expectedInvalidK8sFileParsingResult = {
+  err: new Error('Invalid K8s File!'),
+  failureReason: 'Invalid K8s File!',
+  fileType: 'yml',
+  filePath: 'dont-care',
+  fileContent: invalidK8sFileDataStub.fileContent,
+  engineType: null,
+  jsonContent: null,
+};
+
+const terraformFileContent = `
+resource "aws_security_group" "allow_ssh" {
+    name        = "allow_ssh"
+    description = "Allow SSH inbound from anywhere"
+    vpc_id      = "123"
+
+    ingress {
+      from_port   = 22
+      to_port     = 22
+      protocol    = "tcp"
+      cidr_blocks = ["0.0.0.0/0"]
+    }
+}`;
+
+export const terraformFileDataStub: IacFileData = {
+  fileContent: terraformFileContent,
+  filePath: 'dont-care',
+  fileType: 'tf',
+};
+
+export const expectedKubernetesParsingResult: IacFileParsed = {
+  ...kubernetesFileDataStub,
+  docId: 0,
+  engineType: EngineType.Kubernetes,
+  jsonContent: {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'myapp-pod',
+    },
+    spec: {
+      containers: [
+        {
+          name: 'whatever',
+          securityContext: {
+            privileged: true,
+          },
+        },
+      ],
+    },
+  },
+};
+
+export const expectedTerraformParsingResult: IacFileParsed = {
+  ...terraformFileDataStub,
+  engineType: EngineType.Terraform,
+  jsonContent: {
+    resource: {
+      aws_security_group: {
+        allow_ssh: {
+          description: 'Allow SSH inbound from anywhere',
+          ingress: {
+            cidr_blocks: ['0.0.0.0/0'],
+            from_port: 22,
+            protocol: 'tcp',
+            to_port: 22,
+          },
+          name: 'allow_ssh',
+          vpc_id: 123,
+        },
+      },
+    },
+  },
+};

--- a/test/iac-unit-tests/file-parser.spec.ts
+++ b/test/iac-unit-tests/file-parser.spec.ts
@@ -1,0 +1,37 @@
+import { parseFiles } from '../../src/cli/commands/test/iac-local-execution/file-parser';
+import {
+  expectedKubernetesParsingResult,
+  expectedTerraformParsingResult,
+  kubernetesFileDataStub,
+  terraformFileDataStub,
+  invalidK8sFileDataStub,
+  expectedInvalidK8sFileParsingResult,
+} from './file-parser.fixtures';
+
+const filesToParse = [kubernetesFileDataStub, terraformFileDataStub];
+
+describe('parseFiles', () => {
+  it('parses iac files as expected', async () => {
+    const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
+    expect(parsedFiles[0]).toEqual(expectedKubernetesParsingResult);
+    expect(parsedFiles[1]).toEqual(expectedTerraformParsingResult);
+    expect(failedFiles.length).toEqual(0);
+  });
+
+  it('throws an error if a single file parse fails', async () => {
+    await expect(parseFiles([invalidK8sFileDataStub])).rejects.toThrow(
+      'Invalid K8s File!',
+    );
+  });
+
+  it('does not throw an error if a file parse failed in a directory scan', async () => {
+    const { parsedFiles, failedFiles } = await parseFiles([
+      kubernetesFileDataStub,
+      invalidK8sFileDataStub,
+    ]);
+    expect(parsedFiles.length).toEqual(1);
+    expect(parsedFiles[0]).toEqual(expectedKubernetesParsingResult);
+    expect(failedFiles.length).toEqual(1);
+    expect(failedFiles[0]).toEqual(expectedInvalidK8sFileParsingResult);
+  });
+});

--- a/test/iac-unit-tests/file-scanner.fixtures.ts
+++ b/test/iac-unit-tests/file-scanner.fixtures.ts
@@ -1,0 +1,100 @@
+import {
+  EngineType,
+  IacFileParsed,
+  PolicyMetadata,
+} from '../../src/cli/commands/test/iac-local-execution/types';
+import { SEVERITY } from '../../src/lib/snyk-test/common';
+
+export const expectedViolatedPoliciesForK8s: Array<PolicyMetadata> = [
+  {
+    description: '',
+    id: '1',
+    impact:
+      'Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).',
+    issue: 'Container is running in privileged mode',
+    msg: 'input.spec.containers[whatever].securityContext.privileged',
+    policyEngineType: 'opa',
+    publicId: 'SNYK-CC-K8S-1',
+    references: [
+      'CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers',
+      'https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged',
+      'https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/',
+    ],
+    resolve:
+      'Remove `securityContext.privileged` attribute, or set value to `false`',
+    severity: 'high' as SEVERITY,
+    subType: 'Deployment',
+    title: 'Container is running in privileged mode',
+    type: 'k8s',
+  },
+];
+
+export const expectedViolatedPoliciesForTerraform: Array<PolicyMetadata> = [
+  {
+    description:
+      '## Overview\nUsing Terraform, the `aws_security_group` resource is used to restrict networking to and from different resources.\nWhen the ingress "cidr_blocks" is set to ["0.0.0.0/0"] or ["::/0"] potentially meaning everyone can access your resource.\n\n## Remediation\nThe aws_security_group ingress.cidr_block property should be populated with a specific IP range or address.\n\n## References\nad\n\n',
+    id: '101',
+    impact: 'That potentially everyone can access your resource',
+    issue:
+      'That inbound traffic is allowed to a resource from any source instead of a restricted range',
+    msg: 'input.resource.aws_security_group[allow_ssh].ingress[0]',
+    policyEngineType: 'opa',
+    publicId: 'SNYK-CC-TF-1',
+    references: [],
+    resolve:
+      'Updating the `cidr_block` attribute with a more restrictive IP range or a specific IP address to ensure traffic can only come from known sources. ',
+    severity: 'medium' as SEVERITY,
+    subType: 'Security Group',
+    title: 'Security Group allows open ingress',
+    type: 'terraform',
+  },
+];
+
+export const paresdKubernetesFileStub: IacFileParsed = {
+  engineType: EngineType.Kubernetes,
+  fileContent: 'dont-care',
+  filePath: 'dont-care',
+  fileType: 'yml',
+  jsonContent: {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name: 'myapp-pod',
+    },
+    spec: {
+      containers: [
+        {
+          name: 'whatever',
+          securityContext: {
+            privileged: true,
+          },
+        },
+      ],
+    },
+  },
+};
+export const parsedTerraformFileStub: IacFileParsed = {
+  engineType: EngineType.Terraform,
+  fileContent: 'dont-care',
+  filePath: 'dont-care',
+  fileType: 'tf',
+  jsonContent: {
+    resource: {
+      aws_security_group: {
+        allow_ssh: {
+          description: 'Allow SSH inbound from anywhere',
+          ingress: [
+            {
+              cidr_blocks: ['0.0.0.0/0'],
+              from_port: 22,
+              protocol: 'tcp',
+              to_port: 22,
+            },
+          ],
+          name: 'allow_ssh',
+          vpc_id: '${aws_vpc.main.id}',
+        },
+      },
+    },
+  },
+};

--- a/test/iac-unit-tests/file-scanner.spec.ts
+++ b/test/iac-unit-tests/file-scanner.spec.ts
@@ -1,0 +1,52 @@
+const mockFs = require('mock-fs');
+import * as path from 'path';
+import { scanFiles } from '../../src/cli/commands/test/iac-local-execution/file-scanner';
+import { IacFileParsed } from '../../src/cli/commands/test/iac-local-execution/types';
+
+import {
+  paresdKubernetesFileStub,
+  parsedTerraformFileStub,
+  expectedViolatedPoliciesForK8s,
+  expectedViolatedPoliciesForTerraform,
+} from './file-scanner.fixtures';
+
+describe('scanFiles', () => {
+  const parsedFiles: Array<IacFileParsed> = [
+    paresdKubernetesFileStub,
+    parsedTerraformFileStub,
+  ];
+
+  beforeAll(() => {
+    mockFs({
+      [path.resolve(__dirname, '../../.iac-data')]: mockFs.load(
+        path.resolve(__dirname, '../smoke/.iac-data'),
+      ),
+    });
+  });
+
+  afterAll(mockFs.restore);
+
+  describe('with parsed files', () => {
+    it('returns the expected viloated policies', async () => {
+      const scanResults = await scanFiles(parsedFiles);
+      expect(scanResults[0].violatedPolicies).toEqual(
+        expectedViolatedPoliciesForK8s,
+      );
+      expect(scanResults[1].violatedPolicies).toEqual(
+        expectedViolatedPoliciesForTerraform,
+      );
+    });
+
+    // TODO: Extract policy engine & the cache mechinism, test them separately.
+  });
+
+  describe('missing policy engine wasm files', () => {
+    it('throws an error', async () => {
+      mockFs({
+        [path.resolve(__dirname, '../../.iac-data')]: {},
+      });
+
+      await expect(scanFiles(parsedFiles)).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Adds unit-tests to the new local execution implementation for IaC.

#### Background Context
As part of the new IaC local execution we're making an effort to achieve 100% unit test coverage for the new code.
For the previous implementation, it was dependant only on regression tests, we had 0% unit-tests.
This PR introduces new unit tests to cover the new modules added for `iac-local-execution`.
As we're basically re-wrote our CLI product from scratch, we're trying to do this incrementally, balance with our priorities, and make sure that this time we don't build tech debt of missing tests.
After this PR, probably 1 or 2 more will follow.

#### Notes
Hammer team  are working at the moment on moving jest-unit tests to new folders as part of a wider test cleanup and organisation they are doing. (branch `chore/separate-jest-unit-and-acceptance-tests`)

**Agreed with them (@maxjeffos) on the new directory created for our unit-tests.**
