### PR TITLE
feat: include full path to files to match targetFiles

### DIFF
--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -22,7 +22,7 @@ export async function showResultsSummary(
     resultsByPlugin,
     exceptionsByScanType,
   );
-  return `${successfulFixesSummary}${
+  return `\n${successfulFixesSummary}${
     unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
   }\n\n${overallSummary}`;
 }

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
@@ -95,7 +95,7 @@ async function fixAll(
     try {
       const { dir, base } = pathLib.parse(targetFile);
       // parse & join again to support correct separator
-      if (fixedCache.includes(pathLib.join(dir, base))) {
+      if (fixedCache.includes(pathLib.normalize(pathLib.join(dir, base)))) {
         handlerResult.succeeded.push({
           original: entity,
           changes: [{ success: true, userMessage: 'Previously fixed' }],
@@ -127,12 +127,14 @@ export async function fixIndividualRequirementsTxt(
   options: FixOptions,
   directUpgradesOnly: boolean,
 ): Promise<{ changes: FixChangesSummary[]; appliedRemediation: string[] }> {
-  const fullFilePath = pathLib.join(dir, fileName);
+  const fullFilePath = pathLib.normalize(pathLib.join(dir, fileName));
   const { updatedManifest, changes, appliedRemediation } = updateDependencies(
     parsedRequirements,
     remediation.pin,
     directUpgradesOnly,
-    pathLib.join(dir, entryFileName) !== fullFilePath ? fileName : undefined,
+    pathLib.normalize(pathLib.join(dir, entryFileName)) !== fullFilePath
+      ? fullFilePath
+      : undefined,
   );
 
   if (!changes.length) {
@@ -176,7 +178,7 @@ export async function applyAllFixes(
     );
     appliedUpgradeRemediation.push(...appliedRemediation);
     upgradeChanges.push(...changes);
-    fixedFiles.push(pathLib.join(dir, fileName));
+    fixedFiles.push(pathLib.normalize(pathLib.join(dir, fileName)));
   }
 
   /* Apply all left over remediation as pins in the entry targetFile */

--- a/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -1,26 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fix *req*.txt / *.txt Python projects fixes multiple files that are included via -r 1`] = `
-Array [
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Django from 1.6.1 to 2.0.1",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in base2.txt)",
-  },
-]
-`;
-
 exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -c & -r with the same name (some were already fixed) 1`] = `
-"Successful fixes:
+"
+Successful fixes:
 
   app-with-constraints/requirements.txt
   ✔ Upgraded Django from 1.6.1 to 2.0.1
-  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in constraints.txt)
-  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in lib/requirements.txt)
-  ✔ Pinned transitive from 1.0.1 to 2.0.1 (pinned in constraints.txt)
+  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in app-with-constraints/constraints.txt)
+  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in app-with-constraints/lib/requirements.txt)
+  ✔ Pinned transitive from 1.0.1 to 2.0.1 (pinned in app-with-constraints/constraints.txt)
 
   app-with-constraints/lib/requirements.txt
   ✔ Previously fixed
@@ -31,43 +19,14 @@ Summary:
   2 items were successfully fixed"
 `;
 
-exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -c & -r with the same name (some were already fixed) 2`] = `
-Array [
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Django from 1.6.1 to 2.0.1",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Django from 1.6.1 to 2.0.1 (upgraded in constraints.txt)",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in lib/requirements.txt)",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Pinned transitive from 1.0.1 to 2.0.1 (pinned in constraints.txt)",
-  },
-]
-`;
-
-exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -c & -r with the same name (some were already fixed) 3`] = `
-Array [
-  Object {
-    "success": true,
-    "userMessage": "Previously fixed",
-  },
-]
-`;
-
 exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -r with the same name (some were already fixed) 1`] = `
-"Successful fixes:
+"
+Successful fixes:
 
   app-with-already-fixed/requirements.txt
   ✔ Upgraded Django from 1.6.1 to 2.0.1
-  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in core/requirements.txt)
-  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in lib/requirements.txt)
+  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in app-with-already-fixed/core/requirements.txt)
+  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in app-with-already-fixed/lib/requirements.txt)
 
   app-with-already-fixed/core/requirements.txt
   ✔ Previously fixed
@@ -79,23 +38,6 @@ Summary:
 
   0 items were not fixed
   3 items were successfully fixed"
-`;
-
-exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -r with the same name (some were already fixed) 2`] = `
-Array [
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Django from 1.6.1 to 2.0.1",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Django from 1.6.1 to 2.0.1 (upgraded in core/requirements.txt)",
-  },
-  Object {
-    "success": true,
-    "userMessage": "Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in lib/requirements.txt)",
-  },
-]
 `;
 
 exports[`fix *req*.txt / *.txt Python projects retains python markers 1`] = `

--- a/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/update-dependencies/update-dependencies.spec.ts
@@ -828,7 +828,17 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     // 2 files needed to have changes
     expect(writeFileSpy).toHaveBeenCalledTimes(2);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix);
