### PR TITLE
feat: limit file scan to once per iteration (for hex pm)

### DIFF
--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -47,6 +47,12 @@ export async function getMultiPluginResult(
     optionsClone.packageManager = detectPackageManagerFromFile(
       path.basename(targetFile),
     );
+    if (allResults.some((x) => x.targetFile === optionsClone.file)) {
+      debug(
+        `File ${optionsClone.file} already scanned in previous iteration, skipping`,
+      );
+      continue;
+    }
     try {
       const inspectRes = await getSinglePluginResult(
         root,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Limit each file scan to once.

In umbrella projects (kind of the elixir equivalent to yarn workspaces) scan one `mix.exs` manifest can result in multiple project scans.
In this scenario, we don't want to re-scan apps (as they already been tested)