### PR TITLE
feat: errored items can show a tip

### DIFF
--- a/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
@@ -5,11 +5,14 @@ import { PADDING_SPACE } from './show-results-summary';
 export function formatUnresolved(
   entity: EntityToFix,
   userMessage: string,
+  tip?: string,
 ): string {
   const name =
     entity.scanResult.identity.targetFile ||
     `${entity.scanResult.identity.type} project`;
-  return `${PADDING_SPACE}${name}\n${PADDING_SPACE}${chalk.red(
+  const tipMessage = tip ? `\n${PADDING_SPACE}Tip:     ${tip}` : '';
+  const errorMessage = `${PADDING_SPACE}${name}\n${PADDING_SPACE}${chalk.red(
     '✖',
   )} ${chalk.red(userMessage)}`;
+  return errorMessage + tipMessage;
 }

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -92,7 +92,11 @@ export function generateUnresolvedSummary(
         '\n\n' +
         failed
           .map((s) =>
-            formatUnresolved(s.original, convertErrorToUserMessage(s.error)),
+            formatUnresolved(
+              s.original,
+              convertErrorToUserMessage(s.error),
+              s.tip,
+            ),
           )
           .join('\n\n');
     }

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -190,6 +190,7 @@ export interface EntityToFix {
 export interface WithError<Original> {
   original: Original;
   error: CustomError;
+  tip?: string;
 }
 
 export interface WithFixChangesApplied<Original> {

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/format-unresolved-item.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/format-unresolved-item.spec.ts.snap
@@ -5,6 +5,12 @@ exports[`format unresolved item formats ok when missing targetFile 1`] = `
   ✖ Failed to process item"
 `;
 
+exports[`format unresolved item formats ok with tip 1`] = `
+"  Pipfile
+  ✖ Failed to fix
+  Tip:     Make sure you have pipenv installed"
+`;
+
 exports[`format unresolved item formats unresolved as expected by default 1`] = `
 "  requirements.txt
   ✖ Failed to process item"

--- a/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/format-unresolved-item.spec.ts
@@ -22,4 +22,14 @@ describe('format unresolved item', () => {
     const res = await formatUnresolved(entity, 'Failed to process item');
     expect(stripAnsi(res)).toMatchSnapshot();
   });
+
+  it('formats ok with tip', async () => {
+    const entity = generateEntityToFix(
+      'pip',
+      'Pipfile',
+      JSON.stringify({}),
+    );
+    const res = await formatUnresolved(entity, 'Failed to fix', 'Make sure you have pipenv installed');
+    expect(stripAnsi(res)).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- optionally allow items that errored during fix to show a user `tip` to help users debug the issue locally.

#### Screenshots

<img width="496" alt="CleanShot 2021-04-19 at 10 48 06@2x" src="https://user-images.githubusercontent.com/2911613/115216956-e8086880-a0fc-11eb-90f3-1a92a7daaa6b.png">
