### PR TITLE
feat: remove Terraform plan file name restriction [CC-793]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -1,8 +1,15 @@
-import { tryParsingKubernetesFile } from './parsers/kubernetes-parser';
+import * as YAML from 'js-yaml';
+import {
+  MissingRequiredFieldsInKubernetesYamlError,
+  REQUIRED_K8S_FIELDS,
+  tryParsingKubernetesFile,
+} from './parsers/kubernetes-parser';
 import { tryParsingTerraformFile } from './parsers/terraform-file-parser';
-import { tryParsingTerraformPlan } from './parsers/terraform-plan-parser';
+import {
+  isTerraformPlan,
+  tryParsingTerraformPlan,
+} from './parsers/terraform-plan-parser';
 
-import * as path from 'path';
 import {
   IacFileParsed,
   IacFileData,
@@ -50,22 +57,49 @@ function generateFailedParsedFile(
   };
 }
 
-const TF_PLAN_NAME = 'tf-plan.json';
+function parseIacFileData(fileData: IacFileData): any[] {
+  let yamlDocuments;
+
+  try {
+    yamlDocuments = YAML.safeLoadAll(fileData.fileContent);
+  } catch (e) {
+    if (fileData.fileType === 'json') {
+      throw new InvalidJsonFileError(fileData.filePath);
+    } else {
+      throw new InvalidYamlFileError(fileData.filePath);
+    }
+  }
+
+  return yamlDocuments;
+}
 
 export function tryParseIacFile(fileData: IacFileData): IacFileParsed[] {
   analytics.add('iac-terraform-plan', false);
   switch (fileData.fileType) {
     case 'yaml':
-    case 'yml':
-      return tryParsingKubernetesFile(fileData);
-    case 'json':
-      // TODO: this is a temporary approach for the internal release only
-      if (path.basename(fileData.filePath) === TF_PLAN_NAME) {
+    case 'yml': {
+      const parsedIacFile = parseIacFileData(fileData);
+      return tryParsingKubernetesFile(fileData, parsedIacFile);
+    }
+    case 'json': {
+      const parsedIacFile = parseIacFileData(fileData);
+      // the Kubernetes file can have more than one JSON object in it
+      // but the Terraform plan can only have one
+      if (parsedIacFile.length === 1 && isTerraformPlan(parsedIacFile[0])) {
         analytics.add('iac-terraform-plan', true);
-        return tryParsingTerraformPlan(fileData);
+        return tryParsingTerraformPlan(fileData, parsedIacFile[0]);
+      } else {
+        try {
+          return tryParsingKubernetesFile(fileData, parsedIacFile);
+        } catch (e) {
+          if (e instanceof MissingRequiredFieldsInKubernetesYamlError) {
+            throw new FailedToDetectJsonFileError(fileData.filePath);
+          } else {
+            throw e;
+          }
+        }
       }
-
-      return tryParsingKubernetesFile(fileData);
+    }
     case 'tf':
       return tryParsingTerraformFile(fileData);
     default:
@@ -78,5 +112,33 @@ export class UnsupportedFileTypeError extends CustomError {
     super('Unsupported file extension');
     this.code = IaCErrorCodes.UnsupportedFileTypeError;
     this.userMessage = `Unable to process the file with extension ${fileType}. Supported file extensions are tf, yml, yaml & json.\nMore information can be found by running \`snyk iac test --help\` or through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool\nhttps://support.snyk.io/hc/en-us/articles/360013723877-Test-your-Terraform-files-with-our-CLI-tool`;
+  }
+}
+
+export class InvalidJsonFileError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse JSON file');
+    this.code = IaCErrorCodes.InvalidJsonFileError;
+    this.userMessage = `We were unable to parse the JSON file "${filename}". Please ensure that it contains properly structured JSON`;
+  }
+}
+
+export class InvalidYamlFileError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse YAML file');
+    this.code = IaCErrorCodes.InvalidYamlFileError;
+    this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML`;
+  }
+}
+
+export class FailedToDetectJsonFileError extends CustomError {
+  constructor(filename: string) {
+    super(
+      'Failed to detect either a Kubernetes file or Terraform Plan, missing required fields',
+    );
+    this.code = IaCErrorCodes.FailedToDetectJsonFileError;
+    this.userMessage = `We were unable to detect whether the JSON file "${filename}" is a valid Kubernetes file or Terraform Plan. For Kubernetes it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
+      '", "',
+    )}". For Terraform Plan it was expected to contain fields "planned_values.root_module" and "resource_changes". Please contact support@snyk.io, if possible with a redacted version of the file`;
   }
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -187,9 +187,11 @@ export enum IaCErrorCodes {
 
   // file-parser errors
   UnsupportedFileTypeError = 1020,
+  InvalidJsonFileError = 1021,
+  InvalidYamlFileError = 1022,
+  FailedToDetectJsonFileError = 1023,
 
   // kubernetes-parser errors
-  FailedToParseKubernetesYamlError = 1030,
   MissingRequiredFieldsInKubernetesYamlError = 1031,
   FailedToParseHelmError = 1032,
 
@@ -197,8 +199,6 @@ export enum IaCErrorCodes {
   FailedToParseTerraformFileError = 1040,
 
   // terraform-plan-parser errors
-  FailedToParseTerraformPlanJsonError = 1050,
-  MissingRequiredFieldsInTerraformPlanError = 1051,
   FailedToExtractResourcesInTerraformPlanError = 1052,
 
   // file-scanner errors

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.fixtures.ts
@@ -17,6 +17,10 @@ export const iacFileData: IacFileData = {
   fileType: 'json',
 };
 
+export const terraformPlanJson: TerraformPlanJson = JSON.parse(
+  iacFileData.fileContent,
+);
+
 const resource = {
   ingress: {
     cidr_blocks: ['0.0.0.0/0'],
@@ -92,10 +96,9 @@ export const iacFileDataNoChildModules: IacFileData = {
   fileType: 'json',
 };
 
-export const invalidJsonIacFile = {
-  ...iacFileData,
-  fileContent: tfPlanFixture.toString().slice(1),
-};
+export const terraformPlanNoChildModulesJson = JSON.parse(
+  iacFileDataNoChildModules.fileContent,
+);
 
 export const expectedParsingResultWithoutChildModules: TerraformScanInput = {
   resource: {

--- a/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/terraform-plan-parser.spec.ts
@@ -1,33 +1,23 @@
-import {
-  tryParsingTerraformPlan,
-  FailedToParseTerraformPlanJsonError,
-  FailedToExtractResourcesInTerraformPlanError,
-  MissingRequiredFieldsInTerraformPlanError,
-} from '../../../../src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
+import { tryParsingTerraformPlan } from '../../../../src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser';
 import {
   iacFileData,
-  invalidJsonIacFile,
+  terraformPlanJson,
   iacFileDataNoChildModules,
-  iacFileDataWithoutRootModule,
-  iacFileDataWithoutResourceChanges,
   expectedParsingResultFullScan,
   expectedParsingResultDeltaScan,
   expectedParsingResultWithoutChildModules,
+  terraformPlanNoChildModulesJson,
 } from './terraform-plan-parser.fixtures';
 import { EngineType } from '../../../../src/cli/commands/test/iac-local-execution/types';
 
 describe('tryParsingTerraformPlan', () => {
-  it('throws an error for invalid JSON', () => {
-    expect(() => tryParsingTerraformPlan(invalidJsonIacFile)).toThrowError(
-      FailedToParseTerraformPlanJsonError,
-    );
-  });
-
   describe('full scan', () => {
     it('returns the expected resources', () => {
-      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData, {
-        isFullScan: true,
-      });
+      const parsedTerraformPlan = tryParsingTerraformPlan(
+        iacFileData,
+        terraformPlanJson,
+        { isFullScan: true },
+      );
       expect(parsedTerraformPlan[0]).toEqual({
         ...iacFileData,
         engineType: EngineType.Terraform,
@@ -38,6 +28,7 @@ describe('tryParsingTerraformPlan', () => {
     it('does not fail if no child-modules are present', () => {
       const parsedTerraformPlan = tryParsingTerraformPlan(
         iacFileDataNoChildModules,
+        terraformPlanNoChildModulesJson,
         { isFullScan: true },
       );
       expect(parsedTerraformPlan[0]).toEqual({
@@ -46,30 +37,19 @@ describe('tryParsingTerraformPlan', () => {
         jsonContent: expectedParsingResultWithoutChildModules,
       });
     });
-
-    it('throws an error for missing required fields', () => {
-      expect(() =>
-        tryParsingTerraformPlan(iacFileDataWithoutRootModule, {
-          isFullScan: true,
-        }),
-      ).toThrowError(MissingRequiredFieldsInTerraformPlanError);
-    });
   });
 
   describe('default delta scan', () => {
     it('returns the expected resources', () => {
-      const parsedTerraformPlan = tryParsingTerraformPlan(iacFileData);
+      const parsedTerraformPlan = tryParsingTerraformPlan(
+        iacFileData,
+        terraformPlanJson,
+      );
       expect(parsedTerraformPlan[0]).toEqual({
         ...iacFileData,
         engineType: EngineType.Terraform,
         jsonContent: expectedParsingResultDeltaScan,
       });
-    });
-
-    it('throws an error for missing required fields', () => {
-      expect(() =>
-        tryParsingTerraformPlan(iacFileDataWithoutResourceChanges),
-      ).toThrowError(MissingRequiredFieldsInTerraformPlanError);
     });
   });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR removes the Terraform Plan file name restriction, so that we can run IaC on Terraform Plan files that have any name, not just `tf-plan.json`. 

[CC-793]

#### Where should the reviewer start?
- Start with the `tryParseIacFile` function in `src/cli/commands/test/iac-local-execution/file-parser.ts`. For JSON files, we can have either Kubernetes files or Terraform Plans.
- Have a look at `tryParsingTerraformPlan` and `tryParsingKubernetesFile` in their individual parsers and notice that first we parse the files (using `JSON.parse` and `YAML.safeLoadAll` respectively)
     - This PR moves this parsing logic to `src/cli/commands/test/iac-local-execution/file-parser.ts` file, so that we can do any non-parser specific transformations before we call `tryParsingTerraformPlan` and `tryParsingKubernetesFile`
     - As a result, this PR also replaces some Kubernetes/Terraform specific errors with more generic JSON/YAML parsing errors
- The `assertRequiredFields` function in the Terraform Plan parser has now become `isTerraformPlan` and is used in `src/cli/commands/test/iac-local-execution/file-parser.ts` to decide which of `tryParsingTerraformPlan` and `tryParsingKubernetesFile` to run

#### How should this be manually tested?
1. Compile the code using `npm run build`
2. Run the CLI on the existing Terraform Plan fixture under `test/fixtures/iac/terraform-plan/`: `node ./dist/cli iac test --experimental test/fixtures/iac/terraform-plan/tf-plan.json`.
3. Make a copy of the file and give it a different name (e.g. `tf-plan-custom.json`)
4. Run the CLI on the new file: `node ./dist/cli iac test --experimental test/fixtures/iac/terraform-plan/tf-plan-custom.json`.
5. Run the CLI on the existing, invalid Terraform Plan fixture under `test/fixtures/iac/terraform-plan/` to see the error message: `node ./dist/cli iac test --experimental test/fixtures/iac/terraform-plan/tf-plan-missing-fields.json`.

#### Any background context you want to provide?
The code currently in `master` works with a hardcoded `tf-plan.json` file name for Terraform Plans, in order to differentiate between Kubernetes JSON files and Terraform Plan JSON files. We validate that the file has some required fields in order to continue parsing the Terraform Plan, so we assert that we can use those checks earlier on to remove the hardcoded file name altogether and be able to run on any file that looks like a Terraform Plan.

#### What are the relevant tickets?
[CC-793](https://snyksec.atlassian.net/browse/CC-793): https://snyksec.atlassian.net/browse/CC-793

#### Screenshots
- running `snyk iac test --experimental` on properly named `tf-plan.json`, with and without the change:
- ![Screenshot 2021-04-15 at 10 40 20](https://user-images.githubusercontent.com/81559517/114849049-48369c00-9dd7-11eb-934b-40728741bebd.png)
- running `snyk iac test --experimental` on any Terraform Plan, with and without the change:
- ![Screenshot 2021-04-15 at 10 40 45](https://user-images.githubusercontent.com/81559517/114849053-4967c900-9dd7-11eb-9ccc-5c8104a5af7b.png)
- running `snyk iac test --experimental` on a Terraform Plan without the required fields, with and without the change:
![Screenshot 2021-04-15 at 13 52 49](https://user-images.githubusercontent.com/81559517/114872103-e33c6f80-9df1-11eb-8bed-c494b261d1a8.png)
- running `snyk iac test --experimental` on Helm file, with and without the change:
![Screenshot 2021-04-15 at 10 41 46](https://user-images.githubusercontent.com/81559517/114871883-a8d2d280-9df1-11eb-8cb4-61699ba3c507.png)


[CC-793]: https://snyksec.atlassian.net/browse/CC-793