### PR TITLE
feat(@snyk/fix): unify calculating relevant pins & upgrades

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/calculate-relevant-fixes.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/calculate-relevant-fixes.ts
@@ -1,0 +1,26 @@
+import { DependencyPins } from '../../../../../types';
+import { isDefined } from './is-defined';
+import { Requirement } from './requirements-file-parser';
+
+export type FixesType = 'direct-upgrades' | 'transitive-pins';
+
+export function calculateRelevantFixes(
+  requirements: Requirement[],
+  updates: DependencyPins,
+  type: FixesType,
+): { [upgradeFrom: string]: string } {
+  const lowerCasedUpdates: { [upgradeFrom: string]: string } = {};
+  const topLevelDeps = requirements
+    .map(({ name }) => name && name.toLowerCase())
+    .filter(isDefined);
+
+  Object.keys(updates).forEach((update) => {
+    const { upgradeTo } = updates[update];
+    const [pkgName] = update.split('@');
+    const isTransitive = topLevelDeps.indexOf(pkgName.toLowerCase()) < 0;
+    if (type === 'transitive-pins' ? isTransitive : !isTransitive) {
+      lowerCasedUpdates[update.toLowerCase()] = upgradeTo.toLowerCase();
+    }
+  });
+  return lowerCasedUpdates;
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-upgrades.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-upgrades.ts
@@ -1,4 +1,5 @@
 import { DependencyPins, FixChangesSummary } from '../../../../../types';
+import { calculateRelevantFixes } from './calculate-relevant-fixes';
 import { Requirement } from './requirements-file-parser';
 import { UpgradedRequirements } from './types';
 
@@ -9,14 +10,11 @@ export function generateUpgrades(
   // Lowercase the upgrades object. This might be overly defensive, given that
   // we control this input internally, but its a low cost guard rail. Outputs a
   // mapping of upgrade to -> from, instead of the nested upgradeTo object.
-  const lowerCasedUpgrades: { [upgradeFrom: string]: string } = {};
-
-  Object.keys(updates).forEach((update) => {
-    const { upgradeTo, isTransitive } = updates[update];
-    if (!isTransitive) {
-      lowerCasedUpgrades[update.toLowerCase()] = upgradeTo.toLowerCase();
-    }
-  });
+  const lowerCasedUpgrades = calculateRelevantFixes(
+    requirements,
+    updates,
+    'direct-upgrades',
+  );
   if (Object.keys(lowerCasedUpgrades).length === 0) {
     return {
       updatedRequirements: {},

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -79,26 +79,31 @@ Summary:
 exports[`Error handling Snyk fix returns error when manifest can not be parsed 1`] = `
 Object {
   "exceptions": Object {},
-  "fixSummary": "✖ No successful fixes
-
-Unresolved items:
+  "fixSummary": "Successful fixes:
 
   requirements.txt
-  ✖ No fixes could be applied. Please contact support@snyk.io
+  ✔ Pinned django from 1.6.1 to 2.0.1
 
 Summary:
 
-  1 items were not fixed
-  0 items were successfully fixed",
+  0 items were not fixed
+  1 items were successfully fixed",
   "meta": Object {
-    "failed": 1,
-    "fixed": 0,
+    "failed": 0,
+    "fixed": 1,
   },
   "results": Object {
     "python": Object {
-      "failed": Array [
+      "failed": Array [],
+      "skipped": Array [],
+      "succeeded": Array [
         Object {
-          "error": [NoFixesCouldBeAppliedError: No fixes could be applied. Please contact support@snyk.io],
+          "changes": Array [
+            Object {
+              "success": true,
+              "userMessage": "Pinned django from 1.6.1 to 2.0.1",
+            },
+          ],
           "original": Object {
             "scanResult": Object {
               "facts": Array [
@@ -149,8 +154,6 @@ Summary:
           },
         },
       ],
-      "skipped": Array [],
-      "succeeded": Array [],
     },
   },
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

The change in how `isTransitive` is calculated to allow for provenance based fix also means that this is now more lenient and a dependency that is not in the top level deps in a file is considered to be a transitive. This is needed to allow for changes to be applied in files required in via `-r` https://github.com/snyk/snyk/compare/refactor/unify-calculating-fixes?expand=1#diff-f8c9ac4c7f1aac516985a73192c421f938ee5b35250d07f8adb6305d9d9d0e09R20

#### Where should the reviewer start?
`packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/calculate-relevant-fixes.ts`

#### How should this be manually tested?
`cd packages/snyk-fix && npm run test`
