### PR TITLE
feat: exit code 0 if nothing is vulnerable

### DIFF
--- a/test/fixtures/snyk-fix/test-result-pip-no-vulns.json
+++ b/test/fixtures/snyk-fix/test-result-pip-no-vulns.json
@@ -1,0 +1,20 @@
+{
+  "vulnerabilities": [],
+  "ok": true,
+  "dependencyCount": 2,
+  "org": "bananaq",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {},
+  "packageManager": "pip",
+  "ignoreSettings": null,
+  "summary": "Tested 1 project, no vulnerable paths were found.",
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 4,
+  "projectName": "pip-app",
+  "foundProjectCount": 23
+}


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Improve exit code to help action `snyk fix` output when composing inside pipelines/scripts.
- If `snyk test` failed => error ❌ 
- If `snyk test` returned no vulnerable results => success ✅ 
- If `snyk fix` had some errors and nothing was fixed => error ❌ 
- If `snyk fix` fixed anyrying at all => success ✅ 