### PR TITLE
fix: yarn2 displays a correct error for out of sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "snyk-gradle-plugin": "3.14.4",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.0",
-    "snyk-nodejs-lockfile-parser": "1.34.1",
+    "snyk-nodejs-lockfile-parser": "1.34.2",
     "snyk-nuget-plugin": "1.21.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "1.19.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

When there is an out of sync error in a project using yarn2 then the error message provided now has all the information required, and `undefined` is not seen.