-    expect(result.results.python.succeeded[0].changes).toMatchSnapshot();
+    const basePath = pathLib.normalize('pip-app/base2.txt');
+    expect(result.results.python.succeeded[0].changes).toEqual([
+      {
+        success: true,
+        userMessage: 'Upgraded Django from 1.6.1 to 2.0.1',
+      },
+      {
+        success: true,
+        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${basePath})`,
+      },
+    ]);
   });
   it('fixes multiple files via -r with the same name (some were already fixed)', async () => {
     // Arrange
@@ -942,10 +952,30 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     expect(libRequirements).toEqual(ExpectedLibRequirements);
     expect(coreRequirements).toEqual(expectedCoreRequirements);
     // 3 files needed to have changes
-    expect(result.fixSummary).toMatchSnapshot();
+    expect(result.fixSummary.replace(/\\/g, '/')).toMatchSnapshot();
     expect(writeFileSpy).toHaveBeenCalledTimes(3);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix1);
-    expect(result.results.python.succeeded[0].changes).toMatchSnapshot();
+
+    const coreRequirementsPath = pathLib.normalize(
+      'app-with-already-fixed/core/requirements.txt',
+    );
+    const libRequirementsPath = pathLib.normalize(
+      'app-with-already-fixed/lib/requirements.txt',
+    );
+    expect(result.results.python.succeeded[0].changes).toEqual([
+      {
+        success: true,
+        userMessage: 'Upgraded Django from 1.6.1 to 2.0.1',
+      },
+      {
+        success: true,
+        userMessage: `Upgraded Django from 1.6.1 to 2.0.1 (upgraded in ${coreRequirementsPath})`,
+      },
+      {
+        success: true,
+        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${libRequirementsPath})`,
+      },
+    ]);
   });
   it('fixes multiple files via -c & -r with the same name (some were already fixed)', async () => {
     // Arrange
@@ -1054,13 +1084,43 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     expect(requirements).toEqual(expectedRequirements);
     expect(libRequirements).toEqual(ExpectedLibRequirements);
     expect(constraints).toEqual(expectedConstraints);
-    expect(result.fixSummary).toMatchSnapshot();
+    expect(result.fixSummary.replace(/\\/g, '/')).toMatchSnapshot();
     // 3 files with upgrades + 1 more to apply pins
     expect(writeFileSpy).toHaveBeenCalledTimes(4);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix1);
     expect(result.results.python.succeeded[1].original).toEqual(entityToFix2);
-    expect(result.results.python.succeeded[0].changes).toMatchSnapshot();
-    expect(result.results.python.succeeded[1].changes).toMatchSnapshot();
+
+    const constraintsPath = pathLib.normalize(
+      'app-with-constraints/constraints.txt',
+    );
+    const libRequirementsPath = pathLib.normalize(
+      'app-with-constraints/lib/requirements.txt',
+    );
+
+    expect(result.results.python.succeeded[0].changes).toEqual([
+      {
+        success: true,
+        userMessage: 'Upgraded Django from 1.6.1 to 2.0.1',
+      },
+      {
+        success: true,
+        userMessage: `Upgraded Django from 1.6.1 to 2.0.1 (upgraded in ${constraintsPath})`,
+      },
+      {
+        success: true,
+        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${libRequirementsPath})`,
+      },
+      {
+        success: true,
+        userMessage: `Pinned transitive from 1.0.1 to 2.0.1 (pinned in ${constraintsPath})`,
+      },
+    ]);
+    expect(result.results.python.succeeded[1].changes).toEqual([
+      {
+        success: true,
+        userMessage: 'Previously fixed',
+      },
+    ]);
   });
 });
 

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -57,7 +57,8 @@ Object {
       "userMessage": "npm is not supported.",
     },
   },
-  "fixSummary": "✖ No successful fixes
+  "fixSummary": "
+✖ No successful fixes
 
 Unresolved items:
 
@@ -79,7 +80,8 @@ Summary:
 exports[`Error handling Snyk fix returns error when manifest can not be parsed 1`] = `
 Object {
   "exceptions": Object {},
-  "fixSummary": "Successful fixes:
+  "fixSummary": "
+Successful fixes:
 
   requirements.txt
   ✔ Pinned django from 1.6.1 to 2.0.1
@@ -162,7 +164,8 @@ Summary:
 exports[`Snyk fix Snyk fix returns results for supported & unsupported type 1`] = `
 Object {
   "exceptions": Object {},
-  "fixSummary": "Successful fixes:
+  "fixSummary": "
+Successful fixes:
 
   requirements.txt
   ✔ Upgraded django from 1.6.1 to 2.0.1

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -46,7 +46,8 @@ exports[`generateUnresolvedSummary has failed, skipped & plugin errors 1`] = `
 `;
 
 exports[`showResultsSummary has failed, skipped, successful & plugin errors 1`] = `
-"Successful fixes:
+"
+Successful fixes:
 
   requirements.txt
   ✔ Upgraded Django from 1.6.1 to 2.0.1


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Tweak the user output slightly:
- remove extra `.`
- add extra space before the `Successful Fixes title`
- show the extra folder in the changes messages so the manifest names match always