### PR TITLE
feat: use feature flag to enable local exec [CC-790]

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -244,9 +244,14 @@ async function main() {
       (args.options as unknown) as AllSupportedCliOptions,
     );
 
-    // modify args for IaC if experimental flag not provided based on feature flag
+    // IaC only: used for rolling out the experimental flow
+    // modify args if experimental flag not provided, based on feature flag
     // this can be removed once experimental becomes the default
-    if (args.options['iac'] && !args.options['experimental']) {
+    if (
+      args.options['iac'] &&
+      args.command === 'test' &&
+      !args.options['experimental']
+    ) {
       const iacOrgSettings = await getIacOrgSettings();
       const experimentalFlowEnabled = await isFeatureFlagSupportedForOrg(
         camelCase('experimental-local-exec-iac'),

--- a/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
+++ b/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
@@ -343,3 +343,13 @@ export const iacTestResponseFixturesByThreshold = {
     ['high', 'medium', 'low'].map((severity) => generateDummyIssue(severity)),
   ),
 };
+
+export const iacOrgSettings = {
+  meta: {
+    isPrivate: false,
+    isLicensesEnabled: false,
+    ignoreSettings: null,
+    org: 'test-org',
+  },
+  customPolicies: {},
+};


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR rolls out the experimental CLI by using a feature flag. We want the experimental flow to be the default if the feature flag is enabled or if the `--experimental` flag is provided when running the CLI.

#### Where should the reviewer start?
- Start in `src/cli/index.ts`, where if `iac` is running we now make a call to get the org name (i.e. `getIacOrgSettings`), required for checking if the experimental feature flag is enabled. 
- We only make the extra call to registry to see if the feature flag is enabled if the `experimental` is not passed, to minimise the number of network calls we need. 
- These checks are here instead of `src/cli/commands/test/iac-test-shim.ts` because the analytics report the `args` object and we use that object in our SLO dashboard.

The acceptance tests had to be modified with a new API call added to the fake server and some extra, temporary checks for testing the legacy flow. 

#### How should this be manually tested?
1. Build the CLI using `npm run build`
2. Start [registry](https://github.com/snyk/registry) in another terminal tab and in the tab you're running the CLI from run `export SNYK_API="http://localhost:8000/api"`
3. Authenticate now that you're pointing to a different Snyk API: `node ./dist/cli auth`
4. Run the command `node ./dist/cli iac test test/fixtures/iac/kubernetes/pod-privileged.yaml --debug`, which will run the original flow
5. Run the command `node ./dist/cli iac test test/fixtures/iac/terraform-plan/tf-plan.json --debug`, which will fail because the original flow does not support Terraform Plan scanning
6. Modify your org in the local database to have the `experimentalLocalExecIac` flag on.
7. Run the command `node ./dist/cli iac test test/fixtures/iac/kubernetes/pod-privileged.yaml --debug`, which will run the experimental flow
8. Run the command `node ./dist/cli iac test test/fixtures/iac/terraform-plan/tf-plan.json --debug`, which will work because experimental flow supports it

#### Any background context you want to provide?
The flag has been added under https://github.com/snyk/registry/pull/20370 and this PR just starts checking if it's enabled to decide what execution flow to use.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-790

#### Screenshots
- feature flag is enabled for org `teodora-sandu`
![Screenshot 2021-04-26 at 08 24 19](https://user-images.githubusercontent.com/81559517/116044845-4e473b00-a669-11eb-9080-11a5287743de.png)
![Screenshot 2021-04-26 at 08 24 44](https://user-images.githubusercontent.com/81559517/116044849-4f786800-a669-11eb-872c-047e8c83715c.png)

- feature flag is not enabled enabled for org `test`
![Screenshot 2021-04-26 at 08 25 59](https://user-images.githubusercontent.com/81559517/116044861-52735880-a669-11eb-97a9-4ab72be738d0.png)
![Screenshot 2021-04-26 at 08 26 09](https://user-images.githubusercontent.com/81559517/116044862-52735880-a669-11eb-87b0-63dbe0498388.png)

- proof of analytics being sent correctly:
![Screenshot 2021-04-26 at 12 48 18](https://user-images.githubusercontent.com/81559517/116077750-bc9df480-a68d-11eb-81d7-ec787da24527.png)
