### PR TITLE
refactor: Move linenumber function to its own module.

### DIFF
--- a/src/cli/commands/test/iac-local-execution/extract-line-number.ts
+++ b/src/cli/commands/test/iac-local-execution/extract-line-number.ts
@@ -1,0 +1,52 @@
+import { IaCErrorCodes, IacFileScanResult, PolicyMetadata } from './types';
+import { CustomError } from '../../../../lib/errors';
+import {
+  CloudConfigFileTypes,
+  issuesToLineNumbers,
+} from '@snyk/cloud-config-parser';
+import { UnsupportedFileTypeError } from './file-parser';
+import * as analytics from '../../../../lib/analytics';
+import * as Debug from 'debug';
+const debug = Debug('iac-extract-line-number');
+
+function getFileTypeForLineNumber(fileType: string): CloudConfigFileTypes {
+  switch (fileType) {
+    case 'yaml':
+    case 'yml':
+      return CloudConfigFileTypes.YAML;
+    case 'json':
+      return CloudConfigFileTypes.JSON;
+    case 'tf':
+      return CloudConfigFileTypes.TF;
+    default:
+      throw new UnsupportedFileTypeError(fileType);
+  }
+}
+
+export function extractLineNumber(
+  scanResult: IacFileScanResult,
+  policy: PolicyMetadata,
+): number {
+  try {
+    return issuesToLineNumbers(
+      scanResult.fileContent,
+      getFileTypeForLineNumber(scanResult.fileType),
+      policy.msg.split('.'), // parser defaults to docId:0 and checks for the rest of the path
+    );
+  } catch {
+    const err = new FailedToExtractLineNumberError();
+    analytics.add('error-code', err.code);
+    debug('Parser library failed. Could not assign lineNumber to issue');
+    return -1;
+  }
+}
+
+class FailedToExtractLineNumberError extends CustomError {
+  constructor(message?: string) {
+    super(
+      message || 'Parser library failed. Could not assign lineNumber to issue',
+    );
+    this.code = IaCErrorCodes.FailedToExtractLineNumberError;
+    this.userMessage = ''; // Not a user facing error.
+  }
+}


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Move the two functions relevant to getting line numbers to a new module file. 
The results formatter was getting bigger and not easy enough to read, so with this PR I am trying to seperate the concerns of the modules.


#### Additional questions
