### PR TITLE
refactor: remove SNYK_IAC_SKIP_BUNDLE_DOWNLOAD env var from code

### DIFF
--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -50,15 +50,13 @@ export function getLocalCachePath(engineType: EngineType) {
 }
 
 export async function initLocalCache(): Promise<void> {
-  // temporarily use an ENV var to skip downloading of the bundles if we need to - e.g. smoke tests
-  if (!process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD) {
-    const preSignedUrl =
-      'https://cloud-config-policy-bundles.s3-eu-west-1.amazonaws.com/bundle.tar.gz';
+  const preSignedUrl =
+    'https://cloud-config-policy-bundles.s3-eu-west-1.amazonaws.com/bundle.tar.gz';
 
-    createIacDir();
-    const response: ReadableStream = needle.get(preSignedUrl);
-    await extractBundle(response);
-  }
+  createIacDir();
+  const response: ReadableStream = needle.get(preSignedUrl);
+  await extractBundle(response);
+
   if (!doesLocalCacheExist()) {
     throw Error(
       `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(

--- a/test/jest/unit/iac-unit-tests/local-cache.spec.ts
+++ b/test/jest/unit/iac-unit-tests/local-cache.spec.ts
@@ -1,13 +1,11 @@
 import * as localCacheModule from '../../../../src/cli/commands/test/iac-local-execution/local-cache';
-import { REQUIRED_LOCAL_CACHE_FILES } from '../../../../src/cli/commands/test/iac-local-execution/local-cache';
 import * as fileUtilsModule from '../../../../src/cli/commands/test/iac-local-execution/file-utils';
 import { PassThrough } from 'stream';
 import * as needle from 'needle';
 
-describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is not set', () => {
+describe('initLocalCache - downloads bundle successfully', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    delete process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD;
   });
 
   const fs = require('fs');
@@ -25,31 +23,24 @@ describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is not set', () => {
   });
 });
 
-describe('initLocalCache - SNYK_IAC_SKIP_BUNDLE_DOWNLOAD is true', () => {
+describe('initLocalCache - Missing IaC local cache data', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    process.env.SNYK_IAC_SKIP_BUNDLE_DOWNLOAD = 'true';
   });
 
   const fs = require('fs');
 
-  it('skips the download of the bundle', async () => {
-    fs.existsSync = jest.fn().mockReturnValue(true);
-    jest.spyOn(fileUtilsModule, 'extractBundle');
-
-    await localCacheModule.initLocalCache();
-
-    expect(fileUtilsModule.extractBundle).not.toHaveBeenCalled();
-  });
-
-  it('skips the download of the bundle but throws an error', () => {
+  it('throws an error on download', () => {
     const error = new Error(
-      `Missing IaC local cache data, please validate you have: \n${REQUIRED_LOCAL_CACHE_FILES.join(
-        '\n',
-      )}`,
+      'The .iac-data directory can not be created. ' +
+        'Please make sure that the current working directory has write permissions',
     );
+
     fs.existsSync = jest.fn().mockReturnValue(false);
     jest.spyOn(fileUtilsModule, 'extractBundle');
+    jest.spyOn(fileUtilsModule, 'createIacDir').mockImplementation(() => {
+      throw error;
+    });
 
     const promise = localCacheModule.initLocalCache();
 

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -20,7 +20,7 @@ Describe "Snyk iac test --experimental command"
       When run snyk iac test ../fixtures/iac/file-logging -d --experimental
       # We expect the output, specifically the analytics block not to include
       # the following text from the file.
-      The status should be success
+      The status should be failure  # issues found
       The output should not include "PRIVATE_FILE_CONTENT_CHECK"
       The error should not include "PRIVATE_FILE_CONTENT_CHECK"
     End


### PR DESCRIPTION
#### What does this PR do?

This PR removes the use of SNYK_IAC_SKIP_BUNDLE_DOWNLOAD env var which we use to skip the download of the bundle in smoke tests. This was because tests were very explicit and we now have changed them in [PR](https://github.com/snyk/snyk/pull/1765) to be more vague.
It also refactors the unit tests which depended on that flag.

#### How should this be manually tested?
Run tests locally.