### PR TITLE
fix: prevent update notifications to older versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,7 +136,7 @@
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.0",
     "tempfile": "^2.0.0",
-    "update-notifier": "^4.1.0",
+    "update-notifier": "^5.1.0",
     "uuid": "^3.3.2",
     "wrap-ansi": "^5.1.0"
   },


### PR DESCRIPTION
Older versions of update-notifier suggested updating to older versions.

![image (1)](https://user-images.githubusercontent.com/79453381/116120064-0fd86d00-a6b7-11eb-8766-bc2757295033.png)

Fix in this PR: https://github.com/yeoman/update-notifier/pull/192
Released in 5.0.0: https://github.com/yeoman/update-notifier/releases

This PR upgrades update-notifier from 4.1.0 to 5.1.0. The major bump was dropping Node 8 support which is fine for us as we only support Node 10 and above.
