### PR TITLE
fix: stringify json output to promise valid json

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -253,7 +253,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
   }
   // Part 2: process the output from the Registry
   if (options.json) {
-    return processJsonMonitorResponse(results);
+    return processJsonMonitorResponse(results, options);
   }
 
   const output = results

--- a/src/cli/commands/monitor/process-json-monitor.ts
+++ b/src/cli/commands/monitor/process-json-monitor.ts
@@ -1,7 +1,11 @@
+import { Options } from 'snyk-cpp-plugin';
 import { GoodResult, BadResult } from './types';
+import { formatJsonOutput } from '../test/formatters/format-test-results';
+import { jsonStringifyLargeObject } from '../../../lib/json';
 
 export function processJsonMonitorResponse(
   results: Array<GoodResult | BadResult>,
+  options: Options,
 ): string {
   let dataToSend = results.map((result) => {
     if (result.ok) {
@@ -11,7 +15,13 @@ export function processJsonMonitorResponse(
       }
       return jsonData;
     }
-    return { ok: false, error: result.data.message, path: result.path };
+
+    const jsonData = {
+      ok: false,
+      error: result.data.message,
+      path: result.path,
+    };
+    return jsonStringifyLargeObject(formatJsonOutput(jsonData, options));
   });
   // backwards compat - strip array if only one result
   dataToSend = dataToSend.length === 1 ? dataToSend[0] : dataToSend;


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Call internal stringify functions on `snyk monitor` json output as done in `test` command to promise a valid json output.

Before:
![Screen Shot 2021-03-18 at 14 16 24](https://user-images.githubusercontent.com/44115709/111626289-7afc6d00-87f6-11eb-86b9-07cd043ae564.png)

After:
![Screen Shot 2021-03-18 at 14 16 11](https://user-images.githubusercontent.com/44115709/111626315-80f24e00-87f6-11eb-92cd-a229380538f0.png)


[Jira ticet](https://snyksec.atlassian.net/browse/HAMMER-250)
[ZenDesk ticket](https://snyk.zendesk.com/agent/tickets/9120)