### PR TITLE
feat: introduce envvar to control HTTP-HTTPS upgrade behavior

### DIFF
--- a/help/commands-docs/_ENVIRONMENT.md
+++ b/help/commands-docs/_ENVIRONMENT.md
@@ -29,7 +29,7 @@ By default Snyk CLI will connect to `https://snyk.io/api/v1`.
   Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
 
 - `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
-  If set to the value of `0` the API requests aimed at `http` URLs will not be upgraded to `https`. Useful e.g., for reverse proxies.
+  If set to the value of `0`, API requests aimed at `http` URLs will not be upgraded to `https`. If not set, the default behavior will be to upgrade these requests from `http` to `https`. Useful e.g., for reverse proxies.
 
 - `HTTPS_PROXY` and `HTTP_PROXY`:
   Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.

--- a/help/commands-docs/_ENVIRONMENT.md
+++ b/help/commands-docs/_ENVIRONMENT.md
@@ -8,19 +8,28 @@ You can set these environment variables to change CLI run settings.
   [How to get your account token](https://snyk.co/ucT6J)<br />
   [How to use Service Accounts](https://snyk.co/ucT6L)<br />
 
-- `SNYK_API`:
-  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies.
-
 - `SNYK_CFG_`<KEY>:
   Allows you to override any key that's also available as `snyk config` option.
 
   E.g. `SNYK_CFG_ORG`=myorg will override default org option in `config` with "myorg".
 
 - `SNYK_REGISTRY_USERNAME`:
-    Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-     override this value. This will be ignored in favour of local Docker binary credentials when Docker is present. 
-  
+  Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
 - `SNYK_REGISTRY_PASSWORD`:
-    Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-     override this value. This will be ignored in favour of local Docker binary credentials when Docker is present. 
-    
+  Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
+  override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+
+## Connecting to Snyk API
+
+By default Snyk CLI will connect to `https://snyk.io/api/v1`.
+
+- `SNYK_API`:
+  Sets API host to use for Snyk requests. Useful for on-premise instances and configuring proxies. If set with `http` protocol CLI will upgrade the requests to `https`. Unless `SNYK_HTTP_PROTOCOL_UPGRADE` is set to `0`.
+
+- `SNYK_HTTP_PROTOCOL_UPGRADE`=0:
+  If set to the value of `0` the API requests aimed at `http` URLs will not be upgraded to `https`. Useful e.g., for reverse proxies.
+
+- `HTTPS_PROXY` and `HTTP_PROXY`:
+  Allows you to specify a proxy to use for `https` and `http` calls. The `https` in the `HTTPS_PROXY` means that _requests using `https` protocol_ will use this proxy. The proxy itself doesn't need to use `https`.

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -71,7 +71,8 @@ export = function makeRequest(
 
         if (
           parsedUrl.protocol === 'http:' &&
-          parsedUrl.hostname !== 'localhost'
+          parsedUrl.hostname !== 'localhost' &&
+          process.env.SNYK_HTTP_PROTOCOL_UPGRADE !== '0'
         ) {
           debug('forcing api request to https');
           parsedUrl.protocol = 'https:';
@@ -95,7 +96,10 @@ export = function makeRequest(
         let url = payload.url;
 
         if (payload.qs) {
-          url = url + '?' + querystring.stringify(payload.qs);
+          // Parse the URL and append the search part - this will take care of adding the '/?' part if it's missing
+          const urlObject = new URL(url);
+          urlObject.search = querystring.stringify(payload.qs);
+          url = urlObject.toString();
           delete payload.qs;
         }
 


### PR DESCRIPTION
Follow up to the #1771 

This PR adds an optional ennvar `SNYK_HTTP_PROTOCOL_UPGRADE` to disable the behavior to upgrade `http` endpoints to `https`.

Fixes the behavior about query strings, that could've lacked the `/?` characters

It also updates Help documentation about `HTTP(S)_PROXY` envvar.
