### PR TITLE
feat: add auto detect feature for hex package manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",
     "@snyk/snyk-cocoapods-plugin": "2.5.2",
-    "@snyk/snyk-hex-plugin": "1.1.3",
+    "@snyk/snyk-hex-plugin": "1.1.4",
     "abbrev": "^1.1.1",
     "ansi-escapes": "3.2.0",
     "chalk": "^2.4.2",

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -31,7 +31,8 @@ const DETECTABLE_FILES: string[] = [
   'Podfile.lock',
   'pyproject.toml',
   'poetry.lock',
-  // 'mix.exs', 'mix.lock' // todo @loki: remove when hex is going GA
+  'mix.exs',
+  'mix.lock',
 ];
 
 export const AUTO_DETECTABLE_FILES: string[] = [
@@ -58,7 +59,8 @@ export const AUTO_DETECTABLE_FILES: string[] = [
   'build.gradle.kts',
   'pyproject.toml',
   'poetry.lock',
-  // 'mix.exs', 'mix.lock' // todo @loki: remove when hex is going GA
+  'mix.exs',
+  'mix.lock',
 ];
 
 // when file is specified with --file, we look it up here

--- a/test/acceptance/cli-test/cli-test.elixir.spec.ts
+++ b/test/acceptance/cli-test/cli-test.elixir.spec.ts
@@ -57,7 +57,7 @@ export const ElixirTests: AcceptanceTests = {
       );
     },
 
-    "auto-detect doesn't works": (params, utils) => async (t) => {
+    '`test elixir-hex` auto-detects hex': (params, utils) => async (t) => {
       utils.chdirWorkspaces();
       const plugin = {
         async inspect() {
@@ -77,16 +77,8 @@ export const ElixirTests: AcceptanceTests = {
       t.teardown(loadPlugin.restore);
       loadPlugin.withArgs('hex').returns(plugin);
 
-      try {
-        await params.cli.test('elixir-hex');
-        t.fail('should have failed');
-      } catch (err) {
-        t.pass('throws err');
-        t.match(err.message, 'Could not detect supported target files in');
-      }
+      await params.cli.test('elixir-hex');
 
-      // todo @loki: to be replaced when we enable auto-detect
-      /*
       const req = params.server.popRequest();
       t.equal(req.method, 'POST', 'makes POST request');
       t.equal(
@@ -114,7 +106,6 @@ export const ElixirTests: AcceptanceTests = {
         ],
         'calls elixir-hex plugin',
       );
-*/
     },
   },
 };


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds the auto-detect feature to elixir ecosystem (hex package manager)