### PR TITLE
refactor: Remove unused env var from circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
             echo "Checkout the README in test/smoke folder for more details about this step"
             unset SNYK_API
             unset SNYK_API_KEY
-            shellspec -f d -e REGRESSION_TEST=1 -e SNYK_IAC_SKIP_BUNDLE_DOWNLOAD=true
+            shellspec -f d -e REGRESSION_TEST=1
 
   test-windows:
     <<: *defaults


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Removes `SNYK_IAC_SKIP_BUNDLE_DOWNLOAD` env var from circleCi. 

All references in code have already been removed in previous PR but the flag has not been removed from the .config.yml

### How to test
Search for references and confirm there is none.