### PR TITLE
feat: Update snyk-docker-plugin to v4.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.19.3",
+    "snyk-docker-plugin": "4.20.1",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.14.2",
     "snyk-module": "3.1.0",


### PR DESCRIPTION

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR updates the plugin version to add the algorithm prefix ('sha256:') to the imageId.

#### How should this be manually tested?

Run container test with this CLI version on a docker image will create a project where the imageId of the project test snapshot has a 'sha256:' prefix.

#### Any background context you want to provide?

The full imageId for docker images should contain the algorithm prefix (as can be seen when running 'docker inspect' command). The new version of the plugin adds this prefix.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/DC-1195
