### PR TITLE
Feat: Support custom severities from Org IaC Settings

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -13,6 +13,7 @@ import { cleanLocalCache, initLocalCache } from './local-cache';
 import { addIacAnalytics } from './analytics';
 import { TestResult } from '../../../../lib/snyk-test/legacy';
 import { IacFileInDirectory } from '../../../../lib/types';
+import { applyCustomSeverities } from './org-settings/apply-custom-severities';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // the current version is dependent on files to be present locally which are not part of the source code.
@@ -30,7 +31,11 @@ export async function test(
   const filesToParse = await loadFiles(pathToScan, options);
   const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
   const scannedFiles = await scanFiles(parsedFiles);
-  const formattedResults = formatScanResults(scannedFiles, options);
+  const resultsWithCustomSeverities = await applyCustomSeverities(scannedFiles);
+  const formattedResults = formatScanResults(
+    resultsWithCustomSeverities,
+    options,
+  );
   addIacAnalytics(formattedResults);
   cleanLocalCache();
 

--- a/src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities.ts
+++ b/src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities.ts
@@ -1,0 +1,27 @@
+import { IacFileScanResult } from '../types';
+import { getIacOrgSettings } from './get-iac-org-settings';
+import _ = require('lodash');
+import { SEVERITY } from '../../../../../lib/snyk-test/common';
+
+export async function applyCustomSeverities(
+  scannedFiles: IacFileScanResult[],
+): Promise<IacFileScanResult[]> {
+  const iacOrgSettings = await getIacOrgSettings();
+  const customPolicies = iacOrgSettings.customPolicies;
+
+  if (Object.keys(customPolicies).length > 0) {
+    return scannedFiles.map((file) => {
+      const updatedScannedFiles = _.cloneDeep(file);
+      updatedScannedFiles.violatedPolicies.forEach((existingPolicy) => {
+        const customPolicyForPublicID = customPolicies[existingPolicy.publicId];
+        if (customPolicyForPublicID) {
+          existingPolicy.severity =
+            (customPolicyForPublicID.severity as SEVERITY) ??
+            existingPolicy.severity;
+        }
+      });
+      return updatedScannedFiles;
+    });
+  }
+  return scannedFiles;
+}

--- a/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts
@@ -1,0 +1,40 @@
+import { IaCErrorCodes, IacOrgSettings } from '../types';
+import { Payload } from '../../../../../lib/snyk-test/types';
+import * as config from '../../../../../lib/config';
+import { isCI } from '../../../../../lib/is-ci';
+import { api } from '../../../../../lib/api-token';
+import request = require('../../../../../lib/request');
+import { CustomError } from '../../../../../lib/errors';
+
+export function getIacOrgSettings(): Promise<IacOrgSettings> {
+  const payload: Payload = {
+    method: 'get',
+    url: config.API + '/iac-org-settings',
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: `token ${api()}`,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    request(payload, (error, res) => {
+      if (error) {
+        return reject(error);
+      }
+      if (res.statusCode < 200 || res.statusCode > 299) {
+        return reject(new FailedToGetIacOrgSettingsError());
+      }
+      resolve(res.body);
+    });
+  });
+}
+
+export class FailedToGetIacOrgSettingsError extends CustomError {
+  constructor(message?: string) {
+    super(message || 'Failed to fetch IaC organization settings');
+    this.code = IaCErrorCodes.FailedToGetIacOrgSettingsError;
+    this.userMessage =
+      'We failed to fetch your organization settings, including custom severity overrides for infrastructure-as-code policies. Please run the command again with the `-d` flag and contact support@snyk.io with the contents of the output.';
+  }
+}

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -104,21 +104,25 @@ function groupMultiDocResults(
   return Object.values(groupedData);
 }
 
