### PR TITLE
fix: excluding gradle root project name from allSubProjectNames

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.20.1",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.14.2",
+    "snyk-gradle-plugin": "3.14.3",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
     "snyk-nodejs-lockfile-parser": "1.34.0",


### PR DESCRIPTION
- We were wrongly considering a Gradle root project as subproject