### PR TITLE
fix: be able to scan huge yarn 2 lockfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-gradle-plugin": "3.14.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.25.3",
-    "snyk-nodejs-lockfile-parser": "1.34.0",
+    "snyk-nodejs-lockfile-parser": "1.34.1",
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bumps nodejs parser that fixes parsing huge `yarn.lock` files managed by yarn 2. More info in https://github.com/snyk/nodejs-lockfile-parser/pull/108

Before:

![Screenshot 2021-05-07 at 12 55 10](https://user-images.githubusercontent.com/44169561/117453258-a5d48900-af3c-11eb-92e9-92f4d41a27c5.png)

After:

![Screenshot 2021-05-07 at 12 55 20](https://user-images.githubusercontent.com/44169561/117453271-a9681000-af3c-11eb-81bd-6742a66ec931.png)


#### Manual testing

```bash
npm i && npm run build
node dist/cli/index.js test path/to/nodejs-lockfile-parser/test/fixtures/yarn/yar2/big
```

Expected result: vulnerabilies are successfully scanned