### PR TITLE
fix: terraform plan scan to include data objects

### DIFF
--- a/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
@@ -12,17 +12,16 @@ function terraformPlanReducer(
   resource: TerraformPlanResource,
 ): TerraformScanInput {
   // TODO: investigate if this reduction logic covers all edge-cases (nested modules, similar names, etc')
-  const { type, name } = resource;
-  if (scanInput.resource[resource.type]) {
+  const { type, name, mode, index, values } = resource;
+  const inputKey: keyof TerraformScanInput =
+    mode === 'data' ? 'data' : 'resource';
+  if (scanInput[inputKey][type]) {
     // add new resources of the same type with different names
-    scanInput.resource[type][
-      resource.index !== undefined
-        ? `${resource.name}_${resource.index}`
-        : resource.name
-    ] = resource.values || {};
+    scanInput[inputKey][type][index !== undefined ? `${name}_${index}` : name] =
+      values || {};
   } else {
     // add a new resource type
-    scanInput.resource[type] = { [name]: resource.values };
+    scanInput[inputKey][type] = { [name]: values };
   }
 
   return scanInput;
@@ -59,7 +58,7 @@ export function tryParsingTerraformPlan(
   const parsedInput = [
     ...rootModuleResources,
     ...childModuleResources,
-  ].reduce(terraformPlanReducer, { resource: {} });
+  ].reduce(terraformPlanReducer, { resource: {}, data: {} });
   return [
     {
       ...terraformPlanFile,

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -97,6 +97,7 @@ export interface TerraformPlanJson {
 export interface TerraformScanInput {
   // within the resource field, resources are stored: [type] => [name] => [values]
   resource: Record<string, Record<string, unknown>>;
+  data: Record<string, Record<string, unknown>>;
 }
 
 export interface TerraformPlanResource {


### PR DESCRIPTION
#### What does this PR do?
Fixes the terraform plan parser to scan also data inputs in addition to resources.
