### PR TITLE
Dev Count: limit number of commits returned in git log

### DIFF
--- a/test/dev-count-analysis.spec.ts
+++ b/test/dev-count-analysis.spec.ts
@@ -3,23 +3,30 @@ import {
   getTimestampStartOfContributingDevTimeframe,
   execShell,
   SERIOUS_DELIMITER,
+  MAX_COMMITS_IN_GIT_LOG,
   separateLines,
   hashData,
 } from '../src/lib/monitor/dev-count-analysis';
 
 const testTimeout = 60000;
+
+const TIMESTAMP_TO_TEST = 1590174610000;
+
 describe('cli dev count via git log analysis', () => {
   let expectedContributorUserIds: string[] = [];
   let expectedMergeOnlyUserIds: string[] = [];
 
   // this computes the expectedContributorUserIds and expectedMergeOnlyUserIds
   beforeAll(async () => {
+    const timestampEpochSecondsEndOfPeriod = Math.floor(
+      TIMESTAMP_TO_TEST / 1000,
+    );
     const timestampEpochSecondsStartOfPeriod = getTimestampStartOfContributingDevTimeframe(
-      new Date(1590174610000),
+      new Date(TIMESTAMP_TO_TEST),
       10,
     );
 
-    const withMergesGitLogCommand = `git --no-pager log --pretty=tformat:"%H${SERIOUS_DELIMITER}%an${SERIOUS_DELIMITER}%ae${SERIOUS_DELIMITER}%aI_SNYK_SEPARATOR_%s" --after="${timestampEpochSecondsStartOfPeriod}"`;
+    const withMergesGitLogCommand = `git --no-pager log --pretty=tformat:"%H${SERIOUS_DELIMITER}%an${SERIOUS_DELIMITER}%ae${SERIOUS_DELIMITER}%aI${SERIOUS_DELIMITER}%s" --after="${timestampEpochSecondsStartOfPeriod}" --until="${timestampEpochSecondsEndOfPeriod}" --max-count=${MAX_COMMITS_IN_GIT_LOG}`;
     const withMergesGitLogStdout: string = await execShell(
       withMergesGitLogCommand,
       process.cwd(),
@@ -58,7 +65,7 @@ describe('cli dev count via git log analysis', () => {
     'returns contributors',
     async () => {
       const contributors = await getContributors({
-        endDate: new Date(1590174610000),
+        endDate: new Date(TIMESTAMP_TO_TEST),
         periodDays: 10,
         repoPath: process.cwd(),
       });
@@ -74,7 +81,7 @@ describe('cli dev count via git log analysis', () => {
     'does not include contributors who have only merged pull requests',
     async () => {
       const contributors = await getContributors({
-        endDate: new Date(1590174610000),
+        endDate: new Date(TIMESTAMP_TO_TEST),
         periodDays: 10,
         repoPath: process.cwd(),
       });

--- a/test/dev-count-analysis.test.ts
+++ b/test/dev-count-analysis.test.ts
@@ -147,7 +147,12 @@ test('runGitLog returns empty string and does not throw error when git log comma
   };
 
   try {
-    const gitLog = await runGitLog(123456789, '/some/fake/path', mockExecShell);
+    const gitLog = await runGitLog(
+      123456789,
+      123456989,
+      '/some/fake/path',
+      mockExecShell,
+    );
     t.equals(gitLog, '');
   } catch (e) {
     t.fail('should not throw');


### PR DESCRIPTION
This prevents a crash when too many commits are returned in the dev count module. Also fixes a broken test in [Node 10 that limits buffer size to 200*1024](https://nodejs.org/docs/latest-v10.x/api/child_process.html)