### PR TITLE
refactor: remove if guard that checks if dir exists

### DIFF
--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -74,13 +74,11 @@ export async function initLocalCache(): Promise<void> {
 export function cleanLocalCache() {
   // path to delete is hardcoded for now
   const iacPath: fs.PathLike = path.join(`${process.cwd()}`, '.iac-data');
-  if (fs.existsSync(iacPath) && fs.lstatSync(iacPath).isDirectory()) {
-    try {
-      // when we support Node version >= 12.10.0 , we can replace rimraf
-      // with the native fs.rmdirSync(path, {recursive: true})
-      rimraf.sync(iacPath);
-    } catch (e) {
-      debug('The local cache directory could not be deleted');
-    }
+  try {
+    // when we support Node version >= 12.10.0 , we can replace rimraf
+    // with the native fs.rmdirSync(path, {recursive: true})
+    rimraf.sync(iacPath);
+  } catch (e) {
+    debug('The local cache directory could not be deleted');
   }
 }

--- a/test/jest/unit/iac-unit-tests/local-cache.spec.ts
+++ b/test/jest/unit/iac-unit-tests/local-cache.spec.ts
@@ -25,14 +25,13 @@ describe('initLocalCache - downloads bundle successfully', () => {
 
   it('cleans up the custom folder after finishes', () => {
     const iacPath: fs.PathLike = path.join(`${process.cwd()}`, '.iac-data');
-    const stats: fs.Stats = new fs.Stats();
-    stats.isDirectory = jest.fn().mockReturnValue(true);
-    jest.spyOn(fs, 'lstatSync').mockReturnValueOnce(stats);
     const spy = jest.spyOn(rimraf, 'sync');
 
     localCacheModule.cleanLocalCache();
 
     expect(spy).toHaveBeenCalledWith(iacPath);
+    jest.restoreAllMocks();
+    expect(fs.existsSync(iacPath)).toBeFalsy();
   });
 });
 
@@ -56,13 +55,5 @@ describe('initLocalCache - Missing IaC local cache data', () => {
 
     expect(fileUtilsModule.extractBundle).not.toHaveBeenCalled();
     expect(promise).rejects.toThrow(error);
-  });
-
-  it('does not delete the local cacheDir if it does not exist', () => {
-    const spy = jest.spyOn(rimraf, 'sync');
-
-    localCacheModule.cleanLocalCache();
-
-    expect(spy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
We use rimraf to delete a directory and also have a check to see if the path exists and if it is a directory.
This is already done internally from rimraf, as pointed on a [previous PR](https://github.com/snyk/snyk/pull/1762#pullrequestreview-622187515) , and here https://github.com/isaacs/rimraf.

So now we remove the unneeded check.