### PR TITLE
test: add dedup key to enable alert grouping

### DIFF
--- a/test/cli-alert/src/index.ts
+++ b/test/cli-alert/src/index.ts
@@ -85,6 +85,8 @@ async function sendPagerDuty() {
           source: 'Snyk CLI Smoke tests',
           severity: 'warning',
         },
+        // eslint-disable-next-line @typescript-eslint/camelcase
+        dedup_key: 'b0209ed890d34eb787b3ed58f31553cc',
       },
     });
     console.log(res);


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
https://developer.pagerduty.com/docs/events-api-v2/trigger-events/

> Submitting subsequent events for the same dedup_key will result in those events being applied to an open alert matching that dedup_key. Once the alert is resolved, any further events with the same dedup_key will create a new alert (for trigger events) or be dropped (for acknowledge and resolve events).

This change groups together repeating trigger events caused by smoke tests failing, meaning that PagerDuty won't alert us again and again if the first alert is still open.