### PR TITLE
Ignore node_modules in the packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 config.local.json
 /.nyc_output/
 /node_modules/
+/packages/*/node_modules/
 local.log
 /patches/
 **/dist


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
Ignore `node_modules` folders in the root of a package (`/packages/<package-name>/node_modules`). This will **_NOT_** ignore other `node_modules` such as those used in test fixtures (ex `/packages/<package-name>/test/fixtures...`)

#### Any background context you want to provide?
The `node_modules` generated by `npm install` in the root of the new `snyk-fix` package is not being ignored.
