### PR TITLE
fix: standardize pip package names

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
@@ -21,6 +21,7 @@ import {
   ParsedRequirements,
   parseRequirementsFile,
 } from './update-dependencies/requirements-file-parser';
+import { standardizePackageName } from './update-dependencies/standardize-package-name';
 
 const debug = debugLib('snyk-fix:python:requirements.txt');
 
@@ -208,11 +209,19 @@ function filterOutAppliedUpgrades(
     pin: {}, // delete the pin remediation so we can collect un-applied remediation
   };
   const pins = remediation.pin;
-  const lowerCasedAppliedRemediation = appliedRemediation.map((i) =>
-    i.toLowerCase(),
+  const normalizedAppliedRemediation = appliedRemediation.map(
+    (packageAtVersion) => {
+      const [pkgName, versionAndMore] = packageAtVersion.split('@');
+      return `${standardizePackageName(pkgName)}@${versionAndMore}`;
+    },
   );
   for (const pkgAtVersion of Object.keys(pins)) {
-    if (!lowerCasedAppliedRemediation.includes(pkgAtVersion.toLowerCase())) {
+    const [pkgName, versionAndMore] = pkgAtVersion.split('@');
+    if (
+      !normalizedAppliedRemediation.includes(
+        `${standardizePackageName(pkgName)}@${versionAndMore}`,
+      )
+    ) {
       pinRemediation.pin[pkgAtVersion] = pins[pkgAtVersion];
     }
   }

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-pins.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-pins.ts
@@ -2,6 +2,7 @@ import { DependencyPins, FixChangesSummary } from '../../../../../types';
 import { calculateRelevantFixes } from './calculate-relevant-fixes';
 import { isDefined } from './is-defined';
 import { Requirement } from './requirements-file-parser';
+import { standardizePackageName } from './standardize-package-name';
 
 export function generatePins(
   requirements: Requirement[],
@@ -14,13 +15,13 @@ export function generatePins(
   // Lowercase the upgrades object. This might be overly defensive, given that
   // we control this input internally, but its a low cost guard rail. Outputs a
   // mapping of upgrade to -> from, instead of the nested upgradeTo object.
-  const lowerCasedPins = calculateRelevantFixes(
+  const standardizedPins = calculateRelevantFixes(
     requirements,
     updates,
     'transitive-pins',
   );
 
-  if (Object.keys(lowerCasedPins).length === 0) {
+  if (Object.keys(standardizedPins).length === 0) {
     return {
       pinnedRequirements: [],
       changes: [],
@@ -29,14 +30,18 @@ export function generatePins(
   }
   const appliedRemediation: string[] = [];
   const changes: FixChangesSummary[] = [];
-  const pinnedRequirements = Object.keys(lowerCasedPins)
+  const pinnedRequirements = Object.keys(standardizedPins)
     .map((pkgNameAtVersion) => {
       const [pkgName, version] = pkgNameAtVersion.split('@');
-      const newVersion = lowerCasedPins[pkgNameAtVersion].split('@')[1];
-      const newRequirement = `${pkgName}>=${newVersion}`;
+      const newVersion = standardizedPins[pkgNameAtVersion].split('@')[1];
+      const newRequirement = `${standardizePackageName(
+        pkgName,
+      )}>=${newVersion}`;
       changes.push({
         success: true,
-        userMessage: `Pinned ${pkgName} from ${version} to ${newVersion}`,
+        userMessage: `Pinned ${standardizePackageName(
+          pkgName,
+        )} from ${version} to ${newVersion}`,
       });
       appliedRemediation.push(pkgNameAtVersion);
       return `${newRequirement} # not directly required, pinned by Snyk to avoid a vulnerability`;

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-upgrades.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/generate-upgrades.ts
@@ -1,6 +1,7 @@
 import { DependencyPins, FixChangesSummary } from '../../../../../types';
 import { calculateRelevantFixes } from './calculate-relevant-fixes';
 import { Requirement } from './requirements-file-parser';
+import { standardizePackageName } from './standardize-package-name';
 import { UpgradedRequirements } from './types';
 
 export function generateUpgrades(
@@ -52,10 +53,15 @@ export function generateUpgrades(
 
       // Check if we have an upgrade; if we do, replace the version string with
       // the upgrade, but keep the rest of the content
-      const upgrade = Object.keys(
-        lowerCasedUpgrades,
-      ).filter((packageVersionUpgrade: string) =>
-        packageVersionUpgrade.startsWith(`${name.toLowerCase()}@${version}`),
+      const upgrade = Object.keys(lowerCasedUpgrades).filter(
+        (packageVersionUpgrade: string) => {
+          const [pkgName, versionAndMore] = packageVersionUpgrade.split('@');
+          return `${standardizePackageName(
+            pkgName,
+          )}@${versionAndMore}`.startsWith(
+            `${standardizePackageName(name)}@${version}`,
+          );
+        },
       )[0];
 
       if (!upgrade) {

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/requirements-file-parser.ts
@@ -1,4 +1,5 @@
 import * as debugLib from 'debug';
+import { standardizePackageName } from './standardize-package-name';
 
 const debug = debugLib('snyk-fix:python:requirements-file-parser');
 
@@ -62,10 +63,10 @@ function extractDependencyDataFromLine(
 
     // Regex to match against a Python package specifier. Any invalid lines (or
     // lines we can't handle) should have been returned this point.
-    const regex = /([A-Z0-9]*)(!=|===|==|>=|<=|>|<|~=)(\d*\.?\d*\.?\d*[A-Z0-9]*)(.*)/i;
+    const regex = /([A-Z0-9-._]*)(!=|===|==|>=|<=|>|<|~=)(\d*\.?\d*\.?\d*[A-Z0-9]*)(.*)/i;
     const result = regex.exec(requirementText);
     if (result !== null) {
-      requirement.name = result[1].toLowerCase();
+      requirement.name = standardizePackageName(result[1]);
       requirement.originalName = result[1];
       requirement.versionComparator = result[2] as VersionComparator;
       requirement.version = result[3];

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/standardize-package-name.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/standardize-package-name.ts
@@ -1,0 +1,9 @@
+/*
+ * https://www.python.org/dev/peps/pep-0426/#name
+ * All comparisons of distribution names MUST be case insensitive,
+ * and MUST consider hyphens and underscores to be equivalent.
+ *
+*/
+export function standardizePackageName(name: string): string {
+  return name.replace('_', '-').toLowerCase();
+}

--- a/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
@@ -182,6 +182,13 @@ describe('fix *req*.txt / *.txt Python projects', () => {
             vulns: [],
             isTransitive: true,
           },
+          // in the manifest it is Clickhouse_Driver
+          // but package name on Pypi is clickhouse-driver
+          'clickhouse-driver@0.1.4': {
+            upgradeTo: 'clickhouse-driver@0.1.5',
+            vulns: [],
+            isTransitive: true,
+          },
         },
       },
     };
@@ -200,7 +207,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
 
     // Assert
     const expectedManifest =
-      'Django==2.0.1\ntransitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability\n';
+      'Django==2.0.1\nClickhouse_Driver==0.1.5\nclickhouse-driver==0.1.5\ntransitive>=1.1.1 # not directly required, pinned by Snyk to avoid a vulnerability\n';
     // Note no extra newline was added to the expected manifest
     const fixedFileContent = fs.readFileSync(fixedFilePath, 'utf-8');
     expect(fixedFileContent).toEqual(expectedManifest);
@@ -217,6 +224,14 @@ describe('fix *req*.txt / *.txt Python projects', () => {
                 {
                   success: true,
                   userMessage: 'Upgraded Django from 1.6.1 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Upgraded Clickhouse_Driver from 0.1.4 to 0.1.5',
+                },
+                {
+                  success: true,
+                  userMessage: 'Upgraded clickhouse-driver from 0.1.4 to 0.1.5',
                 },
                 {
                   success: true,

--- a/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/workspaces/basic-with-newline/prod.txt
+++ b/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/workspaces/basic-with-newline/prod.txt
@@ -1,1 +1,3 @@
 Django==1.6.1
+Clickhouse_Driver==0.1.4
+clickhouse-driver==0.1.4

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/standardize-package-name.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/update-dependencies/standardize-package-name.spec.ts
@@ -1,0 +1,16 @@
+import { standardizePackageName } from '../../../../../../src/plugins/python/handlers/pip-requirements/update-dependencies/standardize-package-name';
+
+describe('standardizePackageName', () => {
+  it('lowercases as expected', () => {
+    const name = standardizePackageName('Django');
+    expect(name).toEqual('django');
+  });
+  it('replaces _  as expected', () => {
+    const name = standardizePackageName('clickhouse_driver');
+    expect(name).toEqual('clickhouse-driver');
+  });
+  it('works on package@version', () => {
+    const name = standardizePackageName('clickhouse_driver@0.1.4');
+    expect(name).toEqual('clickhouse-driver@0.1.4');
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Standadrize pip package names to adhere to docs: https://www.python.org/dev/peps/pep-0426/#name
> All comparisons of distribution names MUST be case insensitive, and MUST consider hyphens and underscores to be equivalent.

#### Where should the reviewer start?
packages/snyk-fix/src/plugins/python/handlers/pip-requirements/update-dependencies/standardize-package-name.ts
