### PR TITLE
fix: add support for Pipfiles nested in a project

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "snyk-nuget-plugin": "1.21.0",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",
-    "snyk-python-plugin": "1.19.7",
+    "snyk-python-plugin": "1.19.8",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
     "snyk-sbt-plugin": "2.11.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Add support for Pipfile's nested within a project using the `--file=...` flag