### PR TITLE
feat: add support for resolutions in yarn workspaces

### DIFF
--- a/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
+++ b/src/lib/plugins/nodejs-plugin/yarn-workspaces-parser.ts
@@ -66,12 +66,25 @@ export async function processYarnWorkspaces(
     },
     scannedProjects: [],
   };
+
+  const rootPkgJson: lockFileParser.ManifestFile = JSON.parse(
+    getFileContents(
+      root,
+      pathUtil.join(Object.keys(yarnTargetFiles)[0], 'package.json'),
+    ).content,
+  );
   // the folders must be ordered highest first
   for (const directory of Object.keys(yarnTargetFiles)) {
     let isYarnWorkspacePackage = false;
     let isRootPackageJson = false;
+
     const packageJsonFileName = pathUtil.join(directory, 'package.json');
-    const packageJson = getFileContents(root, packageJsonFileName);
+    const packageJson = createPackageJson(
+      root,
+      packageJsonFileName,
+      rootPkgJson.resolutions,
+    );
+
     yarnWorkspacesMap = {
       ...yarnWorkspacesMap,
       ...getWorkspacesMap(packageJson),
@@ -180,4 +193,28 @@ function packageJsonBelongsToWorkspace(
     workspacesGlobs.map((p) => (p.endsWith('/**') ? p : p + '/**')),
   );
   return match;
+}
+
+function createPackageJson(
+  root: string,
+  packageJsonFileName: string,
+  resolutions?: { [key: string]: string },
+) {
+  if (!resolutions) {
+    return getFileContents(root, packageJsonFileName);
+  }
+
+  const packageJson = getFileContents(root, packageJsonFileName);
+  const pkgJsonObject = JSON.parse(packageJson.content);
+
+  const pkgJsonWithResolutions = {
+    ...pkgJsonObject,
+    resolutions: { ...pkgJsonObject.resolutions, ...resolutions },
+  };
+
+  const augmentedPkgJson = {
+    ...packageJson,
+    content: JSON.stringify(pkgJsonWithResolutions),
+  };
+  return augmentedPkgJson;
 }


### PR DESCRIPTION
### This requires this [PR](https://github.com/snyk/nodejs-lockfile-parser/pull/110) going in first and then being bumped over here

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This allows resolutions to be used in projects with yarn workspaces