-function filterPoliciesBySeverity(
+export function filterPoliciesBySeverity(
   violatedPolicies: PolicyMetadata[],
   severityThreshold?: SEVERITY,
 ): PolicyMetadata[] {
   if (!severityThreshold || severityThreshold === SEVERITY.LOW) {
-    return violatedPolicies;
+    return violatedPolicies.filter((violatedPolicy) => {
+      return violatedPolicy.severity !== 'none';
+    });
   }
 
   const severitiesToInclude = SEVERITIES.slice(
     SEVERITIES.indexOf(severityThreshold),
   );
-
-  return violatedPolicies.filter((policy) =>
-    severitiesToInclude.includes(policy.severity),
-  );
+  return violatedPolicies.filter((policy) => {
+    return (
+      policy.severity !== 'none' &&
+      severitiesToInclude.includes(policy.severity)
+    );
+  });
 }
 
 export class FailedToFormatResults extends CustomError {

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -59,6 +59,17 @@ export type FormattedResult = {
   projectName: string;
 };
 
+export interface IacOrgSettings {
+  meta: TestMeta;
+  customPolicies: Record<string, { severity?: string }>;
+}
+export interface TestMeta {
+  isPrivate: boolean;
+  isLicensesEnabled: boolean;
+  org: string;
+  ignoreSettings?: IgnoreSettings | null;
+}
+
 export interface OpaWasmInstance {
   evaluate: (data: Record<string, any>) => { results: PolicyMetadata[] };
   setData: (data: Record<string, any>) => void;
@@ -81,7 +92,7 @@ export interface PolicyMetadata {
   title: string;
   // Legacy field, still included in WASM eval output, but not in use.
   description: string;
-  severity: SEVERITY;
+  severity: SEVERITY | 'none'; // the 'null' value can be provided by the backend
   msg: string;
   policyEngineType: 'opa';
   issue: string;
@@ -208,4 +219,7 @@ export enum IaCErrorCodes {
   // results-formatter errors
   FailedToFormatResults = 1070,
   FailedToExtractLineNumberError = 1071,
+
+  // get-iac-org-settings errors
+  FailedToGetIacOrgSettingsError = 1080,
 }

--- a/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
+++ b/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
@@ -1,0 +1,50 @@
+import * as getIacOrgSettingsModule from '../../../../src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings';
+import { applyCustomSeverities } from '../../../../src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities';
+import { scanResults } from './results-formatter.fixtures';
+
+describe('applyCustomSeverities', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  const mockedIacSettings = {
+    meta: {
+      isPrivate: false,
+      isLicensesEnabled: false,
+      ignoreSettings: null,
+      org: 'org-name',
+    },
+    customPolicies: {
+      'SNYK-CC-TF-1': { severity: 'high' },
+      'SNYK-CC-K8S-1': { severity: 'low' },
+    },
+  };
+
+  it('updates existing severity with custom one for the same public id', async () => {
+    jest
+      .spyOn(getIacOrgSettingsModule, 'getIacOrgSettings')
+      .mockResolvedValue(mockedIacSettings);
+
+    const actualResults = await applyCustomSeverities(scanResults);
+    const actualSeverity = actualResults[0].violatedPolicies[0].severity;
+
+    expect(actualSeverity).toEqual(
+      mockedIacSettings.customPolicies['SNYK-CC-K8S-1'].severity,
+    );
+  });
+
+  it('does not update existing severity when there is no match for that public id', async () => {
+    const notMatchingCustomPolicies = {
+      ...mockedIacSettings,
+      customPolicies: { 'SNYK-CC-K8S-1039': { severity: 'high' } },
+    };
+    jest
+      .spyOn(getIacOrgSettingsModule, 'getIacOrgSettings')
+      .mockResolvedValue(notMatchingCustomPolicies);
+
+    const actualResults = await applyCustomSeverities(scanResults);
+
+    expect(actualResults).toEqual(scanResults);
+  });
+});

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -7,7 +7,7 @@ import {
 import { IacProjectType } from '../../../../src/lib/iac/constants';
 import { SEVERITY } from '../../../../src/lib/snyk-test/common';
 
-const policyStub: PolicyMetadata = {
+export const policyStub: PolicyMetadata = {
   id: '1',
   description: '',
   impact:


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- This PR fetches organization settings data related to IaC, including customPolicies (custom severities) from an external endpoint. These are needed to be used for updating the local violatedPolicies with any custom severities before formatting the results to the user.
- We will also need the metadata for printing other useful info, such as organization name, etc  in a different PR.

#### Where should the reviewer start?

There are 2 files of interest:
-  `src/cli/commands/test/iac-local-execution/get-iac-org-settings.ts` to fetch the settings
- `src/cli/commands/test/iac-local-execution/apply-custom-severities.ts` to call the GET endpoint, update the existing severities with new ones
- Check that also a severity of `'none'` now results to the file being filtered out of the results (this happens in results-formatter.ts).

#### How should this be manually tested?
- Run npm run build
- Override the severity (via the UI or the local db in the Orgs table) of a rule. Here we are going to provide the example of `test/fixtures/iac/terraform/sg_open_ssh.tf`, the violated policy is 'SNYK-CC-TF-1'. The default severity was set to medium.
- Change it first to 'low' or 'high'
- Run `node ./dist/cli iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental` and check that the issue is now shown as your updated severity
- Now change it to 'none'
- - Run `node ./dist/cli iac test test/fixtures/iac/terraform/sg_open_ssh.tf --experimental` and check that there are now 0 issues coming back as a result.

#### What are the relevant tickets?
[CC-770]

#### Screenshots
Before, with the default customPolicy:
<img width="579" alt="image" src="https://user-images.githubusercontent.com/6989529/115069534-98068780-9eeb-11eb-8e19-2e88b9ab4cf5.png">

Updating it with 'high' severity:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/6989529/115069671-d308bb00-9eeb-11eb-8ac9-6358f7e01b7c.png">


After it with 'none' severity:
<img width="578" alt="image" src="https://user-images.githubusercontent.com/6989529/115069485-891fd500-9eeb-11eb-8817-42062835b4a3.png">


#### Additional questions

[CC-770]: https://snyksec.atlassian.net/browse/CC-770