### PR TITLE
chore: setup devcontainer for vscode

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# https://github.com/microsoft/vscode-dev-containers/tree/master/containers/javascript-node
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-14
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends jq vim
+
+RUN su node -c "curl -fsSL https://git.io/shellspec | sh -s -- --yes"
+RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm alias default system"
+RUN su node -c "npm install -g npm@7"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// https://code.visualstudio.com/docs/remote/devcontainerjson-reference
+{
+	"name": "Node.js",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"esbenp.prettier-vscode",
+		"ms-vsliveshare.vsliveshare",
+		"eamodio.gitlens",
+		"jasonnutter.vscode-codeowners"
+	],
+	"postCreateCommand": "npm install && sudo ./test/smoke/setup-alias-for-snyk.sh",
+	"remoteUser": "node",
+	"remoteEnv": {
+		"SNYK_API_TOKEN": "${localEnv:SNYK_TEST_TOKEN}"
+	}
+}


### PR DESCRIPTION
#### What does this PR do?

Thought I'd share my VS Code `.devcontainer`. e.g. if we wanted it for quick setup / on-boarding.

I'm using this to avoid messing up my laptop environment where I want to use production applications and avoid mixing in various dev builds (e.g. using snyk instead of a symlink to a dev build) and messing up my snyk config during test runs.

You'll need Docker running and also [Remote Extensions for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack). VS Code will automatically build and start in a container when you open the repo.

You'll need a `SNYK_TEST_TOKEN` in your environment (similar to snyk-maven-plugin) which will get pulled in by the container for smoke tests.

For more info on how it works, check out the [extension docs](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).