### PR TITLE
fix: pick up .snyk file given absolute --file

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -1,44 +1,44 @@
 export = monitor;
 
-import chalk from 'chalk';
-import * as fs from 'fs';
-import * as Debug from 'debug';
-import * as pathUtil from 'path';
 import { legacyPlugin as pluginApi } from '@snyk/cli-interface';
-import { validateOptions } from '../../../lib/options-validator';
-
-import {
-  MonitorOptions,
-  MonitorMeta,
-  MonitorResult,
-  Options,
-  Contributor,
-} from '../../../lib/types';
+import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
+import chalk from 'chalk';
+import * as Debug from 'debug';
+import * as fs from 'fs';
+import * as pathUtil from 'path';
+import * as analytics from '../../../lib/analytics';
+import { apiTokenExists } from '../../../lib/api-token';
 import * as config from '../../../lib/config';
 import * as detect from '../../../lib/detect';
-import { GoodResult, BadResult } from './types';
-import * as spinner from '../../../lib/spinner';
-import * as analytics from '../../../lib/analytics';
-import { MethodArgs } from '../../args';
-import { apiTokenExists } from '../../../lib/api-token';
-import { maybePrintDepTree, maybePrintDepGraph } from '../../../lib/print-deps';
-import { monitor as snykMonitor } from '../../../lib/monitor';
-import { processJsonMonitorResponse } from './process-json-monitor';
-import snyk = require('../../../lib'); // TODO(kyegupov): fix import
-import { formatMonitorOutput } from './formatters/format-monitor-response';
-import { getDepsFromPlugin } from '../../../lib/plugins/get-deps-from-plugin';
-import { getExtraProjectCount } from '../../../lib/plugins/get-extra-project-count';
-import { extractPackageManager } from '../../../lib/plugins/extract-package-manager';
-import { MultiProjectResultCustom } from '../../../lib/plugins/get-multi-plugin-result';
-import { convertMultiResultToMultiCustom } from '../../../lib/plugins/convert-multi-plugin-res-to-multi-custom';
-import { convertSingleResultToMultiCustom } from '../../../lib/plugins/convert-single-splugin-res-to-multi-custom';
-import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
-import { getContributors } from '../../../lib/monitor/dev-count-analysis';
-import { FailedToRunTestError, MonitorError } from '../../../lib/errors';
-import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
 import { getEcosystem, monitorEcosystem } from '../../../lib/ecosystems';
 import { getFormattedMonitorOutput } from '../../../lib/ecosystems/monitor';
+import { FailedToRunTestError, MonitorError } from '../../../lib/errors';
+import { isMultiProjectScan } from '../../../lib/is-multi-project-scan';
+import { monitor as snykMonitor } from '../../../lib/monitor';
+import { getContributors } from '../../../lib/monitor/dev-count-analysis';
+import { validateOptions } from '../../../lib/options-validator';
+import { convertMultiResultToMultiCustom } from '../../../lib/plugins/convert-multi-plugin-res-to-multi-custom';
+import { convertSingleResultToMultiCustom } from '../../../lib/plugins/convert-single-splugin-res-to-multi-custom';
+import { extractPackageManager } from '../../../lib/plugins/extract-package-manager';
+import { getDepsFromPlugin } from '../../../lib/plugins/get-deps-from-plugin';
+import { getExtraProjectCount } from '../../../lib/plugins/get-extra-project-count';
+import { MultiProjectResultCustom } from '../../../lib/plugins/get-multi-plugin-result';
+import { maybePrintDepGraph, maybePrintDepTree } from '../../../lib/print-deps';
+import * as spinner from '../../../lib/spinner';
+import {
+  Contributor,
+  MonitorMeta,
+  MonitorOptions,
+  MonitorResult,
+  Options,
+} from '../../../lib/types';
+import { MethodArgs } from '../../args';
 import { processCommandArgs } from '../process-command-args';
+import { formatMonitorOutput } from './formatters/format-monitor-response';
+import { processJsonMonitorResponse } from './process-json-monitor';
+import { BadResult, GoodResult } from './types';
+
+import snyk = require('../../../lib'); // TODO(kyegupov): fix import
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 const debug = Debug('snyk');

--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -212,7 +212,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
           const tFile = projectDeps.targetFile || targetFile;
           const targetFileRelativePath =
             projectDeps.plugin.targetFile ||
