### PR TITLE
[IaC] feat: fetch policy bundle from S3 for local scans [Beta]- CC-627

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ jobs:
             echo "Checkout the README in test/smoke folder for more details about this step"
             unset SNYK_API
             unset SNYK_API_KEY
-            shellspec -f d -e REGRESSION_TEST=1
+            shellspec -f d -e REGRESSION_TEST=1 -e SNYK_IAC_SKIP_BUNDLE_DOWNLOAD=true
 
   test-windows:
     <<: *defaults

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,12 +7,8 @@ module.exports = {
   coverageReporters: ['text-summary', 'html'],
   testMatch: [
     '<rootDir>/test/*.spec.ts',
-    '<rootDir>/test/iac-unit-tests/*.spec.ts',
-    '<rootDir>\\test\\*.spec.ts', // for Windows,
-    '<rootDir>\\test\\iac-unit-tests\\*.spec.ts', // for Windows
     '<rootDir>\\test\\*.spec.ts', // for Windows
     '<rootDir>/test/iac-unit-tests/*.spec.ts',
-    '<rootDir>\\test\\*.spec.ts', // for Windows,
     '<rootDir>\\test\\iac-unit-tests\\*.spec.ts', // for Windows
     '<rootDir>/packages/**/test/*.spec.ts',
     '<rootDir>/packages/**/test/**/*.spec.ts',

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,9 @@ module.exports = {
   coverageReporters: ['text-summary', 'html'],
   testMatch: [
     '<rootDir>/test/*.spec.ts',
+    '<rootDir>/test/iac-unit-tests/*.spec.ts',
+    '<rootDir>\\test\\*.spec.ts', // for Windows,
+    '<rootDir>\\test\\iac-unit-tests\\*.spec.ts', // for Windows
     '<rootDir>\\test\\*.spec.ts', // for Windows
     '<rootDir>/test/iac-unit-tests/*.spec.ts',
     '<rootDir>\\test\\*.spec.ts', // for Windows,

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "snyk-try-require": "1.3.1",
     "source-map-support": "^0.5.11",
     "strip-ansi": "^5.2.0",
+    "tar": "^6.1.0",
     "tempfile": "^2.0.0",
     "update-notifier": "^4.1.0",
     "uuid": "^3.3.2",

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -3,6 +3,7 @@ import * as tar from 'tar';
 import * as path from 'path';
 
 export function createIacDir(): void {
+  // this path will be able to be customised by the user in the future
   const iacPath: fs.PathLike = path.join('.iac-data/');
   try {
     if (!fs.existsSync(iacPath)) {

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -1,0 +1,36 @@
+import * as fs from 'fs';
+import * as tar from 'tar';
+import * as path from 'path';
+
+export function createIacDir(): void {
+  const iacPath: fs.PathLike = path.join('.iac-data/');
+  try {
+    if (!fs.existsSync(iacPath)) {
+      fs.mkdirSync(iacPath, '700');
+    }
+    fs.accessSync(iacPath, fs.constants.W_OK);
+  } catch {
+    throw Error(
+      'The .iac-data directory can not be created. ' +
+        'Please make sure that the current working directory has write permissions',
+    );
+  }
+}
+
+export function extractBundle(
+  response,
+  bundlePath: fs.PathLike,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    fs.createWriteStream(bundlePath).on('error', (err) => reject(err));
+
+    response
+      .pipe(
+        tar.x({
+          C: path.join('.iac-data'),
+        }),
+      )
+      .on('finish', resolve)
+      .on('error', reject);
+  });
+}

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -1,23 +1,17 @@
-import { isLocalCacheExists, REQUIRED_LOCAL_CACHE_FILES } from './local-cache';
 import { loadFiles } from './file-loader';
 import { parseFiles } from './file-parser';
 import { scanFiles } from './file-scanner';
 import { formatScanResults } from './results-formatter';
 import { isLocalFolder } from '../../../../lib/detect';
 import { IacOptionFlags } from './types';
+import { initLocalCache } from './local-cache';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // the current version is dependent on files to be present locally which are not part of the source code.
 // without these files this method would fail.
 // if you're interested in trying out the experimental local execution model for IaC scanning, please reach-out.
 export async function test(pathToScan: string, options: IacOptionFlags) {
-  if (!isLocalCacheExists())
-    throw Error(
-      `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(
-        '\n',
-      )}`,
-    );
-
+  await initLocalCache();
   const filesToParse = await loadFiles(pathToScan);
   const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
   const scannedFiles = await scanFiles(parsedFiles);

--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -30,8 +30,7 @@ export const REQUIRED_LOCAL_CACHE_FILES = [
   TERRAFORM_POLICY_ENGINE_WASM_PATH,
   TERRAFORM_POLICY_ENGINE_DATA_PATH,
 ];
-
-export function isLocalCacheExists(): boolean {
+function doesLocalCacheExist(): boolean {
   return REQUIRED_LOCAL_CACHE_FILES.every(fs.existsSync);
 }
 
@@ -58,10 +57,10 @@ export async function initLocalCache(): Promise<void> {
     const fileName: fs.PathLike = path.join('.iac-data/bundle.tar.gz');
 
     createIacDir();
-    const response: ReadableStream = await needle.get(preSignedUrl);
+    const response: ReadableStream = needle.get(preSignedUrl);
     await extractBundle(response, fileName);
   }
-  if (!isLocalCacheExists()) {
+  if (!doesLocalCacheExist()) {
     throw Error(
       `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(
         '\n',

--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -1,8 +1,11 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import { EngineType } from './types';
+import * as needle from 'needle';
+import { createIacDir, extractBundle } from './file-utils';
+import ReadableStream = NodeJS.ReadableStream;
 
-export const LOCAL_POLICY_ENGINE_DIR = `.iac-data`;
+export const LOCAL_POLICY_ENGINE_DIR = '.iac-data';
 
 const KUBERNETES_POLICY_ENGINE_WASM_PATH = path.join(
   LOCAL_POLICY_ENGINE_DIR,
@@ -44,5 +47,25 @@ export function getLocalCachePath(engineType: EngineType) {
         `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_WASM_PATH}`,
         `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_DATA_PATH}`,
       ];
+  }
+}
+
+export async function initLocalCache(): Promise<void> {
+  // temporarily use an ENV var to skip downloading of the bundles if we need to - e.g. smoke tests
+  if (!process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD) {
+    const preSignedUrl =
+      'https://cloud-config-policy-bundles.s3-eu-west-1.amazonaws.com/bundle.tar.gz';
+    const fileName: fs.PathLike = path.join('.iac-data/bundle.tar.gz');
+
+    createIacDir();
+    const response: ReadableStream = await needle.get(preSignedUrl);
+    await extractBundle(response, fileName);
+  }
+  if (!isLocalCacheExists()) {
+    throw Error(
+      `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(
+        '\n',
+      )}`,
+    );
   }
 }

--- a/test/iac-unit-tests/file-utils.spec.ts
+++ b/test/iac-unit-tests/file-utils.spec.ts
@@ -1,0 +1,37 @@
+import { extractBundle } from '../../src/cli/commands/test/iac-local-execution/file-utils';
+
+describe('extractBundle', () => {
+  const fs = require('fs');
+  const { PassThrough } = require('stream');
+  jest.mock('fs');
+  const mockFilePath = '.iac-data/bundle.tar.gz';
+
+  it('fails to write the file on disk', () => {
+    const mockReadable = new PassThrough();
+    const mockWriteable = new PassThrough();
+    const mockError = new Error('A stream error');
+    fs.createWriteStream.mockReturnValueOnce(mockWriteable);
+
+    const actualPromise = extractBundle(mockReadable, mockFilePath);
+    setTimeout(() => {
+      mockReadable.emit('error', mockError);
+    }, 100);
+
+    expect(actualPromise).rejects.toThrow(mockError);
+  });
+
+  it('resolves data successfully', () => {
+    const mockReadable = new PassThrough();
+    const mockWriteable = new PassThrough();
+    fs.createWriteStream.mockReturnValueOnce(mockWriteable);
+
+    const actualPromise = extractBundle(mockReadable, mockFilePath);
+
+    setTimeout(() => {
+      mockReadable.emit('data', 'this-is-a-file-chunk');
+      mockReadable.emit('end');
+    }, 100);
+
+    expect(actualPromise).resolves.toEqual(undefined);
+  });
+});

--- a/test/iac-unit-tests/local-cache.spec.ts
+++ b/test/iac-unit-tests/local-cache.spec.ts
@@ -1,0 +1,55 @@
+import * as localCacheModule from '../../src/cli/commands/test/iac-local-execution/local-cache';
+import { REQUIRED_LOCAL_CACHE_FILES } from '../../src/cli/commands/test/iac-local-execution/local-cache';
+import * as fileUtilsModule from '../../src/cli/commands/test/iac-local-execution/file-utils';
+import { PassThrough } from 'stream';
+import * as needle from 'needle';
+
+describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is not set', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  const fs = require('fs');
+  fs.existsSync = jest.fn().mockReturnValue(true);
+
+  it('downloads and extracts the bundle successfully', () => {
+    delete process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD;
+    const mockReadable = new PassThrough();
+    const spy = jest.spyOn(fileUtilsModule, 'extractBundle');
+    jest.spyOn(fileUtilsModule, 'createIacDir').mockImplementation(() => null);
+    jest.spyOn(needle, 'get').mockReturnValue(mockReadable);
+
+    localCacheModule.initLocalCache();
+
+    expect(spy).toHaveBeenCalledWith(mockReadable, '.iac-data/bundle.tar.gz');
+  });
+});
+
+describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is true', () => {
+  process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD = 'true';
+  const fs = require('fs');
+
+  it('skips the download of the bundle', async () => {
+    fs.existsSync = jest.fn().mockReturnValue(true);
+    jest.spyOn(fileUtilsModule, 'extractBundle');
+
+    await localCacheModule.initLocalCache();
+
+    expect(fileUtilsModule.extractBundle).not.toHaveBeenCalled();
+  });
+
+  it('skips the download of the bundle but throws an error', () => {
+    const error = new Error(
+      `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(
+        '\n',
+      )}`,
+    );
+    fs.existsSync = jest.fn().mockReturnValue(false);
+    jest.spyOn(fileUtilsModule, 'extractBundle');
+
+    const promise = localCacheModule.initLocalCache();
+
+    expect(fileUtilsModule.extractBundle).not.toHaveBeenCalled();
+    expect(promise).rejects.toThrow(error);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
_This is the basic e2e flow that we need for the Beta release. It will be incrementally enhanced._
Everytime a user runs `snyk iac --experimental`, the wasm policies will be available locally.
What happens in the background: 
- A tarball bundle.tar.gz is downloaded from S3, is extracted and placed in the `.iac-data` directory of your cwd. 

This way, the user will have the policies locally in a wasm file, giving them the ability to scan their files locally against them and not send any files over the network.

**Regarding the smoke tests and the env variable:** 
these are run against a subset of fixtures, but now that we introduce this new flow, the policies would get updated every time. Because of that, we provided an env variable temporarily named `SNYK_IAC_SKIP_BUNDLE_DOWNLOAD` to shellspec to skip downloading the bundle.

#### How should this be manually tested?
- Run `snyk iac test --experimental` as usual to check the full flow.
- Run `SNYK_IAC_SKIP_BUNDLE_DOWNLOAD=true snyk-dev iac test filename --experimental` to skip the download of the bundle from S3, for that you will need to have the `.iac-data` folder with the relevant files locally, or you will get an error.

#### Any background context you want to provide?
There is [this decision document](https://www.notion.so/snyk/Policy-WASM-download-mechanism-8b25b39dceab4520b56f9783e6cd7ecf) in Notion that can be shared internally.

#### What are the relevant tickets?
[CC-627](https://snyksec.atlassian.net/browse/CC-627)