### PR TITLE
feat: include org details in JSON file output [CC-772]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -14,6 +14,7 @@ import { addIacAnalytics } from './analytics';
 import { TestResult } from '../../../../lib/snyk-test/legacy';
 import { IacFileInDirectory } from '../../../../lib/types';
 import { applyCustomSeverities } from './org-settings/apply-custom-severities';
+import { getIacOrgSettings } from './org-settings/get-iac-org-settings';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // the current version is dependent on files to be present locally which are not part of the source code.
@@ -31,10 +32,15 @@ export async function test(
   const filesToParse = await loadFiles(pathToScan, options);
   const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
   const scannedFiles = await scanFiles(parsedFiles);
-  const resultsWithCustomSeverities = await applyCustomSeverities(scannedFiles);
+  const iacOrgSettings = await getIacOrgSettings();
+  const resultsWithCustomSeverities = await applyCustomSeverities(
+    scannedFiles,
+    iacOrgSettings.customPolicies,
+  );
   const formattedResults = formatScanResults(
     resultsWithCustomSeverities,
     options,
+    iacOrgSettings.meta,
   );
   addIacAnalytics(formattedResults);
   cleanLocalCache();

--- a/src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities.ts
+++ b/src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities.ts
@@ -1,14 +1,11 @@
-import { IacFileScanResult } from '../types';
-import { getIacOrgSettings } from './get-iac-org-settings';
+import { IacCustomPolicies, IacFileScanResult } from '../types';
 import _ = require('lodash');
 import { SEVERITY } from '../../../../../lib/snyk-test/common';
 
 export async function applyCustomSeverities(
   scannedFiles: IacFileScanResult[],
+  customPolicies: IacCustomPolicies,
 ): Promise<IacFileScanResult[]> {
-  const iacOrgSettings = await getIacOrgSettings();
-  const customPolicies = iacOrgSettings.customPolicies;
-
   if (Object.keys(customPolicies).length > 0) {
     return scannedFiles.map((file) => {
       const updatedScannedFiles = _.cloneDeep(file);

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -5,6 +5,7 @@ import {
   IacFileScanResult,
   IaCTestFlags,
   PolicyMetadata,
+  TestMeta,
 } from './types';
 import * as path from 'path';
 import { SEVERITY } from '../../../../lib/snyk-test/common';
@@ -20,12 +21,13 @@ const SEVERITIES = [SEVERITY.LOW, SEVERITY.MEDIUM, SEVERITY.HIGH];
 export function formatScanResults(
   scanResults: IacFileScanResult[],
   options: IaCTestFlags,
+  meta: TestMeta,
 ): FormattedResult[] {
   try {
     // Relevant only for multi-doc yaml files
     const scannedResultsGroupedByDocId = groupMultiDocResults(scanResults);
     return scannedResultsGroupedByDocId.map((iacScanResult) =>
-      formatScanResult(iacScanResult, options.severityThreshold),
+      formatScanResult(iacScanResult, meta, options.severityThreshold),
     );
   } catch (e) {
     throw new FailedToFormatResults();
@@ -39,6 +41,7 @@ const engineTypeToProjectType = {
 
 function formatScanResult(
   scanResult: IacFileScanResult,
+  meta: TestMeta,
   severityThreshold?: SEVERITY,
 ): FormattedResult {
   const formattedIssues = scanResult.violatedPolicies.map((policy) => {
@@ -65,7 +68,9 @@ function formatScanResult(
     };
   });
 
+  const policy = '';
   const targetFilePath = path.resolve(scanResult.filePath, '.');
+
   return {
     result: {
       cloudConfigResults: filterPoliciesBySeverity(
@@ -74,15 +79,23 @@ function formatScanResult(
       ),
       projectType: projectTypeByFileType[scanResult.fileType],
     },
-    isPrivate: true,
-    packageManager: engineTypeToProjectType[scanResult.engineType],
-    targetFile: scanResult.filePath,
-    targetFilePath,
+    meta: {
+      ...meta,
+      projectId: '', // we do not have a project at this stage
+      policy,
+    },
+    filesystemPolicy: !!policy,
     vulnerabilities: [],
     dependencyCount: 0,
-    licensesPolicy: null,
+    licensesPolicy: null, // we do not have the concept of license policies
     ignoreSettings: null,
+    targetFile: scanResult.filePath,
     projectName: path.basename(path.dirname(targetFilePath)),
+    org: meta.org,
+    policy,
+    isPrivate: true,
+    targetFilePath,
+    packageManager: engineTypeToProjectType[scanResult.engineType],
   };
 }
 

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -68,7 +68,6 @@ function formatScanResult(
     };
   });
 
-  const policy = '';
   const targetFilePath = path.resolve(scanResult.filePath, '.');
 
   return {
@@ -82,9 +81,9 @@ function formatScanResult(
     meta: {
       ...meta,
       projectId: '', // we do not have a project at this stage
-      policy,
+      policy: '', // we do not have the concept of policy
     },
-    filesystemPolicy: !!policy,
+    filesystemPolicy: false, // we do not have the concept of policy
     vulnerabilities: [],
     dependencyCount: 0,
     licensesPolicy: null, // we do not have the concept of license policies
@@ -92,7 +91,7 @@ function formatScanResult(
     targetFile: scanResult.filePath,
     projectName: path.basename(path.dirname(targetFilePath)),
     org: meta.org,
-    policy,
+    policy: '', // we do not have the concept of policy
     isPrivate: true,
     targetFilePath,
     packageManager: engineTypeToProjectType[scanResult.engineType],

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -48,26 +48,34 @@ export type FormattedResult = {
     cloudConfigResults: Array<PolicyMetadata>;
     projectType: IacProjectTypes;
   };
-  isPrivate: boolean;
-  packageManager: IacProjectType;
-  targetFile: string;
-  targetFilePath: string;
+  meta: TestMeta;
+  filesystemPolicy: boolean;
   vulnerabilities: AnnotatedIssue[];
   dependencyCount: number;
   licensesPolicy: object | null;
   ignoreSettings: IgnoreSettings | null;
+  targetFile: string;
   projectName: string;
+  org: string;
+  policy: string;
+  isPrivate: boolean;
+  targetFilePath: string;
+  packageManager: IacProjectType;
 };
+
+export type IacCustomPolicies = Record<string, { severity?: string }>;
 
 export interface IacOrgSettings {
   meta: TestMeta;
-  customPolicies: Record<string, { severity?: string }>;
+  customPolicies: IacCustomPolicies;
 }
 export interface TestMeta {
   isPrivate: boolean;
   isLicensesEnabled: boolean;
   org: string;
   ignoreSettings?: IgnoreSettings | null;
+  projectId?: string;
+  policy?: string;
 }
 
 export interface OpaWasmInstance {

--- a/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
+++ b/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
@@ -1,49 +1,33 @@
-import * as getIacOrgSettingsModule from '../../../../src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings';
 import { applyCustomSeverities } from '../../../../src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities';
 import { scanResults } from './results-formatter.fixtures';
 
 describe('applyCustomSeverities', () => {
-  afterEach(() => {
-    jest.clearAllMocks();
-    jest.restoreAllMocks();
-  });
-
-  const mockedIacSettings = {
-    meta: {
-      isPrivate: false,
-      isLicensesEnabled: false,
-      ignoreSettings: null,
-      org: 'org-name',
-    },
-    customPolicies: {
-      'SNYK-CC-TF-1': { severity: 'high' },
-      'SNYK-CC-K8S-1': { severity: 'low' },
-    },
+  const mockedCustomPolicies = {
+    'SNYK-CC-TF-1': { severity: 'high' },
+    'SNYK-CC-K8S-1': { severity: 'low' },
   };
 
   it('updates existing severity with custom one for the same public id', async () => {
-    jest
-      .spyOn(getIacOrgSettingsModule, 'getIacOrgSettings')
-      .mockResolvedValue(mockedIacSettings);
-
-    const actualResults = await applyCustomSeverities(scanResults);
+    const actualResults = await applyCustomSeverities(
+      scanResults,
+      mockedCustomPolicies,
+    );
     const actualSeverity = actualResults[0].violatedPolicies[0].severity;
 
     expect(actualSeverity).toEqual(
-      mockedIacSettings.customPolicies['SNYK-CC-K8S-1'].severity,
+      mockedCustomPolicies['SNYK-CC-K8S-1'].severity,
     );
   });
 
   it('does not update existing severity when there is no match for that public id', async () => {
     const notMatchingCustomPolicies = {
-      ...mockedIacSettings,
-      customPolicies: { 'SNYK-CC-K8S-1039': { severity: 'high' } },
+      'SNYK-CC-K8S-1039': { severity: 'high' },
     };
-    jest
-      .spyOn(getIacOrgSettingsModule, 'getIacOrgSettings')
-      .mockResolvedValue(notMatchingCustomPolicies);
 
-    const actualResults = await applyCustomSeverities(scanResults);
+    const actualResults = await applyCustomSeverities(
+      scanResults,
+      notMatchingCustomPolicies,
+    );
 
     expect(actualResults).toEqual(scanResults);
   });

--- a/test/jest/unit/iac-unit-tests/index.spec.ts
+++ b/test/jest/unit/iac-unit-tests/index.spec.ts
@@ -45,6 +45,21 @@ jest.mock('../../../../src/lib/detect', () => ({
   isLocalFolder: () => true,
 }));
 
+jest.mock(
+  '../../../../src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts',
+  () => ({
+    getIacOrgSettings: async () => ({
+      meta: {
+        isPrivate: false,
+        isLicensesEnabled: false,
+        ignoreSettings: null,
+        org: 'org-name',
+      },
+      customPolicies: {},
+    }),
+  }),
+);
+
 import { test } from '../../../../src/cli/commands/test/iac-local-execution';
 import {
   IacFileParsed,

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -3,6 +3,7 @@ import {
   EngineType,
   IacFileScanResult,
   PolicyMetadata,
+  TestMeta,
 } from '../../../../src/cli/commands/test/iac-local-execution/types';
 import { IacProjectType } from '../../../../src/lib/iac/constants';
 import { SEVERITY } from '../../../../src/lib/snyk-test/common';
@@ -57,6 +58,12 @@ export const scanResults: Array<IacFileScanResult> = [
   },
 ];
 
+export const meta: TestMeta = {
+  isPrivate: false,
+  isLicensesEnabled: false,
+  org: 'org-name',
+};
+
 export const expectedFormattedResults = {
   result: {
     cloudConfigResults: [
@@ -86,4 +93,12 @@ export const expectedFormattedResults = {
   ignoreSettings: null,
   licensesPolicy: null,
   projectName: 'snyk',
+  meta: {
+    ...meta,
+    policy: '',
+    projectId: '',
+  },
+  org: meta.org,
+  policy: '',
+  filesystemPolicy: false,
 };

--- a/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
@@ -5,6 +5,7 @@ import {
 import { SEVERITY } from '../../../../src/lib/snyk-test/common';
 import {
   expectedFormattedResults,
+  meta,
   policyStub,
   scanResults,
 } from './results-formatter.fixtures';
@@ -16,9 +17,11 @@ jest.mock('@snyk/cloud-config-parser');
 describe('formatScanResults', () => {
   it('returns the formatted results as expected for output', () => {
     (issuesToLineNumbers as jest.Mock).mockReturnValue(3);
-    const formattedResults = formatScanResults(scanResults, {
-      severityThreshold: SEVERITY.HIGH,
-    });
+    const formattedResults = formatScanResults(
+      scanResults,
+      { severityThreshold: SEVERITY.HIGH },
+      meta,
+    );
     expect(formattedResults.length).toEqual(1);
     expect(formattedResults[0]).toEqual(expectedFormattedResults);
   });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR uses the org details we retrieve from registry to populate the results for the JSON file output flag, as well as for the organisation name in the CLI results.

#### Where should the reviewer start?
The code flow can be read in the order of the changed files. This PR moves the `getIacOrgSettings` function call to the main index file, where we compute the org settings and then pass the contents of `customPolicies` field to the `applyCustomSeverities` call and then the contents of the `meta` field to `formatScanResults` in order to include the missing fields into the result.

#### How should this be manually tested?
1. Build the CLI using `npm run build`
2. Download `deployment_singleissue.yaml` from the Jira ticket
2. Run `node ./dist/cli iac test --experimental deployment_singleissue.yaml --json-file-output=experimental.json`
3. `node ./dist/cli iac test deployment_singleissue.yaml--json-file-output=original.json`
4. Compare using http://jsondiff.com/

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-772

#### Screenshots
![Screenshot 2021-04-20 at 14 17 37](https://user-images.githubusercontent.com/81559517/115402372-460f7b80-a1e3-11eb-84ca-a256e907a2f7.png)

