### PR TITLE
chore: remove duplicate PR steps

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
-- [ ] Ready for review
 - [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
-- [ ] Reviewed by Snyk internal team
 
 #### What does this PR do?
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,5 @@
 test/fixtures/**/*
 packages/**/test/fixtures/**/*
+
+# Has empty lines for templating convenience
+.github/PULL_REQUEST_TEMPLATE.md


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?

Some of the steps on the PR to-do list (as seen above) are already enforced by GitHub's workflow so we end up doing the same thing twice, and often the to-do list isn't in sync as it isn't enforced anyway.

'Ready for review' -> Use Draft PRs if it isn't so that it's visible in the PR list and isn't mergeable. This lets us use GitHub to filter draft/ready PRs easily.
'Reviewed by Snyk internal team' -> Can be seen in the Reviewers sidebar list, PR list and is enforced at the merge dialog.

Could even remove the "Follows CONTRIBUTING" step as GitHub already prompts first PRs to do so. https://docs.github.com/en/github/building-a-strong-community/setting-guidelines-for-repository-contributors