### PR TITLE
feat: Update iac --help documentation to include experimental flag

### DIFF
--- a/help/commands-docs/_EXAMPLES.md
+++ b/help/commands-docs/_EXAMPLES.md
@@ -26,3 +26,4 @@ See `snyk iac --help` for more details and examples:
 
     $ snyk iac test /path/to/Kubernetes.yaml
     $ snyk iac test /path/to/terraform_file.tf
+    $ snyk iac test /path/to/tf-plan.json --experimental

--- a/help/commands-docs/iac-examples.md
+++ b/help/commands-docs/iac-examples.md
@@ -8,5 +8,10 @@
 - `Test terraform file`:
   \$ snyk iac test /path/to/terraform_file.tf
 
+- `Test terraform plan file`:
+  \$ snyk iac test /path/to/tf-plan.json --experimental
+  
+  Note: Your terraform plan file needs to be named exactly as 'tf-plan.json'
+
 - `Test matching files in a directory`:
   \$ snyk iac test /path/to/directory

--- a/help/commands-docs/iac.md
+++ b/help/commands-docs/iac.md
@@ -43,3 +43,8 @@ Find security issues in your Infrastructure as Code files.
   (only in `test` command)
   Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
   This is especially useful if you want to display the human-readable test output via stdout and at the same time save the SARIF format output to a file.
+
+- `--experimental`:
+  (only in `test` command)
+  Enable an experimental feature to scan configuration files locally on your machine. 
+  This feature also gives you the ability to scan terraform plan JSON files.

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -360,3 +360,67 @@ test('test command line "snyk monitor --assets-project-name" should add a proper
   );
   t.end();
 });
+
+test('test command line "iac" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(result.options.help, 'iac', 'help option should be assigned to iac');
+  t.end();
+});
+
+test('test command line "iac --help" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+    '--help',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(result.options.help, 'iac', 'help option should be assigned to iac');
+  t.end();
+});
+
+test('test command line "iac test --help" should display help for mode', (t) => {
+  const cliArgs = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+    'test',
+    '--help',
+  ];
+  const result = args(cliArgs);
+  t.equal(result.command, 'help', 'command should be replaced by help');
+  t.equal(result.options.help, 'iac', 'help option should be assigned to iac');
+  t.end();
+});
+
+test('test command line "snyk iac --experimental" should be true on options', (t) => {
+  const cliArgsWithFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+    '--experimental',
+  ];
+  const resultWithFlag = args(cliArgsWithFlag);
+  t.ok(
+    resultWithFlag.options['experimental'],
+    'expected options[experimental] to be true',
+  );
+  const cliArgsWithoutFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+  ];
+  const resultWithoutFlag = args(cliArgsWithoutFlag);
+  t.notOk(
+    resultWithoutFlag.options['experimental'],
+    'expected options[experimental] to be false',
+  );
+  t.end();
+});


### PR DESCRIPTION
#### What does this PR do?

This PR adds information on how to use the new --experimental flag, when running either `snyk --help` or `snyk iac --help. It also updates the examples.

#### Where should the reviewer start?
Check the Markdown documents for any spelling, formatting errors,wrong wording or examples.

#### How should this be manually tested?
You will need to:
- start docker
- Run `npm run generate-help` to generate the help documents
- Run `node ~/snyk-repos/snyk/dist/cli --help` or `node ~/snyk-repos/snyk/dist/cli  iac --help `

#### What are the relevant tickets?
[CC-606]: https://snyksec.atlassian.net/browse/CC-606

#### Screenshots
When running `snyk --help`:

![image](https://user-images.githubusercontent.com/6989529/111787522-ee65b380-88b6-11eb-99a9-748fdba56440.png)

When running `snyk iac --help`:
![image](https://user-images.githubusercontent.com/6989529/111790897-9761dd80-88ba-11eb-9cfb-b61b51537003.png)
![image](https://user-images.githubusercontent.com/6989529/111790961-aba5da80-88ba-11eb-9187-676777122af3.png)
