### PR TITLE
fix: Error messages when Terraform validation fails due to bad credentials

### DIFF
--- a/src/lib/request/index.ts
+++ b/src/lib/request/index.ts
@@ -4,10 +4,17 @@ import { MetricsCollector } from '../metrics';
 import * as needle from 'needle';
 
 // A hybrid async function: both returns a promise and takes a callback
-export = async (
+async function requestWrapper(
+  payload: any,
+): Promise<{ res: needle.NeedleResponse; body: any }>;
+async function requestWrapper(
+  payload: any,
+  callback: (err: Error | null, res?, body?) => void,
+): Promise<void>;
+async function requestWrapper(
   payload: any,
   callback?: (err: Error | null, res?, body?) => void,
-): Promise<void | { res: needle.NeedleResponse; body: any }> => {
+): Promise<void | { res: needle.NeedleResponse; body: any }> {
   const totalNetworkTimeTimer = MetricsCollector.NETWORK_TIME.createInstance();
   totalNetworkTimeTimer.start();
   try {
@@ -28,4 +35,6 @@ export = async (
   } finally {
     totalNetworkTimeTimer.stop();
   }
-};
+}
+
+export = requestWrapper;


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?

Fixes CC-751

Handles 401 authentication errors when making a validation request to Terraform, previously we would always return a result regardless of the HTTP response, this resulted in misleading error messages.

This PR also fixes the type definition of the `request()` function so the caller no longer has to unwrap the returned response from the promise. The return type for the non-callback approach is now `Promise<{res: NeedleRes, body: any}>` instead of `Promise<void | {res: NeedleRes, body: any}>`

#### Where should the reviewer start?

All the code is in src/lib/iac/iac-parser.ts, we have no unit tests for this code path :/ and it will all soon be replaced by the `--experimental` branch.

#### How should this be manually tested?

    1. Invalidate the API token e.g. `snyk config set api=foo`
    2. Test a Terraform file e.g `node ./dist/cli iac test ./test/fixtures/iac/terraform/sg_open_ssh.tf`

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CC-751

#### Screenshots

Before

![image](https://user-images.githubusercontent.com/47144/111226822-90488000-85d9-11eb-8d6b-8ff18b6ace55.png)

After 
![image](https://user-images.githubusercontent.com/47144/111226886-a9513100-85d9-11eb-866b-a931c0501f0d.png)

