### PR TITLE
fix: support package.json missing name property

### DIFF
--- a/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/npm-modules-parser.ts
@@ -34,6 +34,7 @@ export async function parse(
     const packageJson = JSON.parse(
       getFileContents(root, packageJsonFileName).content,
     );
+
     let dependencies = packageJson.dependencies;
     if (options.dev) {
       dependencies = { ...dependencies, ...packageJson.devDependencies };
@@ -41,7 +42,7 @@ export async function parse(
     if (isEmpty(dependencies)) {
       return new Promise((resolve) =>
         resolve({
-          name: packageJson.name,
+          name: packageJson.name || 'package.json',
           dependencies: {},
           version: packageJson.version,
         }),

--- a/test/jest/unit/npm-modules-parser.spec.ts
+++ b/test/jest/unit/npm-modules-parser.spec.ts
@@ -1,0 +1,64 @@
+import { mocked } from 'ts-jest/utils';
+
+import { parse } from '../../../src/lib/plugins/nodejs-plugin/npm-modules-parser';
+import { getFileContents } from '../../../src/lib/get-file-contents';
+
+jest.mock('../../../src/lib/get-file-contents');
+const mockedGetFileContents = mocked(getFileContents, true);
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+const packageJsonNoNameAndNoDeps = {
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo "Error: no test specified" && exit 1',
+  },
+  author: '',
+  license: 'ISC',
+};
+
+const packageJsonNoDeps = {
+  name: 'test-package',
+  description: '',
+  main: 'index.js',
+  scripts: {
+    test: 'echo "Error: no test specified" && exit 1',
+  },
+  author: '',
+  license: 'ISC',
+};
+
+describe('npm-modules-parser', () => {
+  describe('parse', () => {
+    it('package name should fall back to "package.json" when no name and no dependencies', async () => {
+      mockedGetFileContents.mockImplementation(() => ({
+        content: JSON.stringify(packageJsonNoNameAndNoDeps),
+        fileName: 'package.json',
+      }));
+
+      const result = await parse('some/fake/path', 'package.json', {
+        packageManager: 'npm',
+        file: 'package.json',
+      });
+
+      expect(result.name).toBe('package.json');
+    });
+
+    it('package name should match package.json when no dependencies', async () => {
+      mockedGetFileContents.mockImplementation(() => ({
+        content: JSON.stringify(packageJsonNoDeps),
+        fileName: 'package.json',
+      }));
+
+      const result = await parse('some/fake/path', 'package.json', {
+        packageManager: 'npm',
+        file: 'package.json',
+      });
+
+      expect(result.name).toBe('test-package');
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This is to fix a bug where package.json without name property would throw an error.

