### PR TITLE
Refactor and improve testing and un-skip skipped test re JSON file output

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -29,10 +29,7 @@ import stripAnsi from 'strip-ansi';
 import { ExcludeFlagInvalidInputError } from '../lib/errors/exclude-flag-invalid-input';
 import { modeValidation } from './modes';
 import { JsonFileOutputBadInputError } from '../lib/errors/json-file-output-bad-input-error';
-import {
-  createDirectory,
-  writeContentsToFileSwallowingErrors,
-} from '../lib/json-file-output';
+import { saveJsonToFileCreatingDirectoryIfRequired } from '../lib/json-file-output';
 import {
   Options,
   TestOptions,
@@ -188,12 +185,10 @@ async function saveJsonResultsToFile(
     return;
   }
 
-  // create the directory if it doesn't exist
-  const dirPath = pathLib.dirname(jsonOutputFile);
-  const createDirSuccess = createDirectory(dirPath);
-  if (createDirSuccess) {
-    await writeContentsToFileSwallowingErrors(jsonOutputFile, stringifiedJson);
-  }
+  await saveJsonToFileCreatingDirectoryIfRequired(
+    jsonOutputFile,
+    stringifiedJson,
+  );
 }
 
 function checkRuntime() {

--- a/src/lib/json-file-output.ts
+++ b/src/lib/json-file-output.ts
@@ -1,5 +1,6 @@
 import { gte } from 'semver';
 import { existsSync, mkdirSync, createWriteStream } from 'fs';
+import * as path from 'path';
 
 export const MIN_VERSION_FOR_MKDIR_RECURSIVE = '10.12.0';
 
@@ -65,4 +66,15 @@ export async function writeContentsToFileSwallowingErrors(
       return Promise.resolve();
     }
   });
+}
+
+export async function saveJsonToFileCreatingDirectoryIfRequired(
+  jsonOutputFile: string,
+  contents: string,
+): Promise<void> {
+  const dirPath = path.dirname(jsonOutputFile);
+  const createDirSuccess = createDirectory(dirPath);
+  if (createDirSuccess) {
+    await writeContentsToFileSwallowingErrors(jsonOutputFile, contents);
+  }
 }

--- a/test/jest/acceptance/cli-json-file-output.spec.ts
+++ b/test/jest/acceptance/cli-json-file-output.spec.ts
@@ -1,18 +1,13 @@
 import { exec } from 'child_process';
 import { sep, join } from 'path';
-import { readFileSync, unlinkSync, rmdirSync, mkdirSync, existsSync } from 'fs';
+import { readFileSync, unlinkSync } from 'fs';
 import { v4 as uuidv4 } from 'uuid';
 import { fakeServer } from '../../acceptance/fake-server';
 import cli = require('../../../src/cli/commands');
 
