### PR TITLE
refactor: iac documentation url in outputs

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -65,6 +65,7 @@ function formatScanResult(
       },
       severity: policy.severity,
       lineNumber,
+      documentation: `https://snyk.io/security-rules/${policy.publicId}`,
     };
   });
 

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -209,6 +209,7 @@ export function extractReportingDescriptor(
       },
       properties: {
         tags: ['security', `${issue.type}/${issue.subType}`],
+        documentation: issue.documentation,
       },
     };
   });

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -10,6 +10,7 @@ export interface AnnotatedIacIssue {
   type: string;
   subType: string;
   path: string[];
+  documentation: string;
   // Legacy fields from Registry, unused.
   name?: string;
   from?: string[];

--- a/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
+++ b/test/acceptance/cli-test/iac/cli-test.iac-utils.ts
@@ -303,6 +303,7 @@ function generateDummyIssue(severity): AnnotatedIacIssue {
     subType: 'Deployment',
     path: [],
     lineNumber: 1,
+    documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-1',
   };
 }
 

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -80,6 +80,7 @@ export const expectedFormattedResults = {
         },
         severity: anotherPolicyStub.severity,
         lineNumber: 3,
+        documentation: `https://snyk.io/security-rules/${anotherPolicyStub.publicId}`,
       },
     ],
     projectType: 'k8sconfig',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds `documentation` links to the IaC `--json` and `--sarif` outputs.
For each issue, we will present a link for the relevant public documentation page.

#### How should this be manually tested?
Run IaC test (new flow / experimental) with json/sarif output

#### Screenshots
**Json output**
![Screen Shot 2021-05-05 at 9 53 18](https://user-images.githubusercontent.com/1466549/117106034-d4f5c980-ad87-11eb-81f0-610ce364bbfb.png)


**Sarif output**
![Screen Shot 2021-05-05 at 9 53 53](https://user-images.githubusercontent.com/1466549/117106052-db844100-ad87-11eb-9370-31de6eec3570.png)


**Regular output - not affected**
![Screen Shot 2021-05-05 at 9 54 49](https://user-images.githubusercontent.com/1466549/117106104-f1920180-ad87-11eb-8542-618ab0348485.png)
