### PR TITLE
feat: scan terraform plan delta, experimental

### DIFF
--- a/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
@@ -66,7 +66,7 @@ function extractChildModulesResources(
 function extractResourceChanges(
   terraformPlanJson: TerraformPlanJson,
 ): Array<TerraformPlanResourceChange> {
-  return terraformPlanJson?.resource_changes || [];
+  return terraformPlanJson.resource_changes || [];
 }
 
 function extractResourcesForFullScan(
@@ -92,7 +92,7 @@ function extractResourcesForDeltaScan(
 
 export function tryParsingTerraformPlan(
   terraformPlanFile: IacFileData,
-  isFullScan = false,
+  { isFullScan }: { isFullScan: boolean } = { isFullScan: false },
 ): Array<IacFileParsed> {
   let terraformPlanJson;
   try {

--- a/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
@@ -4,6 +4,7 @@ import {
   IacFileParsed,
   TerraformPlanJson,
   TerraformPlanResource,
+  ResourceActions,
   VALID_RESOURCE_ACTIONS,
   TerraformScanInput,
   TerraformPlanResourceChange,
@@ -35,7 +36,7 @@ function resourceChangeReducer(
 ): TerraformScanInput {
   // TODO: investigate if we need to adress also `after_unknown` field.
   const { actions, after } = resource.change || { actions: [], after: {} };
-  if (actions.some((action) => VALID_RESOURCE_ACTIONS.includes(action))) {
+  if (isValidResourceActions(actions)) {
     const resourceForReduction = { ...resource, values: after || {} };
     return terraformPlanReducer(scanInput, resourceForReduction);
   }
@@ -43,10 +44,19 @@ function resourceChangeReducer(
   return scanInput;
 }
 
+function isValidResourceActions(action: ResourceActions): boolean {
+  return VALID_RESOURCE_ACTIONS.some((validAction: string[]) => {
+    if (action.length !== validAction.length) return false;
+    return validAction.every(
+      (field: string, idx: number) => action[idx] === field,
+    );
+  });
+}
+
 function extractRootModuleResources(
   terraformPlanJson: TerraformPlanJson,
 ): Array<TerraformPlanResource> {
-  return terraformPlanJson?.planned_values?.root_module?.resources || [];
+  return terraformPlanJson.planned_values?.root_module?.resources || [];
 }
 
 function extractChildModulesResources(

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -115,14 +115,19 @@ export interface TerraformScanInput {
 }
 
 // taken from: https://www.terraform.io/docs/internals/json-format.html#change-representation
-type ResourceActions =
+export type ResourceActions =
   | ['no-op']
   | ['create']
   | ['read']
   | ['update']
-  | ['delete', 'create'] // not sure what this pair does
-  | ['create', 'delete'] // not sure what this pair does
+  | ['delete', 'create'] // resources you cannot update in place
+  | ['create', 'delete'] // for zero-downtime upgrades
   | ['delete'];
 
 // we will be scanning the `create` & `update` actions only.
-export const VALID_RESOURCE_ACTIONS = ['create', 'update'];
+export const VALID_RESOURCE_ACTIONS: ResourceActions[] = [
+  ['create'],
+  ['update'],
+  ['create', 'delete'],
+  ['delete', 'create'],
+];

--- a/test/fixtures/iac/terraform-plan/tf-plan.json
+++ b/test/fixtures/iac/terraform-plan/tf-plan.json
@@ -1,201 +1,345 @@
 {
-    "format_version":"0.1",
-    "terraform_version":"0.13.6",
-    "planned_values":{
-       "root_module":{
-          "resources":[
+  "format_version": "0.1",
+  "terraform_version": "0.13.6",
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_security_group.terra_ci_allow_outband",
+          "mode": "managed",
+          "type": "aws_security_group",
+          "name": "terra_ci_allow_outband",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 2,
+          "values": {
+            "ingress": {
+              "cidr_blocks": ["0.0.0.0/0"],
+              "description": null,
+              "from_port": 0,
+              "ipv6_cidr_blocks": null,
+              "prefix_list_ids": null,
+              "protocol": "tcp",
+              "self": false,
+              "to_port": 65535,
+              "type": "ingress"
+            }
+          }
+        }
+      ],
+      "child_modules": [
+        {
+          "resources": [
             {
-                "address":"aws_security_group.terra_ci_allow_outband",
-                "mode":"managed",
-                "type":"aws_security_group",
-                "name":"terra_ci_allow_outband",
-                "provider_name":"registry.terraform.io/hashicorp/aws",
-                "schema_version":2,
-                "values":{
-                   "ingress": {
-                     "cidr_blocks":[
-                        "0.0.0.0/0"
-                     ],
-                     "description":null,
-                     "from_port":0,
-                     "ipv6_cidr_blocks":null,
-                     "prefix_list_ids":null,
-                     "protocol":"tcp",
-                     "self":false,
-                     "to_port":65535,
-                     "type":"ingress"
-                   }
+              "address": "aws_security_group.terra_ci_allow_outband",
+              "mode": "managed",
+              "type": "aws_security_group",
+              "name": "CHILD_MODULE_terra_ci_allow_outband",
+              "index": 0,
+              "provider_name": "registry.terraform.io/hashicorp/aws",
+              "schema_version": 2,
+              "values": {
+                "ingress": {
+                  "cidr_blocks": ["0.0.0.0/0"],
+                  "description": null,
+                  "from_port": 0,
+                  "ipv6_cidr_blocks": null,
+                  "prefix_list_ids": null,
+                  "protocol": "tcp",
+                  "self": false,
+                  "to_port": 65535,
+                  "type": "ingress"
                 }
-             }
-          ],
-          "child_modules":[
-             {
-                "resources":[
-                    {
-                        "address":"aws_security_group.terra_ci_allow_outband",
-                        "mode":"managed",
-                        "type":"aws_security_group",
-                        "name":"CHILD_MODULE_terra_ci_allow_outband",
-                        "index": 0,
-                        "provider_name":"registry.terraform.io/hashicorp/aws",
-                        "schema_version":2,
-                        "values":{
-                           "ingress": {
-                              "cidr_blocks":[
-                                 "0.0.0.0/0"
-                              ],
-                              "description":null,
-                              "from_port":0,
-                              "ipv6_cidr_blocks":null,
-                              "prefix_list_ids":null,
-                              "protocol":"tcp",
-                              "self":false,
-                              "to_port":65535,
-                              "type":"ingress"
-                            }
-                        }
-                     }
-                ]
-             }
+              }
+            }
           ]
-       }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_security_group.some_created_resource",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "some_created_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 2,
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "ingress": {
+            "cidr_blocks": ["0.0.0.0/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        }
+      }
     },
-    "resource_changes": [
-       {
-         "address":"aws_security_group.some_created_resource",
-         "mode":"managed",
-         "type":"aws_security_group",
-         "name":"some_created_resource",
-         "provider_name":"registry.terraform.io/hashicorp/aws",
-         "schema_version":2,
-         "change": {
-            "actions": ["create"],
-            "before": null,
-            "after": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "0.0.0.0/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
+    {
+      "address": "aws_security_group.some_updated_resource",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "some_updated_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 2,
+      "change": {
+        "actions": ["update"],
+        "before": {
+          "ingress": {
+            "cidr_blocks": ["123.45.67.89/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        },
+        "after": {
+          "ingress": {
+            "cidr_blocks": ["0.0.0.0/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        }
+      }
+    },
+    {
+      "address": "aws_security_group.some_deleted_resource",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "some_deleted_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 2,
+      "change": {
+        "actions": ["delete"],
+        "before": {
+          "ingress": {
+            "cidr_blocks": ["0.0.0.0/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        },
+        "after": null
+      }
+    },
+    {
+      "address": "aws_security_group.some_deleted_resource",
+      "mode": "managed",
+      "type": "aws_security_group",
+      "name": "some_deleted_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "schema_version": 2,
+      "change": {
+        "actions": ["no-op"],
+        "before": {
+          "ingress": {
+            "cidr_blocks": ["0.0.0.0/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        },
+        "after": {
+          "ingress": {
+            "cidr_blocks": ["0.0.0.0/0"],
+            "description": null,
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "tcp",
+            "self": false,
+            "to_port": 65535,
+            "type": "ingress"
+          }
+        }
+      }
+    },
+    {
+      "address": "aws_iam_user_group_membership.some_delete_create_resource",
+      "mode": "managed",
+      "type": "aws_iam_user_group_membership",
+      "name": "some_delete_create_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["delete", "create"],
+        "before": {
+          "groups": ["organization-administrators"],
+          "id": "terraform-20210210215502257100000001",
+          "user": "p0tr3c"
+        },
+        "after": {
+          "groups": ["organization-administrators"],
+          "user": "p0tr3c"
+        },
+        "after_unknown": {
+          "groups": [false],
+          "id": true
+        }
+      }
+    },
+    {
+      "address": "aws_instance.some_create_delete_resource",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "some_create_delete_resource",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create", "delete"],
+        "before": {
+          "ami": "ami-096a4ffcb13cbde38",
+          "arn": "arn:aws:ec2:eu-west-1:155403611144:instance/i-00091bc3e2b173598",
+          "associate_public_ip_address": true,
+          "availability_zone": "eu-west-1a",
+          "cpu_core_count": 1,
+          "cpu_threads_per_core": 2,
+          "credit_specification": [
+            {
+              "cpu_credits": "unlimited"
             }
-         }
-       },
-       {
-         "address":"aws_security_group.some_updated_resource",
-         "mode":"managed",
-         "type":"aws_security_group",
-         "name":"some_updated_resource",
-         "provider_name":"registry.terraform.io/hashicorp/aws",
-         "schema_version":2,
-         "change": {
-            "actions": ["update"],
-            "before": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "123.45.67.89/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
-            },
-            "after": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "0.0.0.0/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
+          ],
+          "disable_api_termination": false,
+          "ebs_block_device": [],
+          "ebs_optimized": false,
+          "enclave_options": [
+            {
+              "enabled": false
             }
-         }
-       },
-       {
-         "address":"aws_security_group.some_deleted_resource",
-         "mode":"managed",
-         "type":"aws_security_group",
-         "name":"some_deleted_resource",
-         "provider_name":"registry.terraform.io/hashicorp/aws",
-         "schema_version":2,
-         "change": {
-            "actions": ["delete"],
-            "before": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "0.0.0.0/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
-            },
-            "after": null
-         }
-       },
-       {
-         "address":"aws_security_group.some_deleted_resource",
-         "mode":"managed",
-         "type":"aws_security_group",
-         "name":"some_deleted_resource",
-         "provider_name":"registry.terraform.io/hashicorp/aws",
-         "schema_version":2,
-         "change": {
-            "actions": ["no-op"],
-            "before": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "0.0.0.0/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
-            },
-            "after": {
-               "ingress": {
-                  "cidr_blocks":[
-                     "0.0.0.0/0"
-                  ],
-                  "description":null,
-                  "from_port":0,
-                  "ipv6_cidr_blocks":null,
-                  "prefix_list_ids":null,
-                  "protocol":"tcp",
-                  "self":false,
-                  "to_port":65535,
-                  "type":"ingress"
-                }
+          ],
+          "ephemeral_block_device": [],
+          "get_password_data": false,
+          "hibernation": false,
+          "host_id": null,
+          "iam_instance_profile": "",
+          "id": "i-00091bc3e2b173598",
+          "instance_initiated_shutdown_behavior": null,
+          "instance_state": "running",
+          "instance_type": "t3.micro",
+          "ipv6_address_count": 0,
+          "ipv6_addresses": [],
+          "key_name": "terra-ci",
+          "metadata_options": [
+            {
+              "http_endpoint": "enabled",
+              "http_put_response_hop_limit": 1,
+              "http_tokens": "optional"
             }
-         }
-       }
-    ]
- }
+          ],
+          "monitoring": false,
+          "network_interface": [],
+          "outpost_arn": "",
+          "password_data": "",
+          "placement_group": "",
+          "primary_network_interface_id": "eni-0f558bc9a8b96e4b6",
+          "private_dns": "ip-10-0-101-235.eu-west-1.compute.internal",
+          "private_ip": "10.0.101.235",
+          "public_dns": "",
+          "public_ip": "18.200.191.145",
+          "root_block_device": [
+            {
+              "delete_on_termination": true,
+              "device_name": "/dev/sda1",
+              "encrypted": false,
+              "iops": 100,
+              "kms_key_id": "",
+              "tags": {},
+              "throughput": 0,
+              "volume_id": "vol-00d3e8dfaab6572b3",
+              "volume_size": 8,
+              "volume_type": "gp2"
+            }
+          ],
+          "secondary_private_ips": [],
+          "security_groups": [],
+          "source_dest_check": true,
+          "subnet_id": "subnet-050411f3bb5f9dbe4",
+          "tags": {},
+          "tenancy": "default",
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": ["sg-0455cfe38c670b7b3"]
+        },
+        "after": {
+          "ami": "ami-0831162e2eb204b16",
+          "associate_public_ip_address": true,
+          "credit_specification": [],
+          "disable_api_termination": null,
+          "ebs_optimized": null,
+          "get_password_data": false,
+          "hibernation": null,
+          "iam_instance_profile": null,
+          "instance_initiated_shutdown_behavior": null,
+          "instance_type": "t3.micro",
+          "key_name": "terra-ci",
+          "monitoring": null,
+          "source_dest_check": true,
+          "subnet_id": "subnet-050411f3bb5f9dbe4",
+          "tags": null,
+          "timeouts": null,
+          "user_data": null,
+          "user_data_base64": null,
+          "volume_tags": null,
+          "vpc_security_group_ids": ["sg-0455cfe38c670b7b3"]
+        },
+        "after_unknown": {
+          "arn": true,
+          "availability_zone": true,
+          "cpu_core_count": true,
+          "cpu_threads_per_core": true,
+          "credit_specification": [],
+          "ebs_block_device": true,
+          "enclave_options": true,
+          "ephemeral_block_device": true,
+          "host_id": true,
+          "id": true,
+          "instance_state": true,
+          "ipv6_address_count": true,
+          "ipv6_addresses": true,
+          "metadata_options": true,
+          "network_interface": true,
+          "outpost_arn": true,
+          "password_data": true,
+          "placement_group": true,
+          "primary_network_interface_id": true,
+          "private_dns": true,
+          "private_ip": true,
+          "public_dns": true,
+          "public_ip": true,
+          "root_block_device": true,
+          "secondary_private_ips": true,
+          "security_groups": true,
+          "tenancy": true,
+          "vpc_security_group_ids": [false]
+        }
+      }
+    }
+  ]
+}

--- a/test/fixtures/iac/terraform-plan/tf-plan.json
+++ b/test/fixtures/iac/terraform-plan/tf-plan.json
@@ -59,5 +59,143 @@
              }
           ]
        }
-    }
+    },
+    "resource_changes": [
+       {
+         "address":"aws_security_group.some_created_resource",
+         "mode":"managed",
+         "type":"aws_security_group",
+         "name":"some_created_resource",
+         "provider_name":"registry.terraform.io/hashicorp/aws",
+         "schema_version":2,
+         "change": {
+            "actions": ["create"],
+            "before": null,
+            "after": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "0.0.0.0/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            }
+         }
+       },
+       {
+         "address":"aws_security_group.some_updated_resource",
+         "mode":"managed",
+         "type":"aws_security_group",
+         "name":"some_updated_resource",
+         "provider_name":"registry.terraform.io/hashicorp/aws",
+         "schema_version":2,
+         "change": {
+            "actions": ["update"],
+            "before": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "123.45.67.89/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            },
+            "after": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "0.0.0.0/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            }
+         }
+       },
+       {
+         "address":"aws_security_group.some_deleted_resource",
+         "mode":"managed",
+         "type":"aws_security_group",
+         "name":"some_deleted_resource",
+         "provider_name":"registry.terraform.io/hashicorp/aws",
+         "schema_version":2,
+         "change": {
+            "actions": ["delete"],
+            "before": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "0.0.0.0/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            },
+            "after": null
+         }
+       },
+       {
+         "address":"aws_security_group.some_deleted_resource",
+         "mode":"managed",
+         "type":"aws_security_group",
+         "name":"some_deleted_resource",
+         "provider_name":"registry.terraform.io/hashicorp/aws",
+         "schema_version":2,
+         "change": {
+            "actions": ["no-op"],
+            "before": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "0.0.0.0/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            },
+            "after": {
+               "ingress": {
+                  "cidr_blocks":[
+                     "0.0.0.0/0"
+                  ],
+                  "description":null,
+                  "from_port":0,
+                  "ipv6_cidr_blocks":null,
+                  "prefix_list_ids":null,
+                  "protocol":"tcp",
+                  "self":false,
+                  "to_port":65535,
+                  "type":"ingress"
+                }
+            }
+         }
+       }
+    ]
  }

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
@@ -29,11 +29,21 @@ const resource = {
     type: 'ingress',
   },
 };
-export const expectedParsingResult: TerraformScanInput = {
+export const expectedParsingResultFullScan: TerraformScanInput = {
   resource: {
     aws_security_group: {
       terra_ci_allow_outband: resource,
       CHILD_MODULE_terra_ci_allow_outband_0: resource,
+    },
+  },
+  data: {},
+};
+
+export const expectedParsingResultDeltaScan: TerraformScanInput = {
+  resource: {
+    aws_security_group: {
+      some_updated_resource: resource,
+      some_created_resource: resource,
     },
   },
   data: {},

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import * as fs from 'fs';
 import * as path from 'path';
 import {
@@ -44,6 +45,38 @@ export const expectedParsingResultDeltaScan: TerraformScanInput = {
     aws_security_group: {
       some_updated_resource: resource,
       some_created_resource: resource,
+    },
+    // "delete" | "create"
+    aws_iam_user_group_membership: {
+      some_delete_create_resource: {
+        groups: ['organization-administrators'],
+        user: 'p0tr3c',
+      },
+    },
+    // "create" | "delete"
+    aws_instance: {
+      some_create_delete_resource: {
+        ami: 'ami-0831162e2eb204b16',
+        associate_public_ip_address: true,
+        credit_specification: [],
+        disable_api_termination: null,
+        ebs_optimized: null,
+        get_password_data: false,
+        hibernation: null,
+        iam_instance_profile: null,
+        instance_initiated_shutdown_behavior: null,
+        instance_type: 't3.micro',
+        key_name: 'terra-ci',
+        monitoring: null,
+        source_dest_check: true,
+        subnet_id: 'subnet-050411f3bb5f9dbe4',
+        tags: null,
+        timeouts: null,
+        user_data: null,
+        user_data_base64: null,
+        volume_tags: null,
+        vpc_security_group_ids: ['sg-0455cfe38c670b7b3'],
+      },
     },
   },
   data: {},

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
@@ -18,7 +18,9 @@ describe('tryParsingTerraformPlan', () => {
 
   describe('full scan', () => {
     it('returns the expected resources', () => {
-      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData, true);
+      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData, {
+        isFullScan: true,
+      });
       expect(parsedTerraformPlan[0]).toEqual({
         ...iacFileData,
         engineType: EngineType.Terraform,
@@ -29,7 +31,7 @@ describe('tryParsingTerraformPlan', () => {
     it('does not fail if no child-modules are present', () => {
       const parsedTerraformPlan = tryParsingTerraformPlan(
         iacFileDataNoChildModules,
-        true,
+        { isFullScan: true },
       );
       expect(parsedTerraformPlan[0]).toEqual({
         ...iacFileDataNoChildModules,

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
@@ -3,7 +3,8 @@ import {
   iacFileData,
   invalidJsonIacFile,
   iacFileDataNoChildModules,
-  expectedParsingResult,
+  expectedParsingResultFullScan,
+  expectedParsingResultDeltaScan,
   expectedParsingResultWithoutChildModules,
 } from './terraform-plan-parser.fixtures';
 import { EngineType } from '../../../../src/cli/commands/test/iac-local-execution/types';
@@ -15,23 +16,37 @@ describe('tryParsingTerraformPlan', () => {
     );
   });
 
-  it('returns the expected resources', () => {
-    const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData);
-    expect(parsedTerraformPlan[0]).toEqual({
-      ...iacFileData,
-      engineType: EngineType.Terraform,
-      jsonContent: expectedParsingResult,
+  describe('full scan', () => {
+    it('returns the expected resources', () => {
+      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData, true);
+      expect(parsedTerraformPlan[0]).toEqual({
+        ...iacFileData,
+        engineType: EngineType.Terraform,
+        jsonContent: expectedParsingResultFullScan,
+      });
+    });
+
+    it('does not fail if no child-modules are present', () => {
+      const parsedTerraformPlan = tryParsingTerraformPlan(
+        iacFileDataNoChildModules,
+        true,
+      );
+      expect(parsedTerraformPlan[0]).toEqual({
+        ...iacFileDataNoChildModules,
+        engineType: EngineType.Terraform,
+        jsonContent: expectedParsingResultWithoutChildModules,
+      });
     });
   });
 
-  it('does not fail if no child-modules are present', () => {
-    const parsedTerraformPlan = tryParsingTerraformPlan(
-      iacFileDataNoChildModules,
-    );
-    expect(parsedTerraformPlan[0]).toEqual({
-      ...iacFileDataNoChildModules,
-      engineType: EngineType.Terraform,
-      jsonContent: expectedParsingResultWithoutChildModules,
+  describe('default delta scan', () => {
+    it('returns the expected resources', () => {
+      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData);
+      expect(parsedTerraformPlan[0]).toEqual({
+        ...iacFileData,
+        engineType: EngineType.Terraform,
+        jsonContent: expectedParsingResultDeltaScan,
+      });
     });
   });
 

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -146,7 +146,27 @@ Describe "Snyk iac test --experimental command"
   End
 
   Describe "Terraform plan scanning"
+    # Note that this now defaults to the delta scan, not the full scan.
+    # in the future a flag will be added to control this functionality.
     It "finds issues in a Terraform plan file"
+      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental
+      The status should be failure # issues found
+      The output should include "Testing ../fixtures/iac/terraform-plan/tf-plan.json"
+
+      # Outputs issues
+      The output should include "Infrastructure as code issues:"
+      # Root module
+      The output should include "✗ Security Group allows open ingress [Medium Severity] [SNYK-CC-TF-1] in Security Group"
+      The output should include "  introduced by resource > aws_security_group[some_created_resource] > ingress"
+      # Child modules
+      The output should include "✗ Security Group allows open ingress [Medium Severity] [SNYK-CC-TF-1] in Security Group"
+      The output should include "  introduced by resource > aws_security_group[some_updated_resource] > ingress"
+
+      The output should include "../fixtures/iac/terraform-plan/tf-plan.json for known issues, found 2 issues"
+    End
+
+    # The test below should be enabled once we add the full scan flag
+    xIt "finds issues in a Terraform plan file - full scan flag"
       When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental
       The status should be failure # issues found
       The output should include "Testing ../fixtures/iac/terraform-plan/tf-plan.json"


### PR DESCRIPTION
#### What does this PR do?
Enhances the experimental terraform-plan scanning functionality to do delta scans as a default, instead of a full-state scan as a default.

#### Where should the reviewer start?
Changes to `terraform-plan-parser.ts` contain the new logic to extract resource changes.
Then check the new unit-tests `terraform-plan-parser.spec.ts`.
And then the rest.
Please not some renaming was done to differentiate between the full & delta scans.

#### How should this be manually tested?
`snyk iac test ./tf-plan.json --experimental`

#### Any background context you want to provide?
After some discussions on the topic, we reached consensus that the default should be a delta scan, and not a full scan.
Soon, a flag will be added to allow customers to control which scan they want with a flag.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-758

#### Screenshots
![image](https://user-images.githubusercontent.com/43777855/111915312-426ec480-8a7e-11eb-89e8-473c0e72d1af.png)


#### Additional questions
