### PR TITLE
fix: stringify json output to promise valid json

### DIFF
--- a/src/cli/commands/monitor/process-json-monitor.ts
+++ b/src/cli/commands/monitor/process-json-monitor.ts
@@ -21,6 +21,6 @@ export function processJsonMonitorResponse(
     return stringifiedData;
   }
   const err = new Error(stringifiedData) as any;
-  err.json = dataToSend;
+  err.json = stringifiedData;
   throw err;
 }

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -386,7 +386,8 @@ test('monitor --json no supported target files', async (t) => {
     await cli.monitor('no-supported-target-files', { json: true });
     t.fail('should have thrown');
   } catch (error) {
-    const jsonResponse = error.json;
+    // error.json is a stringified json used for error logging, parse before testing
+    const jsonResponse = JSON.parse(error.json);
 
     if (isObject(jsonResponse)) {
       t.pass('monitor outputted JSON');


### PR DESCRIPTION
- [X] Ready for review
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
When failed, snyk monitor —json propagated an invalid json to the user. This is a fix for that issue.
Fixes [this issue](https://snyk.zendesk.com/agent/tickets/9120)

Before:
![Screen Shot 2021-03-18 at 14 16 24](https://user-images.githubusercontent.com/44115709/111637381-092a2080-8802-11eb-9123-4e1ed35ff22d.png)

After:
![Screen Shot 2021-03-18 at 14 16 11](https://user-images.githubusercontent.com/44115709/111637743-67570380-8802-11eb-95f3-5737a038fcfd.png)

