### PR TITLE
feat: support oauth token for monitor

### DIFF
--- a/src/cli/commands/monitor/index.ts
+++ b/src/cli/commands/monitor/index.ts
@@ -20,7 +20,7 @@ import { GoodResult, BadResult } from './types';
 import * as spinner from '../../../lib/spinner';
 import * as analytics from '../../../lib/analytics';
 import { MethodArgs } from '../../args';
-import { apiTokenExists } from '../../../lib/api-token';
+import { apiOrOAuthTokenExists } from '../../../lib/api-token';
 import { maybePrintDepTree, maybePrintDepGraph } from '../../../lib/print-deps';
 import { monitor as snykMonitor } from '../../../lib/monitor';
 import { processJsonMonitorResponse } from './process-json-monitor';
@@ -75,7 +75,7 @@ async function monitor(...args0: MethodArgs): Promise<any> {
     throw new Error('`--remote-repo-url` is not supported for container scans');
   }
 
-  apiTokenExists();
+  apiOrOAuthTokenExists();
 
   let contributors: Contributor[] = [];
   if (!options.docker && analytics.allowAnalytics()) {

--- a/src/lib/api-token.ts
+++ b/src/lib/api-token.ts
@@ -24,6 +24,14 @@ export function apiTokenExists() {
   return configured;
 }
 
+export function apiOrOAuthTokenExists() {
+  const oauthToken: string | undefined = getOAuthToken();
+  if (oauthToken) {
+    return oauthToken;
+  }
+  return apiTokenExists();
+}
+
 export function getAuthHeader(): string {
   const oauthToken: string | undefined = getOAuthToken();
   const dockerToken: string | undefined = getDockerToken();

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -1,7 +1,6 @@
 import { InspectResult } from '@snyk/cli-interface/legacy/plugin';
 import chalk from 'chalk';
 
-import * as snyk from '../index';
 import * as config from '../config';
 import { isCI } from '../is-ci';
 import { makeRequest } from '../request/promise';
@@ -25,6 +24,7 @@ import {
   MonitorDependenciesResponse,
 } from './types';
 import { findAndLoadPolicyForScanResult } from './policy';
+import { getAuthHeader } from '../api-token';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -106,7 +106,7 @@ async function monitorDependencies(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: 'token ' + snyk.api,
+          authorization: getAuthHeader(),
         },
         body: monitorDependenciesRequest,
         qs: {

--- a/src/lib/ecosystems/test.ts
+++ b/src/lib/ecosystems/test.ts
@@ -1,4 +1,3 @@
-import * as snyk from '../index';
 import * as config from '../config';
 import { isCI } from '../is-ci';
 import { makeRequest } from '../request/promise';
@@ -9,6 +8,7 @@ import { Ecosystem, ScanResult, TestResult } from './types';
 import { getPlugin } from './plugins';
 import { TestDependenciesResponse } from '../snyk-test/legacy';
 import { assembleQueryString } from '../snyk-test/common';
+import { getAuthHeader } from '../api-token';
 
 export async function testEcosystem(
   ecosystem: Ecosystem,
@@ -70,7 +70,7 @@ async function testDependencies(
         json: true,
         headers: {
           'x-is-ci': isCI(),
-          authorization: 'token ' + snyk.api,
+          authorization: getAuthHeader(),
         },
         body: {
           scanResult,

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 
 import * as depGraphLib from '@snyk/dep-graph';
 import * as snyk from '..';
-import { apiTokenExists } from '../api-token';
+import { apiOrOAuthTokenExists, getAuthHeader } from '../api-token';
 import request = require('../request');
 import * as config from '../config';
 import * as os from 'os';
@@ -98,7 +98,7 @@ export async function monitor(
   targetFileRelativePath?: string,
   contributors?: Contributor[],
 ): Promise<MonitorResult> {
-  apiTokenExists();
+  apiOrOAuthTokenExists();
 
   const packageManager = meta.packageManager;
   analytics.add('packageManager', packageManager);
@@ -317,7 +317,7 @@ async function monitorDepTree(
         gzip: true,
         method: 'PUT',
         headers: {
-          authorization: 'token ' + snyk.api,
+          authorization: getAuthHeader(),
           'content-encoding': 'gzip',
         },
         url: config.API + '/monitor/' + packageManager,
@@ -475,7 +475,7 @@ export async function monitorDepGraph(
         gzip: true,
         method: 'PUT',
         headers: {
-          authorization: 'token ' + snyk.api,
+          authorization: getAuthHeader(),
           'content-encoding': 'gzip',
         },
         url: `${config.API}/monitor/${packageManager}/graph`,
@@ -624,7 +624,7 @@ async function experimentalMonitorDepGraphFromDepTree(
         gzip: true,
         method: 'PUT',
         headers: {
-          authorization: 'token ' + snyk.api,
+          authorization: getAuthHeader(),
           'content-encoding': 'gzip',
         },
         url: `${config.API}/monitor/${packageManager}/graph`,

--- a/test/jest/acceptance/oauth-token.spec.ts
+++ b/test/jest/acceptance/oauth-token.spec.ts
@@ -67,4 +67,17 @@ describe('test using OAuth token', () => {
     expect(req.headers.authorization).toBe('Bearer oauth-jwt-token');
     expect(req.method).toBe('POST');
   });
+
+  it('successfully monitors a project with an OAuth env variable set', async () => {
+    process.env.SNYK_OAUTH_TOKEN = 'oauth-jwt-token';
+
+    server.setNextResponse(noVulnsResult);
+    chdirWorkspaces('fail-on');
+    await cli.monitor('no-vulns', {
+      json: true,
+    });
+    const req = server.popRequest();
+    expect(req.headers.authorization).toBe('Bearer oauth-jwt-token');
+    expect(req.method).toBe('PUT');
+  });
 });


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Similar to https://github.com/snyk/snyk/pull/1788, adds OAuth token support for the `monitor` command

#### How should this be manually tested?

* Get hold of an OAuth access token for your user (Extensibility group can help with that).
* Set an environment variable with your access token, e.g. `export SNYK_OAUTH_TOKEN=mytoken`
* Point the CLI to our oauth endpoint, e.g: `snyk-dev set config endpoint=https://api.snyk.io/v1`
* Run a monitor against a project, e.g: snyk-dev monitor

