### PR TITLE
fix: support proxy env vars for code

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@open-policy-agent/opa-wasm": "^1.2.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.9.2",
-    "@snyk/code-client": "3.4.0",
+    "@snyk/code-client": "3.4.1",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/fix": "1.539.0",
     "@snyk/gemfile": "1.2.0",


### PR DESCRIPTION
change in code client removed axios default proxy support, therefore it
won't be clashing with our own proxy support

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps code client version, therefore fixes problems with proxy.