### PR TITLE
Dockerfiles: point maven 3.6.3 to correct location

### DIFF
--- a/docker/Dockerfile.maven-3.6.3
+++ b/docker/Dockerfile.maven-3.6.3
@@ -20,7 +20,7 @@ RUN apt-get update && \
 
 ENV HOME /home/node
 ENV M2 /home/node/.m2
-ENV PATH /home/node/apache-maven-3.6.1/bin:$PATH
+ENV PATH /home/node/apache-maven-3.6.3/bin:$PATH
 
 # The path at which the project is mounted (-v runtime arg)
 ENV PROJECT_PATH /project


### PR DESCRIPTION
Dockerfile was pointing to an incorrect version:

![image](https://user-images.githubusercontent.com/1788727/111811197-19f89600-88d7-11eb-9006-09deee9f8604.png)
