### PR TITLE
fix: filter out file content from iac test --experimental analytics

### DIFF
--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -22,9 +22,7 @@ export async function showResultsSummary(
     resultsByPlugin,
     exceptionsByScanType,
   );
-  return `${successfulFixesSummary}${
-    unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
-  }\n\n${overallSummary}`;
+  return `${successfulFixesSummary}\n\n${unresolvedSummary}\n\n${overallSummary}`;
 }
 
 export function generateSuccessfulFixesSummary(
@@ -101,41 +99,27 @@ export function generateFixedAndFailedSummary(
 ): string {
   const sectionTitle = 'Summary:';
   const formattedTitleHeader = `${chalk.bold(sectionTitle)}`;
-  const fixedItems = calculateFixed(resultsByPlugin);
-  const failedItems = calculateFailed(resultsByPlugin, exceptionsByScanType);
+  let fixedItems = 0;
+  let failedItems = 0;
+  for (const plugin of Object.keys(resultsByPlugin)) {
+    fixedItems += resultsByPlugin[plugin].succeeded.length;
+  }
+
+  for (const plugin of Object.keys(resultsByPlugin)) {
+    const results = resultsByPlugin[plugin];
+    failedItems += results.failed.length + results.skipped.length;
+  }
+
+  if (Object.keys(exceptionsByScanType).length) {
+    for (const ecosystem of Object.keys(exceptionsByScanType)) {
+      const unresolved = exceptionsByScanType[ecosystem];
+      failedItems += unresolved.originals.length;
+    }
+  }
 
   return `${formattedTitleHeader}\n\n${PADDING_SPACE}${chalk.bold.red(
     failedItems,
   )} items were not fixed\n${PADDING_SPACE}${chalk.green.bold(
     fixedItems,
   )} items were successfully fixed`;
-}
-
-export function calculateFixed(
-  resultsByPlugin: FixHandlerResultByPlugin,
-): number {
-  let fixed = 0;
-  for (const plugin of Object.keys(resultsByPlugin)) {
-    fixed += resultsByPlugin[plugin].succeeded.length;
-  }
-  return fixed;
-}
-
-export function calculateFailed(
-  resultsByPlugin: FixHandlerResultByPlugin,
-  exceptionsByScanType: ErrorsByEcoSystem,
-): number {
-  let failed = 0;
-  for (const plugin of Object.keys(resultsByPlugin)) {
-    const results = resultsByPlugin[plugin];
-    failed += results.failed.length + results.skipped.length;
-  }
-
-  if (Object.keys(exceptionsByScanType).length) {
-    for (const ecosystem of Object.keys(exceptionsByScanType)) {
-      const unresolved = exceptionsByScanType[ecosystem];
-      failed += unresolved.originals.length;
-    }
-  }
-  return failed;
 }

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -14,7 +14,7 @@ export async function pythonFix(
   entities: EntityToFix[],
   options: FixOptions,
 ): Promise<FixHandlerResultByPlugin> {
-  const spinner = ora({ isSilent: options.quiet, stream: process.stdout });
+  const spinner = ora({ isSilent: options.quiet });
   spinner.text = 'Looking for supported Python items';
   spinner.start();
   const pluginId = 'python';

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -221,5 +221,4 @@ export interface ErrorsByEcoSystem {
 export interface FixOptions {
   dryRun?: boolean;
   quiet?: boolean;
-  stripAnsi?: boolean;
 }

--- a/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
@@ -62,14 +62,11 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
     // Assert
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [
@@ -139,10 +136,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest =
@@ -151,8 +145,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -230,10 +224,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest =
@@ -242,8 +233,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -321,10 +312,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest =
@@ -334,8 +322,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -408,10 +396,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest = 'django==2.0.1\n';
@@ -420,8 +405,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -491,10 +476,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest = 'Django==2.0.1';
@@ -503,8 +485,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -573,10 +555,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest = 'foo==55.66.7\n';
@@ -585,8 +564,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -660,10 +639,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const expectedManifest = 'django>=2.0.1\nclick>7.1\n';
@@ -672,8 +648,8 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],
@@ -745,17 +721,14 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     };
 
     // Act
-    const result = await snykFix.fix([entityToFix], {
-      quiet: true,
-      stripAnsi: true,
-    });
+    const result = await snykFix.fix([entityToFix], { quiet: true });
 
     // Assert
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toMatchSnapshot();
     expect(result).toMatchObject({
-      exceptions: {},
-      results: {
+      exceptionsByScanType: {},
+      resultsByPlugin: {
         python: {
           failed: [],
           skipped: [],

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`Error handling Snyk fix returns error when called with unsupported type 1`] = `
 Object {
-  "exceptions": Object {
+  "exceptionsByScanType": Object {
     "npm": Object {
       "originals": Array [
         Object {
@@ -57,47 +57,14 @@ Object {
       "userMessage": "npm is not supported.",
     },
   },
-  "fixSummary": "✖ No successful fixes
-
-Unresolved items:
-
-  package.json
-  ✖ npm is not supported.
-
-Summary:
-
-  1 items were not fixed
-  0 items were successfully fixed",
-  "meta": Object {
-    "failed": 1,
-    "fixed": 0,
-  },
-  "results": Object {},
+  "resultsByPlugin": Object {},
 }
 `;
 
 exports[`Snyk fix Snyk fix returns results for supported & unsupported type 1`] = `
 Object {
-  "exceptions": Object {},
-  "fixSummary": "Successful fixes:
-
-  requirements.txt
-  ✔ Pinned django from 1.6.1 to 2.0.1
-
-Unresolved items:
-
-  Pipfile
-  ✖ Pipfile is not supported
-
-Summary:
-
-  1 items were not fixed
-  1 items were successfully fixed",
-  "meta": Object {
-    "failed": 1,
-    "fixed": 1,
-  },
-  "results": Object {
+  "exceptionsByScanType": Object {},
+  "resultsByPlugin": Object {
     "python": Object {
       "failed": Array [],
       "skipped": Array [

--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -13,13 +13,13 @@ export async function loadFiles(pathToScan: string): Promise<IacFileData[]> {
   let filePaths = [pathToScan];
 
   if (isLocalFolder(pathToScan)) {
-    filePaths = await getFilePathsFromDirectory(pathToScan);
+    filePaths = getFilePathsFromDirectory(pathToScan);
   }
 
   const filesToScan: IacFileData[] = [];
   for (const filePath of filePaths) {
     const fileData = await tryLoadFileData(filePath);
-    if (fileData) filesToScan.push(fileData!);
+    if (fileData) filesToScan.push(fileData);
   }
 
   if (filesToScan.length === 0) {

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -3,7 +3,12 @@ import { parseFiles } from './file-parser';
 import { scanFiles } from './file-scanner';
 import { formatScanResults } from './results-formatter';
 import { isLocalFolder } from '../../../../lib/detect';
-import { IacOptionFlags } from './types';
+import {
+  IacOptionFlags,
+  IacFileParsed,
+  IacFileParseFailure,
+  SafeAnalyticsOutput,
+} from './types';
 import { initLocalCache } from './local-cache';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
@@ -19,9 +24,26 @@ export async function test(pathToScan: string, options: IacOptionFlags) {
 
   if (isLocalFolder(pathToScan)) {
     // TODO: This mutation is here merely to support how the old/current directory scan printing works.
-    options.iacDirFiles = [...parsedFiles, ...failedFiles];
+    // NOTE: No file or parsed file data should leave this function.
+    options.iacDirFiles = [...parsedFiles, ...failedFiles].map(
+      removeFileContent,
+    );
   }
 
   // TODO: add support for proper typing of old TestResult interface.
   return formattedResults as any;
+}
+
+export function removeFileContent({
+  filePath,
+  fileType,
+  failureReason,
+  projectType,
+}: IacFileParsed | IacFileParseFailure): SafeAnalyticsOutput {
+  return {
+    filePath,
+    fileType,
+    failureReason,
+    projectType,
+  };
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -49,6 +49,11 @@ export interface OpaWasmInstance {
   setData: (data: Record<string, any>) => void;
 }
 
+export type SafeAnalyticsOutput = Omit<
+  IacFileParsed | IacFileParseFailure,
+  'fileContent' | 'jsonContent' | 'engineType'
+>;
+
 export enum EngineType {
   Kubernetes,
   Terraform,
@@ -70,7 +75,7 @@ export interface PolicyMetadata {
 }
 
 export interface IacOptionFlags {
-  iacDirFiles?: Array<IacFileData>;
+  iacDirFiles?: Array<IacFileInDirectory>;
   severityThreshold?: SEVERITY;
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -120,7 +120,7 @@ export function postAnalytics(
         queryStringParams['org'] = data.org;
       }
 
-      debug('analytics', data);
+      debug('analytics', JSON.stringify(data, null, '  '));
 
       const queryString =
         Object.keys(queryStringParams).length > 0

--- a/test/fixtures/iac/file-logging/file_content_logging.yaml
+++ b/test/fixtures/iac/file-logging/file_content_logging.yaml
@@ -1,0 +1,13 @@
+# NOTE: Kubernetes file with no issues used to detect
+# if our analytics/logs contain file content.
+# PRIVATE_FILE_CONTENT_CHECK
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example
+spec:
+  containers:
+    - name: example
+      image: example:latest
+      securityContext:
+        privileged: false

--- a/test/iac-unit-tests/index.spec.ts
+++ b/test/iac-unit-tests/index.spec.ts
@@ -1,0 +1,64 @@
+jest.mock('../../src/cli/commands/test/iac-local-execution/local-cache');
+jest.mock('../../src/cli/commands/test/iac-local-execution/file-loader');
+jest.mock('../../src/cli/commands/test/iac-local-execution/file-parser', () => {
+  const { IacProjectType } = require('../../src/lib/iac/constants');
+  const {
+    EngineType,
+  } = require('../../src/cli/commands/test/iac-local-execution/types');
+  const parsedFiles: IacFileParsed[] = [
+    {
+      engineType: EngineType.Terraform,
+      fileContent: 'FAKE_FILE_CONTENT',
+      jsonContent: {},
+      filePath: './storage/storage.tf',
+      fileType: 'tf',
+      failureReason: 'Mock Test',
+      projectType: IacProjectType.TERRAFORM,
+    },
+  ];
+  return {
+    parseFiles: async () => ({ parsedFiles, failedFiles: [] }),
+  };
+});
+jest.mock(
+  '../../src/cli/commands/test/iac-local-execution/file-scanner',
+  () => {
+    return {
+      scanFiles: async () => [],
+    };
+  },
+);
+jest.mock('../../src/lib/detect', () => ({
+  isLocalFolder: () => true,
+}));
+
+import { test } from '../../src/cli/commands/test/iac-local-execution';
+import {
+  IacFileParsed,
+  IacOptionFlags,
+} from '../../src/cli/commands/test/iac-local-execution/types';
+import { IacProjectType } from '../../src/lib/iac/constants';
+
+describe('test()', () => {
+  it('extends the options object with iacDirFiles when a local directory is provided', async () => {
+    const opts: IacOptionFlags = {};
+    await test('./storage/', opts);
+
+    expect(opts.iacDirFiles).toEqual([
+      {
+        filePath: './storage/storage.tf',
+        fileType: 'tf',
+        failureReason: 'Mock Test',
+        projectType: IacProjectType.TERRAFORM,
+      },
+    ]);
+    expect(opts.iacDirFiles).not.toEqual(
+      expect.objectContaining([
+        {
+          fileContent: 'FAKE_FILE_CONTENT',
+          jsonContent: {},
+        },
+      ]),
+    );
+  });
+});

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -1,9 +1,22 @@
 #shellcheck shell=sh
 
 Describe "Snyk iac test --experimental command"
-  Skip if "execute only in regression test" check_if_regression_test 
+  Skip if "execute only in regression test" check_if_regression_test
+
   Before snyk_login
   After snyk_logout
+
+  Describe "logging regression tests"
+    It "does not include file content in analytics logs"
+      # Run with the -d flag on directory to output network requests and analytics data.
+      When run snyk iac test ../fixtures/iac/file-logging -d --experimental
+      # We expect the output, specifically the analytics block not to include
+      # the following text from the file.
+      The status should be success
+      The output should not include "PRIVATE_FILE_CONTENT_CHECK"
+      The error should not include "PRIVATE_FILE_CONTENT_CHECK"
+    End
+  End
 
   Describe "k8s single file scan"
     It "finds issues in k8s file"
@@ -71,7 +84,7 @@ Describe "Snyk iac test --experimental command"
     End
 
     # TODO: currently skipped because the parser we're using doesn't fail on invalid terraform
-    # will be fixed before beta 
+    # will be fixed before beta
     xIt "outputs an error for invalid terraforom files"
       When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh_invalid_hcl2.tf --experimental
       The status should be failure


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

We have a minor bug in our Snyk CLI that when the `snyk iac test --experimental` command is run with a directory instead of a single file we include the `iacDirFiles` on the `options` object. This options object is then logged as part of the analytics flow and sent to Big Query. We do not want to be storing user file content in any part of our system so this needs to be filtered out here. 

This PR filters the File content and JSON output from the `iacDirFiles` property added to the `options` object in the test command and adds a smoke test and unit test to assert that the content is not present.

This is not a long term strategy for solving this issue but fixes the immediate problem that prevents users from adopting the beta. In future we'll want to decouple the file + parsed content from any metadata and ensure that the file content is only passed where needed and discarded when used.  We should also look into using a whitelist for the logger to only allow specific arguments to be logged.

#### Where should the reviewer start?

Start at the smoke tests then the `test()` function and finish up with the unit tests. The unit tests are really a temporary measure I think to ensure that the `iacDirFiles` object is clean, we can remove the tests when the flow has been refactored.

#### How should this be manually tested?

Run the following and verify that the "args" property under analytics is clean of file content.

    node ./dist/cli iac test -d --experimental ./test/fixtures/iac/file-logging

