### PR TITLE
feat: show debug mode tip if something failed

### DIFF
--- a/packages/snyk-fix/src/lib/errors/common.ts
+++ b/packages/snyk-fix/src/lib/errors/common.ts
@@ -1,0 +1,4 @@
+export const reTryMessage =
+  'Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>';
+export const contactSupportMessage =
+  'If the issue persists contact support@snyk.io';

--- a/packages/snyk-fix/src/lib/errors/failed-to-parse-manifest.ts
+++ b/packages/snyk-fix/src/lib/errors/failed-to-parse-manifest.ts
@@ -3,7 +3,7 @@ import { CustomError, ERROR_CODES } from './custom-error';
 export class FailedToParseManifest extends CustomError {
   public constructor() {
     super(
-      'Failed to parse manifest. Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>',
+      'Failed to parse manifest',
       ERROR_CODES.FailedToParseManifest,
     );
   }

--- a/packages/snyk-fix/src/lib/errors/invalid-workspace.ts
+++ b/packages/snyk-fix/src/lib/errors/invalid-workspace.ts
@@ -3,7 +3,7 @@ import { CustomError, ERROR_CODES } from './custom-error';
 export class MissingFileNameError extends CustomError {
   public constructor() {
     super(
-      'Filename is missing from test result. Please contact support@snyk.io.',
+      'Filename is missing from test result',
       ERROR_CODES.MissingFileName,
     );
   }

--- a/packages/snyk-fix/src/lib/errors/missing-file-name.ts
+++ b/packages/snyk-fix/src/lib/errors/missing-file-name.ts
@@ -3,7 +3,7 @@ import { CustomError, ERROR_CODES } from './custom-error';
 export class MissingFileNameError extends CustomError {
   public constructor() {
     super(
-      'Filename is missing from test result. Please contact support@snyk.io.',
+      'Filename is missing from test result',
       ERROR_CODES.MissingFileName,
     );
   }

--- a/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
+++ b/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
@@ -3,7 +3,7 @@ import { CustomError, ERROR_CODES } from './custom-error';
 export class NoFixesCouldBeAppliedError extends CustomError {
   public constructor() {
     super(
-      'No fixes could be applied. Please contact support@snyk.io',
+      'No fixes could be applied',
       ERROR_CODES.UnsupportedTypeError,
     );
   }

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -2,6 +2,7 @@ import * as chalk from 'chalk';
 
 import { FixHandlerResultByPlugin } from '../../plugins/types';
 import { ErrorsByEcoSystem, Issue, TestResult } from '../../types';
+import { contactSupportMessage, reTryMessage } from '../errors/common';
 import { convertErrorToUserMessage } from '../errors/error-to-user-message';
 import { hasFixableIssues } from '../issues/fixable-issues';
 import { getIssueCountBySeverity } from '../issues/issues-by-severity';
@@ -32,13 +33,14 @@ export async function showResultsSummary(
   const fixedIssuesSummary = `${chalk.bold(
     calculateFixedIssues(resultsByPlugin),
   )} fixed issues`;
+  const getHelpText = chalk.red(`\n${reTryMessage}. ${contactSupportMessage}`);
   return `\n${successfulFixesSummary}${
     unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
   }${
     unresolvedCount || changedCount
       ? `\n\n${overallSummary}\n${vulnsSummary}\n${PADDING_SPACE}${fixedIssuesSummary}`
       : ''
-  }`;
+  }${unresolvedSummary ? `\n\n${getHelpText}` : ''}`;
 }
 
 export function generateSuccessfulFixesSummary(

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -73,7 +73,10 @@ Summary:
   0 items were successfully fixed
   1 total issues: 1 High
   1 fixable issues
-  0 fixed issues",
+  0 fixed issues
+
+
+Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
   "meta": Object {
     "failed": 1,
     "fixed": 0,
@@ -196,7 +199,10 @@ Summary:
   1 items were successfully fixed
   2 total issues: 2 High
   2 fixable issues
-  1 fixed issues",
+  1 fixed issues
+
+
+Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
   "meta": Object {
     "failed": 1,
     "fixed": 1,

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -82,7 +82,10 @@ Summary:
   1 items were successfully fixed
   3 total issues: 3 High
   3 fixable issues
-  1 fixed issues"
+  1 fixed issues
+
+
+Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
 `;
 
 exports[`showResultsSummary has unresolved only 1`] = `
@@ -100,5 +103,8 @@ Summary:
   0 items were successfully fixed
   1 total issues: 1 High
   1 fixable issues
-  0 fixed issues"
+  0 fixed issues
+
+
+Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
 `;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Instead of repeating the messaging under each item, show it once at the end with more information so users can debug & reach out to support if that does not help.
#### Screenshots
<img width="1381" alt="CleanShot 2021-04-16 at 13 11 43@2x" src="https://user-images.githubusercontent.com/2911613/115046799-caa28700-9ecf-11eb-9988-8b8c4b6cee1a.png">


#### Additional questions