-const osName = require('os-name');
-
 const main = './dist/cli/index.js'.replace(/\//g, sep);
 const testTimeout = 50000;
-const isWindows =
-  osName()
-    .toLowerCase()
-    .indexOf('windows') === 0;
+
 describe('test --json-file-output ', () => {
   let oldkey;
   let oldendpoint;
@@ -122,79 +117,4 @@ describe('test --json-file-output ', () => {
     },
     testTimeout,
   );
-
-  it(
-    '`test --json-file-output can handle a relative path`',
-
-    (done) => {
-      // if 'test-output' doesn't exist, created it
-      if (!existsSync('test-output')) {
-        mkdirSync('test-output');
-      }
-
-      const tempFolder = uuidv4();
-      const outputPath = `test-output/${tempFolder}/snyk-direct-json-test-output.json`;
-
-      exec(
-        `node ${main} test ${noVulnsProjectPath} --json --json-file-output=${outputPath}`,
-        {
-          env: {
-            PATH: process.env.PATH,
-            SNYK_TOKEN: apiKey,
-            SNYK_API,
-            SNYK_HOST,
-          },
-        },
-        async (err, stdout) => {
-          if (err) {
-            throw err;
-          }
-          // give file a little time to be finished to be written
-          await new Promise((r) => setTimeout(r, 5000));
-          const stdoutJson = stdout;
-          const outputFileContents = readFileSync(outputPath, 'utf-8');
-          unlinkSync(outputPath);
-          rmdirSync(`test-output/${tempFolder}`);
-          expect(stdoutJson).toEqual(outputFileContents);
-          done();
-        },
-      );
-    },
-    testTimeout,
-  );
-
-  if (isWindows) {
-    test.skip(
-      '`test --json-file-output can handle an absolute path`',
-      () => {
-        // if 'test-output' doesn't exist, created it
-        if (!existsSync('test-output')) {
-          mkdirSync('test-output');
-        }
-
-        const tempFolder = uuidv4();
-        const outputPath = join(
-          process.cwd(),
-          `test-output/${tempFolder}/snyk-direct-json-test-output.json`,
-        );
-
-        exec(
-          `node ${main} test ${noVulnsProjectPath} --json --json-file-output=${outputPath}`,
-          async (err, stdout) => {
-            if (err) {
-              throw err;
-            }
-            // give file a little time to be finished to be written
-            await new Promise((r) => setTimeout(r, 5000));
-            const stdoutJson = stdout;
-            const outputFileContents = readFileSync(outputPath, 'utf-8');
-            unlinkSync(outputPath);
-            rmdirSync(`test-output/${tempFolder}`);
-            expect(stdoutJson).toEqual(outputFileContents);
-          },
-        );
-      },
-      testTimeout,
-    );
-  }
 });

--- a/test/jest/system/json-file-output.spec.ts
+++ b/test/jest/system/json-file-output.spec.ts
@@ -1,0 +1,181 @@
+import * as jsonFileOutputModule from '../../../src/lib/json-file-output';
+
+import { v4 as uuidv4 } from 'uuid';
+import { readFileSync, unlinkSync, rmdirSync, mkdirSync, existsSync } from 'fs';
+import * as path from 'path';
+import * as fsModule from 'fs';
+
+describe('saveJsonToFileCreatingDirectoryIfRequired', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('supports absolute paths', () => {
+    it('with directory that does not exists', async () => {
+      const tempFolder = uuidv4();
+      const outputPath = path.join(
+        process.cwd(),
+        'test-output',
+        tempFolder,
+        'test-output.json',
+      );
+
+      const fullDirPath = path.dirname(outputPath);
+      expect(fullDirPath).toBe(
+        path.join(process.cwd(), 'test-output', tempFolder),
+      );
+      const jsonString = JSON.stringify({
+        ok: true,
+        somekey: 'someval',
+      });
+
+      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+
+      try {
+        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
+        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
+          outputPath,
+          jsonString,
+        );
+
+        // ensure that mkDirSync was called once
+        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(1);
+
+        const outputFileContents = readFileSync(outputPath, 'utf-8');
+        expect(outputFileContents.trim()).toEqual(jsonString);
+      } finally {
+        unlinkSync(outputPath);
+        rmdirSync(fullDirPath);
+      }
+    });
+
+    it('with directory that already exists', async () => {
+      const tempFolder = uuidv4();
+      const outputPath = path.join(
+        process.cwd(),
+        'test-output',
+        tempFolder,
+        'test-output.json',
+      );
+
+      // if 'test-output' doesn't exist, created it
+      if (!existsSync('test-output')) {
+        mkdirSync('test-output');
+      }
+
+      const fullDirPath = path.dirname(outputPath);
+
+      // create the temp folder before calling saveJsonToFileCreatingDirectoryIfRequired
+      mkdirSync(fullDirPath);
+      expect(fullDirPath).toBe(
+        path.join(process.cwd(), 'test-output', tempFolder),
+      );
+      const jsonString = JSON.stringify({
+        ok: true,
+        somekey: 'someval',
+      });
+
+      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+      expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+
+      try {
+        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
+        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
+          outputPath,
+          jsonString,
+        );
+
+        // ensure that mkDirSync was called once
+        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+
+        const outputFileContents = readFileSync(outputPath, 'utf-8');
+        expect(outputFileContents.trim()).toEqual(jsonString);
+      } finally {
+        unlinkSync(outputPath);
+        rmdirSync(fullDirPath);
+      }
+    });
+  });
+
+  // relative paths
+  describe('supports relative paths', () => {
+    it('with directory that does not exists', async () => {
+      const tempFolder = uuidv4();
+      const outputPath = path.join(
+        'test-output',
+        tempFolder,
+        'test-output.json',
+      );
+
+      const fullDirPath = path.dirname(outputPath);
+      expect(fullDirPath).toBe(path.join('test-output', tempFolder));
+      const jsonString = JSON.stringify({
+        ok: true,
+        somekey: 'someval',
+      });
+
+      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+
+      try {
+        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
+        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
+          outputPath,
+          jsonString,
+        );
+
+        // ensure that mkDirSync was called once
+        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(1);
+
+        const outputFileContents = readFileSync(outputPath, 'utf-8');
+        expect(outputFileContents.trim()).toEqual(jsonString);
+      } finally {
+        unlinkSync(outputPath);
+        rmdirSync(fullDirPath);
+      }
+    });
+
+    it('with directory that already exists', async () => {
+      const tempFolder = uuidv4();
+      const outputPath = path.join(
+        'test-output',
+        tempFolder,
+        'test-output.json',
+      );
+
+      // if 'test-output' doesn't exist, created it
+      if (!existsSync('test-output')) {
+        mkdirSync('test-output');
+      }
+
+      const fullDirPath = path.dirname(outputPath);
+
+      // create the temp folder before calling saveJsonToFileCreatingDirectoryIfRequired
+      mkdirSync(fullDirPath);
+      expect(fullDirPath).toBe(path.join('test-output', tempFolder));
+      const jsonString = JSON.stringify({
+        ok: true,
+        somekey: 'someval',
+      });
+
+      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+      expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+
+      try {
+        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
+        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
+          outputPath,
+          jsonString,
+        );
+
+        // ensure that mkDirSync was called once
+        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+
+        const outputFileContents = readFileSync(outputPath, 'utf-8');
+        expect(outputFileContents.trim()).toEqual(jsonString);
+      } finally {
+        unlinkSync(outputPath);
+        rmdirSync(fullDirPath);
+      }
+    });
+  });
+});


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Refactor to extract a function for better testability so we can better and more directly test that we can output JSON to a given absolute path and create directories as required without having to run the entire snyk test from the outside in order to do so.

#### Any background context you want to provide?
Tests in test/jest/acceptance/cli-json-file-output.spec.ts can be flakey and one of them in particular, `test --json-file-output can handle an absolute path` was recently skipped to unblock other work.

#### What are the relevant tickets?
Where the test was skipped: https://github.com/snyk/snyk/pull/1731/commits/453db4c33571b37076d198875ef928e9e6ff7336
