### PR TITLE
fix: bubble up auth error on fix

### DIFF
--- a/src/cli/commands/fix/validate-fix-command-is-supported.ts
+++ b/src/cli/commands/fix/validate-fix-command-is-supported.ts
@@ -6,6 +6,7 @@ import { isFeatureFlagSupportedForOrg } from '../../../lib/feature-flags';
 import { CommandNotSupportedError } from '../../../lib/errors/command-not-supported';
 import { FeatureNotSupportedByEcosystemError } from '../../../lib/errors/not-supported-by-ecosystem';
 import { Options, TestOptions } from '../../../lib/types';
+import { AuthFailedError } from '../../../lib/errors';
 
 const debug = Debug('snyk-fix');
 const snykFixFeatureFlag = 'cliSnykFix';
@@ -27,8 +28,12 @@ export async function validateFixCommandIsSupported(
     options.org,
   );
 
+  if (snykFixSupported.code === 401 || snykFixSupported.code === 403) {
+    throw AuthFailedError(snykFixSupported.error, snykFixSupported.code);
+  }
+
   if (!snykFixSupported.ok) {
-    debug(snykFixSupported.userMessage);
+    debug('Feature flag check returned: ', snykFixSupported);
     throw new CommandNotSupportedError('snyk fix', options.org || undefined);
   }
 

--- a/test/smoke/spec/snyk_fix_spec.sh
+++ b/test/smoke/spec/snyk_fix_spec.sh
@@ -1,12 +1,29 @@
 #shellcheck shell=sh
 
-Describe "Snyk fix command"
+Describe "Snyk fix command logged in"
+  Before snyk_login
+  After snyk_logout
+
   Describe "supported only with FF"
 
     It "by default snyk fix is not supported"
       When run snyk fix
       The status should be failure
       The output should include "is not supported"
+      The stderr should equal ""
+    End
+  End
+End
+
+Describe "Snyk fix command logged out"
+  Before snyk_logout
+
+  Describe "Bubbles up auth error"
+
+    It "not authed"
+      When run snyk fix
+      The status should be failure
+      The output should include "Not authorised"
       The stderr should equal ""
     End
   End

--- a/test/validate-fix-command-is-supported.spec.ts
+++ b/test/validate-fix-command-is-supported.spec.ts
@@ -1,4 +1,5 @@
 import { validateFixCommandIsSupported } from '../src/cli/commands/fix/validate-fix-command-is-supported';
+import { AuthFailedError } from '../src/lib/errors';
 import { CommandNotSupportedError } from '../src/lib/errors/command-not-supported';
 import { FeatureNotSupportedByEcosystemError } from '../src/lib/errors/not-supported-by-ecosystem';
 import * as featureFlags from '../src/lib/feature-flags';
@@ -23,6 +24,16 @@ describe('setDefaultTestOptions', () => {
     const options = { path: '/', showVulnPaths: 'all' as ShowVulnPaths };
     expect(validateFixCommandIsSupported(options)).rejects.toThrowError(
       new CommandNotSupportedError('snyk fix', undefined),
+    );
+  });
+
+  it('fix is NOT supported and bubbles up auth error invalid auth token', () => {
+    jest
+      .spyOn(featureFlags, 'isFeatureFlagSupportedForOrg')
+      .mockResolvedValue({ ok: false, code: 401, error: 'Invalid auth token' });
+    const options = { path: '/', showVulnPaths: 'all' as ShowVulnPaths };
+    expect(validateFixCommandIsSupported(options)).rejects.toThrowError(
+      AuthFailedError('Invalid auth token', 401),
     );
   });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bubble up an auth error and display the message rather than say that the feature is not supported.
