### PR TITLE
Feat: use path in filenames

### DIFF
--- a/packages/snyk-fix/src/lib/output-formatters/format-display-name.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/format-display-name.ts
@@ -1,0 +1,16 @@
+import * as pathLib from 'path';
+import { Identity } from '../../types';
+
+export function formatDisplayName(
+  path: string,
+  identity: Pick<Identity, 'type' | 'targetFile'>,
+): string {
+  if (!identity.targetFile) {
+    return `${identity.type} project`;
+  }
+  // show paths relative to where `snyk fix` is running
+  return pathLib.relative(
+    process.cwd(),
+    pathLib.join(path, identity.targetFile),
+  );
+}

--- a/packages/snyk-fix/src/lib/output-formatters/format-successful-item.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/format-successful-item.ts
@@ -1,6 +1,7 @@
 import * as chalk from 'chalk';
 
 import { EntityToFix, FixChangesSummary } from '../../types';
+import { formatDisplayName } from './format-display-name';
 import { PADDING_SPACE } from './show-results-summary';
 
 /*
@@ -10,9 +11,10 @@ export function formatChangesSummary(
   entity: EntityToFix,
   changes: FixChangesSummary[],
 ): string {
-  return `${PADDING_SPACE}${
-    entity.scanResult.identity.targetFile
-  }\n${changes.map((c) => formatAppliedChange(c)).join('\n')}`;
+  return `${PADDING_SPACE}${formatDisplayName(
+    entity.workspace.path,
+    entity.scanResult.identity,
+  )}\n${changes.map((c) => formatAppliedChange(c)).join('\n')}`;
 }
 
 function formatAppliedChange(change: FixChangesSummary): string | null {

--- a/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/format-unresolved-item.ts
@@ -1,5 +1,7 @@
 import * as chalk from 'chalk';
+
 import { EntityToFix } from '../../types';
+import { formatDisplayName } from './format-display-name';
 import { PADDING_SPACE } from './show-results-summary';
 
 export function formatUnresolved(
@@ -8,8 +10,10 @@ export function formatUnresolved(
   tip?: string,
 ): string {
   const name =
-    entity.scanResult.identity.targetFile ||
-    `${entity.scanResult.identity.type} project`;
+    formatDisplayName(
+      entity.workspace.path,
+      entity.scanResult.identity,
+    );
   const tipMessage = tip ? `\n${PADDING_SPACE}Tip:     ${tip}` : '';
   const errorMessage = `${PADDING_SPACE}${name}\n${PADDING_SPACE}${chalk.red(
     '✖',

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -177,6 +177,7 @@ export enum SEVERITY {
 export type SupportedScanTypes = 'pip';
 
 export interface Workspace {
+  path: string;
   readFile: (path: string) => Promise<string>;
   writeFile: (path: string, content: string) => Promise<void>;
 }

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -4,14 +4,14 @@ exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -c & -r 
 "
 Successful fixes:
 
-  app-with-constraints/requirements.txt
+  test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/requirements.txt
   ✔ Upgraded Django from 1.6.1 to 2.0.1
-  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in app-with-constraints/constraints.txt)
-  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in app-with-constraints/lib/requirements.txt)
-  ✔ Pinned transitive from 1.0.1 to 2.0.1 (pinned in app-with-constraints/constraints.txt)
+  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/constraints.txt)
+  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/lib/requirements.txt)
+  ✔ Pinned transitive from 1.0.1 to 2.0.1 (pinned in test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/constraints.txt)
 
-  app-with-constraints/lib/requirements.txt
-  ✔ Fixed through app-with-constraints/requirements.txt
+  test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/lib/requirements.txt
+  ✔ Fixed through test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-constraints/requirements.txt
 
 Summary:
 
@@ -26,16 +26,16 @@ exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -r with 
 "
 Successful fixes:
 
-  app-with-already-fixed/requirements.txt
+  test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/requirements.txt
   ✔ Upgraded Django from 1.6.1 to 2.0.1
-  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in app-with-already-fixed/core/requirements.txt)
-  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in app-with-already-fixed/lib/requirements.txt)
+  ✔ Upgraded Django from 1.6.1 to 2.0.1 (upgraded in test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/core/requirements.txt)
+  ✔ Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/lib/requirements.txt)
 
-  app-with-already-fixed/core/requirements.txt
-  ✔ Fixed through app-with-already-fixed/requirements.txt
+  test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/core/requirements.txt
+  ✔ Fixed through test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/requirements.txt
 
-  app-with-already-fixed/lib/requirements.txt
-  ✔ Fixed through app-with-already-fixed/requirements.txt
+  test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/lib/requirements.txt
+  ✔ Fixed through test/acceptance/plugins/python/handlers/update-dependencies/workspaces/app-with-already-fixed/requirements.txt
 
 Summary:
 

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/extract-provenance.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/extract-provenance.spec.ts
@@ -1,3 +1,4 @@
+
 import * as fs from 'fs';
 import * as pathLib from 'path';
 import { extractProvenance } from '../../../../../../src/plugins/python/handlers/pip-requirements/extract-version-provenance';
@@ -10,6 +11,7 @@ describe('extractProvenance', () => {
     const targetFile = pathLib.resolve(workspacesPath, 'with-require/dev.txt');
 
     const workspace = {
+      path: workspacesPath,
       readFile: async (path: string) => {
         return fs.readFileSync(pathLib.resolve(workspacesPath, path), 'utf-8');
       },
@@ -40,6 +42,7 @@ describe('extractProvenance', () => {
     );
 
     const workspace = {
+      path: workspacesPath,
       readFile: async (path: string) => {
         return fs.readFileSync(pathLib.resolve(workspacesPath, path), 'utf-8');
       },
@@ -69,6 +72,7 @@ describe('extractProvenance', () => {
     const targetFile = pathLib.resolve(workspacesPath, `${folder}/dev.txt`);
 
     const workspace = {
+      path: workspacesPath,
       readFile: async (path: string) => {
         return fs.readFileSync(pathLib.resolve(workspacesPath, path), 'utf-8');
       },
@@ -112,6 +116,7 @@ describe('extractProvenance', () => {
     const targetFile = pathLib.resolve(workspacesPath, `${folder}/dev.txt`);
 
     const workspace = {
+      path: workspacesPath,
       readFile: async (path: string) => {
         return fs.readFileSync(pathLib.resolve(workspacesPath, path), 'utf-8');
       },

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
@@ -1250,6 +1250,7 @@ function generateEntityToFix(
 ): snykFix.EntityToFix {
   const entityToFix = {
     workspace: {
+      path: workspacesPath,
       readFile: async (path: string) => {
         return readFileHelper(workspacesPath, path);
       },

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/update-dependencies/update-dependencies.spec.ts
@@ -828,7 +828,6 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     // 2 files needed to have changes
     expect(writeFileSpy).toHaveBeenCalledTimes(2);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix);
-    const basePath = pathLib.normalize('pip-app/base2.txt');
     expect(result.results.python.succeeded[0].changes).toEqual([
       {
         success: true,
@@ -839,7 +838,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
       },
       {
         success: true,
-        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${basePath})`,
+        userMessage: expect.stringContaining('base2.txt'),
         from: 'Jinja2@2.7.2',
         to: 'Jinja2@2.7.3',
         issueIds: [],
@@ -982,16 +981,14 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     expect(libRequirements).toEqual(ExpectedLibRequirements);
     expect(coreRequirements).toEqual(expectedCoreRequirements);
     // 3 files needed to have changes
-    expect(result.fixSummary.replace(/\\/g, '/')).toMatchSnapshot();
+    expect(
+      result.fixSummary
+        .replace(/\\/g, '/')
+        .replace(/packages\/snyk-fix\//g, ''),
+    ).toMatchSnapshot();
     expect(writeFileSpy).toHaveBeenCalledTimes(3);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix1);
 
-    const coreRequirementsPath = pathLib.normalize(
-      'app-with-already-fixed/core/requirements.txt',
-    );
-    const libRequirementsPath = pathLib.normalize(
-      'app-with-already-fixed/lib/requirements.txt',
-    );
     expect(result.results.python.succeeded[0].changes).toEqual([
       {
         from: 'Django@1.6.1',
@@ -1005,14 +1002,14 @@ describe('fix *req*.txt / *.txt Python projects', () => {
         to: 'Django@2.0.1',
         issueIds: ['SNYK-1'],
         success: true,
-        userMessage: `Upgraded Django from 1.6.1 to 2.0.1 (upgraded in ${coreRequirementsPath})`,
+        userMessage: expect.stringContaining('requirements.txt'),
       },
       {
         from: 'Jinja2@2.7.2',
         to: 'Jinja2@2.7.3',
         issueIds: ['SNYK-2'],
         success: true,
-        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${libRequirementsPath})`,
+        userMessage: expect.stringContaining('requirements.txt'),
       },
     ]);
   });
@@ -1147,7 +1144,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
       ),
       'utf-8',
     );
-    const ExpectedLibRequirements = fs.readFileSync(
+    const expectedLibRequirements = fs.readFileSync(
       pathLib.resolve(
         workspacesPath,
         'app-with-constraints/lib/expected-requirements.txt',
@@ -1169,20 +1166,17 @@ describe('fix *req*.txt / *.txt Python projects', () => {
       'utf-8',
     );
     expect(requirements).toEqual(expectedRequirements);
-    expect(libRequirements).toEqual(ExpectedLibRequirements);
+    expect(libRequirements).toEqual(expectedLibRequirements);
     expect(constraints).toEqual(expectedConstraints);
-    expect(result.fixSummary.replace(/\\/g, '/')).toMatchSnapshot();
+    expect(
+      result.fixSummary
+        .replace(/\\/g, '/')
+        .replace(/packages\/snyk-fix\//g, ''),
+    ).toMatchSnapshot();
     // 3 files with upgrades + 1 more to apply pins
     expect(writeFileSpy).toHaveBeenCalledTimes(4);
     expect(result.results.python.succeeded[0].original).toEqual(entityToFix1);
     expect(result.results.python.succeeded[1].original).toEqual(entityToFix2);
-
-    const constraintsPath = pathLib.normalize(
-      'app-with-constraints/constraints.txt',
-    );
-    const libRequirementsPath = pathLib.normalize(
-      'app-with-constraints/lib/requirements.txt',
-    );
 
     expect(result.results.python.succeeded[0].changes).toEqual([
       {
@@ -1197,28 +1191,28 @@ describe('fix *req*.txt / *.txt Python projects', () => {
         to: 'Django@2.0.1',
         issueIds: ['SNYK-1'],
         success: true,
-        userMessage: `Upgraded Django from 1.6.1 to 2.0.1 (upgraded in ${constraintsPath})`,
+        userMessage: expect.stringContaining('constraints.txt'),
       },
       {
         from: 'Jinja2@2.7.2',
         to: 'Jinja2@2.7.3',
         issueIds: ['SNYK-2'],
         success: true,
-        userMessage: `Upgraded Jinja2 from 2.7.2 to 2.7.3 (upgraded in ${libRequirementsPath})`,
+        userMessage: expect.stringContaining('requirements.txt'),
       },
       {
         from: 'transitive@1.0.1',
         to: 'transitive@2.0.1',
         issueIds: ['SNYK-3'],
         success: true,
-        userMessage: `Pinned transitive from 1.0.1 to 2.0.1 (pinned in ${constraintsPath})`,
+        userMessage: expect.stringContaining('constraints.txt'),
       },
     ]);
     expect(result.results.python.succeeded[1].changes).toEqual([
       {
         success: true,
         issueIds: ['SNYK-1', 'SNYK-2', 'SNYK-3'],
-        userMessage: 'Fixed through app-with-constraints/requirements.txt',
+        userMessage: expect.stringContaining('requirements.txt'),
       },
     ]);
   });

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -15,7 +15,7 @@ export function generateEntityToFix(
 
 function generateWorkspace(contents: string, path?: string) {
   return {
-    path: path || 'src/lib',
+    path: path || '.',
     readFile: async () => {
       return contents;
     },

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -5,15 +5,17 @@ export function generateEntityToFix(
   type: string,
   targetFile: string,
   contents: string,
+  path?: string,
 ): EntityToFix {
   const scanResult = generateScanResult(type, targetFile);
   const testResult = generateTestResult();
-  const workspace = generateWorkspace(contents);
+  const workspace = generateWorkspace(contents, path);
   return { scanResult, testResult, workspace };
 }
 
-function generateWorkspace(contents: string) {
+function generateWorkspace(contents: string, path?: string) {
   return {
+    path: path || 'src/lib',
     readFile: async () => {
       return contents;
     },

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -51,7 +51,7 @@ Object {
             },
           },
           "workspace": Object {
-            "path": "src/lib",
+            "path": ".",
             "readFile": [Function],
             "writeFile": [Function],
           },
@@ -169,7 +169,7 @@ Summary:
               },
             },
             "workspace": Object {
-              "path": "src/lib",
+              "path": ".",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -260,7 +260,7 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
               },
             },
             "workspace": Object {
-              "path": "src/lib",
+              "path": ".",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -327,7 +327,7 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
               },
             },
             "workspace": Object {
-              "path": "src/lib",
+              "path": ".",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -405,7 +405,7 @@ Object {
             },
           },
           "workspace": Object {
-            "path": "src/lib",
+            "path": ".",
             "readFile": [Function],
             "writeFile": [MockFunction] {
               "calls": Array [

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -51,6 +51,7 @@ Object {
             },
           },
           "workspace": Object {
+            "path": "src/lib",
             "readFile": [Function],
             "writeFile": [Function],
           },
@@ -168,6 +169,7 @@ Summary:
               },
             },
             "workspace": Object {
+              "path": "src/lib",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -258,6 +260,7 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
               },
             },
             "workspace": Object {
+              "path": "src/lib",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -324,6 +327,7 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
               },
             },
             "workspace": Object {
+              "path": "src/lib",
               "readFile": [Function],
               "writeFile": [Function],
             },
@@ -401,6 +405,7 @@ Object {
             },
           },
           "workspace": Object {
+            "path": "src/lib",
             "readFile": [Function],
             "writeFile": [MockFunction] {
               "calls": Array [


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

when  users run `snyk fix --all-projects` the path is `.` and all manifest files are correctly referenced from here e.g 'requirements.txt'
when users run `snyk fix path/to-folder --all-projects`  the manifest are still being referenced in relation to the provied path so we end up with 'requirements.txt' and if many are found in different folders you can't tell them apart in the output.

Now that CLI sends `path` to @snyk/fix use it to reference the full path relative to where the `snyk fix` command is run

#### Where should the reviewer start?
`packages/snyk-fix/src/lib/output-formatters/format-display-name.ts`

#### Screenshots
##### Before
- When running `snyk fix test/acceptance/plugins/python/handlers/update-dependencies/workspaces --all-projects`:

<img width="948" alt="CleanShot 2021-04-19 at 13 53 59@2x" src="https://user-images.githubusercontent.com/2911613/115239486-b43a3c80-a116-11eb-8999-0c1dd7ba5c1a.png">

##### Now
- When running `snyk fix test/acceptance/plugins/python/handlers/update-dependencies/workspaces --all-projects` now you see:
<img width="1409" alt="CleanShot 2021-04-19 at 13 44 08@2x" src="https://user-images.githubusercontent.com/2911613/115239568-cd42ed80-a116-11eb-8e59-a2dcfb179752.png">

- When running `snyk fix  --all-projects` nothing changes:
<img width="1440" alt="CleanShot 2021-04-19 at 13 51 28@2x" src="https://user-images.githubusercontent.com/2911613/115239187-5d346780-a116-11eb-9daf-68d286d4e23d.png">


