### PR TITLE
Support sarif output for container test without a `--file` parameter set

### DIFF
--- a/src/cli/commands/test/container-sarif-output.ts
+++ b/src/cli/commands/test/container-sarif-output.ts
@@ -73,24 +73,34 @@ export function getResults(testResult): sarif.Result[] {
     return results;
   }
   testResult.vulnerabilities.forEach((vuln) => {
-    results.push({
-      ruleId: vuln.id,
-      message: {
-        text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
-      },
-      locations: [
-        {
-          physicalLocation: {
-            artifactLocation: {
-              uri: testResult.displayTargetFile,
-            },
-            region: {
-              startLine: vuln.lineNumber || 1,
-            },
-          },
-        },
-      ],
-    });
+    results.push(getSarifResult(vuln, testResult.displayTargetFile));
   });
   return results;
+}
+
+export function getSarifResult(
+  vuln,
+  targetFile: string | undefined,
+): sarif.Result {
+  const result: sarif.Result = {
+    ruleId: vuln.id,
+    message: {
+      text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
+    },
+  };
+  if (targetFile) {
+    result.locations = [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: targetFile,
+          },
+          region: {
+            startLine: vuln.lineNumber || 1,
+          },
+        },
+      },
+    ];
+  }
+  return result;
 }

--- a/src/cli/commands/test/formatters/format-test-results.ts
+++ b/src/cli/commands/test/formatters/format-test-results.ts
@@ -24,7 +24,7 @@ import {
 } from './remediation-based-format-issues';
 import { formatIssues } from './legacy-format-issue';
 import { formatDockerBinariesIssues } from './docker';
-import { createSarifOutputForContainers } from '../sarif-output';
+import { createSarifOutputForContainers } from '../container-sarif-output';
 import { createSarifOutputForIac } from '../iac-output';
 import { isNewVuln, isVulnFixable } from '../vuln-helpers';
 import { jsonStringifyLargeObject } from '../../../../lib/json';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -416,22 +416,6 @@ function validateUnsupportedSarifCombinations(args) {
       'sarif-file-output',
     ]);
   }
-
-  if (
-    args.options['sarif'] &&
-    args.options['docker'] &&
-    !args.options['file']
-  ) {
-    throw new OptionMissingErrorError('sarif', ['--file']);
-  }
-
-  if (
-    args.options['sarif-file-output'] &&
-    args.options['docker'] &&
-    !args.options['file']
-  ) {
-    throw new OptionMissingErrorError('sarif-file-output', ['--file']);
-  }
 }
 
 async function saveResultsToFile(

--- a/test/acceptance/cli-test/cli-test.docker.spec.ts
+++ b/test/acceptance/cli-test/cli-test.docker.spec.ts
@@ -735,7 +735,10 @@ export const DockerTests: AcceptanceTests = {
     '`test --docker --file=Dockerfile --sarif `': (params, utils) => async (
       t,
     ) => {
-      const testableObject = await testSarif(t, utils, params, { sarif: true });
+      const testableObject = await testSarif(t, utils, params, {
+        sarif: true,
+        file: 'Dockerfile',
+      });
       const results = JSON.parse(testableObject.message);
       const sarifResults = require('../fixtures/docker/sarif-container-result.json');
       t.deepEqual(results, sarifResults, 'stdout containing sarif results');

--- a/test/acceptance/fixtures/docker/sarif-container-result.json
+++ b/test/acceptance/fixtures/docker/sarif-container-result.json
@@ -33,7 +33,9 @@
           "locations": [
             {
               "physicalLocation": {
-                "artifactLocation": {},
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
                 "region": { "startLine": 1 }
               }
             }
@@ -47,7 +49,9 @@
           "locations": [
             {
               "physicalLocation": {
-                "artifactLocation": {},
+                "artifactLocation": {
+                  "uri": "Dockerfile"
+                },
                 "region": { "startLine": 1 }
               }
             }

--- a/test/jest/unit/cli/commands/test/container-sarif-output.spec.ts
+++ b/test/jest/unit/cli/commands/test/container-sarif-output.spec.ts
@@ -1,0 +1,60 @@
+import { getSarifResult } from '../../../../../../src/cli/commands/test/container-sarif-output';
+
+type Vulnerability = {
+  id: string;
+  packageName: string;
+  severity: string;
+  lineNumber?: number;
+};
+
+describe('getSarifResult', () => {
+  test('should have a message with package and severity details', () => {
+    const vuln: Vulnerability = {
+      id: 'my-id',
+      packageName: 'my-package',
+      severity: 'error',
+    };
+    const result = getSarifResult(vuln, undefined);
+    expect(result).toEqual({
+      ruleId: 'my-id',
+      message: {
+        text: `This file introduces a vulnerable my-package package with a error severity vulnerability.`,
+      },
+    });
+    expect(result).not.toHaveProperty('locations');
+  });
+
+  test('should include target file at artifact location', () => {
+    const vuln: Vulnerability = {
+      id: '',
+      packageName: 'my-package',
+      severity: 'error',
+    };
+    const result = getSarifResult(vuln, 'my-file');
+    expect(result).toHaveProperty('locations', [
+      {
+        physicalLocation: {
+          artifactLocation: {
+            uri: 'my-file',
+          },
+          region: {
+            startLine: 1,
+          },
+        },
+      },
+    ]);
+  });
+
+  test('should include line number from vulnerability', () => {
+    const vuln: Vulnerability = {
+      id: '',
+      packageName: 'my-package',
+      severity: 'error',
+      lineNumber: 99,
+    };
+    const result = getSarifResult(vuln, 'my-file');
+    expect(result).toHaveProperty('locations.0.physicalLocation.region', {
+      startLine: 99,
+    });
+  });
+});


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Allows you to run `snyk container test --sarif` without specifying `--file=`.
Now, when not specifying the `--file` we will not include the `locations` field in the results in the SARIF output. Note that `locations` is not a required field if `result`: 
- https://github.com/microsoft/sarif-tutorials/blob/main/docs/2-Basics.md#locations
- https://docs.oasis-open.org/sarif/sarif/v2.1.0/csprd01/sarif-v2.1.0-csprd01.html#_Toc10540999

#### How should this be manually tested?
Try running `snyk container test --sarif` with and without a `--file=`.

#### Any background context you want to provide?
We want to be able to not require the `--file` in the Snyk GitHub Action which uses Snyk's Docker images.
This other PR (https://github.com/snyk/snyk-images/pull/10) would become mergeable after change.
This makes `snyk container test --sarif` inline with `iac` and the default CLI mode (i.e. open source).
