### PR TITLE
feat: Add detection-depth flag to IaC for directory scan [CC-769]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -1,6 +1,11 @@
 import { makeDirectoryIterator } from '../../../../lib/iac/makeDirectoryIterator';
 import { promises as fs } from 'fs';
-import { IaCErrorCodes, IacFileData, IaCTestFlags, VALID_FILE_TYPES } from './types';
+import {
+  IaCErrorCodes,
+  IacFileData,
+  IaCTestFlags,
+  VALID_FILE_TYPES,
+} from './types';
 import { getFileType } from '../../../../lib/iac/iac-parser';
 import { IacFileTypes } from '../../../../lib/iac/constants';
 import { isLocalFolder } from '../../../../lib/detect';

--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -1,6 +1,6 @@
 import { makeDirectoryIterator } from '../../../../lib/iac/makeDirectoryIterator';
 import { promises as fs } from 'fs';
-import { IaCErrorCodes, IacFileData, VALID_FILE_TYPES } from './types';
+import { IaCErrorCodes, IacFileData, IaCTestFlags, VALID_FILE_TYPES } from './types';
 import { getFileType } from '../../../../lib/iac/iac-parser';
 import { IacFileTypes } from '../../../../lib/iac/constants';
 import { isLocalFolder } from '../../../../lib/detect';
@@ -8,11 +8,16 @@ import { CustomError } from '../../../../lib/errors';
 
 const DEFAULT_ENCODING = 'utf-8';
 