-            (tFile && pathUtil.join(pathUtil.resolve(path), tFile)) ||
+            (tFile && pathUtil.resolve(path, tFile)) ||
             '';
 
           const res: MonitorResult = await promiseOrCleanup(

--- a/src/lib/ecosystems/policy.ts
+++ b/src/lib/ecosystems/policy.ts
@@ -1,5 +1,4 @@
 import * as path from 'path';
-
 import { SupportedPackageManagers } from '../package-managers';
 import { findAndLoadPolicy } from '../policy';
 import { Options, PolicyOptions } from '../types';

--- a/src/lib/ecosystems/policy.ts
+++ b/src/lib/ecosystems/policy.ts
@@ -8,11 +8,14 @@ export async function findAndLoadPolicyForScanResult(
   scanResult: ScanResult,
   options: Options & PolicyOptions,
 ): Promise<object | undefined> {
-  const targetFileRelativePath = scanResult.identity.targetFile
-    ? path.join(path.resolve(`${options.path}`), scanResult.identity.targetFile)
+  const targetFilePath = scanResult.identity.targetFile
+    ? path.resolve(
+        path.resolve(`${options.path}`),
+        scanResult.identity.targetFile,
+      )
     : undefined;
-  const targetFileDir = targetFileRelativePath
-    ? path.parse(targetFileRelativePath).dir
+  const targetFileDir = targetFilePath
+    ? path.dirname(targetFilePath)
     : undefined;
   const scanType = options.docker
     ? 'docker'

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -1,58 +1,57 @@
-import * as Debug from 'debug';
-import * as path from 'path';
-
-import * as depGraphLib from '@snyk/dep-graph';
-import * as snyk from '..';
-import { apiTokenExists } from '../api-token';
-import request = require('../request');
-import * as config from '../config';
-import * as os from 'os';
-const get = require('lodash.get');
-const camelCase = require('lodash.camelcase');
-import { isCI } from '../is-ci';
-import * as analytics from '../analytics';
-import {
-  DepTree,
-  MonitorMeta,
-  MonitorResult,
-  PolicyOptions,
-  MonitorOptions,
-  Options,
-  Contributor,
-} from '../types';
-import * as projectMetadata from '../project-metadata';
-
-import {
-  MonitorError,
-  ConnectionTimeoutError,
-  AuthFailedError,
-  FailedToRunTestError,
-} from '../errors';
-import { pruneGraph } from '../prune';
-import { GRAPH_SUPPORTED_PACKAGE_MANAGERS } from '../package-managers';
-import { isFeatureFlagSupportedForOrg } from '../feature-flags';
-import { countTotalDependenciesInTree } from './count-total-deps-in-tree';
-import { filterOutMissingDeps } from './filter-out-missing-deps';
-import { dropEmptyDeps } from './drop-empty-deps';
-import { pruneTree } from './prune-dep-tree';
-import { findAndLoadPolicy } from '../policy';
-import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import {
   CallGraph,
   CallGraphError,
   ScannedProject,
 } from '@snyk/cli-interface/legacy/common';
+import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
+import * as depGraphLib from '@snyk/dep-graph';
+import * as Debug from 'debug';
+import * as camelCase from 'lodash.camelcase';
+import * as get from 'lodash.get';
+import * as os from 'os';
+import * as path from 'path';
+import * as snyk from '..';
+import * as alerts from '../alerts';
+import * as analytics from '../analytics';
+import { apiTokenExists } from '../api-token';
+import * as config from '../config';
+import { abridgeErrorMessage } from '../error-format';
+import {
+  AuthFailedError,
+  ConnectionTimeoutError,
+  FailedToRunTestError,
+  MonitorError,
+} from '../errors';
+import { isFeatureFlagSupportedForOrg } from '../feature-flags';
+import { isCI } from '../is-ci';
+import { GRAPH_SUPPORTED_PACKAGE_MANAGERS } from '../package-managers';
+import { findAndLoadPolicy } from '../policy';
+import * as projectMetadata from '../project-metadata';
 import { isGitTarget } from '../project-metadata/types';
+import { pruneGraph } from '../prune';
 import { serializeCallGraphWithMetrics } from '../reachable-vulns';
 import {
-  getNameDepTree,
+  Contributor,
+  DepTree,
+  MonitorMeta,
+  MonitorOptions,
+  MonitorResult,
+  Options,
+  PolicyOptions,
+} from '../types';
+import { countPathsToGraphRoot } from '../utils';
+import { countTotalDependenciesInTree } from './count-total-deps-in-tree';
+import { dropEmptyDeps } from './drop-empty-deps';
+import { filterOutMissingDeps } from './filter-out-missing-deps';
+import { pruneTree } from './prune-dep-tree';
+import {
   getNameDepGraph,
+  getNameDepTree,
   getProjectName,
   getTargetFile,
 } from './utils';
-import { countPathsToGraphRoot } from '../utils';
-import * as alerts from '../alerts';
-import { abridgeErrorMessage } from '../error-format';
+
+import request = require('../request');
 
 const debug = Debug('snyk');
 

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -195,13 +195,6 @@ async function monitorDepTree(
     treeMissingDeps = missingDeps;
   }
 
-  let targetFileDir;
-
-  if (targetFileRelativePath) {
-    const { dir } = path.parse(targetFileRelativePath);
-    targetFileDir = dir;
-  }
-
   const policy = await findAndLoadPolicy(
     root,
     meta.isDocker ? 'docker' : packageManager!,
@@ -209,7 +202,7 @@ async function monitorDepTree(
     // TODO: fix this and send only send when we used resolve-deps for node
     // it should be a ExpandedPkgTree type instead
     depTree,
-    targetFileDir,
+    targetFileRelativePath ? path.dirname(targetFileRelativePath) : undefined,
   );
 
   const target = await projectMetadata.getInfo(scannedProject, meta, depTree);
@@ -367,19 +360,12 @@ export async function monitorDepGraph(
     );
   }
 
-  let targetFileDir;
-
-  if (targetFileRelativePath) {
-    const { dir } = path.parse(targetFileRelativePath);
-    targetFileDir = dir;
-  }
-
   const policy = await findAndLoadPolicy(
     root,
     meta.isDocker ? 'docker' : packageManager!,
     options,
     undefined,
-    targetFileDir,
+    targetFileRelativePath ? path.dirname(targetFileRelativePath) : undefined,
   );
 
   const target = await projectMetadata.getInfo(scannedProject, meta);
@@ -530,13 +516,6 @@ async function experimentalMonitorDepGraphFromDepTree(
     );
   }
 
-  let targetFileDir;
-
-  if (targetFileRelativePath) {
-    const { dir } = path.parse(targetFileRelativePath);
-    targetFileDir = dir;
-  }
-
   const policy = await findAndLoadPolicy(
     root,
     meta.isDocker ? 'docker' : packageManager!,
@@ -544,7 +523,7 @@ async function experimentalMonitorDepGraphFromDepTree(
     // TODO: fix this and send only send when we used resolve-deps for node
     // it should be a ExpandedPkgTree type instead
     depTree,
-    targetFileDir,
+    targetFileRelativePath ? path.dirname(targetFileRelativePath) : undefined,
   );
 
   if (['npm', 'yarn'].includes(meta.packageManager)) {

--- a/src/lib/snyk-test/run-iac-test.ts
+++ b/src/lib/snyk-test/run-iac-test.ts
@@ -16,7 +16,7 @@ import { Payload } from './types';
 export async function parseIacTestResult(
   res: IacTestResponse,
   targetFile: string | undefined,
-  targetFileRelativePath: string | undefined,
+  targetFilePath: string | undefined,
   projectName: any,
   severityThreshold?: SEVERITY,
   //TODO(orka): future - return a proper type
@@ -38,7 +38,7 @@ export async function parseIacTestResult(
     policy: meta.policy,
     isPrivate: !meta.isPublic,
     severityThreshold,
-    targetFilePath: targetFileRelativePath,
+    targetFilePath,
   };
 }
 
@@ -59,7 +59,7 @@ export async function assembleIacLocalPayloads(
     const fileType = pathLib.extname(root).substr(1);
     const targetFile = pathLib.resolve(root, '.');
     const targetFileRelativePath = targetFile
-      ? pathUtil.join(pathUtil.resolve(`${options.path}`), targetFile)
+      ? pathUtil.resolve(`${options.path}`, targetFile)
       : '';
     filesToTest.push({
       fileType,

--- a/src/lib/snyk-test/run-iac-test.ts
+++ b/src/lib/snyk-test/run-iac-test.ts
@@ -1,18 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import * as pathUtil from 'path';
-import { TestResult } from './legacy';
-import { IacTestResponse } from './iac-test-result';
-import * as snyk from '..';
-import { isCI } from '../is-ci';
-import * as common from './common';
-import * as config from '../config';
-import { Options, TestOptions } from '../types';
-import { Payload } from './types';
-import { IacScan } from './payload-schema';
-import { SEVERITY } from './legacy';
 import * as pathLib from 'path';
-import { projectTypeByFileType, IacFileTypes } from '../iac/constants';
+import * as pathUtil from 'path';
+import * as snyk from '..';
+import * as config from '../config';
+import { IacFileTypes, projectTypeByFileType } from '../iac/constants';
+import { isCI } from '../is-ci';
+import { Options, TestOptions } from '../types';
+import * as common from './common';
+import { IacTestResponse } from './iac-test-result';
+import { SEVERITY, TestResult } from './legacy';
+import { IacScan } from './payload-schema';
+import { Payload } from './types';
 
 export async function parseIacTestResult(
   res: IacTestResponse,


### PR DESCRIPTION
Work in progress.

--file (targetFile) can be a relative or absolute path so using `path.join` causes invalid paths. Instead we should `path.resolve`, using --path or project root as base and resolving --file to a valid path.

I've also run organise imports as matter of best practice to keep our import list... organised.

## To Do

- [ ] Repro test
- [ ] Check what `options.path` is and how it's populated.