### PR TITLE
fix: ensure wizard maintains newlines in package.json

### DIFF
--- a/src/cli/commands/protect/wizard.ts
+++ b/src/cli/commands/protect/wizard.ts
@@ -202,8 +202,8 @@ async function processWizardFlow(options) {
 
         return snyk.policy.loadFromText(res.policy).then((combinedPolicy) => {
           return tryRequire(packageFile).then((pkg) => {
-            options.packageLeading = pkg.prefix;
-            options.packageTrailing = pkg.suffix;
+            options.packageLeading = pkg.leading;
+            options.packageTrailing = pkg.trailing;
             return interactive(
               res,
               pkg,


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Fixes #1549

Detecting newlines is dependant on try-require which uses `leading` and `trailing`, not `prefix` and `suffix`.

https://github.com/snyk/snyk/blob/3262519c9ec9b53952d46273e7a733080c9c7388/src/cli/commands/protect/wizard.ts#L205-L206

https://github.com/snyk/try-require/blob/a79f6c1dfe4c806b04f1b847d70b79354e1f78a2/lib/try-require.js#L40-L41

This PR fixes this to use the correct properties.

#### Where should the reviewer start?

There are no acceptance tests for the wizard as it's an interactive CLI. So easiest way is to manually run it before and after.

#### How should this be manually tested?

```
# Check current behaviour
cd test/fixtures/protect
snyk wizard # say yes to add snyk command to package.json
git diff package.json # notice new line at end of file is removed

# Checkout this PR and repeat for fixed behaviour, newline is maintained
```