### PR TITLE
fix: JSON output for IaC shows line number [CC-680]

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
+    "@snyk/cloud-config-parser": "^1.9.2",
     "@snyk/code-client": "3.4.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "1.518.0",

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -196,4 +196,5 @@ export enum IaCErrorCodes {
 
   // results-formatter errors
   FailedToFormatResults = 1070,
+  FailedToExtractLineNumberError = 1071,
 }

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -71,7 +71,7 @@ export const expectedFormattedResults = {
           resolve: anotherPolicyStub.resolve,
         },
         severity: anotherPolicyStub.severity,
-        lineNumber: -1,
+        lineNumber: 3,
       },
     ],
   },

--- a/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
@@ -4,9 +4,13 @@ import {
   expectedFormattedResults,
   scanResults,
 } from './results-formatter.fixtures';
+import { issuesToLineNumbers } from '@snyk/cloud-config-parser';
+
+jest.mock('@snyk/cloud-config-parser');
 
 describe('formatScanResults', () => {
   it('returns the formatted results as expected for output', () => {
+    (issuesToLineNumbers as jest.Mock).mockReturnValue(3);
     const formattedResults = formatScanResults(scanResults, {
       severityThreshold: SEVERITY.HIGH,
     });


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR adds the cloud-config-parser library which is a utility library for identifying the issue path in a YAML/JSON/HCL file and returning the relevant line number in order to highlight the relevant line to the users in their files.
This was an existing functionality in the old flow and it is now added in the `--experimental` flow. 

This way, we can add a line number for the specific issue path when running a test command with the `--json` output option.
If the parser library fails for some reason, we capture this in Debug and we set lineNumber as '-1' to indicate this.

#### Where should the reviewer start?
- Package.json for the library
- Results-formatter.ts for adding the function where we call the parser functions to get the lineNumber.

#### How should this be manually tested?
- Run `npm run build` on this branch
- Run `node ~/snyk-repos/snyk/dist/cli iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental --json`

#### What are the relevant tickets?
[CC-680]

#### Screenshots
![image](https://user-images.githubusercontent.com/6989529/114197020-dc24e580-9949-11eb-8427-3e855e0c1b20.png)

[CC-680]: https://snyksec.atlassian.net/browse/CC-680