### PR TITLE
chore: Add error types and debug logs for IaC [CC-754, CC-764]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as tar from 'tar';
 import * as path from 'path';
+import { FailedToInitLocalCacheError } from './local-cache';
 
 export function createIacDir(): void {
   // this path will be able to be customised by the user in the future
@@ -11,10 +12,7 @@ export function createIacDir(): void {
     }
     fs.accessSync(iacPath, fs.constants.W_OK);
   } catch {
-    throw Error(
-      'The .iac-data directory can not be created. ' +
-        'Please make sure that the current working directory has write permissions',
-    );
+    throw new FailedToInitLocalCacheError();
   }
 }
 

--- a/src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser.ts
@@ -1,12 +1,23 @@
 import * as YAML from 'js-yaml';
-import { EngineType, IacFileParsed, IacFileData } from '../types';
+import { CustomError } from '../../../../../lib/errors';
+import {
+  EngineType,
+  IacFileParsed,
+  IacFileData,
+  IaCErrorCodes,
+} from '../types';
 
 const REQUIRED_K8S_FIELDS = ['apiVersion', 'kind', 'metadata'];
 
 export function tryParsingKubernetesFile(
   fileData: IacFileData,
 ): IacFileParsed[] {
-  const yamlDocuments = YAML.safeLoadAll(fileData.fileContent);
+  let yamlDocuments;
+  try {
+    yamlDocuments = YAML.safeLoadAll(fileData.fileContent);
+  } catch (e) {
+    throw new FailedToParseKubernetesYamlError(fileData.filePath);
+  }
 
   return yamlDocuments.map((parsedYamlDocument, docId) => {
     if (
@@ -21,7 +32,22 @@ export function tryParsingKubernetesFile(
         docId,
       };
     } else {
-      throw new Error('Invalid K8s File!');
+      throw new MissingRequiredFieldsInKubernetesYamlError(fileData.filePath);
     }
   });
+}
+
+class FailedToParseKubernetesYamlError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse Kubernetes YAML file');
+    this.code = IaCErrorCodes.FailedToParseKubernetesYamlError;
+    this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML`;
+  }
+}
+export class MissingRequiredFieldsInKubernetesYamlError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to detect Kubernetes file, missing required fields');
+    this.code = IaCErrorCodes.MissingRequiredFieldsInKubernetesYamlError;
+    this.userMessage = `We were unable to detect whether the YAML file "${filename}" is a valid Kubernetes file, it is missing the following fields: 'apiVersion', 'kind', 'metadata'`;
+  }
 }

--- a/src/cli/commands/test/iac-local-execution/parsers/terraform-file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/terraform-file-parser.ts
@@ -1,5 +1,11 @@
 import * as hclToJson from 'hcl-to-json';
-import { EngineType, IacFileData, IacFileParsed } from '../types';
+import {
+  EngineType,
+  IaCErrorCodes,
+  IacFileData,
+  IacFileParsed,
+} from '../types';
+import { CustomError } from '../../../../../lib/errors';
 
 export function tryParsingTerraformFile(
   fileData: IacFileData,
@@ -16,6 +22,14 @@ export function tryParsingTerraformFile(
       },
     ];
   } catch (err) {
-    throw new Error('Invalid Terraform File!');
+    throw new FailedToParseTerraformFileError(fileData.filePath);
+  }
+}
+
+class FailedToParseTerraformFileError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse Terraform file');
+    this.code = IaCErrorCodes.FailedToParseTerraformFileError;
+    this.userMessage = `We were unable to parse the Terraform file "${filename}", please ensure it is valid HCL2. This can be done by running it through the 'terraform validate' command.`;
   }
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -161,3 +161,38 @@ export const VALID_RESOURCE_ACTIONS: ResourceActions[] = [
   ['create', 'delete'],
   ['delete', 'create'],
 ];
+
+// Error codes used for Analytics & Debugging
+// Within a single module, increments are in 1.
+// Between modules, increments are in 10, according to the order of execution.
+export enum IaCErrorCodes {
+  // local-cache errors
+  FailedToInitLocalCacheError = 1000,
+  FailedToCleanLocalCacheError = 1001,
+
+  // file-loader errors
+  NoFilesToScanError = 1010,
+  FailedToLoadFileError = 1011,
+
+  // file-parser errors
+  UnsupportedFileTypeError = 1020,
+
+  // kubernetes-parser errors
+  FailedToParseKubernetesYamlError = 1030,
+  MissingRequiredFieldsInKubernetesYamlError = 1031,
+
+  // terraform-file-parser errors
+  FailedToParseTerraformFileError = 1040,
+
+  // terraform-plan-parser errors
+  FailedToParseTerraformPlanJsonError = 1050,
+  MissingRequiredFieldsInTerraformPlanError = 1051,
+  FailedToExtractResourcesInTerraformPlanError = 1052,
+
+  // file-scanner errors
+  FailedToBuildPolicyEngine = 1060,
+  FailedToExecutePolicyEngine = 1061,
+
+  // results-formatter errors
+  FailedToFormatResults = 1070,
+}

--- a/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
@@ -3,6 +3,7 @@ import {
   IacFileData,
   IacFileParsed,
 } from '../../../../src/cli/commands/test/iac-local-execution/types';
+import { MissingRequiredFieldsInKubernetesYamlError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
 
 const kubernetesFileContent = `
 apiVersion: v1
