### PR TITLE
chore: remove windows-specific test paths

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,12 +7,8 @@ module.exports = {
   coverageReporters: ['text-summary', 'html'],
   testMatch: [
     '<rootDir>/test/*.spec.ts',
-    '<rootDir>\\test\\*.spec.ts', // for Windows
     '<rootDir>/test/iac-unit-tests/*.spec.ts',
-    '<rootDir>\\test\\iac-unit-tests\\*.spec.ts', // for Windows
-    '<rootDir>/packages/**/test/*.spec.ts',
     '<rootDir>/packages/**/test/**/*.spec.ts',
-    '<rootDir>\\packages\\**\\test\\**\\*.spec.ts,' // for Windows
   ],
   modulePathIgnorePatterns: [
     '<rootDir>/test/.*fixtures',


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Jest uses micromatch for these paths which should handle Windows path separators automatically. Removing these will reduce the amount of test config to maintain.

#### Where should the reviewer start?

See small diff. Windows tests should run like Linux tests in CI.

#### How should this be manually tested?

Run Jest tests in Windows (or use CI)