### PR TITLE
fix: fix invalid poetry detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",
-    "snyk-python-plugin": "1.19.8",
+    "snyk-python-plugin": "1.19.9",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.2",
     "snyk-sbt-plugin": "2.11.0",

--- a/src/lib/detect.ts
+++ b/src/lib/detect.ts
@@ -3,7 +3,10 @@ import * as pathLib from 'path';
 import * as debugLib from 'debug';
 const endsWith = require('lodash.endswith');
 import { NoSupportedManifestsFoundError } from './errors';
-import { SupportedPackageManagers } from './package-managers';
+import {
+  SupportedPackageManagers,
+  SUPPORTED_MANIFEST_FILES,
+} from './package-managers';
 
 const debug = debugLib('snyk-detect');
 
@@ -29,7 +32,6 @@ const DETECTABLE_FILES: string[] = [
   'composer.lock',
   'Podfile',
   'Podfile.lock',
-  'pyproject.toml',
   'poetry.lock',
   'mix.exs',
   'mix.lock',
@@ -57,46 +59,45 @@ export const AUTO_DETECTABLE_FILES: string[] = [
   'build.sbt',
   'build.gradle',
   'build.gradle.kts',
-  'pyproject.toml',
   'poetry.lock',
   'mix.exs',
   'mix.lock',
 ];
 
 // when file is specified with --file, we look it up here
+// this is also used when --all-projects flag is enabled and auto detection plugin is triggered
 const DETECTABLE_PACKAGE_MANAGERS: {
-  [name: string]: SupportedPackageManagers;
+  [key in SUPPORTED_MANIFEST_FILES]: SupportedPackageManagers;
 } = {
-  Gemfile: 'rubygems',
-  'Gemfile.lock': 'rubygems',
-  '.gemspec': 'rubygems',
-  'package-lock.json': 'npm',
-  'pom.xml': 'maven',
-  '.jar': 'maven',
-  '.war': 'maven',
-  'build.gradle': 'gradle',
-  'build.gradle.kts': 'gradle',
-  'build.sbt': 'sbt',
-  'yarn.lock': 'yarn',
-  'package.json': 'npm',
-  Pipfile: 'pip',
-  'setup.py': 'pip',
-  'requirements.txt': 'pip',
-  'Gopkg.lock': 'golangdep',
-  'go.mod': 'gomodules',
-  'vendor.json': 'govendor',
-  'project.assets.json': 'nuget',
-  'packages.config': 'nuget',
-  'project.json': 'nuget',
-  'paket.dependencies': 'paket',
-  'composer.lock': 'composer',
-  'Podfile.lock': 'cocoapods',
-  'CocoaPods.podfile.yaml': 'cocoapods',
-  'CocoaPods.podfile': 'cocoapods',
-  Podfile: 'cocoapods',
-  'pyproject.toml': 'poetry',
-  'poetry.lock': 'poetry',
-  'mix.exs': 'hex',
+  [SUPPORTED_MANIFEST_FILES.GEMFILE]: 'rubygems',
+  [SUPPORTED_MANIFEST_FILES.GEMFILE_LOCK]: 'rubygems',
+  [SUPPORTED_MANIFEST_FILES.GEMSPEC]: 'rubygems',
+  [SUPPORTED_MANIFEST_FILES.PACKAGE_LOCK_JSON]: 'npm',
+  [SUPPORTED_MANIFEST_FILES.POM_XML]: 'maven',
+  [SUPPORTED_MANIFEST_FILES.JAR]: 'maven',
+  [SUPPORTED_MANIFEST_FILES.WAR]: 'maven',
+  [SUPPORTED_MANIFEST_FILES.BUILD_GRADLE]: 'gradle',
+  [SUPPORTED_MANIFEST_FILES.BUILD_GRADLE_KTS]: 'gradle',
+  [SUPPORTED_MANIFEST_FILES.BUILD_SBT]: 'sbt',
+  [SUPPORTED_MANIFEST_FILES.YARN_LOCK]: 'yarn',
+  [SUPPORTED_MANIFEST_FILES.PACKAGE_JSON]: 'npm',
+  [SUPPORTED_MANIFEST_FILES.PIPFILE]: 'pip',
+  [SUPPORTED_MANIFEST_FILES.SETUP_PY]: 'pip',
+  [SUPPORTED_MANIFEST_FILES.REQUIREMENTS_TXT]: 'pip',
+  [SUPPORTED_MANIFEST_FILES.GOPKG_LOCK]: 'golangdep',
+  [SUPPORTED_MANIFEST_FILES.GO_MOD]: 'gomodules',
+  [SUPPORTED_MANIFEST_FILES.VENDOR_JSON]: 'govendor',
+  [SUPPORTED_MANIFEST_FILES.PROJECT_ASSETS_JSON]: 'nuget',
+  [SUPPORTED_MANIFEST_FILES.PACKAGES_CONFIG]: 'nuget',
+  [SUPPORTED_MANIFEST_FILES.PROJECT_JSON]: 'nuget',
+  [SUPPORTED_MANIFEST_FILES.PAKET_DEPENDENCIES]: 'paket',
+  [SUPPORTED_MANIFEST_FILES.COMPOSER_LOCK]: 'composer',
+  [SUPPORTED_MANIFEST_FILES.PODFILE_LOCK]: 'cocoapods',
+  [SUPPORTED_MANIFEST_FILES.COCOAPODS_PODFILE_YAML]: 'cocoapods',
+  [SUPPORTED_MANIFEST_FILES.COCOAPODS_PODFILE]: 'cocoapods',
+  [SUPPORTED_MANIFEST_FILES.PODFILE]: 'cocoapods',
+  [SUPPORTED_MANIFEST_FILES.POETRY_LOCK]: 'poetry',
+  [SUPPORTED_MANIFEST_FILES.MIX_EXS]: 'hex',
 };
 
 export function isPathToPackageFile(path) {
@@ -200,6 +201,7 @@ export function detectPackageManagerFromFile(
     // we throw and error here because the file was specified by the user
     throw new Error('Could not detect package manager for file: ' + file);
   }
+
   return DETECTABLE_PACKAGE_MANAGERS[key];
 }
 

--- a/src/lib/package-managers.ts
+++ b/src/lib/package-managers.ts
@@ -16,6 +16,38 @@ export type SupportedPackageManagers =
   | 'poetry'
   | 'hex';
 
+export enum SUPPORTED_MANIFEST_FILES {
+  GEMFILE = 'Gemfile',
+  GEMFILE_LOCK = 'Gemfile.lock',
+  GEMSPEC = '.gemspec',
+  PACKAGE_LOCK_JSON = 'package-lock.json',
+  POM_XML = 'pom.xml',
+  JAR = '.jar',
+  WAR = '.war',
+  BUILD_GRADLE = 'build.gradle',
+  BUILD_GRADLE_KTS = 'build.gradle.kts',
+  BUILD_SBT = 'build.sbt',
+  YARN_LOCK = 'yarn.lock',
+  PACKAGE_JSON = 'package.json',
+  PIPFILE = 'Pipfile',
+  SETUP_PY = 'setup.py',
+  REQUIREMENTS_TXT = 'requirements.txt',
+  GOPKG_LOCK = 'Gopkg.lock',
+  GO_MOD = 'go.mod',
+  VENDOR_JSON = 'vendor.json',
+  PROJECT_ASSETS_JSON = 'project.assets.json',
+  PACKAGES_CONFIG = 'packages.config',
+  PROJECT_JSON = 'project.json',
+  PAKET_DEPENDENCIES = 'paket.dependencies',
+  COMPOSER_LOCK = 'composer.lock',
+  PODFILE_LOCK = 'Podfile.lock',
+  COCOAPODS_PODFILE_YAML = 'CocoaPods.podfile.yaml',
+  COCOAPODS_PODFILE = 'CocoaPods.podfile',
+  PODFILE = 'Podfile',
+  POETRY_LOCK = 'poetry.lock',
+  MIX_EXS = 'mix.exs',
+}
+
 export const SUPPORTED_PACKAGE_MANAGER_NAME: {
   readonly [packageManager in SupportedPackageManagers]: string;
 } = {

--- a/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
+++ b/test/acceptance/cli-monitor/cli-monitor.acceptance.test.ts
@@ -933,7 +933,7 @@ if (!isWindows) {
       'sends version number',
     );
     t.match(req.url, '/monitor/poetry/graph', 'puts at correct url');
-    t.equal(req.body.targetFile, 'pyproject.toml', 'sends targetFile');
+    t.equal(req.body.targetFile, 'poetry.lock', 'sends targetFile');
     const depGraphJSON = req.body.depGraphJSON;
     t.ok(depGraphJSON);
   });

