### PR TITLE
feat: allow peerDeps and optionalDeps from manifests in npm projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-gradle-plugin": "3.14.2",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
-    "snyk-nodejs-lockfile-parser": "1.32.0",
+    "snyk-nodejs-lockfile-parser": "1.33.2",
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support for the scanning of peer and optional dependencies in node projects
