### PR TITLE
fix: use depGraph for npm/yarn with lock files

### DIFF
--- a/src/lib/plugins/nodejs-plugin/index.ts
+++ b/src/lib/plugins/nodejs-plugin/index.ts
@@ -3,6 +3,8 @@ import * as lockParser from './npm-lock-parser';
 import * as types from '../types';
 import { MissingTargetFileError } from '../../errors/missing-targetfile-error';
 import { MultiProjectResult } from '@snyk/cli-interface/legacy/plugin';
+import { ScannedProject } from '@snyk/cli-interface/legacy/common';
+import * as depGraphLib from '@snyk/dep-graph';
 
 export async function inspect(
   root: string,
@@ -12,20 +14,33 @@ export async function inspect(
   if (!targetFile) {
     throw MissingTargetFileError(root);
   }
-  const isLockFileBased =
-    targetFile.endsWith('package-lock.json') ||
-    targetFile.endsWith('yarn.lock');
+  const isNpmLockFile = targetFile.endsWith('package-lock.json');
+  const isYarnLockFile = targetFile.endsWith('yarn.lock');
+  const isLockFileBased = isNpmLockFile || isYarnLockFile;
 
   const getLockFileDeps = isLockFileBased && !options.traverseNodeModules;
   const depTree: any = getLockFileDeps
     ? await lockParser.parse(root, targetFile, options)
     : await modulesParser.parse(root, targetFile, options);
 
+  const scannedProject: ScannedProject = {};
+  if (getLockFileDeps) {
+    const pkgManagerName =
+      options?.packageManager || (isYarnLockFile ? 'yarn' : 'npm');
+    const depGraph = await depGraphLib.legacy.depTreeToGraph(
+      depTree,
+      pkgManagerName,
+    );
+    scannedProject.depGraph = depGraph;
+  } else {
+    scannedProject.depTree = depTree;
+  }
+
   return {
     plugin: {
       name: 'snyk-nodejs-lockfile-parser',
       runtime: process.version,
     },
-    scannedProjects: [{ depTree }],
+    scannedProjects: [scannedProject],
   };
 }


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Uses DepGraph instead of DepTree for npm/yarn + lockfiles