### PR TITLE
fix: gradle scanning error due of mishandled root value

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.20.1",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.14.3",
+    "snyk-gradle-plugin": "3.14.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
     "snyk-nodejs-lockfile-parser": "1.34.0",


### PR DESCRIPTION
While processing Gradle snykGraphs from extractedJSON to depGraph,
projectName is generated using the basename of the rootDir,
we were not handling it if by any chance it was null or undefined.
Now that we are handling it properly, we are preventing possible scanning error.