### PR TITLE
fix: supports using --project-name flag with hex umbrella projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",
     "@snyk/snyk-cocoapods-plugin": "2.5.2",
-    "@snyk/snyk-hex-plugin": "1.1.2",
+    "@snyk/snyk-hex-plugin": "1.1.3",
     "abbrev": "^1.1.1",
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",

--- a/src/lib/monitor/utils.ts
+++ b/src/lib/monitor/utils.ts
@@ -38,6 +38,11 @@ export function getProjectName(
   if (isContainer(scannedProject)) {
     return getContainerProjectName(scannedProject, meta);
   }
+
+  if (meta['project-name'] && scannedProject.meta?.projectName) {
+    return scannedProject.meta.projectName;
+  }
+
   return meta['project-name'];
 }
 

--- a/test/jest/unit/lib/monitor/utils.spec.ts
+++ b/test/jest/unit/lib/monitor/utils.spec.ts
@@ -1,0 +1,29 @@
+import { getProjectName } from '../../../../../src/lib/monitor/utils';
+import { MonitorMeta } from '../../../../../src/lib/types';
+import { ScannedProject } from '@snyk/cli-interface/legacy/common';
+
+describe('utils', () => {
+  describe('getProjectName', () => {
+    it('if project name flag provided and scannedProject.meta.projectName exists, use the scannedProject value', () => {
+      const mockScannedProject = {
+        meta: { projectName: 'newPackageName' },
+      } as ScannedProject;
+
+      const mockMeta = { 'project-name': 'newPackageName' } as MonitorMeta;
+
+      expect(getProjectName(mockScannedProject, mockMeta)).toBe(
+        'newPackageName',
+      );
+    });
+
+    it('if project name flag not provided at all, should return undefined', () => {
+      const mockScannedProjectNoHex = {
+        meta: { projectName: 'newPackageName' },
+      } as ScannedProject;
+
+      const mockMeta = {} as MonitorMeta;
+
+      expect(getProjectName(mockScannedProjectNoHex, mockMeta)).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Elixir projects can be `umbrella` projects. These projects can have multiple manifests and dependency declarations so each manifest is scanned individually. 

However if the `--project-name` is provided when running `monitor` each of the sub projects get given the same name so overwrite each other in the ui. This adds a check to use a provided projectName from the scanned projects instead