### PR TITLE
fix: IaC run with no vulnerabilities and --json flag should be successful [CC-805]

### DIFF
--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -171,8 +171,17 @@ async function test(...args: MethodArgs): Promise<TestCommandResult> {
   } = extractDataToSendFromResults(results, jsonData, options);
 
   if (options.json || options.sarif) {
-    // if all results are ok (.ok == true) then return the json
-    if (errorMappedResults.every((res) => res.ok)) {
+    // the new experimental IaC flow does not have the ok field because it returns vulnerabilities and errors separately
+    // the legacy IaC flow may return errors that get mapped into errorMappedResults, but that flow will be removed soon
+    const successfulIacScanning =
+      options.iac &&
+      !foundVulnerabilities &&
+      (!iacScanFailures || iacScanFailures.length === 0);
+
+    // if running iac and it was successful, or
+    // if all results are ok (.ok == true)
+    // then return the json
+    if (successfulIacScanning || errorMappedResults.every((res) => res.ok)) {
       return TestCommandResult.createJsonTestCommandResult(
         stringifiedData,
         stringifiedJsonData,

--- a/test/acceptance/cli-test/iac/cli-test.iac-dir.spec.ts
+++ b/test/acceptance/cli-test/iac/cli-test.iac-dir.spec.ts
@@ -86,17 +86,11 @@ export const IacDirTests: AcceptanceTests = {
 
     '`iac test directory --json - no issues`': (params, utils) => async (t) => {
       utils.chdirWorkspaces();
-      let testableObject;
-      try {
-        await params.cli.test('iac-kubernetes/', {
-          iac: true,
-          json: true,
-        });
-        t.fail('should have thrown');
-      } catch (error) {
-        testableObject = error;
-      }
-      const res: any = JSON.parse(testableObject.message);
+      const testableObject = await params.cli.test('iac-kubernetes/', {
+        iac: true,
+        json: true,
+      });
+      const res: any = JSON.parse(testableObject);
       iacTestJsonAssertions(
         t,
         res,
@@ -145,17 +139,11 @@ export const IacDirTests: AcceptanceTests = {
       t,
     ) => {
       utils.chdirWorkspaces();
-      let testableObject;
-      try {
-        await params.cli.test('iac-kubernetes/', {
-          iac: true,
-          sarif: true,
-        });
-        t.fail('should have thrown');
-      } catch (error) {
-        testableObject = error;
-      }
-      const res: any = JSON.parse(testableObject.message);
+      const testableObject = await params.cli.test('iac-kubernetes/', {
+        iac: true,
+        sarif: true,
+      });
+      const res: any = JSON.parse(testableObject);
       iacTestSarifAssertions(t, res, null, false);
     },
     '`iac test directory --severity-threshold=low --sarif`': (

--- a/test/acceptance/cli-test/iac/cli-test.iac-k8s.spec.ts
+++ b/test/acceptance/cli-test/iac/cli-test.iac-k8s.spec.ts
@@ -147,17 +147,14 @@ export const IacK8sTests: AcceptanceTests = {
       t,
     ) => {
       utils.chdirWorkspaces();
-      let testableObject;
-      try {
-        await params.cli.test('iac-kubernetes/multi-file.yaml', {
+      const testableObject = await params.cli.test(
+        'iac-kubernetes/multi-file.yaml',
+        {
           iac: true,
           json: true,
-        });
-        t.fail('should have thrown');
-      } catch (error) {
-        testableObject = error;
-      }
-      const res: any = JSON.parse(testableObject.message);
+        },
+      );
+      const res: any = JSON.parse(testableObject);
       iacTestJsonAssertions(
         t,
         res,
@@ -206,17 +203,14 @@ export const IacK8sTests: AcceptanceTests = {
       t,
     ) => {
       utils.chdirWorkspaces();
-      let testableObject;
-      try {
-        await params.cli.test('iac-kubernetes/multi-file.yaml', {
+      const testableObject = await params.cli.test(
+        'iac-kubernetes/multi-file.yaml',
+        {
           iac: true,
           sarif: true,
-        });
-        t.fail('should have thrown');
-      } catch (error) {
-        testableObject = error;
-      }
-      const res: any = JSON.parse(testableObject.message);
+        },
+      );
+      const res: any = JSON.parse(testableObject);
       iacTestSarifAssertions(t, res, null, false);
     },
     '`iac test multi-file.yaml --severity-threshold=low --sarif`': (

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -120,6 +120,14 @@ Describe "Snyk iac test --experimental command"
       The output should include '"packageManager": "terraformconfig",'
       The result of function check_valid_json should be success
     End
+
+    It "outputs the expected text when running with --json flag and getting no vulnerabilities"
+      When run snyk iac test ../fixtures/iac/terraform/sg_open_ssh.tf --experimental --severity-threshold=high --json
+      The status should be success # no issues found
+      The output should not include '"id": "SNYK-CC-TF-1",'
+      The output should include '"packageManager": "terraformconfig",'
+      The result of function check_valid_json should be success
+    End
   End
 
   Describe "directory scanning"


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR makes sure that when the `snyk iac test --experimental` command is run with the extra `--json` flag on a file with no vulnerabilities, the command returns successfully.

#### Where should the reviewer start?
The first commit contains a new smoke test that covers this edge case. It modifies an existing test by adding the `--json` flag. As we can see from Circle, this new smoke test fails because the command does not return successfully. However, the original smoke test without the `--json` flag returns successfully.

The new IaC experimental flow returns the valid scannings (including vulnerabilities) separately from failed scannings (parse errors or any other errors to return to the user). So, the code needs to check first that there are no vulnerabilities (since there is an if statement a few lines below that deal with that case) and that there are no proper failures. If there aren't any of those, then we return successfully. 

#### How should this be manually tested?
1. Build the CLI using `npm run build`
2. Run the command on a file with no vulnerabilities (e.g. https://github.com/snyk/cloud-config-opa-policies/blob/master/schemas/terraform/gcp/SNYK_CC_GCP_91/provider.tf): `node ./dist/cli iac test --experimental path/to/cloud-config-opa-policies/schemas/terraform/gcp/SNYK_CC_GCP_91/provider.tf --json`
3. Notice that the command returns **and** says it has finished successfully
4. Run the existing CLI on the same file:`snyk iac test --experimental path/to/cloud-config-opa-policies/schemas/terraform/gcp/SNYK_CC_GCP_91/provider.tf --json`
5. Notice that the command returns **but** says it has finished with an error

#### Any background context you want to provide?
This problem surfaced when looking at our analytics, where we noticed some errors without any error codes and with error messages that looked like valid scanning results. For more information read the ticket.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-805

#### Screenshots
Before (notice red warning):
![Screenshot 2021-04-21 at 10 56 41](https://user-images.githubusercontent.com/81559517/115535232-76612380-a290-11eb-84c5-343143ab6ab8.png)

After (notice green tick):
![Screenshot 2021-04-21 at 10 56 26](https://user-images.githubusercontent.com/81559517/115535259-7cef9b00-a290-11eb-8d1d-e944fd6bec6a.png)

