### PR TITLE
test: improve cleanup for unreliable json test

### DIFF
--- a/test/jest/system/json-file-output.spec.ts
+++ b/test/jest/system/json-file-output.spec.ts
@@ -1,181 +1,86 @@
-import * as jsonFileOutputModule from '../../../src/lib/json-file-output';
-
-import { v4 as uuidv4 } from 'uuid';
-import { readFileSync, unlinkSync, rmdirSync, mkdirSync, existsSync } from 'fs';
+import * as fse from 'fs-extra';
 import * as path from 'path';
-import * as fsModule from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { saveJsonToFileCreatingDirectoryIfRequired } from '../../../src/lib/json-file-output';
+
+const setupOutput = () => {
+  const dir = path.resolve('test-output', uuidv4());
+  const outputPath = path.resolve(dir, 'test-output.json');
+  return {
+    path: outputPath,
+    read: async () => {
+      return (await fse.readFile(outputPath, 'utf-8')).trim();
+    },
+    mkdir: async () => {
+      await fse.ensureDir(dir);
+    },
+    remove: async () => {
+      await fse.remove(dir);
+    },
+  };
+};
 
 describe('saveJsonToFileCreatingDirectoryIfRequired', () => {
+  let output: ReturnType<typeof setupOutput>;
+
   beforeEach(() => {
+    output = setupOutput();
+  });
+
+  afterEach(async () => {
+    await output.remove();
     jest.restoreAllMocks();
   });
 
   describe('supports absolute paths', () => {
     it('with directory that does not exists', async () => {
-      const tempFolder = uuidv4();
-      const outputPath = path.join(
-        process.cwd(),
-        'test-output',
-        tempFolder,
-        'test-output.json',
-      );
-
-      const fullDirPath = path.dirname(outputPath);
-      expect(fullDirPath).toBe(
-        path.join(process.cwd(), 'test-output', tempFolder),
-      );
-      const jsonString = JSON.stringify({
+      const input = JSON.stringify({
         ok: true,
         somekey: 'someval',
       });
 
-      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+      await saveJsonToFileCreatingDirectoryIfRequired(output.path, input);
 
-      try {
-        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
-        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
-          outputPath,
-          jsonString,
-        );
-
-        // ensure that mkDirSync was called once
-        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(1);
-
-        const outputFileContents = readFileSync(outputPath, 'utf-8');
-        expect(outputFileContents.trim()).toEqual(jsonString);
-      } finally {
-        unlinkSync(outputPath);
-        rmdirSync(fullDirPath);
-      }
+      expect(output.read()).resolves.toEqual(input);
     });
 
     it('with directory that already exists', async () => {
-      const tempFolder = uuidv4();
-      const outputPath = path.join(
-        process.cwd(),
-        'test-output',
-        tempFolder,
-        'test-output.json',
-      );
+      await output.mkdir();
 
-      // if 'test-output' doesn't exist, created it
-      if (!existsSync('test-output')) {
-        mkdirSync('test-output');
-      }
-
-      const fullDirPath = path.dirname(outputPath);
-
-      // create the temp folder before calling saveJsonToFileCreatingDirectoryIfRequired
-      mkdirSync(fullDirPath);
-      expect(fullDirPath).toBe(
-        path.join(process.cwd(), 'test-output', tempFolder),
-      );
-      const jsonString = JSON.stringify({
+      const input = JSON.stringify({
         ok: true,
         somekey: 'someval',
       });
 
-      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
-      expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+      await saveJsonToFileCreatingDirectoryIfRequired(output.path, input);
 
-      try {
-        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
-        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
-          outputPath,
-          jsonString,
-        );
-
-        // ensure that mkDirSync was called once
-        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
-
-        const outputFileContents = readFileSync(outputPath, 'utf-8');
-        expect(outputFileContents.trim()).toEqual(jsonString);
-      } finally {
-        unlinkSync(outputPath);
-        rmdirSync(fullDirPath);
-      }
+      expect(output.read()).resolves.toEqual(input);
     });
   });
 
-  // relative paths
   describe('supports relative paths', () => {
     it('with directory that does not exists', async () => {
-      const tempFolder = uuidv4();
-      const outputPath = path.join(
-        'test-output',
-        tempFolder,
-        'test-output.json',
-      );
-
-      const fullDirPath = path.dirname(outputPath);
-      expect(fullDirPath).toBe(path.join('test-output', tempFolder));
-      const jsonString = JSON.stringify({
+      const input = JSON.stringify({
         ok: true,
         somekey: 'someval',
       });
 
-      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
+      await saveJsonToFileCreatingDirectoryIfRequired(output.path, input);
 
-      try {
-        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
-        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
-          outputPath,
-          jsonString,
-        );
-
-        // ensure that mkDirSync was called once
-        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(1);
-
-        const outputFileContents = readFileSync(outputPath, 'utf-8');
-        expect(outputFileContents.trim()).toEqual(jsonString);
-      } finally {
-        unlinkSync(outputPath);
-        rmdirSync(fullDirPath);
-      }
+      expect(output.read()).resolves.toEqual(input);
     });
 
     it('with directory that already exists', async () => {
-      const tempFolder = uuidv4();
-      const outputPath = path.join(
-        'test-output',
-        tempFolder,
-        'test-output.json',
-      );
+      await output.mkdir();
 
-      // if 'test-output' doesn't exist, created it
-      if (!existsSync('test-output')) {
-        mkdirSync('test-output');
-      }
-
-      const fullDirPath = path.dirname(outputPath);
-
-      // create the temp folder before calling saveJsonToFileCreatingDirectoryIfRequired
-      mkdirSync(fullDirPath);
-      expect(fullDirPath).toBe(path.join('test-output', tempFolder));
-      const jsonString = JSON.stringify({
+      const input = JSON.stringify({
         ok: true,
         somekey: 'someval',
       });
 
-      const mkdirSyncDirSpy = jest.spyOn(fsModule, 'mkdirSync');
-      expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
+      await saveJsonToFileCreatingDirectoryIfRequired(output.path, input);
 
-      try {
-        // this should create the tempFolder inside of test-output (and test-ouptut if it doesn't exist yet) as well as write the file
-        await jsonFileOutputModule.saveJsonToFileCreatingDirectoryIfRequired(
-          outputPath,
-          jsonString,
-        );
-
-        // ensure that mkDirSync was called once
-        expect(mkdirSyncDirSpy).toHaveBeenCalledTimes(0); // zero because we already created the temp folder, so should have to create it again
-
-        const outputFileContents = readFileSync(outputPath, 'utf-8');
-        expect(outputFileContents.trim()).toEqual(jsonString);
-      } finally {
-        unlinkSync(outputPath);
-        rmdirSync(fullDirPath);
-      }
+      expect(output.read()).resolves.toEqual(input);
     });
   });
 });


### PR DESCRIPTION
I've noticed this JSON test tends to fail now and then so hopefully these changes should make it more reliable.

- Setup and teardown is now encapsulated in a single model.
- Using `afterEach` instead of try/catch.
- Less repetition, less to go wrong.
- The spy was useless as: 
  - If the file exists, it will be read and asserted in the next assertion.
  - If directories aren't made, it will fail to write.
  - If directories already exist and the implementation incorrect tries to make them again, that will also fail the test.