### PR TITLE
fix: add error code to FlagError

### DIFF
--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -1,6 +1,6 @@
 import { CustomError } from '../../../../lib/errors';
 import { args } from '../../../args';
-import { IaCTestFlags } from './types';
+import { IaCErrorCodes, IaCTestFlags } from './types';
 
 const keys: (keyof IaCTestFlags)[] = [
   'debug',
@@ -31,6 +31,7 @@ class FlagError extends CustomError {
     const flag = camelcaseToDash(key);
     const msg = `Unsupported flag "${dashes}${flag}" provided. Run snyk iac test --help for supported flags.`;
     super(msg);
+    this.code = IaCErrorCodes.FlagError;
     this.userMessage = msg;
   }
 }

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -222,4 +222,7 @@ export enum IaCErrorCodes {
 
   // get-iac-org-settings errors
   FailedToGetIacOrgSettingsError = 1080,
+
+  // assert-iac-options-flag
+  FlagError = 1090,
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This commit adds a new error code to the FlagError so we can use the code when debugging.

#### How should this be manually tested?
1. Build the CLI by running `npm run build`
2. Run `node ./dist/cli iac test --experimental test/fixtures/iac/terraform-plan --ignore-policy`

#### Any background context you want to provide?
When trying to build the SLO dashboard for the IaC experimental flow we noticed that there are some errors without an `error_code`, specifically ones resulting from `FlagError`. By adding this error code, we are able to debug and differentiate between actual errors and expected errors.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-777

#### Screenshots
![Screenshot 2021-04-20 at 08 48 54](https://user-images.githubusercontent.com/81559517/115358139-442ec380-a1b5-11eb-8561-51c61ccb68a5.png)
