### PR TITLE
feat: send options & path to @snyk/fix

### DIFF
--- a/src/cli/commands/fix/convert-legacy-tests-results-to-fix-entities.ts
+++ b/src/cli/commands/fix/convert-legacy-tests-results-to-fix-entities.ts
@@ -4,17 +4,21 @@ import { convertLegacyTestResultToNew } from './convert-legacy-test-result-to-ne
 import { convertLegacyTestResultToScanResult } from './convert-legacy-test-result-to-scan-result';
 import { TestResult } from '../../../lib/snyk-test/legacy';
 import { EntityToFix } from '@snyk/fix';
+import { Options, TestOptions } from '../../../lib/types';
 
 export function convertLegacyTestResultToFixEntities(
   testResults: (TestResult | TestResult[]) | Error,
   root: string,
+  options: Partial<Options & TestOptions>,
 ): EntityToFix[] {
   if (testResults instanceof Error) {
     return [];
   }
   const oldResults = Array.isArray(testResults) ? testResults : [testResults];
   return oldResults.map((res) => ({
+    options,
     workspace: {
+      path: root,
       readFile: async (path: string) => {
         return fs.readFileSync(pathLib.resolve(root, path), 'utf8');
       },

--- a/src/cli/commands/fix/index.ts
+++ b/src/cli/commands/fix/index.ts
@@ -98,7 +98,11 @@ async function runSnykTestLegacy(
           ? testResultForPath
           : [testResultForPath]),
       );
-      const newRes = convertLegacyTestResultToFixEntities(testResults, path);
+      const newRes = convertLegacyTestResultToFixEntities(
+        testResults,
+        path,
+        options,
+      );
       results.push(...newRes);
       stdOutSpinner.stopAndPersist({
         text: spinnerMessage,

--- a/test/jest/unit/lib/commands/fix/__snapshots__/convert-legacy-tests-results-to-fix-entities.spec.ts.snap
+++ b/test/jest/unit/lib/commands/fix/__snapshots__/convert-legacy-tests-results-to-fix-entities.spec.ts.snap
@@ -3,6 +3,9 @@
 exports[`Convert legacy TestResult to ScanResult can convert npm test result with no remediation 1`] = `
 Array [
   Object {
+    "options": Object {
+      "allProjects": true,
+    },
     "scanResult": Object {
       "facts": Array [],
       "identity": Object {
@@ -70,6 +73,7 @@ patch: {}
       "remediation": undefined,
     },
     "workspace": Object {
+      "path": "acceptance/fixtures/npm-package-with-severity-override",
       "readFile": [Function],
       "writeFile": [Function],
     },
@@ -80,6 +84,9 @@ patch: {}
 exports[`Convert legacy TestResult to ScanResult can convert npm test result with remediation 1`] = `
 Array [
   Object {
+    "options": Object {
+      "allProjects": true,
+    },
     "scanResult": Object {
       "facts": Array [],
       "identity": Object {
@@ -177,6 +184,7 @@ patch: {}
       },
     },
     "workspace": Object {
+      "path": "acceptance/fixtures/npm-package-with-severity-override",
       "readFile": [Function],
       "writeFile": [Function],
     },
@@ -187,6 +195,7 @@ patch: {}
 exports[`Convert legacy TestResult to ScanResult can convert pip test result with remediation (pins) 1`] = `
 Array [
   Object {
+    "options": Object {},
     "scanResult": Object {
       "facts": Array [],
       "identity": Object {
@@ -351,6 +360,7 @@ Upgrade \`django\` to version 2.2.18, 3.0.12, 3.1.6 or higher.
       },
     },
     "workspace": Object {
+      "path": ".",
       "readFile": [Function],
       "writeFile": [Function],
     },

--- a/test/jest/unit/lib/commands/fix/convert-legacy-tests-results-to-fix-entities.spec.ts
+++ b/test/jest/unit/lib/commands/fix/convert-legacy-tests-results-to-fix-entities.spec.ts
@@ -17,7 +17,10 @@ describe('Convert legacy TestResult to ScanResult', () => {
     );
     const res = convertLegacyTestResultToFixEntities(
       noRemediationRes,
-      __dirname,
+      'acceptance/fixtures/npm-package-with-severity-override',
+      {
+        allProjects: true,
+      },
     );
     expect(res).toMatchSnapshot();
   });
@@ -35,11 +38,10 @@ describe('Convert legacy TestResult to ScanResult', () => {
     );
     const res = convertLegacyTestResultToFixEntities(
       withRemediation,
-      path.resolve(
-        __dirname,
-        '../../../../../',
-        'acceptance/fixtures/npm-package-with-severity-override',
-      ),
+      'acceptance/fixtures/npm-package-with-severity-override',
+      {
+        allProjects: true,
+      },
     );
     expect(res).toMatchSnapshot();
   });
@@ -54,7 +56,7 @@ describe('Convert legacy TestResult to ScanResult', () => {
         'utf8',
       ),
     );
-    const res = convertLegacyTestResultToFixEntities(withRemediation, '.');
+    const res = convertLegacyTestResultToFixEntities(withRemediation, '.', {});
     expect(res).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

- send scanned `root` / `path` to @snyk/fix 
- send original CLI options to @snyk/fix 

@snyk/fix requires to know the original options & path for situations where a package manager command has to be run. (E.g. `--command` for Python which provides which Python interpreter to use)
