### PR TITLE
fix(@snyk/fix): hide summary unless any failed, fixed or unresolved

### DIFF
--- a/packages/snyk-fix/src/index.ts
+++ b/packages/snyk-fix/src/index.ts
@@ -28,6 +28,7 @@ export async function fix(
   fixSummary: string;
 }> {
   const spinner = ora({ isSilent: options.quiet, stream: process.stdout });
+
   let resultsByPlugin: FixHandlerResultByPlugin = {};
   const entitiesPerType = groupEntitiesPerScanType(entities);
   const exceptionsByScanType: ErrorsByEcoSystem = {};
@@ -57,10 +58,14 @@ export async function fix(
   const meta = extractMeta(resultsByPlugin, exceptionsByScanType);
 
   spinner.start();
-  spinner.stopAndPersist({
-    text: 'Done',
-    symbol: meta.fixed === 0 ? chalk.red('✖') : chalk.green('✔'),
-  });
+  if (meta.fixed > 0) {
+    spinner.stopAndPersist({
+      text: 'Done',
+      symbol: chalk.green('✔'),
+    });
+  } else {
+    spinner.stop();
+  }
 
   return {
     results: resultsByPlugin,

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -7,6 +7,7 @@ import { FixHandlerResultByPlugin } from '../types';
 import { loadHandler } from './load-handler';
 import { SUPPORTED_HANDLER_TYPES } from './supported-handler-types';
 import { mapEntitiesPerHandlerType } from './map-entities-per-handler-type';
+import chalk = require('chalk');
 
 const debug = debugLib('snyk-fix:python');
 
@@ -15,7 +16,8 @@ export async function pythonFix(
   options: FixOptions,
 ): Promise<FixHandlerResultByPlugin> {
   const spinner = ora({ isSilent: options.quiet, stream: process.stdout });
-  spinner.text = 'Looking for supported Python items';
+  const spinnerMessage = 'Looking for supported Python items';
+  spinner.text = spinnerMessage;
   spinner.start();
 
   const handlerResult: FixHandlerResultByPlugin = {
@@ -31,14 +33,18 @@ export async function pythonFix(
   );
   results.skipped.push(...notSupported);
 
-  spinner.succeed();
+  spinner.stopAndPersist({
+    text: spinnerMessage,
+    symbol: chalk.green('\n✔'),
+  });
 
   await pMap(
     Object.keys(entitiesPerType),
     async (projectType) => {
       const projectsToFix: EntityToFix[] = entitiesPerType[projectType];
 
-      spinner.text = `Processing ${projectsToFix.length} ${projectType} items.`;
+      const processingMessage = `Processing ${projectsToFix.length} ${projectType} items`;
+      spinner.text = processingMessage;
       spinner.render();
 
       try {
@@ -50,6 +56,10 @@ export async function pythonFix(
         results.failed.push(...failed);
         results.skipped.push(...skipped);
         results.succeeded.push(...succeeded);
+        spinner.stopAndPersist({
+          text: processingMessage,
+          symbol: chalk.green('✔'),
+        });
       } catch (e) {
         debug(
           `Failed to fix ${projectsToFix.length} ${projectType} projects.\nError: ${e.message}`,
@@ -63,6 +73,5 @@ export async function pythonFix(
       concurrency: 5,
     },
   );
-  spinner.succeed();
   return handlerResult;
 }

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -58,7 +58,7 @@ Object {
     },
   },
   "fixSummary": "
-✖ No successful fixes
+ ✖ No successful fixes
 
 Unresolved items:
 

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -38,11 +38,16 @@ exports[`generateSuccessfulFixesSummary has fixed & failed 1`] = `
   Tip:     Apply the changes manually"
 `;
 
-exports[`generateUnresolvedSummary has failed, skipped & plugin errors 1`] = `
+exports[`generateUnresolvedSummary has failed upgrades & unsupported 1`] = `
 "Unresolved items:
 
   package.json
   ✖ npm is not supported"
+`;
+
+exports[`showResultsSummary called with nothing to fix 1`] = `
+"
+ ✖ No successful fixes"
 `;
 
 exports[`showResultsSummary has failed, skipped, successful & plugin errors 1`] = `
@@ -57,7 +62,7 @@ Successful fixes:
 
 Unresolved items:
 
-  package.json
+  pip project
   ✖ Missing required file name
 
   package.json
@@ -67,4 +72,19 @@ Summary:
 
   2 items were not fixed
   1 items were successfully fixed"
+`;
+
+exports[`showResultsSummary has unresolved only 1`] = `
+"
+ ✖ No successful fixes
+
+Unresolved items:
+
+  package.json
+  ✖ npm is not supported
+
+Summary:
+
+  1 items were not fixed
+  0 items were successfully fixed"
 `;

--- a/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
@@ -48,7 +48,7 @@ describe('generateFixedAndFailedSummary', () => {
       },
     };
     const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
-    expect(stripAnsi(res)).toMatchSnapshot();
+    expect(stripAnsi(res.summary)).toMatchSnapshot();
   });
 
   it('has fixed only', async () => {
@@ -75,7 +75,8 @@ describe('generateFixedAndFailedSummary', () => {
       },
     };
     const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
-    expect(stripAnsi(res)).toMatchSnapshot();
+    expect(stripAnsi(res.summary)).toMatchSnapshot();
+    expect(res.count).toEqual(1);
   });
 
   it('has failed only', async () => {
@@ -97,7 +98,8 @@ describe('generateFixedAndFailedSummary', () => {
       },
     };
     const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
-    expect(stripAnsi(res)).toMatchSnapshot();
+    expect(stripAnsi(res.summary)).toMatchSnapshot();
+    expect(res.count).toEqual(1);
   });
 
   it('has skipped & failed & plugin errors', async () => {
@@ -141,7 +143,8 @@ describe('generateFixedAndFailedSummary', () => {
       },
     };
     const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
-    expect(stripAnsi(res)).toMatchSnapshot();
+    expect(stripAnsi(res.summary)).toMatchSnapshot();
+    expect(res.count).toEqual(3);
   });
 });
 
@@ -181,7 +184,7 @@ describe('generateSuccessfulFixesSummary', () => {
 });
 
 describe('generateUnresolvedSummary', () => {
-  it('has failed, skipped & plugin errors', async () => {
+  it('has failed upgrades & unsupported', async () => {
     const entity = generateEntityToFix(
       'pip',
       'requirements.txt',
@@ -226,7 +229,8 @@ describe('generateUnresolvedSummary', () => {
       resultsByPlugin,
       exceptionsByScanType,
     );
-    expect(stripAnsi(res)).toMatchSnapshot();
+    expect(stripAnsi(res.summary)).toMatchSnapshot();
+    expect(res.count).toEqual(1);
   });
 });
 
@@ -243,8 +247,8 @@ describe('showResultsSummary', () => {
       JSON.stringify({}),
     );
     const entityFailed = generateEntityToFix(
-      'npm',
-      'package.json',
+      'pip',
+      '',
       JSON.stringify({}),
     );
     const resultsByPlugin: FixHandlerResultByPlugin = {
@@ -284,6 +288,42 @@ describe('showResultsSummary', () => {
         userMessage: 'npm is not supported',
       },
     };
+
+    const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
+    expect(stripAnsi(res)).toMatchSnapshot();
+  });
+  it('has unresolved only', async () => {
+    const entityFailed = generateEntityToFix(
+      'npm',
+      'package.json',
+      JSON.stringify({}),
+    );
+    const resultsByPlugin: FixHandlerResultByPlugin = {
+      python: {
+        succeeded: [],
+        failed: [],
+        skipped: [],
+      },
+    };
+    const exceptionsByScanType: ErrorsByEcoSystem = {
+      python: {
+        originals: [entityFailed],
+        userMessage: 'npm is not supported',
+      },
+    };
+
+    const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
+    expect(stripAnsi(res)).toMatchSnapshot();
+  });
+  it('called with nothing to fix', async () => {
+    const resultsByPlugin: FixHandlerResultByPlugin = {
+      python: {
+        succeeded: [],
+        failed: [],
+        skipped: [],
+      },
+    };
+    const exceptionsByScanType: ErrorsByEcoSystem = {};
 
     const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
     expect(stripAnsi(res)).toMatchSnapshot();


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Only show summary if any items were fixed, failed, unresolved. If a plugin is called with empty test results return `No successful fixes` only.

Changes made as part of a design review of the CLI output