--- a/test/acceptance/cli-test/cli-test.all-projects.spec.ts
+++ b/test/acceptance/cli-test/cli-test.all-projects.spec.ts
@@ -1154,26 +1154,5 @@ export const AllProjectsTests: AcceptanceTests = {
         'Go dep package manager',
       );
     },
-    '`test mono-repo-poetry --all-projects`': (params, utils) => async (t) => {
-      utils.chdirWorkspaces();
-      const res: CommandResult = await params.cli.test('mono-repo-poetry', {
-        allProjects: true,
-      });
-      t.match(
-        res.getDisplayResults(),
-        /Tested 2 projects, no vulnerable paths were found./,
-        'Two projects tested',
-      );
-      t.match(
-        res.getDisplayResults(),
-        'Package manager:   npm',
-        'Npm package manager',
-      );
-      t.match(
-        res.getDisplayResults(),
-        'Package manager:   poetry',
-        'Poetry package manager',
-      );
-    },
   },
 };

--- a/test/acceptance/cli-test/cli-test.python.spec.ts
+++ b/test/acceptance/cli-test/cli-test.python.spec.ts
@@ -279,22 +279,5 @@ export const PythonTests: AcceptanceTests = {
         'calls python plugin',
       );
     },
-    '`test poetry-app with pyproject.toml and poetry.lock`': (
-      params,
-      utils,
-    ) => async (t) => {
-      utils.chdirWorkspaces();
-      await params.cli.test('poetry-app', {});
-      const req = params.server.popRequest();
-      t.equal(req.method, 'POST', 'makes POST request');
-      t.equal(
-        req.headers['x-snyk-cli-version'],
-        params.versionNumber,
-        'sends version number',
-      );
-      t.match(req.url, '/test-dep-graph', 'posts to correct url');
-      t.equal(req.body.targetFile, 'pyproject.toml', 'specifies target');
-      t.equal(req.body.depGraph.pkgManager.name, 'poetry');
-    },
   },
 };

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/Pipfile
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/Pipfile.lock
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/Pipfile.lock
@@ -1,0 +1,119 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8684575dc2e2ee3ef130963dade592c67e470b510ee5ccd3a60920b144ac8e32"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
+                "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.3"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.1"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.0.1"
+        }
+    },
+    "develop": {}
+}

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/poetry.lock
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/poetry.lock
@@ -1,0 +1,391 @@
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "20.3.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+
+[[package]]
+name = "click"
+version = "7.0"
+description = "Composable command line interface toolkit"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "colorama"
+version = "0.4.1"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "configparser"
+version = "4.0.2"
+description = "Updated configparser from Python 3.7 for Python 2.6+."
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
+
+[[package]]
+name = "contextlib2"
+version = "0.6.0.post1"
+description = "Backports and enhancements for the contextlib module"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "flask"
+version = "1.0.4"
+description = "A simple framework for building complex web applications."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+click = ">=5.1"
+itsdangerous = ">=0.24"
+Jinja2 = ">=2.10"
+Werkzeug = ">=0.14"
+
+[package.extras]
+dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
+docs = ["sphinx", "pallets-sphinx-themes", "sphinxcontrib-log-cabinet", "sphinx-issues"]
+dotenv = ["python-dotenv"]
+
+[[package]]
+name = "funcsigs"
+version = "1.0.2"
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "1.1.3"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+configparser = {version = ">=3.5", markers = "python_version < \"3\""}
+contextlib2 = {version = "*", markers = "python_version < \"3\""}
+pathlib2 = {version = "*", markers = "python_version == \"3.4.*\" or python_version < \"3\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
+
+[[package]]
+name = "itsdangerous"
+version = "1.1.0"
+description = "Various helpers to pass data to untrusted environments and back."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "jinja2"
+version = "2.10.3"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+name = "markupsafe"
+version = "1.1.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
+
+[[package]]
+name = "more-itertools"
+version = "5.0.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.0.0,<2.0.0"
+
+[[package]]
+name = "pathlib2"
+version = "2.3.5"
+description = "Object-oriented filesystem paths"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+scandir = {version = "*", markers = "python_version < \"3.5\""}
+six = "*"
+
+[[package]]
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pytest"
+version = "3.10.1"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+funcsigs = {version = "*", markers = "python_version < \"3.0\""}
+more-itertools = ">=4.0.0"
+pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
+pluggy = ">=0.7"
+py = ">=1.5.0"
+six = ">=1.10.0"
+
+[[package]]
+name = "scandir"
+version = "1.10.0"
+description = "scandir, a better directory iterator and faster os.walk()"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "six"
+version = "1.15.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "werkzeug"
+version = "0.16.1"
+description = "The comprehensive WSGI web application library."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["pytest", "coverage", "tox", "sphinx", "pallets-sphinx-themes", "sphinx-issues"]
+termcolor = ["termcolor"]
+watchdog = ["watchdog"]
+
+[[package]]
+name = "zipp"
+version = "1.2.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+contextlib2 = {version = "*", markers = "python_version < \"3.4\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "938fb2a6dec4a578797591818761a141f088cceea21a180cf7f2148db9b2f0a3"
+
+[metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
+]
+click = [
+    {file = "Click-7.0-py2.py3-none-any.whl", hash = "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13"},
+    {file = "Click-7.0.tar.gz", hash = "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"},
+]
+colorama = [
+    {file = "colorama-0.4.1-py2.py3-none-any.whl", hash = "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"},
+    {file = "colorama-0.4.1.tar.gz", hash = "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"},
+]
+configparser = [
+    {file = "configparser-4.0.2-py2.py3-none-any.whl", hash = "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c"},
+    {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
+]
+contextlib2 = [
+    {file = "contextlib2-0.6.0.post1-py2.py3-none-any.whl", hash = "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"},
+    {file = "contextlib2-0.6.0.post1.tar.gz", hash = "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e"},
+]
+flask = [
+    {file = "Flask-1.0.4-py2.py3-none-any.whl", hash = "sha256:1a21ccca71cee5e55b6a367cc48c6eb47e3c447f76e64d41f3f3f931c17e7c96"},
+    {file = "Flask-1.0.4.tar.gz", hash = "sha256:ed1330220a321138de53ec7c534c3d90cf2f7af938c7880fc3da13aa46bf870f"},
+]
+funcsigs = [
+    {file = "funcsigs-1.0.2-py2.py3-none-any.whl", hash = "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"},
+    {file = "funcsigs-1.0.2.tar.gz", hash = "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.1.3-py2.py3-none-any.whl", hash = "sha256:7c7f8ac40673f507f349bef2eed21a0e5f01ddf5b2a7356a6c65eb2099b53764"},
+    {file = "importlib_metadata-1.1.3.tar.gz", hash = "sha256:7a99fb4084ffe6dae374961ba7a6521b79c1d07c658ab3a28aa264ee1d1b14e3"},
+]
+itsdangerous = [
+    {file = "itsdangerous-1.1.0-py2.py3-none-any.whl", hash = "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"},
+    {file = "itsdangerous-1.1.0.tar.gz", hash = "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19"},
+]
+jinja2 = [
+    {file = "Jinja2-2.10.3-py2.py3-none-any.whl", hash = "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f"},
+    {file = "Jinja2-2.10.3.tar.gz", hash = "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"},
+]
+markupsafe = [
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win32.whl", hash = "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27m-win_amd64.whl", hash = "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f"},
+    {file = "MarkupSafe-1.1.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-macosx_10_6_intel.whl", hash = "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win32.whl", hash = "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21"},
+    {file = "MarkupSafe-1.1.1-cp34-cp34m-win_amd64.whl", hash = "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win32.whl", hash = "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1"},
+    {file = "MarkupSafe-1.1.1-cp35-cp35m-win_amd64.whl", hash = "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win32.whl", hash = "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66"},
+    {file = "MarkupSafe-1.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
+    {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
+    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win32.whl", hash = "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39"},
+    {file = "MarkupSafe-1.1.1-cp39-cp39-win_amd64.whl", hash = "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8"},
+    {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
+]
+more-itertools = [
+    {file = "more-itertools-5.0.0.tar.gz", hash = "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4"},
+    {file = "more_itertools-5.0.0-py2-none-any.whl", hash = "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc"},
+    {file = "more_itertools-5.0.0-py3-none-any.whl", hash = "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"},
+]
+pathlib2 = [
+    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
+    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pytest = [
+    {file = "pytest-3.10.1-py2.py3-none-any.whl", hash = "sha256:3f193df1cfe1d1609d4c583838bea3d532b18d6160fd3f55c9447fdca30848ec"},
+    {file = "pytest-3.10.1.tar.gz", hash = "sha256:e246cf173c01169b9617fc07264b7b1316e78d7a650055235d6d897bc80d9660"},
+]
+scandir = [
+    {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
+    {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
+    {file = "scandir-1.10.0-cp34-cp34m-win32.whl", hash = "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"},
+    {file = "scandir-1.10.0-cp34-cp34m-win_amd64.whl", hash = "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"},
+    {file = "scandir-1.10.0-cp35-cp35m-win32.whl", hash = "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"},
+    {file = "scandir-1.10.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"},
+    {file = "scandir-1.10.0-cp36-cp36m-win32.whl", hash = "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"},
+    {file = "scandir-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"},
+    {file = "scandir-1.10.0-cp37-cp37m-win32.whl", hash = "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"},
+    {file = "scandir-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"},
+    {file = "scandir-1.10.0.tar.gz", hash = "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"},
+]
+six = [
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+werkzeug = [
+    {file = "Werkzeug-0.16.1-py2.py3-none-any.whl", hash = "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2"},
+    {file = "Werkzeug-0.16.1.tar.gz", hash = "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"},
+]
+zipp = [
+    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
+    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+]

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/pyproject.toml
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "poetry-demo"
+version = "0.1.0"
+description = ""
+authors = []
+
+[tool.poetry.dependencies]
+flask = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "^3.4"
+

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/Pipfile
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+flask = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.8"

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/Pipfile.lock
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/Pipfile.lock
@@ -1,0 +1,119 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8684575dc2e2ee3ef130963dade592c67e470b510ee5ccd3a60920b144ac8e32"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "click": {
+            "hashes": [
+                "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a",
+                "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==7.1.2"
+        },
+        "flask": {
+            "hashes": [
+                "sha256:4efa1ae2d7c9865af48986de8aeb8504bf32c7f3d6fdc9353d34b21f4b127060",
+                "sha256:8a4fdd8936eba2512e9c85df320a37e694c93945b33ef33c89946a340a238557"
+            ],
+            "index": "pypi",
+            "version": "==1.1.2"
+        },
+        "itsdangerous": {
+            "hashes": [
+                "sha256:321b033d07f2a4136d3ec762eac9f16a10ccd60f53c0c91af90217ace7ba1f19",
+                "sha256:b12271b2047cb23eeb98c8b5622e2e5c5e9abd9784a153e9d8ef9cb4dd09d749"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.0"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419",
+                "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.11.3"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:195d7d2c4fbb0ee8139a6cf67194f3973a6b3042d742ebe0a9ed36d8b6f0c07f",
+                "sha256:22c178a091fc6630d0d045bdb5992d2dfe14e3259760e713c490da5323866c39",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:2beec1e0de6924ea551859edb9e7679da6e4870d32cb766240ce17e0a0ba2014",
+                "sha256:3b8a6499709d29c2e2399569d96719a1b21dcd94410a586a18526b143ec8470f",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:6f1e273a344928347c1290119b493a1f0303c52f5a5eae5f16d74f48c15d4a85",
+                "sha256:6fffc775d90dcc9aed1b89219549b329a9250d918fd0b8fa8d93d154918422e1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:7fed13866cf14bba33e7176717346713881f56d9d2bcebab207f7a036f41b850",
+                "sha256:84dee80c15f1b560d55bcfe6d47b27d070b4681c699c572af2e3c7cc90a3b8e0",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98bae9582248d6cf62321dcb52aaf5d9adf0bad3b40582925ef7c7f0ed85fceb",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:a6a744282b7718a2a62d2ed9d993cad6f5f585605ad352c11de459f4108df0a1",
+                "sha256:acf08ac40292838b3cbbb06cfe9b2cb9ec78fce8baca31ddb87aaac2e2dc3bc2",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b1dba4527182c95a0db8b6060cc98ac49b9e2f5e64320e2b56e47cb2831978c7",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:b7d644ddb4dbd407d31ffb699f1d140bc35478da613b441c582aeb7c43838dd8",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:bf5aa3cbcfdf57fa2ee9cd1822c862ef23037f5c832ad09cfea57fa846dec193",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:caabedc8323f1e93231b52fc32bdcde6db817623d33e100708d9a68e1f53b26b",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:d53bc011414228441014aa71dbec320c66468c1030aae3a6e29778a3382d96e5",
+                "sha256:d73a845f227b0bfe8a7455ee623525ee656a9e2e749e4742706d80a6065d5e2c",
+                "sha256:d9be0ba6c527163cbed5e0857c451fcd092ce83947944d6c14bc95441203f032",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be",
+                "sha256:feb7b34d6325451ef96bc0e36e1a6c0c1c64bc1fbec4b854f4529e51887b1621"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.1.1"
+        },
+        "werkzeug": {
+            "hashes": [
+                "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43",
+                "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.0.1"
+        }
+    },
+    "develop": {}
+}

--- a/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/pyproject.toml
+++ b/test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/pyproject.toml
@@ -1,0 +1,21 @@
+[tool.black]
+line-length = 119
+target-version = ['py38']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | \.venv
+    | _build
+    | buck-out
+    | build
+    | dist
+  )
+)
+'''
+

--- a/test/jest/system/snyk-test/python/snyk-test-pyproject.spec.ts
+++ b/test/jest/system/snyk-test/python/snyk-test-pyproject.spec.ts
@@ -1,0 +1,320 @@
+import { join } from 'path';
+import { mocked } from 'ts-jest/utils';
+import { NeedleResponse } from 'needle';
+import { test } from '../../../../../src/cli/commands';
+import { loadPlugin } from '../../../../../src/lib/plugins/index';
+import { CommandResult } from '../../../../../src/cli/commands/types';
+import makeRequest = require('../../../../../src/lib/request/request');
+
+jest.mock('../../../../../src/lib/plugins/index');
+jest.mock('../../../../../src/lib/request/request');
+
+const mockedLoadPlugin = mocked(loadPlugin, true);
+const mockedMakeRequest = mocked(makeRequest);
+
+describe('snyk test for python project', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('no flag is used', () => {
+    describe('project contains poetry.lock file', () => {
+      it('should scan poetry vulnerabilities', async (done) => {
+        const fixturePath = join(
+          __dirname,
+          '../../../../acceptance/workspaces',
+          'poetry-app',
+        );
+
+        const plugin = {
+          async inspect() {
+            return {
+              plugin: {
+                targetFile: 'poetry.lock',
+                name: 'snyk-python-plugin',
+                runtime: 'Python',
+              },
+              package: {},
+            };
+          },
+        };
+        mockedLoadPlugin.mockImplementationOnce(() => {
+          return plugin;
+        });
+        mockedMakeRequest.mockImplementationOnce(() => {
+          return Promise.resolve({
+            res: { statusCode: 200 } as NeedleResponse,
+            body: {
+              result: { issuesData: {}, affectedPkgs: {} },
+              meta: { org: 'test-org', isPublic: false },
+              filesystemPolicy: false,
+            },
+          });
+        });
+
+        const result: CommandResult = await test(fixturePath, {
+          json: true,
+        });
+
+        expect(mockedLoadPlugin).toHaveBeenCalledTimes(1);
+        expect(mockedLoadPlugin).toHaveBeenCalledWith('poetry');
+
+        expect(mockedMakeRequest).toHaveBeenCalledTimes(1);
+        expect(mockedMakeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              displayTargetFile: 'poetry.lock',
+            }),
+          }),
+        );
+
+        const expectedResultObject = {
+          vulnerabilities: [],
+          ok: true,
+          dependencyCount: 0,
+          org: 'test-org',
+          policy: undefined,
+          isPrivate: true,
+          licensesPolicy: null,
+          packageManager: 'poetry',
+          projectId: undefined,
+          ignoreSettings: null,
+          docker: undefined,
+          summary: 'No known vulnerabilities',
+          severityThreshold: undefined,
+          remediation: undefined,
+          filesystemPolicy: false,
+          uniqueCount: 0,
+          targetFile: 'poetry.lock',
+          projectName: undefined,
+          foundProjectCount: undefined,
+          displayTargetFile: 'poetry.lock',
+          platform: undefined,
+          path: fixturePath,
+        };
+        expect(result).toMatchObject({
+          result: JSON.stringify(expectedResultObject, null, 2),
+        });
+
+        done();
+      });
+    });
+  });
+
+  describe('--all-projects flag is used to scan the project', () => {
+    describe('project does not contain poetry.lock file', () => {
+      it('should not attempt to scan poetry vulnerabilities', async (done) => {
+        const fixturePath = join(
+          __dirname,
+          'fixtures',
+          'pyproject-without-poetry',
+        );
+        const plugin = {
+          async inspect() {
+            return {
+              plugin: {
+                targetFile: 'Pipfile',
+                name: 'snyk-python-plugin',
+                runtime: 'Python',
+              },
+              package: {},
+            };
+          },
+        };
+        mockedLoadPlugin.mockImplementationOnce(() => {
+          return plugin;
+        });
+        mockedMakeRequest.mockImplementationOnce(() => {
+          return Promise.resolve({
+            res: { statusCode: 200 } as NeedleResponse,
+            body: {
+              result: { issuesData: {}, affectedPkgs: {} },
+              meta: { org: 'test-org', isPublic: false },
+              filesystemPolicy: false,
+            },
+          });
+        });
+
+        const result: CommandResult = await test(fixturePath, {
+          allProjects: true,
+          json: true,
+        });
+
+        expect(mockedLoadPlugin).toHaveBeenCalledTimes(1);
+        expect(mockedLoadPlugin).toHaveBeenCalledWith('pip');
+
+        expect(mockedMakeRequest).toHaveBeenCalledTimes(1);
+        expect(mockedMakeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              displayTargetFile: 'Pipfile',
+            }),
+          }),
+        );
+
+        const expectedResultObject = {
+          vulnerabilities: [],
+          ok: true,
+          dependencyCount: 0,
+          org: 'test-org',
+          policy: undefined,
+          isPrivate: true,
+          licensesPolicy: null,
+          packageManager: 'pip',
+          projectId: undefined,
+          ignoreSettings: null,
+          docker: undefined,
+          summary: 'No known vulnerabilities',
+          severityThreshold: undefined,
+          remediation: undefined,
+          filesystemPolicy: false,
+          uniqueCount: 0,
+          targetFile: 'Pipfile',
+          projectName: undefined,
+          foundProjectCount: undefined,
+          displayTargetFile: 'Pipfile',
+          platform: undefined,
+          path: fixturePath,
+        };
+        expect(result).toMatchObject({
+          result: JSON.stringify(expectedResultObject, null, 2),
+        });
+
+        done();
+      });
+    });
+
+    describe('project does contain poetry.lock file', () => {
+      it('should scan poetry vulnerabilities', async (done) => {
+        const fixturePath = join(
+          __dirname,
+          'fixtures',
+          'pyproject-with-poetry',
+        );
+
+        const pipfilePythonPluginResponse = {
+          async inspect() {
+            return {
+              plugin: {
+                targetFile: 'Pipfile',
+                name: 'snyk-python-plugin',
+                runtime: 'Python',
+              },
+              package: {},
+            };
+          },
+        };
+        const pyprojectPythonPluginResponse = {
+          async inspect() {
+            return {
+              plugin: {
+                targetFile: 'poetry.lock',
+                name: 'snyk-python-plugin',
+                runtime: 'Python',
+              },
+              package: {},
+            };
+          },
+        };
+        mockedLoadPlugin
+          .mockImplementationOnce(() => pipfilePythonPluginResponse)
+          .mockImplementationOnce(() => pyprojectPythonPluginResponse);
+        mockedMakeRequest.mockImplementation(() => {
+          return Promise.resolve({
+            res: { statusCode: 200 } as NeedleResponse,
+            body: {
+              result: { issuesData: {}, affectedPkgs: {} },
+              meta: { org: 'test-org', isPublic: false },
+              filesystemPolicy: false,
+            },
+          });
+        });
+
+        const result: CommandResult = await test(fixturePath, {
+          allProjects: true,
+          json: true,
+        });
+
+        expect(mockedLoadPlugin).toHaveBeenCalledTimes(2);
+        expect(mockedLoadPlugin).toHaveBeenCalledWith('pip');
+        expect(mockedLoadPlugin).toHaveBeenCalledWith('poetry');
+
+        expect(mockedMakeRequest).toHaveBeenCalledTimes(2);
+        expect(mockedMakeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              displayTargetFile: 'Pipfile',
+              foundProjectCount: 1,
+            }),
+          }),
+        );
+        expect(mockedMakeRequest).toHaveBeenCalledWith(
+          expect.objectContaining({
+            body: expect.objectContaining({
+              displayTargetFile: 'poetry.lock',
+              foundProjectCount: 1,
+            }),
+          }),
+        );
+
+        const expectedPipfileResultObject = {
+          vulnerabilities: [],
+          ok: true,
+          dependencyCount: 0,
+          org: 'test-org',
+          policy: undefined,
+          isPrivate: true,
+          licensesPolicy: null,
+          packageManager: 'pip',
+          projectId: undefined,
+          ignoreSettings: null,
+          docker: undefined,
+          summary: 'No known vulnerabilities',
+          severityThreshold: undefined,
+          remediation: undefined,
+          filesystemPolicy: false,
+          uniqueCount: 0,
+          targetFile: 'Pipfile',
+          foundProjectCount: 1,
+          projectName: undefined,
+          displayTargetFile: 'Pipfile',
+          platform: undefined,
+          path: fixturePath,
+        };
+        const expectedPyprojectResultObject = {
+          vulnerabilities: [],
+          ok: true,
+          dependencyCount: 0,
+          org: 'test-org',
+          policy: undefined,
+          isPrivate: true,
+          licensesPolicy: null,
+          packageManager: 'poetry',
+          projectId: undefined,
+          ignoreSettings: null,
+          docker: undefined,
+          summary: 'No known vulnerabilities',
+          severityThreshold: undefined,
+          remediation: undefined,
+          filesystemPolicy: false,
+          uniqueCount: 0,
+          targetFile: 'poetry.lock',
+          foundProjectCount: 1,
+          projectName: undefined,
+          displayTargetFile: 'poetry.lock',
+          platform: undefined,
+          path: fixturePath,
+        };
+        expect(result).toMatchObject({
+          result: JSON.stringify(
+            [expectedPipfileResultObject, expectedPyprojectResultObject],
+            null,
+            2,
+          ),
+        });
+
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Fix invalid detection of poetry project based solely on presence of `pyproject.toml`. Fixes https://github.com/snyk/snyk/issues/1802

Before we assumed that poetry package manager is present if `pyproject.toml` exists in a folder structure.

The solution is to parse  rely on `poetry.lock` alone to determine if project uses poetry or not.

#### Where should the reviewer start?

Run the test cases below

#### How should this be manually tested?

2 testcases:

1. Run `snyk test` for project with `pyproject.toml` that doesn't use poetry
```bash
# in snyk repo
npm i
npm run build
cd test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/
pipenv install
cd -
node dist/cli/index.js test test/jest/system/snyk-test/python/fixtures/pyproject-without-poetry/ --all-projects
```

Expected result: only one file package manager is recognised pip for `Pipfile` manifest

2. Run `snyk test` for project with `pyproject.toml` that does use poetry
```bash
# in snyk repo
npm i
npm run build
cd test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/
pipenv install && poetry install
cd -
node dist/cli/index.js test test/jest/system/snyk-test/python/fixtures/pyproject-with-poetry/ --all-projects
```

Expected result: 2 package managers are recognised pip for `Pipfile` manifest and poetry for `pyproject.toml` manifest


#### What are the relevant tickets?

https://github.com/snyk/snyk/issues/1802


