### PR TITLE
Feat/improve parse requirements

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/extract-version-provenance.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/extract-version-provenance.ts
@@ -2,14 +2,14 @@ import * as path from 'path';
 import * as debugLib from 'debug';
 
 import {
+  ParsedRequirements,
   parseRequirementsFile,
-  Requirement,
 } from './update-dependencies/requirements-file-parser';
 import { Workspace } from '../../../../types';
 import { containsRequireDirective } from './contains-require-directive';
 
 interface PythonProvenance {
-  [fileName: string]: Requirement[];
+  [fileName: string]: ParsedRequirements;
 }
 
 const debug = debugLib('snyk-fix:python:extract-version-provenance');

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/index.ts
@@ -21,7 +21,10 @@ export function updateDependencies(
   requirementsTxt: string,
   updates: DependencyPins,
 ): { updatedManifest: string; changes: FixChangesSummary[] } {
-  const parsedRequirementsData = parseRequirementsFile(requirementsTxt);
+  const {
+    requirements: parsedRequirementsData,
+    endsWithNewLine: shouldEndWithNewLine,
+  } = parseRequirementsFile(requirementsTxt);
 
   if (!parsedRequirementsData.length) {
     debug(
@@ -50,7 +53,7 @@ export function updateDependencies(
 
   // This is a bit of a hack, but an easy one to follow. If a file ends with a
   // new line, ensure we keep it this way. Don't hijack customers formatting.
-  if (requirementsTxt.endsWith('\n')) {
+  if (shouldEndWithNewLine) {
     updatedManifest += '\n';
   }
   debug('Finished applying changes to manifest');

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/index.ts
@@ -1,10 +1,9 @@
 import * as debugLib from 'debug';
 
-import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
 import { DependencyPins, FixChangesSummary } from '../../../../../types';
 import { generatePins } from './generate-pins';
 import { applyUpgrades } from './apply-upgrades';
-import { parseRequirementsFile } from './requirements-file-parser';
+import { ParsedRequirements } from './requirements-file-parser';
 import { generateUpgrades } from './generate-upgrades';
 import { FailedToParseManifest } from '../../../../../lib/errors/failed-to-parse-manifest';
 
@@ -18,15 +17,14 @@ const debug = debugLib('snyk-fix:python:update-dependencies');
  * `requirements.txt` must be in the manifests.
  */
 export function updateDependencies(
-  requirementsTxt: string,
+  parsedRequirementsData: ParsedRequirements,
   updates: DependencyPins,
 ): { updatedManifest: string; changes: FixChangesSummary[] } {
   const {
-    requirements: parsedRequirementsData,
+    requirements,
     endsWithNewLine: shouldEndWithNewLine,
-  } = parseRequirementsFile(requirementsTxt);
-
-  if (!parsedRequirementsData.length) {
+  } = parsedRequirementsData;
+  if (!requirements.length) {
     debug(
       'Error: Expected to receive parsed manifest data. Is manifest empty?',
     );
@@ -35,19 +33,19 @@ export function updateDependencies(
   debug('Finished parsing manifest');
 
   const { updatedRequirements, changes: upgradedChanges } = generateUpgrades(
-    parsedRequirementsData,
+    requirements,
     updates,
   );
   debug('Finished generating upgrades to apply');
 
   const { pinnedRequirements, changes: pinChanges } = generatePins(
-    parsedRequirementsData,
+    requirements,
     updates,
   );
   debug('Finished generating pins to apply');
 
   let updatedManifest = [
-    ...applyUpgrades(parsedRequirementsData, updatedRequirements),
+    ...applyUpgrades(requirements, updatedRequirements),
     ...pinnedRequirements,
   ].join('\n');
 
@@ -57,12 +55,6 @@ export function updateDependencies(
     updatedManifest += '\n';
   }
   debug('Finished applying changes to manifest');
-
-  // TODO: do this with the changes now that we only return new
-  if (updatedManifest === requirementsTxt) {
-    debug('Manifest has not changed!');
-    throw new NoFixesCouldBeAppliedError();
-  }
 
   return {
     updatedManifest,

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
@@ -19,12 +19,13 @@ export interface Requirement {
  * such as name, version, etc.
  * @param requirementsFile A requirements.txt file as a string
  */
-export function parseRequirementsFile(
-  requirementsFile: string,
-): {
+export interface ParsedRequirements {
   requirements: Requirement[];
   endsWithNewLine: boolean;
-} {
+}
+export function parseRequirementsFile(
+  requirementsFile: string,
+): ParsedRequirements {
   const endsWithNewLine = requirementsFile.endsWith('\n');
   const lines = requirementsFile.replace(/\n$/, '').split('\n');
   const requirements: Requirement[] = [];

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
@@ -19,7 +19,13 @@ export interface Requirement {
  * such as name, version, etc.
  * @param requirementsFile A requirements.txt file as a string
  */
-export function parseRequirementsFile(requirementsFile: string): Requirement[] {
+export function parseRequirementsFile(
+  requirementsFile: string,
+): {
+  requirements: Requirement[];
+  endsWithNewLine: boolean;
+} {
+  const endsWithNewLine = requirementsFile.endsWith('\n');
   const lines = requirementsFile.replace(/\n$/, '').split('\n');
   const requirements: Requirement[] = [];
   lines.map((requirementText: string, line: number) => {
@@ -28,7 +34,7 @@ export function parseRequirementsFile(requirementsFile: string): Requirement[] {
       requirements.push(requirement);
     }
   });
-  return requirements;
+  return { requirements, endsWithNewLine };
 }
 
 function extractDependencyDataFromLine(

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/apply-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/apply-upgrades.spec.ts
@@ -7,9 +7,9 @@ describe('applyUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = applyUpgrades(parseManifest, updates);
-    expect(result).toEqual(parseManifest.map((o) => o.originalText));
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = applyUpgrades(requirements, updates);
+    expect(result).toEqual(requirements.map((o) => o.originalText));
   });
 
   it('returns correctly when upgrade is to itself', () => {
@@ -19,8 +19,8 @@ describe('applyUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = applyUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = applyUpgrades(requirements, updates);
     expect(result).toEqual(['Django==1.6.1']);
   });
 
@@ -31,8 +31,8 @@ describe('applyUpgrades', () => {
 
     const manifestContents = 'django>=1.6.1\nclick>7.0';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = applyUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = applyUpgrades(requirements, updates);
     expect(result.sort()).toEqual(['click>7.0', 'django==2.0.1'].sort());
   });
 
@@ -45,8 +45,8 @@ describe('applyUpgrades', () => {
     const manifestContents =
       "click==7.1 ; python_version > '1.0'\nconnexion[swagger-ui]==2.2.0";
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = applyUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = applyUpgrades(requirements, updates);
     expect(result.sort()).toEqual(
       [
         'connexion[swagger-ui]==2.2.0',

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/generate-pins.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/generate-pins.spec.ts
@@ -14,8 +14,8 @@ describe('generatePins', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generatePins(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generatePins(requirements, updates);
     expect(result.changes).toEqual([]);
     expect(result.pinnedRequirements).toEqual([]);
   });
@@ -38,8 +38,8 @@ describe('generatePins', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generatePins(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generatePins(requirements, updates);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       ['Pinned transitive from 1.0.0 to 1.1.1'].sort(),
     );
@@ -66,8 +66,8 @@ describe('generatePins', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generatePins(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generatePins(requirements, updates);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       ['Pinned transitive from 1.0.0 to 1.1.1'].sort(),
     );

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/generate-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/generate-upgrades.spec.ts
@@ -14,8 +14,8 @@ describe('generateUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generateUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generateUpgrades(requirements, updates);
     expect(result.changes).toEqual([]);
     expect(result.updatedRequirements).toEqual({});
   });
@@ -38,8 +38,8 @@ describe('generateUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generateUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generateUpgrades(requirements, updates);
     expect(result.changes).toEqual([]);
     expect(result.updatedRequirements).toEqual({});
   });
@@ -62,8 +62,8 @@ describe('generateUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generateUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generateUpgrades(requirements, updates);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       ['Upgraded Django from 1.6.1 to 2.0.1'].sort(),
     );
@@ -90,8 +90,8 @@ describe('generateUpgrades', () => {
 
     const manifestContents = 'Django==1.6.1';
 
-    const parseManifest = parseRequirementsFile(manifestContents);
-    const result = generateUpgrades(parseManifest, updates);
+    const { requirements } = parseRequirementsFile(manifestContents);
+    const result = generateUpgrades(requirements, updates);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       ['Upgraded Django from 1.6.1 to 2.0.1'].sort(),
     );

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import * as path from 'path';
 import { updateDependencies } from '../../../../../../src/plugins/python/handlers/pip-requirements/update-dependencies';
+import { parseRequirementsFile } from '../../../../../../src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser';
 
 describe('remediation', () => {
   it('does not add extra new lines', () => {
@@ -24,7 +25,8 @@ describe('remediation', () => {
     const expectedManifest =
       'Django==2.0.1\ntransitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       [
         'Upgraded Django from 1.6.1 to 2.0.1',
@@ -56,7 +58,8 @@ describe('remediation', () => {
     const expectedManifest =
       'Django==2.0.1\ntransitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability\n';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       [
         'Upgraded Django from 1.6.1 to 2.0.1',
@@ -87,7 +90,8 @@ describe('remediation', () => {
     const expectedManifest =
       '\n#some comment\n\nDjango==2.0.1\ntransitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability\n';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       [
         'Upgraded Django from 1.6.1 to 2.0.1',
@@ -110,8 +114,8 @@ describe('remediation', () => {
     const manifestContents = 'django==1.6.1\n';
 
     const expectedManifest = 'django==2.0.1\n';
-
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes[0].userMessage).toEqual(
       'Upgraded django from 1.6.1 to 2.0.1',
     );
@@ -132,7 +136,8 @@ describe('remediation', () => {
 
     const expectedManifest = 'Django==2.0.1\n';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes[0].userMessage).toEqual(
       'Upgraded Django from 1.6.1 to 2.0.1',
     );
@@ -153,7 +158,8 @@ describe('remediation', () => {
 
     const expectedManifest = 'foo==55.66.7\n';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes[0].userMessage).toEqual(
       'Upgraded foo from 12.123.14 to 55.66.7',
     );
@@ -174,7 +180,8 @@ describe('remediation', () => {
 
     const expectedManifest = 'django==2.0.1 # this is a comment\n';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes[0].userMessage).toEqual(
       'Upgraded django from 1.6.1 to 2.0.1',
     );
@@ -201,7 +208,8 @@ describe('remediation', () => {
 
     const expectedManifest = 'django>=2.0.1\nclick>7.1';
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes.map((c) => c.userMessage)).toEqual([
       'Upgraded django from 1.6.1 to 2.0.1',
       'Upgraded click from 7.0 to 7.1',
@@ -236,7 +244,8 @@ describe('remediation', () => {
       'utf8',
     );
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes.map((c) => c.userMessage).sort()).toEqual(
       [
         'Upgraded Django from 1.6.1 to 2.0.1',
@@ -267,7 +276,8 @@ describe('remediation', () => {
       'utf8',
     );
 
-    const result = updateDependencies(manifestContents, upgrades);
+    const requirements = parseRequirementsFile(manifestContents);
+    const result = updateDependencies(requirements, upgrades);
     expect(result.changes[0].userMessage).toEqual(
       'Upgraded click from 7.0 to 7.1',
     );
@@ -286,10 +296,14 @@ describe('remediation', () => {
       ),
       'utf8',
     );
+    const requirements = parseRequirementsFile(manifestContents);
+
     try {
-      updateDependencies(manifestContents, upgrades);
+      updateDependencies(requirements, upgrades);
     } catch (e) {
-      expect(e.message).toEqual('No fixes could be applied. Please contact support@snyk.io');
+      expect(e.message).toEqual(
+        'No fixes could be applied. Please contact support@snyk.io',
+      );
     }
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- let the requirements parse extract information about newLine being present at the end of the file to avoid doing a hack later.
- change updateDependencies to work with parsed data and not parse the manifest there and then. This will help us to use versionProvenance instead of parsing the file again. Version provenance contains all the dependencies data so we should not need to parse it all again later.

#### Where should the reviewer start?
`packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts`

#### How should this be manually tested?
`npm run test ` inside the package

#### Any background context you want to provide?
This PR is refactoring some code to make using version provenance easier in the future PRs. 
