### PR TITLE
chore(ci): use draft release until files are uploaded

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -458,14 +458,11 @@ jobs:
           command: |
             ../release-scripts/validate-checksums.sh
       - run:
-          name: Create a GitHub release
+          name: Generate Release Notes
           command: |
-            latest_version=$(cat lerna.json | jq .version -r)
-            new_tag="v${latest_version}"
             npx conventional-changelog-cli -p angular -l -r 1 > RELEASE_NOTES.txt
-            gh release create ${new_tag} --title "${new_tag}" --notes-file RELEASE_NOTES.txt
       - run:
-          name: Upload assets to the GitHub Release and a public S3
+          name: Upload Artifacts
           command: ./release-scripts/upload-artifacts.sh
       - run:
           name: Handle failed CLI release


### PR DESCRIPTION
Currently we create a published release then upload artifacts. This means:
- If we fail to upload artifacts, we'll have a broken release.
- Someone (especially automation) can grab a release but not find any artifacts.

So we should use Draft Releases to avoid this.

GitHub CLI doesn't have a `release update` command.

https://github.com/cli/cli/issues/1997

So the alternative is to use the GitHub API. However, updating requires knowing the `release_id` or querying for it before updating which is very messy.

https://docs.github.com/en/rest/reference/repos#update-a-release

`gh release create` supports draft releases if you provide files in a single command.

https://github.com/cli/cli/blob/trunk/pkg/cmd/release/create/create.go#L286

So I've squashed the release and upload steps into a single script. This also means we don't need to figure out the release tag again when uploading.

For testing, I created a test project with a similar release flow.

https://github.com/jahed-snyk/testproj1

You can see a release here:

https://github.com/jahed-snyk/testproj1/releases/tag/v0.2.0