### PR TITLE
chore: upload CLI artifacts to S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,21 +445,8 @@ jobs:
             npx conventional-changelog-cli -p angular -l -r 1 > RELEASE_NOTES.txt
             gh release create ${new_tag} --title "${new_tag}" --notes-file RELEASE_NOTES.txt
       - run:
-          name: Add Assets to GitHub Release
-          command: |
-            gh_latest_release_tag=$(gh api repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/releases/latest | jq .tag_name -r)
-            echo "gh_latest_release_tag: ${gh_latest_release_tag}"
-            gh release upload $gh_latest_release_tag \
-              binary-releases/snyk-alpine \
-              binary-releases/snyk-linux \
-              binary-releases/snyk-macos \
-              binary-releases/snyk-win.exe \
-              binary-releases/docker-mac-signed-bundle.tar.gz \
-              binary-releases/snyk-alpine.sha256 \
-              binary-releases/snyk-linux.sha256 \
-              binary-releases/snyk-macos.sha256 \
-              binary-releases/snyk-win.exe.sha256 \
-              binary-releases/docker-mac-signed-bundle.tar.gz.sha256
+          name: Upload assets to the GitHub Release and a public S3
+          command: ./release-scripts/upload-artifacts.sh
 
 workflows:
   version: 2

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -e
+
+gh_latest_release_tag=$(gh api repos/"${CIRCLE_PROJECT_USERNAME}"/"${CIRCLE_PROJECT_REPONAME}"/releases/latest | jq .tag_name -r)
+echo "gh_latest_release_tag: ${gh_latest_release_tag}"
+[[ ! $gh_latest_release_tag =~ ^v[0-9.]+$ ]] && echo "gh_latest_release_tag is not a valid version" && exit 1
+
+declare -a StaticFiles=(
+  "binary-releases/snyk-alpine"
+  "binary-releases/snyk-linux"
+  "binary-releases/snyk-macos"
+  "binary-releases/snyk-win.exe"
+  "binary-releases/docker-mac-signed-bundle.tar.gz"
+  "binary-releases/snyk-alpine.sha256"
+  "binary-releases/snyk-linux.sha256"
+  "binary-releases/snyk-macos.sha256"
+  "binary-releases/snyk-win.exe.sha256"
+  "binary-releases/docker-mac-signed-bundle.tar.gz.sha256"
+)
+
+# Upload files to the GitHub release
+for filename in "${StaticFiles[@]}"; do
+  gh release upload "${gh_latest_release_tag}" "${filename}"
+done
+
+# Upload files to the versioned folder
+for filename in "${StaticFiles[@]}"; do
+  aws s3 cp "${filename}" s3://"${PUBLIC_S3_BUCKET}"/cli/"${gh_latest_release_tag}"/
+done
+
+# Upload files to the /latest folder
+for filename in "${StaticFiles[@]}"; do
+  aws s3 cp "${filename}" s3://"${PUBLIC_S3_BUCKET}"/cli/latest/
+done


### PR DESCRIPTION
This will allow users to have a nice and static URL to fetch a specific CLI release