### PR TITLE
fix: gradle project name being empty string

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-cpp-plugin": "2.2.1",
     "snyk-docker-plugin": "4.20.2",
     "snyk-go-plugin": "1.17.0",
-    "snyk-gradle-plugin": "3.14.4",
+    "snyk-gradle-plugin": "3.14.5",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.0",
     "snyk-nodejs-lockfile-parser": "1.34.1",


### PR DESCRIPTION
Previously we were validating if the root cwd value being passed down
  from cli was either null or undefined, skipping empty string as an invalid case.
  With this pr we are adding empty string as an invalid case and avoid
  its usage as a gradle project name. What is the outcome? prevent
`Invalid DepGraph` error during scanning test/monitor phases