### PR TITLE
Fix: fix spinner multiple paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@snyk/cloud-config-parser": "^1.9.2",
     "@snyk/code-client": "3.4.0",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/fix": "1.526.0",
+    "@snyk/fix": "1.539.0",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -63,10 +63,6 @@ export async function pythonFix(
         results.failed.push(
           ...projectsToFix.map((p) => ({ original: p, error: e })),
         );
-        spinner.stopAndPersist({
-          text: processingMessage,
-          symbol: chalk.green('✔'),
-        });
       }
       spinner.stopAndPersist({
         text: processingMessage,

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -63,6 +63,10 @@ export async function pythonFix(
         results.failed.push(
           ...projectsToFix.map((p) => ({ original: p, error: e })),
         );
+        spinner.stopAndPersist({
+          text: processingMessage,
+          symbol: chalk.green('✔'),
+        });
       }
       spinner.stopAndPersist({
         text: processingMessage,

--- a/src/cli/commands/fix/validate-fix-command-is-supported.ts
+++ b/src/cli/commands/fix/validate-fix-command-is-supported.ts
@@ -28,12 +28,13 @@ export async function validateFixCommandIsSupported(
     options.org,
   );
 
+  debug('Feature flag check returned: ', snykFixSupported);
+
   if (snykFixSupported.code === 401 || snykFixSupported.code === 403) {
     throw AuthFailedError(snykFixSupported.error, snykFixSupported.code);
   }
 
   if (!snykFixSupported.ok) {
-    debug('Feature flag check returned: ', snykFixSupported);
     throw new CommandNotSupportedError('snyk fix', options.org || undefined);
   }
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Swap out ℹ️ for ⏯️  icon in spinner
- fix clearing bug when multiple paths are tested with `snyk fix path1 path2`
- bump @snyk/fix packages to latest version that has small output improvements (e.g. `Previously fixed` => `Fixed through manifestPath`)
- style the failed test errors
- spacing

#### Screenshots
**Before**
<img width="1440" alt="CleanShot 2021-04-08 at 17 43 55@2x" src="https://user-images.githubusercontent.com/2911613/114372250-3ce63500-9b79-11eb-9cc1-093de12dc643.png">

**After**
<img width="1440" alt="CleanShot 2021-04-14 at 09 53 54@2x" src="https://user-images.githubusercontent.com/2911613/114683182-b875ec80-9d07-11eb-8b36-509bd415b887.png">
<img width="1294" alt="CleanShot 2021-04-14 at 09 54 15@2x" src="https://user-images.githubusercontent.com/2911613/114683190-bad84680-9d07-11eb-8ab5-e886ce5e410a.png">