@@ -42,8 +43,10 @@ export const invalidK8sFileDataStub: IacFileData = {
 };
 
 export const expectedInvalidK8sFileParsingResult = {
-  err: new Error('Invalid K8s File!'),
-  failureReason: 'Invalid K8s File!',
+  err: new MissingRequiredFieldsInKubernetesYamlError(
+    'Failed to detect Kubernetes file, missing required fields',
+  ),
+  failureReason: 'Failed to detect Kubernetes file, missing required fields',
   fileType: 'yml',
   filePath: 'dont-care',
   fileContent: invalidK8sFileDataStub.fileContent,

--- a/test/jest/unit/iac-unit-tests/file-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.spec.ts
@@ -1,14 +1,28 @@
-import { parseFiles } from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
 import {
+  parseFiles,
+  tryParseIacFile,
+  UnsupportedFileTypeError,
+} from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
+import * as fileParser from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
+import {
+  expectedInvalidK8sFileParsingResult,
   expectedKubernetesParsingResult,
   expectedTerraformParsingResult,
+  invalidK8sFileDataStub,
   kubernetesFileDataStub,
   terraformFileDataStub,
-  invalidK8sFileDataStub,
-  expectedInvalidK8sFileParsingResult,
 } from './file-parser.fixtures';
+import { MissingRequiredFieldsInKubernetesYamlError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
+import { IacFileData } from '../../../../src/cli/commands/test/iac-local-execution/types';
+import { IacFileTypes } from '../../../../dist/lib/iac/constants';
+import { UnsupportedError } from 'snyk-nodejs-lockfile-parser/dist/errors';
+import * as fileLoader from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
+import { FailedToLoadFileError } from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
 
-const filesToParse = [kubernetesFileDataStub, terraformFileDataStub];
+const filesToParse: IacFileData[] = [
+  kubernetesFileDataStub,
+  terraformFileDataStub,
+];
 
 describe('parseFiles', () => {
   it('parses iac files as expected', async () => {
@@ -20,7 +34,7 @@ describe('parseFiles', () => {
 
   it('throws an error if a single file parse fails', async () => {
     await expect(parseFiles([invalidK8sFileDataStub])).rejects.toThrow(
-      'Invalid K8s File!',
+      MissingRequiredFieldsInKubernetesYamlError,
     );
   });
 
@@ -33,5 +47,21 @@ describe('parseFiles', () => {
     expect(parsedFiles[0]).toEqual(expectedKubernetesParsingResult);
     expect(failedFiles.length).toEqual(1);
     expect(failedFiles[0]).toEqual(expectedInvalidK8sFileParsingResult);
+  });
+
+  it('throws an error for unsupported file types', async () => {
+    jest.spyOn(fileParser, 'tryParseIacFile').mockImplementation(() => {
+      throw UnsupportedFileTypeError;
+    });
+
+    const parseFilesFn = parseFiles([
+      {
+        fileContent: 'file.java',
+        filePath: 'path/to/file',
+        fileType: 'java' as IacFileTypes,
+      },
+    ]);
+
+    await expect(parseFilesFn).rejects.toThrow(UnsupportedFileTypeError);
   });
 });

--- a/test/jest/unit/iac-unit-tests/file-scanner.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-scanner.spec.ts
@@ -1,3 +1,5 @@
+import { FailedToBuildPolicyEngine } from '../../../../dist/cli/commands/test/iac-local-execution/file-scanner';
+
 const mockFs = require('mock-fs');
 import * as path from 'path';
 import {
@@ -25,7 +27,7 @@ describe('scanFiles', () => {
   });
 
   describe('with parsed files', () => {
-    it('returns the expected viloated policies', async () => {
+    it('returns the expected violated policies', async () => {
       mockFs({
         [path.resolve(__dirname, '../../../../.iac-data')]: mockFs.load(
           path.resolve(__dirname, '../../../smoke/.iac-data'),
@@ -41,7 +43,7 @@ describe('scanFiles', () => {
       );
     });
 
-    // TODO: Extract policy engine & the cache mechinism, test them separately.
+    // TODO: Extract policy engine & the cache mechanism, test them separately.
   });
 
   describe('missing policy engine wasm files', () => {

--- a/test/jest/unit/iac-unit-tests/local-cache.spec.ts
+++ b/test/jest/unit/iac-unit-tests/local-cache.spec.ts
@@ -1,4 +1,5 @@
 import * as localCacheModule from '../../../../src/cli/commands/test/iac-local-execution/local-cache';
+import { FailedToInitLocalCacheError } from '../../../../src/cli/commands/test/iac-local-execution/local-cache';
 import * as fileUtilsModule from '../../../../src/cli/commands/test/iac-local-execution/file-utils';
 import { PassThrough } from 'stream';
 import * as needle from 'needle';
@@ -35,13 +36,13 @@ describe('initLocalCache - downloads bundle successfully', () => {
   });
 });
 
-describe('initLocalCache - Missing IaC local cache data', () => {
+describe('initLocalCache - errors', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     jest.spyOn(fs, 'existsSync').mockReturnValueOnce(false);
   });
 
-  it('throws an error on download', () => {
+  it('throws an error on creation of cache dir', () => {
     const error = new Error(
       'The .iac-data directory can not be created. ' +
         'Please make sure that the current working directory has write permissions',
@@ -54,6 +55,6 @@ describe('initLocalCache - Missing IaC local cache data', () => {
     const promise = localCacheModule.initLocalCache();
 
     expect(fileUtilsModule.extractBundle).not.toHaveBeenCalled();
-    expect(promise).rejects.toThrow(error);
+    expect(promise).rejects.toThrow(FailedToInitLocalCacheError);
   });
 });

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
@@ -105,3 +105,23 @@ export const expectedParsingResultWithoutChildModules: TerraformScanInput = {
   },
   data: {},
 };
+
+const planWithoutRootModule = (JSON.parse(
+  tfPlanFixture.toString(),
+) as unknown) as TerraformPlanJson;
+delete planWithoutRootModule.planned_values;
+export const iacFileDataWithoutRootModule: IacFileData = {
+  fileContent: JSON.stringify(planWithoutRootModule),
+  filePath: 'dont-care',
+  fileType: 'json',
+};
+
+const planWithoutResourceChanges = (JSON.parse(
+  tfPlanFixture.toString(),
+) as unknown) as TerraformPlanJson;
+delete planWithoutResourceChanges.resource_changes;
+export const iacFileDataWithoutResourceChanges: IacFileData = {
+  fileContent: JSON.stringify(planWithoutResourceChanges),
+  filePath: 'dont-care',
+  fileType: 'json',
+};

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
@@ -1,8 +1,15 @@
-import { tryParsingTerraformPlan } from '../../../../src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
+import {
+  tryParsingTerraformPlan,
+  FailedToParseTerraformPlanJsonError,
+  FailedToExtractResourcesInTerraformPlanError,
+  MissingRequiredFieldsInTerraformPlanError,
+} from '../../../../src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
 import {
   iacFileData,
   invalidJsonIacFile,
   iacFileDataNoChildModules,
+  iacFileDataWithoutRootModule,
+  iacFileDataWithoutResourceChanges,
   expectedParsingResultFullScan,
   expectedParsingResultDeltaScan,
   expectedParsingResultWithoutChildModules,
@@ -12,7 +19,7 @@ import { EngineType } from '../../../../src/cli/commands/test/iac-local-executio
 describe('tryParsingTerraformPlan', () => {
   it('throws an error for invalid JSON', () => {
     expect(() => tryParsingTerraformPlan(invalidJsonIacFile)).toThrowError(
-      'Failed to parse Terraform plan JSON file.',
+      FailedToParseTerraformPlanJsonError,
     );
   });
 
@@ -39,6 +46,14 @@ describe('tryParsingTerraformPlan', () => {
         jsonContent: expectedParsingResultWithoutChildModules,
       });
     });
+
+    it('throws an error for missing required fields', () => {
+      expect(() =>
+        tryParsingTerraformPlan(iacFileDataWithoutRootModule, {
+          isFullScan: true,
+        }),
+      ).toThrowError(MissingRequiredFieldsInTerraformPlanError);
+    });
   });
 
   describe('default delta scan', () => {
@@ -49,6 +64,12 @@ describe('tryParsingTerraformPlan', () => {
         engineType: EngineType.Terraform,
         jsonContent: expectedParsingResultDeltaScan,
       });
+    });
+
+    it('throws an error for missing required fields', () => {
+      expect(() =>
+        tryParsingTerraformPlan(iacFileDataWithoutResourceChanges),
+      ).toThrowError(MissingRequiredFieldsInTerraformPlanError);
     });
   });
 

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -51,7 +51,7 @@ Describe "Snyk iac test --experimental command"
     It "outputs an error for files with no valid k8s objects"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-invalid.yaml --experimental
       The status should be failure
-      The output should include "Invalid K8s File!"
+      The output should include "We were unable to detect whether the YAML file"
     End
 
     It "outputs the expected text when running with --sarif flag"
@@ -149,7 +149,7 @@ Describe "Snyk iac test --experimental command"
 
       # Second File
       The output should include "Testing pod-invalid.yaml..."
-      The output should include "Invalid K8s File!"
+      The output should include "Failed to detect Kubernetes file, missing required fields"
     End
   End
 


### PR DESCRIPTION
Co-authored-by: ipapast <ipapast@users.noreply.github.com>

#### What does this PR do?
Adds error types for all potential IaC paths in the new experimental flow that can break.
Each error now has a unique error code that will be visible in analytics and in the debug logs.

Todo:
- [x] Update user messages of all errors.
- [x] Update tests to expect specific error types instead of messages.