### PR TITLE
chore: remove redundant lodash.endswith package

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "lodash.assign": "^4.2.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.clonedeep": "^4.5.0",
-    "lodash.endswith": "^4.2.1",
     "lodash.flatten": "^4.4.0",
     "lodash.flattendeep": "^4.4.0",
     "lodash.get": "^4.4.2",

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as pathLib from 'path';
 import * as debugLib from 'debug';
-const endsWith = require('lodash.endswith');
 import { NoSupportedManifestsFoundError } from './errors';
 import { SupportedPackageManagers } from './package-managers';
 
@@ -99,9 +98,9 @@ const DETECTABLE_PACKAGE_MANAGERS: {
   'mix.exs': 'hex',
 };
 
-export function isPathToPackageFile(path) {
+export function isPathToPackageFile(path: string) {
   for (const fileName of DETECTABLE_FILES) {
-    if (endsWith(path, fileName)) {
+    if (path.endsWith(fileName)) {
       return true;
     }
   }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Remove redundant [lodash.endswith](https://www.npmjs.com/package/lodash.endswith) library

#### Where should the reviewer start?

The change affects only one comand `snyk test` the test scenario is described below

#### How should this be manually tested?

```bash
snyk test /path/to/any/package/with/known/manifest/file pathB --project-name=ANY
```

Expected output to stderr:
`Not a recognised option did you mean --file=/Users/jan/projects/customer-bugs/snyk-poetry-bug/Pipfile? Check other options by running snyk --help`

#### Any background context you want to provide?

As a part of working on other ticket I've noticed that we use `lodash.endswith` only in one place and it can easily be removed.

