### PR TITLE
refactor: Update release scripts to the previous version

### DIFF
--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -6,10 +6,10 @@ mkdir binary-releases
 # adds a file to identify a build as a standalone binary
 echo '' >dist/STANDALONE
 
-npx pkg . -t node14.4.0-alpine-x64 -o binary-releases/snyk-alpine
-npx pkg . -t node12.18.1-linux-x64 -o binary-releases/snyk-linux
-npx pkg . -t node12.18.1-macos-x64 -o binary-releases/snyk-macos
-npx pkg . -t node12.18.1-win-x64 -o binary-releases/snyk-win-unsigned.exe
+npx pkg . -t node14-alpine-x64 -o binary-releases/snyk-alpine
+npx pkg . -t node12-linux-x64 -o binary-releases/snyk-linux
+npx pkg . -t node12-macos-x64 -o binary-releases/snyk-macos
+npx pkg . -t node12-win-x64 -o binary-releases/snyk-win-unsigned.exe
 
 # build docker package
 ./release-scripts/docker-desktop-release.sh


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
We started targetting specific node versions for our binaries in this PR https://github.com/snyk/snyk/pull/1770
This was breaking our builds. Vercel team has now fixed their side of `pkg` and we do not need to target specific versions anymore.

Relevant links:
- https://github.com/vercel/pkg-fetch/issues/137
- https://github.com/vercel/pkg/releases/tag/4.5.1