### PR TITLE
feat: map 'critical' severity to 'error' in sarif format

### DIFF
--- a/src/cli/commands/test/open-source-sarif-output.ts
+++ b/src/cli/commands/test/open-source-sarif-output.ts
@@ -117,6 +117,7 @@ export function getResults(testResult): sarif.Result[] {
 
 export function getLevel(vuln: AnnotatedIssue) {
   switch (vuln.severity) {
+    case SEVERITY.CRITICAL:
     case SEVERITY.HIGH:
       return 'error';
     case SEVERITY.MEDIUM:

--- a/test/jest/unit/sarif.spec.ts
+++ b/test/jest/unit/sarif.spec.ts
@@ -11,6 +11,7 @@ describe('createSarifOutputForOpenSource', () => {
     expect(run.tool.driver.name).toEqual('Snyk Open Source');
     expect(run.tool.driver.rules).toHaveLength(1);
     expect(run.results).toHaveLength(1);
+    expect(run.results?.[0].level === 'error');
   });
 
   describe('replace lock-file to manifest-file', () => {
@@ -63,7 +64,7 @@ function getTestResult(testResultOverride = {}, vulnOverride = {}): TestResult {
         semver: {
           vulnerable: ['<6.12.3'],
         },
-        severity: SEVERITY.HIGH,
+        severity: SEVERITY.CRITICAL,
         title: 'Prototype Pollution',
         from: [
           'PROJECT_NAME@1.0.0',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support for CRITICAL severity in the `--sarif` output format