### PR TITLE
Bump gradle plugin to fix macOS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.19.3",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.14.0",
+    "snyk-gradle-plugin": "3.14.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
     "snyk-nodejs-lockfile-parser": "1.32.0",


### PR DESCRIPTION
Fixes the currently failing Smoke tests under Yarn installation.

This resolve an issue with Node prematurely closing a file descriptor.