### PR TITLE
fix: make transitive deps lowercase in python

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-nuget-plugin": "1.21.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",
-    "snyk-python-plugin": "1.19.5",
+    "snyk-python-plugin": "1.19.7",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
     "snyk-sbt-plugin": "2.11.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This is to fix a bug where we flag multiple licenses for the same node due to case sensitivity