-export async function loadFiles(pathToScan: string): Promise<IacFileData[]> {
+export async function loadFiles(
+  pathToScan: string,
+  options: IaCTestFlags,
+): Promise<IacFileData[]> {
   let filePaths = [pathToScan];
 
   if (isLocalFolder(pathToScan)) {
-    filePaths = getFilePathsFromDirectory(pathToScan);
+    filePaths = getFilePathsFromDirectory(pathToScan, {
+      maxDepth: options.detectionDepth,
+    });
   }
 
   const filesToScan: IacFileData[] = [];
@@ -34,8 +39,13 @@ export async function loadFiles(pathToScan: string): Promise<IacFileData[]> {
   return filesToScan;
 }
 
-function getFilePathsFromDirectory(pathToScan: string): string[] {
-  const directoryPaths = makeDirectoryIterator(pathToScan);
+function getFilePathsFromDirectory(
+  pathToScan: string,
+  options: { maxDepth?: number } = {},
+): string[] {
+  const directoryPaths = makeDirectoryIterator(pathToScan, {
+    maxDepth: options.maxDepth,
+  });
 
   const directoryFilePaths: string[] = [];
   for (const filePath of directoryPaths) {

--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -15,7 +15,7 @@ const DEFAULT_ENCODING = 'utf-8';
 
 export async function loadFiles(
   pathToScan: string,
-  options: IaCTestFlags,
+  options: IaCTestFlags = {},
 ): Promise<IacFileData[]> {
   let filePaths = [pathToScan];
 

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -27,7 +27,7 @@ export async function test(
   failures?: IacFileInDirectory[];
 }> {
   await initLocalCache();
-  const filesToParse = await loadFiles(pathToScan);
+  const filesToParse = await loadFiles(pathToScan, options);
   const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
   const scannedFiles = await scanFiles(parsedFiles);
   const formattedResults = formatScanResults(scannedFiles, options);

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -424,3 +424,32 @@ test('test command line "snyk iac --experimental" should be true on options', (t
   );
   t.end();
 });
+
+test('test command line "snyk iac --experimental --detection-depth=1" should be 1 on options', (t) => {
+  const cliArgsWithFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+    '--experimental',
+    '--detection-depth=1',
+  ];
+  const resultWithFlag = args(cliArgsWithFlag);
+  t.equal(
+    resultWithFlag.options['detectionDepth'],
+    1,
+    'expected options[detectionDepth] to be 1',
+  );
+  const cliArgsWithoutFlag = [
+    '/Users/dror/.nvm/versions/node/v6.9.2/bin/node',
+    '/Users/dror/work/snyk/snyk-internal/cli',
+    'iac',
+    '--experimental',
+  ];
+  const resultWithoutFlag = args(cliArgsWithoutFlag);
+  t.equal(
+    resultWithoutFlag.options['detectionDepth'],
+    undefined,
+    'expected options[detectionDepth] to be undefined',
+  );
+  t.end();
+});

--- a/test/jest/unit/iac-unit-tests/file-loader.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.fixtures.ts
@@ -40,3 +40,17 @@ export const anotherNonIacFileStub = {
   filePath: path.join(mixedDirectory, 'this_also_shouldnt_load.js'),
   fileType: 'js',
 };
+
+export const level1Directory = path.join(__dirname, 'dir1');
+export const level2Directory = path.join(level1Directory, 'dir2');
+export const level3Directory = path.join(level2Directory, 'dir3');
+
+export const level3FileStub = {
+  ...terraformFileStub,
+  filePath: path.join(level3Directory, 'main.tf'),
+};
+
+export const level2FileStub = {
+  ...terraformFileStub,
+  filePath: path.join(level2Directory, 'main.tf'),
+};

--- a/test/jest/unit/iac-unit-tests/file-loader.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.spec.ts
@@ -30,7 +30,7 @@ describe('loadFiles', () => {
     describe('with a k8s file', () => {
       it('returns an array with a single file', async () => {
         mockFs({ [k8sFileStub.filePath]: k8sFileStub.fileContent });
-        const loadedFiles = await loadFiles(k8sFileStub.filePath, {});
+        const loadedFiles = await loadFiles(k8sFileStub.filePath);
         expect(loadedFiles).toContainEqual(k8sFileStub);
       });
     });
@@ -38,7 +38,7 @@ describe('loadFiles', () => {
     describe('with a terraform file', () => {
       it('returns an array with a single file', async () => {
         mockFs({ [terraformFileStub.filePath]: terraformFileStub.fileContent });
-        const loadedFiles = await loadFiles(terraformFileStub.filePath, {});
+        const loadedFiles = await loadFiles(terraformFileStub.filePath);
         expect(loadedFiles).toContainEqual(terraformFileStub);
       });
     });
@@ -56,7 +56,7 @@ describe('loadFiles', () => {
           throw FailedToLoadFileError;
         });
 
-        const loadFilesFn = loadFiles(anotherK8sFileStub.filePath, {});
+        const loadFilesFn = loadFiles(anotherK8sFileStub.filePath);
 
         await expect(loadFilesFn).rejects.toThrow(FailedToLoadFileError);
       });
@@ -71,7 +71,7 @@ describe('loadFiles', () => {
           [anotherK8sFileStub.filePath]: anotherK8sFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles(k8sDirectory, {});
+        const loadedFiles = await loadFiles(k8sDirectory);
         expect(loadedFiles).toEqual([k8sFileStub, anotherK8sFileStub]);
       });
     });
@@ -84,7 +84,7 @@ describe('loadFiles', () => {
             anotherTerraformFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles(terraformDirectory, {});
+        const loadedFiles = await loadFiles(terraformDirectory);
         expect(loadedFiles).toEqual([
           terraformFileStub,
           anotherTerraformFileStub,
@@ -131,14 +131,14 @@ describe('loadFiles', () => {
 
       describe('with detectionDepth 3', () => {
         it('returns the files at level 2 and level 3', async () => {
-          const loadedFiles = await loadFiles(level1Directory, {});
+          const loadedFiles = await loadFiles(level1Directory);
           expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
         });
       });
 
       describe('with detectionDepth 4', () => {
         it('returns the files at level 2 and level 3', async () => {
-          const loadedFiles = await loadFiles(level1Directory, {});
+          const loadedFiles = await loadFiles(level1Directory);
           expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
         });
       });
@@ -168,7 +168,7 @@ describe('loadFiles', () => {
             anotherTerraformFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles('.', {});
+        const loadedFiles = await loadFiles('.');
         expect(loadedFiles).toEqual([
           k8sFileStub,
           anotherK8sFileStub,

--- a/test/jest/unit/iac-unit-tests/file-loader.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.spec.ts
@@ -1,4 +1,5 @@
 const mockFs = require('mock-fs');
+import * as path from 'path';
 import {
   FailedToLoadFileError,
   loadFiles,
@@ -15,6 +16,11 @@ import {
   nonIacFileStub,
   terraformDirectory,
   terraformFileStub,
+  level1Directory,
+  level2Directory,
+  level2FileStub,
+  level3Directory,
+  level3FileStub,
 } from './file-loader.fixtures';
 
 describe('loadFiles', () => {
@@ -24,7 +30,7 @@ describe('loadFiles', () => {
     describe('with a k8s file', () => {
       it('returns an array with a single file', async () => {
         mockFs({ [k8sFileStub.filePath]: k8sFileStub.fileContent });
-        const loadedFiles = await loadFiles(k8sFileStub.filePath);
+        const loadedFiles = await loadFiles(k8sFileStub.filePath, {});
         expect(loadedFiles).toContainEqual(k8sFileStub);
       });
     });
@@ -32,7 +38,7 @@ describe('loadFiles', () => {
     describe('with a terraform file', () => {
       it('returns an array with a single file', async () => {
         mockFs({ [terraformFileStub.filePath]: terraformFileStub.fileContent });
-        const loadedFiles = await loadFiles(terraformFileStub.filePath);
+        const loadedFiles = await loadFiles(terraformFileStub.filePath, {});
         expect(loadedFiles).toContainEqual(terraformFileStub);
       });
     });
@@ -40,7 +46,7 @@ describe('loadFiles', () => {
     describe('errors', () => {
       it('throws an error when there is no valid iac file', async () => {
         mockFs({ [nonIacFileStub.filePath]: nonIacFileStub.fileContent });
-        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
+        await expect(loadFiles(nonIacFileStub.filePath, {})).rejects.toThrow(
           NoFilesToScanError,
         );
       });
@@ -50,7 +56,7 @@ describe('loadFiles', () => {
           throw FailedToLoadFileError;
         });
 
-        const loadFilesFn = loadFiles(anotherK8sFileStub.filePath);
+        const loadFilesFn = loadFiles(anotherK8sFileStub.filePath, {});
 
         await expect(loadFilesFn).rejects.toThrow(FailedToLoadFileError);
       });
@@ -65,7 +71,7 @@ describe('loadFiles', () => {
           [anotherK8sFileStub.filePath]: anotherK8sFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles(k8sDirectory);
+        const loadedFiles = await loadFiles(k8sDirectory, {});
         expect(loadedFiles).toEqual([k8sFileStub, anotherK8sFileStub]);
       });
     });
@@ -78,11 +84,63 @@ describe('loadFiles', () => {
             anotherTerraformFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles(terraformDirectory);
+        const loadedFiles = await loadFiles(terraformDirectory, {});
         expect(loadedFiles).toEqual([
           terraformFileStub,
           anotherTerraformFileStub,
         ]);
+      });
+    });
+
+    describe('with nested files inside multiple-level directories', () => {
+      beforeEach(() => {
+        mockFs({
+          [level1Directory]: {
+            [path.basename(level2Directory)]: {
+              [path.basename(
+                level2FileStub.filePath,
+              )]: level2FileStub.fileContent,
+              [path.basename(level3Directory)]: {
+                [path.basename(
+                  level3FileStub.filePath,
+                )]: level3FileStub.fileContent,
+              },
+            },
+          },
+        });
+      });
+
+      describe('with detectionDepth 1', () => {
+        it('throws an error as there are no files at that level', async () => {
+          await expect(
+            loadFiles(level1Directory, {
+              detectionDepth: 1,
+            }),
+          ).rejects.toThrow(NoFilesToScanError);
+        });
+      });
+
+      describe('with detectionDepth 2', () => {
+        it('returns the files at level 2', async () => {
+          const loadedFiles = await loadFiles(level1Directory, {
+            detectionDepth: 2,
+          });
+          expect(loadedFiles).toEqual([level2FileStub]);
+        });
+      });
+
+      describe('with detectionDepth 3', () => {
+        it('returns the files at level 2 and level 3', async () => {
+          const loadedFiles = await loadFiles(level1Directory, {});
+          expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
+        });
+      });
+
+      describe('with detectionDepth 4', () => {
+        it('returns the files at level 2 and level 3', async () => {
+          const loadedFiles = await loadFiles(level1Directory, {});
+          expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
+        });
       });
     });
 
@@ -92,7 +150,7 @@ describe('loadFiles', () => {
           [emptyDirectory]: {},
         });
 
-        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
+        await expect(loadFiles(nonIacFileStub.filePath, {})).rejects.toThrow(
           NoFilesToScanError,
         );
       });
@@ -110,7 +168,7 @@ describe('loadFiles', () => {
             anotherTerraformFileStub.fileContent,
         });
 
-        const loadedFiles = await loadFiles('.');
+        const loadedFiles = await loadFiles('.', {});
         expect(loadedFiles).toEqual([
           k8sFileStub,
           anotherK8sFileStub,

--- a/test/jest/unit/iac-unit-tests/file-loader.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.spec.ts
@@ -46,7 +46,7 @@ describe('loadFiles', () => {
     describe('errors', () => {
       it('throws an error when there is no valid iac file', async () => {
         mockFs({ [nonIacFileStub.filePath]: nonIacFileStub.fileContent });
-        await expect(loadFiles(nonIacFileStub.filePath, {})).rejects.toThrow(
+        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
           NoFilesToScanError,
         );
       });
@@ -131,14 +131,18 @@ describe('loadFiles', () => {
 
       describe('with detectionDepth 3', () => {
         it('returns the files at level 2 and level 3', async () => {
-          const loadedFiles = await loadFiles(level1Directory);
+          const loadedFiles = await loadFiles(level1Directory, {
+            detectionDepth: 3,
+          });
           expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
         });
       });
 
       describe('with detectionDepth 4', () => {
         it('returns the files at level 2 and level 3', async () => {
-          const loadedFiles = await loadFiles(level1Directory);
+          const loadedFiles = await loadFiles(level1Directory, {
+            detectionDepth: 4,
+          });
           expect(loadedFiles).toEqual([level3FileStub, level2FileStub]);
         });
       });
@@ -150,7 +154,7 @@ describe('loadFiles', () => {
           [emptyDirectory]: {},
         });
 
-        await expect(loadFiles(nonIacFileStub.filePath, {})).rejects.toThrow(
+        await expect(loadFiles(nonIacFileStub.filePath)).rejects.toThrow(
           NoFilesToScanError,
         );
       });

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -165,12 +165,12 @@ Describe "Snyk iac test --experimental command"
       # Only File
       The output should include "Testing one.tf..."
       The output should include "Infrastructure as code issues:"
-      The output should include "Tested one.tf for known issues, found 0 issues"
+      The output should include "Tested one.tf for known issues, found"
 
       # Second File
       The output should include "Testing root.tf..."
       The output should include "Infrastructure as code issues:"
-      The output should include "Tested root.tf for known issues, found 0 issues"
+      The output should include "Tested root.tf for known issues, found"
 
       # Directory scan summary
       The output should include "Tested 2 projects, no vulnerable paths were found."

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -158,6 +158,23 @@ Describe "Snyk iac test --experimental command"
       The output should include "Testing pod-invalid.yaml..."
       The output should include "Failed to detect Kubernetes file, missing required fields"
     End
+
+    It "limits the depth of the directories"
+      When run snyk iac test ../fixtures/iac/depth_detection/ --experimental --detection-depth=2
+      The status should be success # no issues found
+      # Only File
+      The output should include "Testing one.tf..."
+      The output should include "Infrastructure as code issues:"
+      The output should include "Tested one.tf for known issues, found 0 issues"
+
+      # Second File
+      The output should include "Testing root.tf..."
+      The output should include "Infrastructure as code issues:"
+      The output should include "Tested root.tf for known issues, found 0 issues"
+
+      # Directory scan summary
+      The output should include "Tested 2 projects, no vulnerable paths were found."
+    End
   End
 
   Describe "Terraform plan scanning"


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds the already defined `--detection-depth` flag to the `--experimental` flow for IaC. The flag was already defined and used in non-experimental mode, so this PR just passes the CLI options and `detectionDepth` value to the correct function. Unit tests and smoke tests were added to verify functionality, as well as tests to make sure that the flag gets initialised correctly when passed to the CLI.

#### Where should the reviewer start?
The flow starts in `src/cli/commands/test/iac-local-execution/index.ts` by passing the `options` variable to the `loadFiles ` function. The rest of the code changes are in `src/cli/commands/test/iac-local-execution/file-loader.ts` and make use of the existing `makeDirectoryIterator` function which is used by the non-experimental flow.

#### How should this be manually tested?
1. Run `npm run build`
2. Run `node ./dist/cli iac test test/fixtures/iac/depth_detection --experimental --detection-depth=2` and notice that 2 projects were tested.
3. Run`node ./dist/cli iac test test/fixtures/iac/depth_detection --experimental --detection-depth=3`  and notice that 3 projects were tested.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[CC-769](https://snyksec.atlassian.net/browse/CC-769): https://snyksec.atlassian.net/browse/CC-769

#### Screenshots
![Screenshot 2021-04-09 at 15 51 49](https://user-images.githubusercontent.com/81559517/114198710-881b0080-994b-11eb-856c-2bdacdc2497f.png)

![Screenshot 2021-04-12 at 09 46 00](https://user-images.githubusercontent.com/81559517/114367008-ec200d80-9b73-11eb-8c0e-87c464b2a2f8.png)

#### Additional questions
N/A