### PR TITLE
refactor: Remove writeable stream to stop writing tarball to the disk [IaC]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -18,13 +18,8 @@ export function createIacDir(): void {
   }
 }
 
-export function extractBundle(
-  response,
-  bundlePath: fs.PathLike,
-): Promise<void> {
+export function extractBundle(response): Promise<void> {
   return new Promise((resolve, reject) => {
-    fs.createWriteStream(bundlePath).on('error', (err) => reject(err));
-
     response
       .pipe(
         tar.x({

--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -54,11 +54,10 @@ export async function initLocalCache(): Promise<void> {
   if (!process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD) {
     const preSignedUrl =
       'https://cloud-config-policy-bundles.s3-eu-west-1.amazonaws.com/bundle.tar.gz';
-    const fileName: fs.PathLike = path.join('.iac-data/bundle.tar.gz');
 
     createIacDir();
     const response: ReadableStream = needle.get(preSignedUrl);
-    await extractBundle(response, fileName);
+    await extractBundle(response);
   }
   if (!doesLocalCacheExist()) {
     throw Error(

--- a/test/iac-unit-tests/file-utils.spec.ts
+++ b/test/iac-unit-tests/file-utils.spec.ts
@@ -1,18 +1,14 @@
 import { extractBundle } from '../../src/cli/commands/test/iac-local-execution/file-utils';
 
 describe('extractBundle', () => {
-  const fs = require('fs');
   const { PassThrough } = require('stream');
   jest.mock('fs');
-  const mockFilePath = '.iac-data/bundle.tar.gz';
 
   it('fails to write the file on disk', () => {
     const mockReadable = new PassThrough();
-    const mockWriteable = new PassThrough();
     const mockError = new Error('A stream error');
-    fs.createWriteStream.mockReturnValueOnce(mockWriteable);
 
-    const actualPromise = extractBundle(mockReadable, mockFilePath);
+    const actualPromise = extractBundle(mockReadable);
     setTimeout(() => {
       mockReadable.emit('error', mockError);
     }, 100);
@@ -22,10 +18,8 @@ describe('extractBundle', () => {
 
   it('resolves data successfully', () => {
     const mockReadable = new PassThrough();
-    const mockWriteable = new PassThrough();
-    fs.createWriteStream.mockReturnValueOnce(mockWriteable);
 
-    const actualPromise = extractBundle(mockReadable, mockFilePath);
+    const actualPromise = extractBundle(mockReadable);
 
     setTimeout(() => {
       mockReadable.emit('data', 'this-is-a-file-chunk');

--- a/test/iac-unit-tests/local-cache.spec.ts
+++ b/test/iac-unit-tests/local-cache.spec.ts
@@ -21,7 +21,7 @@ describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is not set', () => {
 
     localCacheModule.initLocalCache();
 
-    expect(spy).toHaveBeenCalledWith(mockReadable, '.iac-data/bundle.tar.gz');
+    expect(spy).toHaveBeenCalledWith(mockReadable);
   });
 });
 


### PR DESCRIPTION
#### What does this PR do?
On a previous PR, we introduced the download of a tarball with policies and the extraction of its contents.

The code was unnecessarily writing the bundle.tar.gz to the disk before extracting the files too. This file is not needed, we only need its contents to be written to the disk, so this PR removes it.

#### How should this be manually tested?

Run `snyk iac test file.tf --experimental` and check that there is no bundle.tar.gz into your `.iac-data` folder

Related to CC-627
