### PR TITLE
fix: update docker-plugin to improve detection of the OS of images

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.17.3",
+    "snyk-docker-plugin": "4.19.3",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.13.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Update docker-plugin to improve detection of the OS of images.

#### Any background context you want to provide?

https://github.com/snyk/snyk-docker-plugin/pull/331

#### What are the relevant tickets?

https://snyk.zendesk.com/agent/tickets/9475
