### PR TITLE
docs: remove help note for tf-plan.json restriction [CC-793]

### DIFF
--- a/help/commands-docs/iac-examples.md
+++ b/help/commands-docs/iac-examples.md
@@ -11,7 +11,5 @@
 - `Test terraform plan file`:
   \$ snyk iac test /path/to/tf-plan.json --experimental
   
-  Note: Your terraform plan file needs to be named exactly as 'tf-plan.json'
-
 - `Test matching files in a directory`:
   \$ snyk iac test /path/to/directory

--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -57,10 +57,12 @@ function generateFailedParsedFile(
   };
 }
 
-function parseIacFileData(fileData: IacFileData): any[] {
+function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
   let yamlDocuments;
 
   try {
+    // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
+    // by using this library we don't have to disambiguate between these different contents ourselves
     yamlDocuments = YAML.safeLoadAll(fileData.fileContent);
   } catch (e) {
     if (fileData.fileType === 'json') {
@@ -78,11 +80,11 @@ export function tryParseIacFile(fileData: IacFileData): IacFileParsed[] {
   switch (fileData.fileType) {
     case 'yaml':
     case 'yml': {
-      const parsedIacFile = parseIacFileData(fileData);
+      const parsedIacFile = parseYAMLOrJSONFileData(fileData);
       return tryParsingKubernetesFile(fileData, parsedIacFile);
     }
     case 'json': {
-      const parsedIacFile = parseIacFileData(fileData);
+      const parsedIacFile = parseYAMLOrJSONFileData(fileData);
       // the Kubernetes file can have more than one JSON object in it
       // but the Terraform plan can only have one
       if (parsedIacFile.length === 1 && isTerraformPlan(parsedIacFile[0])) {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR updates the `snyk --help` command to remove the note about the Terraform plan file name restriction.

#### Where should the reviewer start?
Have a look at the markdown document for any spelling mistakes.

#### How should this be manually tested?
Run `npm run generate-help` and have a look at the sections that changed.

#### Any background context you want to provide?
The code changes were delivered under https://github.com/snyk/snyk/pull/1822.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-793

#### Screenshots
![Screenshot 2021-04-16 at 16 22 15](https://user-images.githubusercontent.com/81559517/115047093-19e8b780-9ed0-11eb-9b1e-3773a3809586.png)

