### PR TITLE
feat: show only unique vulnerabilities in sarif format

### DIFF
--- a/src/cli/commands/test/open-source-sarif-output.ts
+++ b/src/cli/commands/test/open-source-sarif-output.ts
@@ -94,25 +94,29 @@ ${vuln.description}`.replace(/##\s/g, '# '),
 }
 
 export function getResults(testResult): sarif.Result[] {
-  return testResult.vulnerabilities.map((vuln) => ({
-    ruleId: vuln.id,
-    level: getLevel(vuln),
-    message: {
-      text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
-    },
-    locations: [
-      {
-        physicalLocation: {
-          artifactLocation: {
-            uri: testResult.displayTargetFile,
-          },
-          region: {
-            startLine: vuln.lineNumber || 1,
+  const groupedVulnerabilities = groupBy(testResult.vulnerabilities, 'id');
+  return map(
+    groupedVulnerabilities,
+    ([vuln]): sarif.Result => ({
+      ruleId: vuln.id,
+      level: getLevel(vuln),
+      message: {
+        text: `This file introduces a vulnerable ${vuln.packageName} package with a ${vuln.severity} severity vulnerability.`,
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: testResult.displayTargetFile,
+            },
+            region: {
+              startLine: vuln.lineNumber || 1,
+            },
           },
         },
-      },
-    ],
-  }));
+      ],
+    }),
+  );
 }
 
 export function getLevel(vuln: AnnotatedIssue) {


### PR DESCRIPTION
Today in sarif output we have a result item per each "vulnerable path"
This will reduce the number of items to be the number of vulnerabilities
