### PR TITLE
fix: Add error code to error object for json/sarif test output

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -210,6 +210,14 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
       err.jsonNoVulns = dataToSendNoVulns;
     }
 
+    if (notSuccess) {
+      // Take the code of the first problem to go through error
+      // translation.
+      // Note: this is done based on the logic done below
+      // for non-json/sarif outputs, where we take the code of
+      // the first error.
+      err.code = errorResults[0].code;
+    }
     err.json = stringifiedData;
     err.jsonStringifiedResults = stringifiedJsonData;
     err.sarifStringifiedResults = stringifiedSarifData;

--- a/test/acceptance/cli-test/cli-test.generic.spec.ts
+++ b/test/acceptance/cli-test/cli-test.generic.spec.ts
@@ -34,7 +34,10 @@ export const GenericTests: AcceptanceTests = {
       t.end();
     },
 
-    'userMessage correctly bubbles with npm': (params, utils) => async (t) => {
+    'userMessage and error code correctly bubbles with npm': (
+      params,
+      utils,
+    ) => async (t) => {
       utils.chdirWorkspaces();
       try {
         await params.cli.test('npm-package', { org: 'missing-org' });
@@ -45,6 +48,29 @@ export const GenericTests: AcceptanceTests = {
           "Couldn't find the requested package",
           'got correct err message',
         );
+        t.equal(err.code, 404);
+      }
+      t.end();
+    },
+
+    'userMessage and error code correctly bubbles with npm and json output': (
+      params,
+      utils,
+    ) => async (t) => {
+      utils.chdirWorkspaces();
+      try {
+        await params.cli.test('npm-package', {
+          org: 'missing-org',
+          json: true,
+        });
+        t.fail('expect to err');
+      } catch (err) {
+        t.has(
+          err.jsonStringifiedResults,
+          "Couldn't find the requested package",
+          'got correct err message',
+        );
+        t.equal(err.code, 404);
       }
       t.end();
     },


### PR DESCRIPTION

- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

This PR adds an error code to the error object when using the --json or --sarif output types.
When the --json or --sarif options are used we do not add the error code in the thrown error, as opposed to when not using these output types.
This results in the error code not being shown in analytics and in logs.
This PR fixes this behavior by adding the error code of the first found error (as done for non-json/sarif outputs).

#### Where should the reviewer start?

The review should start in the src/cli/commands/test/index.ts Line 213, where the error code is added.
The code change is based on the same logic that is done for non-json/sarif outputs, in line 270.

#### How should this be manually tested?

This can be reproduced by running the CLI from local code, and changing the following code:
src/lib/snyk-test/assemble-payloads.ts Line 57, change "/test-dependencies" to "/test-dependencies-dummy-path", so that the call would result in error code 404.

Then build the code: npm run build

Then run the CLI test command with --json from local code: node dist/cli/ container test alpine:latest --json

#### Any background context you want to provide?

This issue was found because the error code was missing in some of our logs, causing alerts based on the error code to be missed.

#### What are the relevant tickets?


#### Screenshots


#### Additional questions
