### PR TITLE
fix: display current folder instead of . for fix

### DIFF
--- a/src/cli/commands/fix/get-display-path.ts
+++ b/src/cli/commands/fix/get-display-path.ts
@@ -7,7 +7,7 @@ export function getDisplayPath(path: string): string {
     return path;
   }
   if (path === process.cwd()) {
-    return '.';
+    return pathLib.parse(path).name;
   }
   return pathLib.relative(process.cwd(), path);
 }

--- a/test/jest/unit/lib/commands/fix/get-display-path.spec.ts
+++ b/test/jest/unit/lib/commands/fix/get-display-path.spec.ts
@@ -1,5 +1,5 @@
 import * as pathLib from 'path';
-import { getDisplayPath } from '../src/cli/commands/fix/get-display-path';
+import { getDisplayPath } from '../../../../../../src/cli/commands/fix/get-display-path';
 
 describe('getDisplayPath', () => {
   it('paths that do not exist on disk returned as is', () => {
@@ -8,7 +8,7 @@ describe('getDisplayPath', () => {
   });
   it('current path is displayed as .', () => {
     const displayPath = getDisplayPath(process.cwd());
-    expect(displayPath).toEqual('.');
+    expect(displayPath).toEqual('snyk');
   });
   it('a local path is returned as relative path to current dir', () => {
     const displayPath = getDisplayPath(`test${pathLib.sep}fixtures`);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Instead of displaying `.` for current directory show directory name being tested similar to `snyk test` command.

#### Screenshots

**Before**:
<img width="560" alt="CleanShot 2021-04-07 at 18 21 58@2x" src="https://user-images.githubusercontent.com/2911613/113908187-297c4800-97ce-11eb-8543-a4eac982ae38.png">

**After**:
<img width="768" alt="CleanShot 2021-04-07 at 17 46 55@2x" src="https://user-images.githubusercontent.com/2911613/113907537-65fb7400-97cd-11eb-8bf0-e8b3bf08caad.png">

#### Additional questions
