### PR TITLE
feat(@snyk/fix): propagate cli test options

### DIFF
--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -185,9 +185,16 @@ export interface EntityToFix {
   readonly workspace: Workspace;
   readonly scanResult: ScanResult;
   readonly testResult: TestResult;
-  // options
+  readonly options: CliTestOptions;
 }
 
+// Partial CLI test options interface
+// defining only what is used by @snyk/fix
+// add more as needed
+export interface PythonTestOptions {
+  command?: string; // python interpreter to use for python tests
+}
+export type CliTestOptions = PythonTestOptions;
 export interface WithError<Original> {
   original: Original;
   error: CustomError;

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/update-dependencies.spec.ts
@@ -1243,6 +1243,9 @@ function generateEntityToFix(
   testResult: TestResult,
 ): snykFix.EntityToFix {
   const entityToFix = {
+    options: {
+      command: 'python3',
+    },
     workspace: {
       path: workspacesPath,
       readFile: async (path: string) => {

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -1,5 +1,11 @@
 import { DepGraphData } from '@snyk/dep-graph';
-import { EntityToFix, ScanResult, TestResult, FixInfo, SEVERITY } from '../../src/types';
+import {
+  EntityToFix,
+  ScanResult,
+  TestResult,
+  FixInfo,
+  SEVERITY,
+} from '../../src/types';
 
 export function generateEntityToFix(
   type: string,
@@ -10,7 +16,10 @@ export function generateEntityToFix(
   const scanResult = generateScanResult(type, targetFile);
   const testResult = generateTestResult();
   const workspace = generateWorkspace(contents, path);
-  return { scanResult, testResult, workspace };
+  const cliTestOptions = {
+    command: 'python3',
+  };
+  return { scanResult, testResult, workspace, options: cliTestOptions };
 }
 
 function generateWorkspace(contents: string, path?: string) {

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -6,6 +6,9 @@ Object {
     "npm": Object {
       "originals": Array [
         Object {
+          "options": Object {
+            "command": "python3",
+          },
           "scanResult": Object {
             "facts": Array [
               Object {
@@ -124,6 +127,9 @@ Summary:
             },
           ],
           "original": Object {
+            "options": Object {
+              "command": "python3",
+            },
             "scanResult": Object {
               "facts": Array [
                 Object {
@@ -215,6 +221,9 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
       "skipped": Array [
         Object {
           "original": Object {
+            "options": Object {
+              "command": "python3",
+            },
             "scanResult": Object {
               "facts": Array [
                 Object {
@@ -282,6 +291,9 @@ Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the iss
             },
           ],
           "original": Object {
+            "options": Object {
+              "command": "python3",
+            },
             "scanResult": Object {
               "facts": Array [
                 Object {
@@ -360,6 +372,9 @@ Object {
           },
         ],
         "original": Object {
+          "options": Object {
+            "command": "python3",
+          },
           "scanResult": Object {
             "facts": Array [
               Object {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -21,6 +21,7 @@ export interface TestOptions {
   reachableVulnsTimeout?: number;
   initScript?: string;
   yarnWorkspaces?: boolean;
+  command?: string; // python interpreter to use for python tests
   testDepGraphDockerEndpoint?: string | null;
   isDockerUser?: boolean;
   /** @deprecated Only used by the legacy `iac test` flow remove once local exec path is GA */


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
CLI now sends down the options each entity was tested with, define this in @snyk/fix and pass it through ready to be used when we start running commands that require `python` version.
