### PR TITLE
refactor: Scanning Helm files for iac test fails [CC-768]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -16,8 +16,8 @@ import { CustomError } from '../../../../lib/errors';
 export async function parseFiles(
   filesData: IacFileData[],
 ): Promise<ParsingResults> {
-  const parsedFiles: Array<IacFileParsed> = [];
-  const failedFiles: Array<IacFileParseFailure> = [];
+  const parsedFiles: IacFileParsed[] = [];
+  const failedFiles: IacFileParseFailure[] = [];
   for (const fileData of filesData) {
     try {
       parsedFiles.push(...tryParseIacFile(fileData));
@@ -52,11 +52,12 @@ function generateFailedParsedFile(
 
 const TF_PLAN_NAME = 'tf-plan.json';
 
-export function tryParseIacFile(fileData: IacFileData): Array<IacFileParsed> {
+export function tryParseIacFile(fileData: IacFileData): IacFileParsed[] {
   analytics.add('iac-terraform-plan', false);
   switch (fileData.fileType) {
     case 'yaml':
     case 'yml':
+      return tryParsingKubernetesFile(fileData);
     case 'json':
       // TODO: this is a temporary approach for the internal release only
       if (path.basename(fileData.filePath) === TF_PLAN_NAME) {

--- a/src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser.ts
@@ -2,17 +2,30 @@ import * as YAML from 'js-yaml';
 import { CustomError } from '../../../../../lib/errors';
 import {
   EngineType,
-  IacFileParsed,
-  IacFileData,
   IaCErrorCodes,
+  IacFileData,
+  IacFileParsed,
 } from '../types';
 
 const REQUIRED_K8S_FIELDS = ['apiVersion', 'kind', 'metadata'];
+
+export function assertHelmAndThrow(fileData: IacFileData) {
+  const lines: string[] = fileData.fileContent.split(/\r\n|\r|\n/);
+
+  lines.forEach((line) => {
+    const isHelmFile = line.includes('{{') && line.includes('}}');
+    if (isHelmFile) {
+      throw new HelmFileNotSupportedError(fileData.filePath);
+    }
+  });
+}
 
 export function tryParsingKubernetesFile(
   fileData: IacFileData,
 ): IacFileParsed[] {
   let yamlDocuments;
+
+  assertHelmAndThrow(fileData);
   try {
     yamlDocuments = YAML.safeLoadAll(fileData.fileContent);
   } catch (e) {
@@ -44,6 +57,15 @@ class FailedToParseKubernetesYamlError extends CustomError {
     this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML`;
   }
 }
+
+export class HelmFileNotSupportedError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse Helm file');
+    this.code = IaCErrorCodes.FailedToParseHelmError;
+    this.userMessage = `We were unable to parse the YAML file "${filename}" as we currently do not support scanning of Helm files. More information can be found through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool`;
+  }
+}
+
 export class MissingRequiredFieldsInKubernetesYamlError extends CustomError {
   constructor(filename: string) {
     super('Failed to detect Kubernetes file, missing required fields');

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -180,6 +180,7 @@ export enum IaCErrorCodes {
   // kubernetes-parser errors
   FailedToParseKubernetesYamlError = 1030,
   MissingRequiredFieldsInKubernetesYamlError = 1031,
+  FailedToParseHelmError = 1032,
 
   // terraform-file-parser errors
   FailedToParseTerraformFileError = 1040,

--- a/test/fixtures/iac/kubernetes/helm-config.yaml
+++ b/test/fixtures/iac/kubernetes/helm-config.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.svc.myapp }}
+  labels:
+    app: {{ template "myapp.name" . }}
+    chart: {{ template "myapp.chart" . }}
+    release: {{ .Release.Name }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http

--- a/test/jest/unit/iac-unit-tests/file-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.spec.ts
@@ -1,8 +1,13 @@
+import * as fileParser from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
 import {
   parseFiles,
   UnsupportedFileTypeError,
 } from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
-import * as fileParser from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
+import * as k8sParser from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
+import {
+  HelmFileNotSupportedError,
+  MissingRequiredFieldsInKubernetesYamlError,
+} from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
 import {
   expectedInvalidK8sFileParsingResult,
   expectedKubernetesParsingResult,
@@ -11,12 +16,14 @@ import {
   kubernetesFileDataStub,
   terraformFileDataStub,
 } from './file-parser.fixtures';
-import { MissingRequiredFieldsInKubernetesYamlError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
 import { IacFileData } from '../../../../src/cli/commands/test/iac-local-execution/types';
+import { tryParsingKubernetesFile } from '../../../../dist/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
 import { IacFileTypes } from '../../../../dist/lib/iac/constants';
-import { UnsupportedError } from 'snyk-nodejs-lockfile-parser/dist/errors';
-import * as fileLoader from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
-import { FailedToLoadFileError } from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
+import {
+  MissingRequiredFieldsInTerraformPlanError,
+  tryParsingTerraformPlan,
+} from '../../../../src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
+import { iacFileDataWithoutResourceChanges } from './terraform-plan-parser.fixtures';
 
 const filesToParse: IacFileData[] = [
   kubernetesFileDataStub,
@@ -62,5 +69,17 @@ describe('parseFiles', () => {
     ]);
 
     await expect(parseFilesFn).rejects.toThrow(UnsupportedFileTypeError);
+  });
+
+  it('throws an error for a Helm file', async () => {
+    const helmFileData: IacFileData = {
+      fileContent: ' {{ something }}',
+      filePath: 'path/to/file',
+      fileType: 'yaml',
+    };
+
+    expect(() => tryParsingKubernetesFile(helmFileData)).toThrowError(
+      'Failed to parse Helm file',
+    );
   });
 });

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -54,6 +54,13 @@ Describe "Snyk iac test --experimental command"
       The output should include "We were unable to detect whether the YAML file"
     End
 
+    It "outputs an error for Helm files"
+      When run snyk iac test ../fixtures/iac/kubernetes/helm-config.yaml --experimental
+      The status should be failure
+      The output should include "We were unable to parse the YAML file"
+      The output should include "do not support scanning of Helm files"
+    End
+
     It "outputs the expected text when running with --sarif flag"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml --experimental --sarif
       The status should be failure


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fixes the issue where YAML Helm files were scanned incorrectly. 
Instead, we now check if a yaml file contains a template and throw a `HelmFileNotSupportedError` error on that case.

We also add a new smoke test case and a new unit test case.

#### Where should the reviewer start?
In the `parser.ts`:
-  we now have a validateYamlFile function for the 'yml' and 'yaml' cases. 
- This function will get the fileContent, split it by line and create an array of strings (every line is a new string).
- Then, we check if there is a template, line by line. A template is considered a line that has both `{{` and `}}` chars.
- The moment we detect a template, we throw a `HelmFileNotSupportedError` with a useful user error message and a new error code.

#### How should this be manually tested?
- Run `node ~/snyk-repos/snyk/dist/cli iac test test/fixtures/iac/kubernetes/helm-unsupported.yaml --experimental` to see a Helm file failing.


#### Any background context you want to provide?
We do not support scanning of Helm files via the CLI, thus it should fail gracefully.

#### What are the relevant tickets?

[CC-768]
#### Screenshots

![image](https://user-images.githubusercontent.com/6989529/113313605-4ebb1300-9303-11eb-9623-461625db4fe9.png)



[CC-768]: https://snyksec.atlassian.net/browse/CC-768