### PR TITLE
Fix: target different Node versions for binaries for pkg-fetch

### DIFF
--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -6,10 +6,10 @@ mkdir binary-releases
 # adds a file to identify a build as a standalone binary
 echo '' >dist/STANDALONE
 
-npx pkg . -t node14-alpine-x64 -o binary-releases/snyk-alpine
-npx pkg . -t node12-linux-x64 -o binary-releases/snyk-linux
-npx pkg . -t node12-macos-x64 -o binary-releases/snyk-macos
-npx pkg . -t node12-win-x64 -o binary-releases/snyk-win-unsigned.exe
+npx pkg . -t node14.4.0-alpine-x64 -o binary-releases/snyk-alpine
+npx pkg . -t node12.18.1-linux-x64 -o binary-releases/snyk-linux
+npx pkg . -t node12.18.1-macos-x64 -o binary-releases/snyk-macos
+npx pkg . -t node12.18.1-win-x64 -o binary-releases/snyk-win-unsigned.exe
 
 # build docker package
 ./release-scripts/docker-desktop-release.sh


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
We are targeting the latest tag of pkg-fetch and last evening they introduced a new version with no binaries, so our build broke when it tried to download them.
https://github.com/vercel/pkg-fetch/releases/

![image](https://user-images.githubusercontent.com/6989529/112619171-ea89e200-8e1e-11eb-93e8-ae41fe7eb7a4.png)

Tag 2.7.0 is now deleted but our script tries to find an image from a previous version to match.  The last working version is 2.5
We are targeting non existing versions for those images, eg node14 for alpine. 
To unblock the build temporarily this PR targets specific versions:

```
npx pkg . -t node14.4.0-alpine-x64 -o binary-releases/snyk-alpine
npx pkg . -t node12.18.1-linux-x64 -o binary-releases/snyk-linux
npx pkg . -t node12.18.1-macos-x64 -o binary-releases/snyk-macos
npx pkg . -t node12.18.1-win-x64 -o binary-releases/snyk-win-unsigned.exe
```