### PR TITLE
fix: improved error messages in elixir

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",
     "@snyk/snyk-cocoapods-plugin": "2.5.2",
-    "@snyk/snyk-hex-plugin": "1.0.0",
+    "@snyk/snyk-hex-plugin": "1.0.1",
     "abbrev": "^1.1.1",
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
Error messages regarding missing "mix" and "hex" packages improved.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules