### PR TITLE
feat: adds oauth token support for the test command

### DIFF
--- a/src/cli/commands/test/validate-credentials.ts
+++ b/src/cli/commands/test/validate-credentials.ts
@@ -1,11 +1,17 @@
-import { apiTokenExists, getDockerToken } from '../../../lib/api-token';
+import {
+  apiTokenExists,
+  getOAuthToken,
+  getDockerToken,
+} from '../../../lib/api-token';
 import { TestOptions, Options } from '../../../lib/types';
 
-export function validateCredentials(options: Options & TestOptions) {
+export function validateCredentials(options: Options & TestOptions): void {
   try {
     apiTokenExists();
   } catch (err) {
-    if (options.docker && getDockerToken()) {
+    if (getOAuthToken()) {
+      return;
+    } else if (options.docker && getDockerToken()) {
       options.testDepGraphDockerEndpoint = '/docker-jwt/test-dependencies';
       options.isDockerUser = true;
     } else {

--- a/src/lib/api-token.ts
+++ b/src/lib/api-token.ts
@@ -8,6 +8,10 @@ export function api() {
   return config.api || config.TOKEN || userConfig.get('api');
 }
 
+export function getOAuthToken(): string | undefined {
+  return process.env.SNYK_OAUTH_TOKEN;
+}
+
 export function getDockerToken(): string | undefined {
   return process.env.SNYK_DOCKER_TOKEN;
 }
@@ -20,10 +24,15 @@ export function apiTokenExists() {
   return configured;
 }
 
-export function authHeaderWithApiTokenOrDockerJWT() {
-  const dockerToken = getDockerToken();
-  if (dockerToken) {
-    return 'bearer ' + dockerToken;
+export function getAuthHeader(): string {
+  const oauthToken: string | undefined = getOAuthToken();
+  const dockerToken: string | undefined = getDockerToken();
+
+  if (oauthToken) {
+    return `Bearer ${oauthToken}`;
   }
-  return 'token ' + api();
+  if (dockerToken) {
+    return `Bearer ${dockerToken}`;
+  }
+  return `token ${api()}`;
 }

--- a/src/lib/snyk-test/assemble-payloads.ts
+++ b/src/lib/snyk-test/assemble-payloads.ts
@@ -8,7 +8,7 @@ import { Payload } from './types';
 import { assembleQueryString } from './common';
 import spinner = require('../spinner');
 import { findAndLoadPolicyForScanResult } from '../ecosystems/policy';
-import { authHeaderWithApiTokenOrDockerJWT } from '../../lib/api-token';
+import { getAuthHeader } from '../../lib/api-token';
 
 export async function assembleEcosystemPayloads(
   ecosystem: Ecosystem,
@@ -60,7 +60,7 @@ export async function assembleEcosystemPayloads(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: authHeaderWithApiTokenOrDockerJWT(),
+          authorization: getAuthHeader(),
         },
         body: {
           scanResult,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -66,7 +66,7 @@ import {
 import { CallGraphError, CallGraph } from '@snyk/cli-interface/legacy/common';
 import * as alerts from '../alerts';
 import { abridgeErrorMessage } from '../error-format';
-import { authHeaderWithApiTokenOrDockerJWT } from '../api-token';
+import { getAuthHeader } from '../api-token';
 import { getEcosystem } from '../ecosystems';
 import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
@@ -794,7 +794,7 @@ async function assembleLocalPayloads(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: authHeaderWithApiTokenOrDockerJWT(),
+          authorization: getAuthHeader(),
         },
         qs: common.assembleQueryString(options),
         body,

--- a/test/acceptance/docker-token.test.ts
+++ b/test/acceptance/docker-token.test.ts
@@ -78,7 +78,7 @@ test('`snyk test` with docker flag - docker token and no api key', async (t) => 
     const req = server.popRequest();
     t.match(
       req.headers.authorization,
-      'bearer docker-jwt-token',
+      'Bearer docker-jwt-token',
       'sends correct authorization header',
     );
     t.equal(req.method, 'POST', 'makes POST request');

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -127,7 +127,7 @@ export function fakeServer(root, apikey) {
   server.post(root + '/docker-jwt/test-dependencies', (req, res, next) => {
     if (
       req.headers.authorization &&
-      !req.headers.authorization.includes('bearer')
+      !req.headers.authorization.includes('Bearer')
     ) {
       res.send(401);
     }

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -1,0 +1,70 @@
+import {
+  chdirWorkspaces,
+  getWorkspaceJSON,
+} from '../../acceptance/workspace-helper';
+import { fakeServer } from '../../acceptance/fake-server';
+import cli = require('../../../src/cli/commands');
+
+describe('test using OAuth token', () => {
+  let oldkey: string;
+  let oldendpoint: string;
+  const apiKey = '123456789';
+  const port: string = process.env.PORT || process.env.SNYK_PORT || '12345';
+
+  const BASE_API = '/api/v1';
+
+  const server = fakeServer(BASE_API, apiKey);
+
+  const noVulnsResult = getWorkspaceJSON(
+    'fail-on',
+    'no-vulns',
+    'vulns-result.json',
+  );
+
+  beforeAll(async () => {
+    process.env.SNYK_API = `http://localhost:${port}${BASE_API}`;
+    process.env.SNYK_HOST = `http://localhost:${port}`;
+
+    let key = await cli.config('get', 'api');
+    oldkey = key;
+
+    key = await cli.config('get', 'endpoint');
+    oldendpoint = key;
+
+    await new Promise((resolve) => {
+      server.listen(port, resolve);
+    });
+  });
+
+  afterAll(async () => {
+    delete process.env.SNYK_API;
+    delete process.env.SNYK_HOST;
+    delete process.env.SNYK_PORT;
+    delete process.env.SNYK_OAUTH_TOKEN;
+
+    await server.close();
+    let key = 'set';
+    let value = `api=${oldkey}`;
+    if (!oldkey) {
+      key = 'unset';
+      value = 'api';
+    }
+    await cli.config(key, value);
+    if (oldendpoint) {
+      await cli.config('endpoint', oldendpoint);
+    }
+  });
+
+  it('successfully tests a project with an OAuth env variable set', async () => {
+    process.env.SNYK_OAUTH_TOKEN = 'oauth-jwt-token';
+
+    server.setNextResponse(noVulnsResult);
+    chdirWorkspaces('fail-on');
+    await cli.test('no-vulns', {
+      json: true,
+    });
+    const req = server.popRequest();
+    expect(req.headers.authorization).toBe('Bearer oauth-jwt-token');
+    expect(req.method).toBe('POST');
+  });
+});


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support for providing an oauth token as authorization using an environment variable, `SNYK_OAUTH_TOKEN`.

#### How should this be manually tested?

- Get hold of an OAuth access token for your user on the Dev server (Extensibility group can help with that).
- Set an environment variable with your access token, e.g. `export SNYK_OAUTH_TOKEN=mytoken`
- Point the CLI to our oauth endpoint, e.g: `snyk-dev set config endpoint=`snyk-dev config set endpoint=https://api.dev.snyk.io/v1`
- Run a test against a project, e.g: `snyk-dev test`

#### Any background context you want to provide?

We are in the process of providing an OAuth flow into Snyk for third party integrations and partners. Adding OAuth token support to the CLI allows better integration into these workflows so that they can use the same mechanism to connect their systems to Snyk and then perform various commands on projects. We are limiting the implementation to the `test` command for now as this is all that is needed in the short-term and because there are many areas to update the header in the code.
