### PR TITLE
chore: use @snyk/fix entity type in conversion

### DIFF
--- a/src/cli/commands/fix/convert-legacy-tests-results-to-fix-entities.ts
+++ b/src/cli/commands/fix/convert-legacy-tests-results-to-fix-entities.ts
@@ -3,11 +3,12 @@ import * as pathLib from 'path';
 import { convertLegacyTestResultToNew } from './convert-legacy-test-result-to-new';
 import { convertLegacyTestResultToScanResult } from './convert-legacy-test-result-to-scan-result';
 import { TestResult } from '../../../lib/snyk-test/legacy';
+import { EntityToFix } from '@snyk/fix';
 
 export function convertLegacyTestResultToFixEntities(
   testResults: (TestResult | TestResult[]) | Error,
   root: string,
-): any {
+): EntityToFix[] {
   if (testResults instanceof Error) {
     return [];
   }

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -1,4 +1,5 @@
 import { DepGraphData } from '@snyk/dep-graph';
+import { SEVERITY } from '../snyk-test/common';
 import { RemediationChanges } from '../snyk-test/legacy';
 import { Options } from '../types';
 
@@ -63,7 +64,7 @@ export interface Issue {
 export interface IssuesData {
   [issueId: string]: {
     id: string;
-    severity: string;
+    severity: SEVERITY;
     title: string;
   };
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Drop `any` and use the @snyk/fix expected type. 
Use expected severity type