### PR TITLE
feat: snyk fix --dry-run and --quiet mode

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -216,6 +216,7 @@ export function args(rawArgv: string[]): Args {
     'integration-name',
     'integration-version',
     'prune-repeated-subdependencies',
+    'dry-run',
   ];
   for (const dashedArg of argumentsToTransform) {
     if (argv[dashedArg]) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -187,7 +187,8 @@ export type SupportedUserReachableFacingCliArgs =
   | 'init-script'
   | 'integration-name'
   | 'integration-version'
-  | 'show-vulnerable-paths';
+  | 'show-vulnerable-paths'
+  | 'dry-run';
 
 export enum SupportedCliCommands {
   version = 'version',

--- a/test/jest/unit/lib/commands/fix/__snapshots__/fix.spec.ts.snap
+++ b/test/jest/unit/lib/commands/fix/__snapshots__/fix.spec.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snyk fix (functional tests) shows successful fixes Python requirements.txt project on stdout 1`] = `
+"⠋ ⠋ ℹ Running \`snyk test\` for 
+⠋ Looking for supported Python items✔ Looking for supported Python items
+⠋ Processing 1 requirements.txt items.✔ Processing 1 requirements.txt items.
+⠋ ✔ Done
+"
+`;

--- a/test/jest/unit/lib/commands/fix/__snapshots__/fix.spec.ts.snap
+++ b/test/jest/unit/lib/commands/fix/__snapshots__/fix.spec.ts.snap
@@ -1,9 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`snyk fix (functional tests) shows successful fixes Python requirements.txt project on stdout 1`] = `
-"⠋ ⠋ ℹ Running \`snyk test\` for 
-⠋ Looking for supported Python items✔ Looking for supported Python items
-⠋ Processing 1 requirements.txt items.✔ Processing 1 requirements.txt items.
-⠋ ✔ Done
-"
-`;

--- a/test/jest/unit/lib/commands/fix/fix.spec.ts
+++ b/test/jest/unit/lib/commands/fix/fix.spec.ts
@@ -1,5 +1,6 @@
 import * as pathLib from 'path';
 import * as fs from 'fs';
+import * as snykFix from '@snyk/fix';
 
 import cli = require('../../../../../../src/cli/commands');
 import * as snyk from '../../../../../../src/lib';
@@ -51,11 +52,21 @@ const pipWithRemediation = JSON.parse(
 
 describe('snyk fix (functional tests)', () => {
   let origStdWrite;
+  let snykFixSpy: jest.SpyInstance;
+
   beforeAll(async () => {
     origStdWrite = process.stdout.write;
     jest
       .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
       .mockResolvedValue({ ok: true });
+  });
+
+  beforeEach(() => {
+    snykFixSpy = jest.spyOn(snykFix, 'fix');
+  });
+
+  afterEach(() => {
+    snykFixSpy.mockClear();
   });
 
   afterAll(async () => {
@@ -65,15 +76,11 @@ describe('snyk fix (functional tests)', () => {
   it(
     'shows successful fixes Python requirements.txt project was fixed via --file',
     async () => {
-      // read data from console.log
       let stdoutMessages = '';
-      let stderrMessages = '';
-      jest
-        .spyOn(console, 'log')
-        .mockImplementation((msg: string) => (stdoutMessages += msg));
-      jest
-        .spyOn(console, 'error')
-        .mockImplementation((msg: string) => (stderrMessages += msg));
+      process.stdout.write = (str) => {
+        stdoutMessages += str;
+        return true;
+      };
 
       jest.spyOn(snyk, 'test').mockResolvedValue({
         ...pipWithRemediation,
@@ -85,45 +92,19 @@ describe('snyk fix (functional tests)', () => {
         dryRun: true, // prevents write to disc
         quiet: true,
       });
-      expect(stripAnsi(res)).toMatch('✔ Upgraded Jinja2 from 2.7.2 to 2.11.3');
-      expect(stdoutMessages).toEqual('');
-      expect(stderrMessages).toEqual('');
-    },
-    testTimeout,
-  );
-  it(
-    'shows successful fixes Python requirements.txt project was fixed via --file',
-    async () => {
-      // read data from console.log
-      let stdoutMessages = '';
-      let stderrMessages = '';
-      jest
-        .spyOn(console, 'log')
-        .mockImplementation((msg: string) => (stdoutMessages += msg));
-      jest
-        .spyOn(console, 'error')
-        .mockImplementation((msg: string) => (stderrMessages += msg));
-
-      jest.spyOn(snyk, 'test').mockResolvedValue({
-        ...pipWithRemediation,
-        // pip plugin does not return targetFile, instead fix will fallback to displayTargetFile
-        displayTargetFile: pipRequirementsTxt,
-      });
-      const res = await cli.fix('.', {
-        file: pipRequirementsTxt,
-        dryRun: true, // prevents write to disc
+      expect(snykFixSpy).toHaveBeenCalledTimes(1);
+      expect(snykFixSpy.mock.calls[0][1]).toEqual({
+        dryRun: true,
         quiet: true,
       });
       expect(stripAnsi(res)).toMatch('✔ Upgraded Jinja2 from 2.7.2 to 2.11.3');
       expect(stdoutMessages).toEqual('');
-      expect(stderrMessages).toEqual('');
     },
     testTimeout,
   );
   it(
     'shows successful fixes Python requirements.txt project on stdout',
     async () => {
-      // read data from console.log
       let stdoutMessages = '';
       process.stdout.write = (str) => {
         stdoutMessages += str;
@@ -138,8 +119,14 @@ describe('snyk fix (functional tests)', () => {
         file: pipRequirementsTxt,
         dryRun: true, // prevents write to disc
       });
+      expect(snykFixSpy).toHaveBeenCalledTimes(1);
+      expect(snykFixSpy.mock.calls[0][1]).toEqual({
+        dryRun: true,
+      });
       expect(stripAnsi(res)).toMatch('✔ Upgraded Jinja2 from 2.7.2 to 2.11.3');
-      expect(stripAnsi(stdoutMessages)).toMatchSnapshot();
+      expect(stripAnsi(stdoutMessages)).toMatch(
+        '✔ Looking for supported Python items',
+      );
     },
     testTimeout,
   );
@@ -165,6 +152,11 @@ describe('snyk fix (functional tests)', () => {
         file: pipRequirementsCustomTxt,
         packageManager: 'pip',
         dryRun: true, // prevents write to disc
+        quiet: true,
+      });
+      expect(snykFixSpy).toHaveBeenCalledTimes(1);
+      expect(snykFixSpy.mock.calls[0][1]).toEqual({
+        dryRun: true,
         quiet: true,
       });
       expect(stripAnsi(res)).toMatch('✔ Upgraded Jinja2 from 2.7.2 to 2.11.3');
@@ -199,6 +191,11 @@ describe('snyk fix (functional tests)', () => {
         dryRun: true, // prevents write to disc
         quiet: true,
       });
+      expect(snykFixSpy.mock.calls[0][1]).toEqual({
+        dryRun: true,
+        quiet: true,
+      });
+      expect(snykFixSpy).toHaveBeenCalledTimes(1);
       expect(stripAnsi(res)).toMatch('✔ Upgraded Jinja2 from 2.7.2 to 2.11.3');
       // only use ora to output
       expect(stdoutMessages).toEqual('');
@@ -233,6 +230,11 @@ describe('snyk fix (functional tests)', () => {
       } catch (error) {
         res = error;
       }
+      expect(snykFixSpy).toHaveBeenCalledTimes(1);
+      expect(snykFixSpy.mock.calls[0][1]).toEqual({
+        dryRun: true,
+        quiet: true,
+      });
       expect(stripAnsi(res.message)).toMatch('No successful fixes');
       expect(stdoutMessages).toEqual('');
       expect(stderrMessages).toEqual('');


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Expose `---dry-run` as a `snyk fix` parameter. No help text while this is in Beta.
Update existing tests to ensure both `dryRun` and `quiet` get passed though to the `@snyk/fix` package


#### Any background context you want to provide?
Relies on https://github.com/snyk/snyk/pull/1785 being merged that moves the tests
