### PR TITLE
feat: tf plan full scan flag support

### DIFF
--- a/help/commands-docs/iac.md
+++ b/help/commands-docs/iac.md
@@ -48,3 +48,10 @@ Find security issues in your Infrastructure as Code files.
   (only in `test` command)
   Enable an experimental feature to scan configuration files locally on your machine. 
   This feature also gives you the ability to scan terraform plan JSON files.
+
+- `--scan=`<TERRAFORM_PLAN_SCAN_MODE>:
+  Dedicated flag for Terraform plan scanning modes (available only under `--experimental` mode).  
+  It enables to control whether the scan should analyse the full final state (e.g. `planned-values`), or the proposed changes only  (e.g. `resource-changes`).  
+  Default: If the `--scan` flag is not provided it would scan the proposed changes only by default.  
+  Example #1: `--scan=planned-values` (full state scan)
+  Example #2: `--scan=resource-changes` (proposed changes scan)

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -30,7 +30,7 @@ export async function test(
 }> {
   await initLocalCache();
   const filesToParse = await loadFiles(pathToScan, options);
-  const { parsedFiles, failedFiles } = await parseFiles(filesToParse);
+  const { parsedFiles, failedFiles } = await parseFiles(filesToParse, options);
   const scannedFiles = await scanFiles(parsedFiles);
   const iacOrgSettings = await getIacOrgSettings();
   const resultsWithCustomSeverities = await applyCustomSeverities(

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -130,7 +130,17 @@ export type IaCTestFlags = Pick<
   help?: 'help';
   q?: boolean;
   quiet?: boolean;
-};
+} & TerraformPlanFlags;
+
+// Flags specific for Terraform plan scanning
+interface TerraformPlanFlags {
+  scan?: TerraformPlanScanMode;
+}
+
+export enum TerraformPlanScanMode {
+  DeltaScan = 'resource-changes', // default value
+  FullScan = 'planned-values',
+}
 
 // Includes all IaCTestOptions plus additional properties
 // that are added at runtime and not part of the parsed
@@ -233,4 +243,5 @@ export enum IaCErrorCodes {
 
   // assert-iac-options-flag
   FlagError = 1090,
+  FlagValueError = 1091,
 }

--- a/test/jest/unit/iac-unit-tests/assert-iac-options-flag.spec.ts
+++ b/test/jest/unit/iac-unit-tests/assert-iac-options-flag.spec.ts
@@ -1,4 +1,7 @@
-import { assertIaCOptionsFlags } from '../../../../src/cli/commands/test/iac-local-execution/assert-iac-options-flag';
+import {
+  assertIaCOptionsFlags,
+  FlagValueError,
+} from '../../../../src/cli/commands/test/iac-local-execution/assert-iac-options-flag';
 
 describe('assertIaCOptionsFlags()', () => {
   const command = ['node', 'cli', 'iac', 'test'];
@@ -43,5 +46,33 @@ describe('assertIaCOptionsFlags()', () => {
     expect(() =>
       assertIaCOptionsFlags([...command, ...options, ...files]),
     ).toThrow();
+  });
+
+  describe('Terraform plan scan modes', () => {
+    it('throws an error if the scan flag has no value', () => {
+      const options = ['--scan'];
+      expect(() =>
+        assertIaCOptionsFlags([...command, ...options, ...files]),
+      ).toThrow(FlagValueError);
+    });
+
+    it('throws an error if the scan flag has an unsupported value', () => {
+      const options = ['--scan=rsrce-changes'];
+      expect(() =>
+        assertIaCOptionsFlags([...command, ...options, ...files]),
+      ).toThrow(FlagValueError);
+    });
+
+    it.each([
+      ['--scan=resource-changes', 'delta-scan'],
+      ['--scan=planned-values', 'full-scan'],
+    ])(
+      'does not throw an error if the scan flag has a valid value of %s',
+      (options) => {
+        expect(() =>
+          assertIaCOptionsFlags([...command, ...options, ...files]),
+        ).not.toThrow(FlagValueError);
+      },
+    );
   });
 });

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -236,9 +236,8 @@ Describe "Snyk iac test --experimental command"
       The output should include "tf-plan.json for known issues, found"
     End
 
-    # The test below should be enabled once we add the full scan flag
-    xIt "finds issues in a Terraform plan file - full scan flag"
-      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental
+    It "finds issues in a Terraform plan file - full scan flag"
+      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental --scan=planned-values
       The status should equal 1 # issues found
       The output should include "Testing tf-plan.json"
 
@@ -249,6 +248,32 @@ Describe "Snyk iac test --experimental command"
       The output should include "  introduced by"
 
       The output should include "tf-plan.json for known issues, found"
+    End
+
+    It "finds issues in a Terraform plan file - explicit delta scan with flag"
+      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental --scan=resource-changes
+      The status should equal 1 # issues found
+      The output should include "Testing tf-plan.json"
+
+      # Outputs issues
+      The output should include "Infrastructure as code issues:"
+      # Root module
+      The output should include "✗ "
+      The output should include "  introduced by"
+
+      The output should include "tf-plan.json for known issues, found"
+    End
+
+    It "errors when a wrong value is passed to the --scan flag"
+      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental --scan=rsrc-changes
+      The status should equal 2 # failure
+      The output should include "Unsupported value"
+    End
+
+    It "errors when no value is provided to the --scan flag"
+      When run snyk iac test ../fixtures/iac/terraform-plan/tf-plan.json --experimental --scan
+      The status should equal 2 # failure
+      The output should include "Unsupported value"
     End
   End
 End


### PR DESCRIPTION
#### What does this PR do?
Adds a new flag that supports scanning the full state of a terraform plan (the default is scanning only the delta).
```
snyk iac test tfplan.json --scan=resource-changes --experimental
snyk iac test tfplan.json --scan=planned-values --experimental
```

#### Where should the reviewer start?
```
New flag:
src/cli/commands/test/iac-local-execution/types.ts
src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts

Updated control flow:
src/cli/commands/test/iac-local-execution/index.ts
src/cli/commands/test/iac-local-execution/file-parser.ts

Tests:
test/jest/unit/iac-unit-tests/assert-iac-options-flag.spec.ts
test/smoke/spec/iac/snyk_test_local_exec_spec.sh

Documentation:
help/commands-docs/iac.md
```
#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-819

#### Slack Threads:
https://snyk.slack.com/archives/CS61093QC/p1619695624205800
https://snyk.slack.com/archives/CMM9V3XPY/p1619611809119700