### PR TITLE
fix: stop spinner on errors too for @snyk/fix python plugin

### DIFF
--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -56,10 +56,6 @@ export async function pythonFix(
         results.failed.push(...failed);
         results.skipped.push(...skipped);
         results.succeeded.push(...succeeded);
-        spinner.stopAndPersist({
-          text: processingMessage,
-          symbol: chalk.green('✔'),
-        });
       } catch (e) {
         debug(
           `Failed to fix ${projectsToFix.length} ${projectType} projects.\nError: ${e.message}`,
@@ -68,6 +64,10 @@ export async function pythonFix(
           ...projectsToFix.map((p) => ({ original: p, error: e })),
         );
       }
+      spinner.stopAndPersist({
+        text: processingMessage,
+        symbol: chalk.green('✔'),
+      });
     },
     {
       concurrency: 5,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
On error also stop spinner as success as we log the error and keep going