### PR TITLE
refactor: Check if org is undefined in the CLI formatted output

### DIFF
--- a/src/cli/commands/test/formatters/format-test-meta.ts
+++ b/src/cli/commands/test/formatters/format-test-meta.ts
@@ -13,9 +13,9 @@ export function formatTestMeta(
   const packageManager = res.packageManager || options.packageManager;
   const targetFile = res.targetFile || res.displayTargetFile || options.file;
   const openSource = res.isPrivate ? 'no' : 'yes';
-  const meta = [
-    chalk.bold(rightPadWithSpaces('Organization: ', padToLength)) + res.org,
-  ];
+  const meta = res.org
+    ? [chalk.bold(rightPadWithSpaces('Organization: ', padToLength)) + res.org]
+    : [];
   if (options.iac) {
     meta.push(
       chalk.bold(rightPadWithSpaces('Type: ', padToLength)) +


### PR DESCRIPTION
#### What does this PR do?
This PR changes the formatted output of the Snyk CLI to NOT display an organization name, if it is undefined.

The CLI currently displays `undefined` for the formatted final output of a test run, if an organization is not defined. We add a check here to not print it if it is undefined.

As we are moving towards the Beta release of the IaC experimental flow, we want to have an org name correctly displayed. 
At this moment, the org name is getting passed from a test endpoint, so there is no easy way to do it without using it in the new experimental flow. 

We will tackle this problem in a next PR, however we don't want to show `undefined` to our users for now, so we skip the organization name.

#### How should this be manually tested?
Run `node ~/snyk-repos/snyk/dist/cli iac test file.tf --experimental` before 
Run `npm run build && node ~/snyk-repos/snyk/dist/cli iac test file.tf --experimental` after to check that the org name is not getting displayed anymore. 

#### Screenshots
Before

![image](https://user-images.githubusercontent.com/6989529/112132480-94b8fe00-8bc2-11eb-8341-c72507681658.png)

After

![image](https://user-images.githubusercontent.com/6989529/112132881-009b6680-8bc3-11eb-9348-849fb7279e5f.png)
