### PR TITLE
feat: Fetch customPolicies and org settings for IaC

### DIFF
--- a/src/cli/commands/test/iac-local-execution/get-iac-org-settings.ts
+++ b/src/cli/commands/test/iac-local-execution/get-iac-org-settings.ts
@@ -1,0 +1,36 @@
+import { CustomPoliciesWithMeta } from './types';
+import { Payload } from '../../../../lib/snyk-test/types';
+import * as config from '../../../../lib/config';
+import { isCI } from '../../../../lib/is-ci';
+import { api } from '../../../../lib/api-token';
+import * as Debug from 'debug';
+import request = require('../../../../lib/request');
+
+const debug = Debug('iac-get-iac-org-settings');
+
+/*
+ * Fetches custom policies (updated severities) and some org metadata
+ * If there is an error, it returns an object of the form {code, message, error}, example:
+ * {code: 401, message: 'Invalid auth token provided', error: 'Invalid auth token provided'}
+ */
+export function getIacOrgSettings(): Promise<CustomPoliciesWithMeta> {
+  const payload: Payload = {
+    method: 'get',
+    url: config.API + '/iac-org-settings',
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: `token ${api()}`,
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    request(payload, (error, res) => {
+      if (error) {
+        debug('Could not retrieve custom policies, an error occurred');
+        return reject(error);
+      }
+      resolve(res.body);
+    });
+  });
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -59,6 +59,17 @@ export type FormattedResult = {
   projectName: string;
 };
 
+export interface CustomPoliciesWithMeta {
+  meta: TestMeta;
+  customPolicies: Record<string, string>;
+}
+export interface TestMeta {
+  isPrivate: boolean;
+  isLicensesEnabled: boolean;
+  ignoreSettings: object;
+  org: string;
+}
+
 export interface OpaWasmInstance {
   evaluate: (data: Record<string, any>) => { results: PolicyMetadata[] };
   setData: (data: Record<string, any>) => void;


### PR DESCRIPTION
CC-770

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR fetches the customPolicies (custom severities) from an external endpoint. 
This is needed to be used for updating the local violatedPolicies with any custom severities before formatting the results to the user.

#### Where should the reviewer start?
1. Run `npm run build`
2. Override a severity (via the UI or the local db in the Orgs table)
2. Add a console.log to check that the response of the endpoint returns customPolicies
(For now, this endpoint is just provided and does not do anything else)

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
