### PR TITLE
fix: exclude gradle/cache path when extracting jars

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.20.1",
+    "snyk-docker-plugin": "4.20.2",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.14.4",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
monitoring container images with app-vulns
will now ignore jar files paths that contain gradle/cache

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bumping `snyk-docker-plugin` to include a fix that excludes paths matching `gradle/cache` when extracting `jar` files from a container image.

#### How should this be manually tested?

Monitor container image with a `jar` in a path that contains `gradle/cache`

