### PR TITLE
fix: redundant line number extraction call

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -27,7 +27,7 @@ export function formatScanResults(
     // Relevant only for multi-doc yaml files
     const scannedResultsGroupedByDocId = groupMultiDocResults(scanResults);
     return scannedResultsGroupedByDocId.map((iacScanResult) =>
-      formatScanResult(iacScanResult, meta, options.severityThreshold),
+      formatScanResult(iacScanResult, meta, options),
     );
   } catch (e) {
     throw new FailedToFormatResults();
@@ -42,7 +42,7 @@ const engineTypeToProjectType = {
 function formatScanResult(
   scanResult: IacFileScanResult,
   meta: TestMeta,
-  severityThreshold?: SEVERITY,
+  { severityThreshold, json, sarif }: IaCTestFlags,
 ): FormattedResult {
   const formattedIssues = scanResult.violatedPolicies.map((policy) => {
     const cloudConfigPath =
@@ -50,7 +50,10 @@ function formatScanResult(
         ? [`[DocId:${scanResult.docId}]`].concat(policy.msg.split('.'))
         : policy.msg.split('.');
 
-    const lineNumber: number = extractLineNumber(scanResult, policy);
+    const shouldExtractLineNumber = json || sarif;
+    const lineNumber: number = shouldExtractLineNumber
+      ? extractLineNumber(scanResult, policy)
+      : -1;
 
     return {
       ...policy,

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -98,6 +98,7 @@ export interface PolicyMetadata {
   type: string;
   subType: string;
   title: string;
+  documentation?: string; // e.g. "https://snyk.io/security-rules/SNYK-CC-K8S-2",
   // Legacy field, still included in WASM eval output, but not in use.
   description: string;
   severity: SEVERITY | 'none'; // the 'null' value can be provided by the backend

--- a/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
+++ b/test/jest/unit/iac-unit-tests/apply-custom-severities.spec.ts
@@ -1,5 +1,5 @@
 import { applyCustomSeverities } from '../../../../src/cli/commands/test/iac-local-execution/org-settings/apply-custom-severities';
-import { scanResults } from './results-formatter.fixtures';
+import { generateScanResults } from './results-formatter.fixtures';
 
 describe('applyCustomSeverities', () => {
   const mockedCustomPolicies = {
@@ -8,6 +8,7 @@ describe('applyCustomSeverities', () => {
   };
 
   it('updates existing severity with custom one for the same public id', async () => {
+    const scanResults = generateScanResults();
     const actualResults = await applyCustomSeverities(
       scanResults,
       mockedCustomPolicies,
@@ -23,7 +24,7 @@ describe('applyCustomSeverities', () => {
     const notMatchingCustomPolicies = {
       'SNYK-CC-K8S-1039': { severity: 'high' },
     };
-
+    const scanResults = generateScanResults();
     const actualResults = await applyCustomSeverities(
       scanResults,
       notMatchingCustomPolicies,

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -28,6 +28,7 @@ export const policyStub: PolicyMetadata = {
   subType: 'Deployment',
   title: 'Container is running in privileged mode',
   type: 'k8s',
+  documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-2',
 };
 
 const anotherPolicyStub: PolicyMetadata = {
@@ -37,26 +38,28 @@ const anotherPolicyStub: PolicyMetadata = {
   publicId: 'SNYK-CC-K8S-2',
 };
 
-export const scanResults: Array<IacFileScanResult> = [
-  {
-    violatedPolicies: [policyStub],
-    jsonContent: { dontCare: null },
-    docId: 0,
-    engineType: EngineType.Kubernetes,
-    fileContent: 'dont-care',
-    filePath: 'dont-care',
-    fileType: 'yaml',
-  },
-  {
-    violatedPolicies: [anotherPolicyStub],
-    jsonContent: { dontCare: null },
-    docId: 0,
-    engineType: EngineType.Kubernetes,
-    fileContent: 'dont-care',
-    filePath: 'dont-care',
-    fileType: 'yaml',
-  },
-];
+export function generateScanResults(): Array<IacFileScanResult> {
+  return [
+    {
+      violatedPolicies: [{ ...policyStub }],
+      jsonContent: { dontCare: null },
+      docId: 0,
+      engineType: EngineType.Kubernetes,
+      fileContent: 'dont-care',
+      filePath: 'dont-care',
+      fileType: 'yaml',
+    },
+    {
+      violatedPolicies: [{ ...anotherPolicyStub }],
+      jsonContent: { dontCare: null },
+      docId: 0,
+      engineType: EngineType.Kubernetes,
+      fileContent: 'dont-care',
+      filePath: 'dont-care',
+      fileType: 'yaml',
+    },
+  ];
+}
 
 export const meta: TestMeta = {
   isPrivate: false,
@@ -64,42 +67,53 @@ export const meta: TestMeta = {
   org: 'org-name',
 };
 
-export const expectedFormattedResults = {
-  result: {
-    cloudConfigResults: [
-      {
-        ...anotherPolicyStub,
-        id: anotherPolicyStub.publicId,
-        name: anotherPolicyStub.title,
-        cloudConfigPath: ['[DocId:0]'].concat(anotherPolicyStub.msg.split('.')),
-        isIgnored: false,
-        iacDescription: {
-          issue: anotherPolicyStub.issue,
-          impact: anotherPolicyStub.impact,
-          resolve: anotherPolicyStub.resolve,
+function generateFormattedResults(withLineNumber: boolean = true) {
+  return {
+    result: {
+      cloudConfigResults: [
+        {
+          ...anotherPolicyStub,
+          id: anotherPolicyStub.publicId,
+          name: anotherPolicyStub.title,
+          cloudConfigPath: ['[DocId:0]'].concat(
+            anotherPolicyStub.msg.split('.'),
+          ),
+          isIgnored: false,
+          iacDescription: {
+            issue: anotherPolicyStub.issue,
+            impact: anotherPolicyStub.impact,
+            resolve: anotherPolicyStub.resolve,
+          },
+          severity: anotherPolicyStub.severity,
+          lineNumber: withLineNumber ? 3 : -1,
+          documentation: anotherPolicyStub.documentation,
         },
-        severity: anotherPolicyStub.severity,
-        lineNumber: 3,
-        documentation: `https://snyk.io/security-rules/${anotherPolicyStub.publicId}`,
-      },
-    ],
-    projectType: 'k8sconfig',
-  },
-  isPrivate: true,
-  packageManager: IacProjectType.K8S,
-  targetFile: 'dont-care',
-  targetFilePath: path.resolve('dont-care', '.'),
-  vulnerabilities: [],
-  dependencyCount: 0,
-  ignoreSettings: null,
-  licensesPolicy: null,
-  projectName: 'snyk',
-  meta: {
-    ...meta,
+      ],
+      projectType: 'k8sconfig',
+    },
+    isPrivate: true,
+    packageManager: IacProjectType.K8S,
+    targetFile: 'dont-care',
+    targetFilePath: path.resolve('dont-care', '.'),
+    vulnerabilities: [],
+    dependencyCount: 0,
+    ignoreSettings: null,
+    licensesPolicy: null,
+    projectName: 'snyk',
+    meta: {
+      ...meta,
+      policy: '',
+      projectId: '',
+    },
+    org: meta.org,
     policy: '',
-    projectId: '',
-  },
-  org: meta.org,
-  policy: '',
-  filesystemPolicy: false,
-};
+    filesystemPolicy: false,
+  };
+}
+
+export const expectedFormattedResultsWithLineNumber = generateFormattedResults(
+  true,
+);
+export const expectedFormattedResultsWithoutLineNumber = generateFormattedResults(
+  false,
+);


### PR DESCRIPTION
#### What does this PR do?
removes a redundant call to extract line-number in IAC scans whenever the `sarif` or `json` flags are not passed, as it is not being used in the regular default output and has been proved to be quite slow.
https://snyksec.atlassian.net/browse/CC-833