### PR TITLE
feat: Add iac metadata for analytics [CC-731]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -1,0 +1,26 @@
+import { FormattedResult } from './types';
+import * as analytics from '../../../../lib/analytics';
+
+export function addIacAnalytics(formattedResults: FormattedResult[]) {
+  let totalIssuesCount = 0;
+  const issuesByType: Record<string, object> = {};
+  const packageManagers = Array<string>();
+
+  formattedResults.forEach((res) => {
+    totalIssuesCount =
+      (totalIssuesCount || 0) + res.result.cloudConfigResults.length;
+    packageManagers.push(res.packageManager);
+
+    res.result.cloudConfigResults.forEach((policy) => {
+      const configType = policy.type + 'config';
+      issuesByType[configType] = issuesByType[configType] ?? {};
+      issuesByType[configType][policy.severity] =
+        (issuesByType[configType][policy.severity] || 0) + 1;
+    });
+  });
+
+  analytics.add('packageManager', Array.from(new Set(packageManagers)));
+  analytics.add('iac-issues-count', totalIssuesCount);
+  analytics.add('iac-type', issuesByType);
+  analytics.add('iac-test-count', formattedResults.length);
+}

--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -1,6 +1,7 @@
 import { tryParsingKubernetesFile } from './parsers/kubernetes-parser';
 import { tryParsingTerraformFile } from './parsers/terraform-file-parser';
 import { tryParsingTerraformPlan } from './parsers/terraform-plan-parser';
+
 import * as path from 'path';
 import {
   IacFileParsed,
@@ -8,6 +9,7 @@ import {
   ParsingResults,
   IacFileParseFailure,
 } from './types';
+import * as analytics from '../../../../lib/analytics';
 
 export async function parseFiles(
   filesData: IacFileData[],
@@ -47,12 +49,14 @@ function generateFailedParsedFile(
 const TF_PLAN_NAME = 'tf-plan.json';
 
 function tryParseIacFile(fileData: IacFileData): Array<IacFileParsed> {
+  analytics.add('iac-terraform-plan', false);
   switch (fileData.fileType) {
     case 'yaml':
     case 'yml':
     case 'json':
       // TODO: this is a temporary approach for the internal release only
       if (path.basename(fileData.filePath) === TF_PLAN_NAME) {
+        analytics.add('iac-terraform-plan', true);
         return tryParsingTerraformPlan(fileData);
       }
 

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -10,6 +10,7 @@ import {
   SafeAnalyticsOutput,
 } from './types';
 import { initLocalCache } from './local-cache';
+import { addIacAnalytics } from './analytics';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // the current version is dependent on files to be present locally which are not part of the source code.
@@ -21,6 +22,7 @@ export async function test(pathToScan: string, options: IacOptionFlags) {
   const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
   const scannedFiles = await scanFiles(parsedFiles);
   const formattedResults = formatScanResults(scannedFiles, options);
+  addIacAnalytics(formattedResults);
 
   if (isLocalFolder(pathToScan)) {
     // TODO: This mutation is here merely to support how the old/current directory scan printing works.


### PR DESCRIPTION
#### What does this PR do?

This PR adds a few more analytics for the new iac local execution flow.
- `iac-test-count`: total tested files tested for a run 
- `iac-issues-count`: total issues found for a run
- `iac-terraform-plan`: a boolean flag to indicate if a tf-plan.json was scanned as part of this run
- `iac-type`: an object containing count of file types with issues, by severity, e.g.  
``` 
"iacTerraformPlan": false,
      "iacTestCount": 235,
      "iacIssuesCount": 1283,
      "iacType": "{\"terraformconfig\":{\"low\":385,\"high\":143,\"medium\":267},\"k8sconfig\":{\"low\":257,\"medium\":172,\"high\":59}}",
      "packageManagers": [    
      "terraformconfig",
      "k8sconfig"
      ]
 ```
- `package-managers` was already there, but was not picking the type for this flow, so this is updated to reflect what packageManagers our runs contain. This shows unique values, the number of configs for each type are in the iac-type field.

#### How should this be manually tested?
`node ./dist/cli iac test file.tf --experimental -d` or `node ./dist/cli iac test directory --experimental -d` 

#### Any background context you want to provide?
These are all in the metadata analytics object so they are going to be added in seperate fields (by key) in a BigQuery table. 
There is discussion about having a different way to differentiate the terraformplan from terraform configsin the future.

For now, there is an edge case that if we scan e.g. a directory which contains both a tf-plan.json and other k8s files, then we won't be able to tell where the issues came from, but they will all show under the terraformconfig.

#### What are the relevant tickets?
[JIRA CC-731](https://snyksec.atlassian.net/browse/CC-731)

#### Screenshots
<img width="371" alt="image" src="https://user-images.githubusercontent.com/6989529/111542012-1810c480-8769-11eb-982b-9a159bed9d51.png">


