### PR TITLE
feat: Delete local .iac-data directory after scan is finished, using fs [CC-765]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -9,7 +9,7 @@ import {
   IacFileParseFailure,
   SafeAnalyticsOutput,
 } from './types';
-import { initLocalCache } from './local-cache';
+import { cleanLocalCache, initLocalCache } from './local-cache';
 import { addIacAnalytics } from './analytics';
 import { TestResult } from '../../../../lib/snyk-test/legacy';
 import { IacFileInDirectory } from '../../../../lib/types';
@@ -32,6 +32,7 @@ export async function test(
   const scannedFiles = await scanFiles(parsedFiles);
   const formattedResults = formatScanResults(scannedFiles, options);
   addIacAnalytics(formattedResults);
+  cleanLocalCache();
 
   // TODO: add support for proper typing of old TestResult interface.
   return {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

In a previous task, we introduced the download and extraction of files in a local cache directory, called '.iac-data'. 

We do not need the files anymore after the scan/test, so we decided to clean up that local directory after the tests finishes.

#### How should this be manually tested?
- Run `npm run build && node iac test file.tf --experimental`
- Run ` ls .iac-data` and see that there is no such directory in the filesystem anymore.

#### What are the relevant tickets?
[CC-765]

[CC-765]: https://snyksec.atlassian.net/browse/CC-765