### PR TITLE
Feat: pipfile handler check & share common functionality

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -42,7 +42,6 @@
     "@snyk/dep-graph": "^1.21.0",
     "chalk": "4.1.0",
     "debug": "^4.3.1",
-    "micromatch": "4.0.2",
     "ora": "5.3.0",
     "p-map": "^4.0.0",
     "strip-ansi": "6.0.0"

--- a/packages/snyk-fix/src/plugins/python/get-handler-type.ts
+++ b/packages/snyk-fix/src/plugins/python/get-handler-type.ts
@@ -1,5 +1,3 @@
-import * as micromatch from 'micromatch';
-
 import { EntityToFix } from '../../types';
 import { SUPPORTED_HANDLER_TYPES } from './supported-handler-types';
 
@@ -18,11 +16,5 @@ export function getHandlerType(
 }
 
 export function isRequirementsTxtManifest(targetFile: string): boolean {
-  return micromatch.isMatch(
-    targetFile,
-    // micromatch needs **/* to match filenames that may include folders
-    ['*.txt'].map(
-      (f) => '**/' + f,
-    ),
-  );
+  return targetFile.endsWith('.txt');
 }

--- a/packages/snyk-fix/src/plugins/python/get-handler-type.ts
+++ b/packages/snyk-fix/src/plugins/python/get-handler-type.ts
@@ -18,3 +18,7 @@ export function getHandlerType(
 export function isRequirementsTxtManifest(targetFile: string): boolean {
   return targetFile.endsWith('.txt');
 }
+
+export function isPipfileManifest(targetFile: string): boolean {
+  return targetFile.endsWith('Pipfile') || targetFile.endsWith('Pipfile.lock');
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/is-supported.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/is-supported.ts
@@ -1,4 +1,4 @@
-import { EntityToFix, WithUserMessage } from '../../../../types';
+import { EntityToFix, WithUserMessage } from '../../../types';
 
 interface Supported {
   supported: true;

--- a/packages/snyk-fix/src/plugins/python/handlers/valdidate-required-data.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/valdidate-required-data.ts
@@ -1,0 +1,26 @@
+import { MissingRemediationDataError } from '../../../lib/errors/missing-remediation-data';
+import { MissingFileNameError } from '../../../lib/errors/missing-file-name';
+import { NoFixesCouldBeAppliedError } from '../../../lib/errors/no-fixes-applied';
+import { EntityToFix, RemediationChanges, Workspace } from '../../../types';
+
+export function validateRequiredData(
+  entity: EntityToFix,
+): {
+  remediation: RemediationChanges;
+  targetFile: string;
+  workspace: Workspace;
+} {
+  const { remediation } = entity.testResult;
+  if (!remediation) {
+    throw new MissingRemediationDataError();
+  }
+  const { targetFile } = entity.scanResult.identity;
+  if (!targetFile) {
+    throw new MissingFileNameError();
+  }
+  const { workspace } = entity;
+  if (!workspace) {
+    throw new NoFixesCouldBeAppliedError();
+  }
+  return { targetFile, remediation, workspace };
+}

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -42,7 +42,9 @@ export async function pythonFix(
     Object.keys(entitiesPerType),
     async (projectType) => {
       const projectsToFix: EntityToFix[] = entitiesPerType[projectType];
-
+      if (!projectsToFix.length) {
+        return;
+      }
       const processingMessage = `Processing ${projectsToFix.length} ${projectType} items`;
       spinner.text = processingMessage;
       spinner.render();

--- a/packages/snyk-fix/src/plugins/types.ts
+++ b/packages/snyk-fix/src/plugins/types.ts
@@ -1,6 +1,5 @@
 import {
   EntityToFix,
-  FixChangesSummary,
   FixOptions,
   WithError,
   WithFixChangesApplied,

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
@@ -1,5 +1,6 @@
 import {
   getHandlerType,
+  isPipfileManifest,
   isRequirementsTxtManifest,
 } from '../../../../../../src/plugins/python/get-handler-type';
 import { SUPPORTED_HANDLER_TYPES } from '../../../../../../src/plugins/python/supported-handler-types';
@@ -40,5 +41,18 @@ describe('isRequirementsTxtManifest', () => {
 
   it('package.json is correctly classed as NOT a requirements.txt manifest', () => {
     expect(isRequirementsTxtManifest('package.json')).toBeFalsy();
+  });
+});
+
+describe('isPipfileManifest', () => {
+  it('dev.txt is NOT a Pipfile file', () => {
+    expect(isPipfileManifest('dev.txt')).toBeFalsy();
+  });
+  it('path/to/Pipfile is Pipfile file', () => {
+    expect(isPipfileManifest('path/to/Pipfile')).toBeTruthy();
+  });
+
+  it('path/to/Pipfile.lock is Pipfile file', () => {
+    expect(isPipfileManifest('lib/Pipfile.lock')).toBeTruthy();
   });
 });

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
@@ -30,6 +30,10 @@ describe('isRequirementsTxtManifest', () => {
   it('dev.txt is requirements.txt manifest', () => {
     expect(isRequirementsTxtManifest('dev.txt')).toBeTruthy();
   });
+
+  it('lib/prod.txt is requirements.txt manifest', () => {
+    expect(isRequirementsTxtManifest('dev.txt')).toBeTruthy();
+  });
   it('requirements.txt is correctly classed as requirements.txt manifest', () => {
     expect(isRequirementsTxtManifest('requirements.txt')).toBeTruthy();
   });

--- a/packages/snyk-fix/test/unit/plugins/python/is-supported.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/is-supported.spec.ts
@@ -1,4 +1,4 @@
-import { isSupported } from '../../../../src/plugins/python/handlers/pip-requirements/is-supported';
+import { isSupported } from '../../../../src/plugins/python/handlers/is-supported';
 import { generateEntityToFix } from '../../../helpers/generate-entity-to-fix';
 
 describe('isSupported', () => {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- drop micromatch it was under used and not needed, the check is much simpler here as CLI already had done the work of classifying the project type as python.
- add a new check with tests for a project that has a `Pipfile` manifest  + tests (nothing is using it yet)
