### PR TITLE
feat: fallback to type when missing targetFile

### DIFF
--- a/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
@@ -6,7 +6,10 @@ export function formatUnresolved(
   entity: EntityToFix,
   userMessage: string,
 ): string {
-  return `${PADDING_SPACE}${entity.scanResult.identity.targetFile}\n${PADDING_SPACE}${chalk.red(
+  const name =
+    entity.scanResult.identity.targetFile ||
+    `${entity.scanResult.identity.type} project`;
+  return `${PADDING_SPACE}${name}\n${PADDING_SPACE}${chalk.red(
     '✖',
   )} ${chalk.red(userMessage)}`;
 }

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/format-unresolved-item.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/format-unresolved-item.spec.ts.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`format unresolved item successful item & changes formatted 1`] = `
+exports[`format unresolved item formats ok when missing targetFile 1`] = `
+"  npm project
+  ✖ Failed to process item"
+`;
+
+exports[`format unresolved item formats unresolved as expected by default 1`] = `
 "  requirements.txt
   ✖ Failed to process item"
 `;

--- a/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
@@ -3,10 +3,20 @@ import { formatUnresolved } from '../../../../src/lib/output-formatters/format-u
 import { generateEntityToFix } from '../../../helpers/generate-entity-to-fix';
 
 describe('format unresolved item', () => {
-  it('successful item & changes formatted', async () => {
+  it('formats unresolved as expected by default', async () => {
     const entity = generateEntityToFix(
       'pip',
       'requirements.txt',
+      JSON.stringify({}),
+    );
+    const res = await formatUnresolved(entity, 'Failed to process item');
+    expect(stripAnsi(res)).toMatchSnapshot();
+  });
+
+  it('formats ok when missing targetFile', async () => {
+    const entity = generateEntityToFix(
+      'npm',
+      undefined as any,
       JSON.stringify({}),
     );
     const res = await formatUnresolved(entity, 'Failed to process item');


### PR DESCRIPTION
- [x] Ready for review
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [x] Reviewed by Snyk internal team

#### What does this PR do?
- some remote scans do not have much information to use to identify the scanned project. If we don't have targetFile for now fallback to `${type} project` e.g. `npm project`


#### Screenshots
**Before**
<img width="1251" alt="CleanShot 2021-03-16 at 09 47 00@2x" src="https://user-images.githubusercontent.com/2911613/111288979-9a4f9a80-863c-11eb-8012-b51250dffe0f.png">

**After**
<img width="430" alt="CleanShot 2021-03-16 at 10 23 17@2x" src="https://user-images.githubusercontent.com/2911613/111293875-a558f980-8641-11eb-82ef-b6ed77e8e1bc.png">

