### PR TITLE
chore: send alert when release fails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,11 @@ jobs:
       - run:
           name: Upload assets to the GitHub Release and a public S3
           command: ./release-scripts/upload-artifacts.sh
+      - run:
+          name: Handle failed CLI release
+          command: |
+            ./release-scripts/handle-failed-release.sh
+          when: on_fail
 
 workflows:
   version: 2

--- a/release-scripts/handle-failed-release.sh
+++ b/release-scripts/handle-failed-release.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "Something failed during releasing, stopping and sending alert"
+
+curl 'https://events.pagerduty.com/v2/enqueue' \
+  --data-raw "{\"payload\":{\"summary\":\"CLI release failed\",\"severity\":\"critical\",\"source\":\"CircleCI\"},
+  \"routing_key\":\"${PD_ROUTING_KEY}\",\"event_action\":\"trigger\"}"


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds alerting that'd be fired if one of the CircleCI steps during releasing fails. 
