### PR TITLE
feat: enhance JSON file output for experimental IaC [CC-679]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -6,8 +6,12 @@ import {
   IaCTestFlags,
   PolicyMetadata,
 } from './types';
+import * as path from 'path';
 import { SEVERITY } from '../../../../lib/snyk-test/common';
-import { IacProjectType } from '../../../../lib/iac/constants';
+import {
+  IacProjectType,
+  projectTypeByFileType,
+} from '../../../../lib/iac/constants';
 import { CustomError } from '../../../../lib/errors';
 
 // import {
@@ -90,16 +94,25 @@ function formatScanResult(
       lineNumber,
     };
   });
+
+  const targetFilePath = path.resolve(scanResult.filePath, '.');
   return {
     result: {
       cloudConfigResults: filterPoliciesBySeverity(
         formattedIssues,
         severityThreshold,
       ),
+      projectType: projectTypeByFileType[scanResult.fileType],
     },
     isPrivate: true,
     packageManager: engineTypeToProjectType[scanResult.engineType],
     targetFile: scanResult.filePath,
+    targetFilePath,
+    vulnerabilities: [],
+    dependencyCount: 0,
+    licensesPolicy: null,
+    ignoreSettings: null,
+    projectName: path.basename(path.dirname(targetFilePath)),
   };
 }
 

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -1,5 +1,9 @@
-import { IacProjectType } from '../../../../lib/iac/constants';
+import { IacProjectType, IacProjectTypes } from '../../../../lib/iac/constants';
 import { SEVERITY } from '../../../../lib/snyk-test/common';
+import {
+  AnnotatedIssue,
+  IgnoreSettings,
+} from '../../../../lib/snyk-test/legacy';
 import {
   IacFileInDirectory,
   Options,
@@ -42,10 +46,17 @@ export interface IacFileScanResult extends IacFileParsed {
 export type FormattedResult = {
   result: {
     cloudConfigResults: Array<PolicyMetadata>;
+    projectType: IacProjectTypes;
   };
   isPrivate: boolean;
   packageManager: IacProjectType;
   targetFile: string;
+  targetFilePath: string;
+  vulnerabilities: AnnotatedIssue[];
+  dependencyCount: number;
+  licensesPolicy: object | null;
+  ignoreSettings: IgnoreSettings | null;
+  projectName: string;
 };
 
 export interface OpaWasmInstance {

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import {
   EngineType,
   IacFileScanResult,
@@ -74,8 +75,15 @@ export const expectedFormattedResults = {
         lineNumber: -1,
       },
     ],
+    projectType: 'k8sconfig',
   },
   isPrivate: true,
   packageManager: IacProjectType.K8S,
   targetFile: 'dont-care',
+  targetFilePath: path.resolve('dont-care', '.'),
+  vulnerabilities: [],
+  dependencyCount: 0,
+  ignoreSettings: null,
+  licensesPolicy: null,
+  projectName: 'snyk',
 };


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR enhances the JSON file output for the local execution (experimental) flow of IaC so it matches better with the original flow. 
[CC-679]

#### Where should the reviewer start?
The `formatScanResult` function in `src/cli/commands/test/iac-local-execution/results-formatter.ts` creates the structure and contents that will end up in the JSON file output. The changes in `src/cli/commands/test/iac-local-execution/types.ts` are the corresponding type changes for the new fields.

#### How should this be manually tested?
1. Download the `deployment_singleissue.yaml` attached to the JIRA task under the cloned `snyk` repo
2. Build the CLI using `npm run build`
3. Get the original JSON file output: `node ./dist/cli iac test deployment_singleissue.yaml --json-file-output=original.json`
4. Get the experimental JSON file output: `node ./dist/cli iac test deployment_singleissue.yaml --experimental --json-file-output=experimental.json`
5. Compare the two resulting files
6. Run from another folder to make sure the `targetFilePath` is correct: `cd src; node ../dist/cli iac test ../deployment_singleissue.yaml --experimental --json-file-output=experimental.json`

#### Any background context you want to provide?
The original flow uses default values for some of the fields and computes the `projectName` and `targetFilePath` from the scanned file path. Some fields relating to the org are still missing and will be covered by https://snyksec.atlassian.net/browse/CC-772

#### What are the relevant tickets?
[CC-679](https://snyksec.atlassian.net/browse/CC-679): https://snyksec.atlassian.net/browse/CC-679

#### Screenshots
![Screenshot 2021-04-13 at 13 38 08](https://user-images.githubusercontent.com/81559517/114554155-4f866a00-9c5e-11eb-911a-22b2c5390337.png)
![Screenshot 2021-04-13 at 13 38 26](https://user-images.githubusercontent.com/81559517/114554160-50b79700-9c5e-11eb-9261-99e6e18636a2.png)


[CC-679]: https://snyksec.atlassian.net/browse/CC-679