### PR TITLE
Don’t force https for custom API endpoints

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -1,6 +1,6 @@
 import { debug as debugModule } from 'debug';
 import * as needle from 'needle';
-import { parse, format } from 'url';
+import { parse } from 'url';
 import * as querystring from 'querystring';
 import * as zlib from 'zlib';
 import * as config from '../config';
@@ -68,15 +68,6 @@ export = function makeRequest(
         }
 
         const parsedUrl = parse(payload.url);
-
-        if (
-          parsedUrl.protocol === 'http:' &&
-          parsedUrl.hostname !== 'localhost'
-        ) {
-          debug('forcing api request to https');
-          parsedUrl.protocol = 'https:';
-          payload.url = format(parsedUrl);
-        }
 
         // prefer config timeout unless payload specified
         if (!payload.hasOwnProperty('timeout')) {


### PR DESCRIPTION
CLI shouldn't try to force the https protocol, when using a custom API endpoint.
It prevents usage with reverse proxies and similar network setups.