### PR TITLE
chore: IaC --rules feature flag [CC-875]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@ test/smoke/.iac-data/ @snyk/cloudconfig
 test/fixtures/sast/ @snyk/sast-team
 test/snyk-code-test.spec.ts @snyk/sast-team
 test/jest/unit/iac-unit-tests/ @snyk/cloudconfig
+test/jest/acceptance/iac/ @snyk/cloudconfig
 src/lib/errors/invalid-iac-file.ts @snyk/cloudconfig
 src/lib/errors/unsupported-options-iac-error.ts @snyk/cloudconfig
 help/commands-docs/iac-examples.md @snyk/cloudconfig

--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -34,7 +34,7 @@ function getFlagName(key: string) {
   return `${dashes}${flag}`;
 }
 
-class FlagError extends CustomError {
+export class FlagError extends CustomError {
   constructor(key: string) {
     const flag = getFlagName(key);
     const msg = `Unsupported flag "${flag}" provided. Run snyk iac test --help for supported flags.`;

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -279,16 +279,13 @@ export function fakeServer(root, apikey) {
   server.get(
     root + '/cli-config/feature-flags/:featureFlag',
     (req, res, next) => {
+      const org = req.params.org;
       const flag = req.params.featureFlag;
-      if (
-        (req as any).params.org === 'no-flag' ||
-        flag === 'experimentalLocalExecIac'
-      ) {
+      const disabled = new Set(['optOutFromLocalExecIac']);
+      if (org === 'no-flag' || disabled.has(flag)) {
         res.send({
           ok: false,
-          userMessage: `Org ${
-            (req as any).org
-          } doesn\'t have \'${flag}\' feature enabled'`,
+          userMessage: `Org ${org} doesn't have '${flag}' feature enabled'`,
         });
         return next();
       }

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -1,0 +1,51 @@
+import { startMockServer } from './helpers';
+
+describe('iac test --rules', () => {
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const result = await startMockServer();
+    run = result.run;
+    teardown = result.teardown;
+  });
+
+  afterAll(async () => teardown());
+
+  it('scans custom rules provided via the --rules flag', async () => {
+    const { stdout, exitCode } = await run(
+      `snyk iac test --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
+    );
+    expect(exitCode).toBe(1);
+
+    expect(stdout).toContain('Testing sg_open_ssh.tf');
+    expect(stdout).toContain('Infrastructure as code issues:');
+    expect(stdout).toContain('Missing tags');
+    expect(stdout).toContain('CUSTOM-123');
+    expect(stdout).toContain(
+      'introduced by resource > aws_security_group[allow_ssh] > tags',
+    );
+  });
+
+  it('presents an error message when the rules cannot be found', async () => {
+    const { stdout, exitCode } = await run(
+      `snyk iac test --rules=./not/a/real/path.tar.gz ./iac/terraform/sg_open_ssh.tf`,
+    );
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toContain(
+      'We were unable to extract the rules provided at: ./not/a/real/path.tar.gz',
+    );
+  });
+
+  xit('presents an error message when the user is not part of the experiment', async () => {
+    const { stdout, exitCode } = await run(
+      `snyk iac test --org=no-flag --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
+    );
+
+    expect(exitCode).toBe(2);
+    expect(stdout).toContain(`Unsupported flag "--rules" provided`);
+  });
+});

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -1,0 +1,64 @@
+import { exec } from 'child_process';
+import { join } from 'path';
+import { fakeServer } from '../../../acceptance/fake-server';
+
+/**
+ * Starts a local version of the fixture webserver and returns
+ * two utilities.
+ * - `run()` which will execute a terminal command with the environment
+ *   variables set.
+ * - `teardown()` which will shutdown the server.
+ */
+export async function startMockServer() {
+  const SNYK_TOKEN = '123456789';
+  const BASE_API = '/api/v1';
+  const server = fakeServer(BASE_API, SNYK_TOKEN);
+
+  // Use port of 0 to find a free port.
+  await new Promise((resolve) => server.listen(0, resolve));
+
+  const SNYK_HOST = 'http://localhost:' + server.address().port;
+  const SNYK_API = SNYK_HOST + BASE_API;
+
+  const env: Record<string, string> = {
+    PATH: process.env.PATH ?? '',
+    SNYK_TOKEN,
+    SNYK_API,
+    SNYK_HOST,
+  };
+
+  return {
+    run: async (cmd: string) => run(cmd, env),
+    teardown: async () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+/**
+ * Run a command from within the test/fixtures directory.
+ */
+export async function run(
+  cmd: string,
+  env: Record<string, string>,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    const root = join(__dirname, '../../../../');
+    const main = join(root, 'dist/cli/index.js');
+    const child = exec(
+      cmd.trim().replace(/^snyk/, `node ${main}`),
+      {
+        env,
+        cwd: join(root, 'test/fixtures'),
+      },
+      function(err, stdout, stderr) {
+        // err.code indicates the shell exited with non-zero code
+        // which is in our case a success and we resolve.
+        if (err && typeof err.code !== 'number') {
+          reject(err);
+        } else {
+          if (child.exitCode === null) throw Error();
+          resolve({ stderr, stdout, exitCode: child.exitCode });
+        }
+      },
+    );
+  });
+}

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -286,26 +286,4 @@ Describe "Snyk iac local test command"
       The result of function check_valid_json should be success
     End
   End
-
-  Describe "custom rules scanning"
-    It "scans custom rules provided via the --rules flag"
-      When run snyk iac test --rules=../fixtures/iac/custom-rules/custom.tar.gz ../fixtures/iac/terraform/sg_open_ssh.tf
-      The status should equal 1 # issues found
-      The output should include "Testing sg_open_ssh.tf"
-
-      # Outputs issues
-      The output should include "Infrastructure as code issues:"
-      # Root module
-      The output should include "✗ "
-      The output should include "Missing tags"
-      The output should include "CUSTOM-123"
-      The output should include "introduced by resource > aws_security_group[allow_ssh] > tags"
-    End
-
-    It "presents an error message when the rules cannot be found"
-      When run snyk iac test --rules=./not/a/real/path.tar.gz ../fixtures/iac/terraform/sg_open_ssh.tf
-      The status should equal 2 # error
-      The output should include "We were unable to extract the rules provided at: ./not/a/real/path.tar.gz"
-    End
-  End
 End


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

Fixes CC-875
Depends on https://github.com/snyk/snyk/pull/1913

#### What does this PR do?

This PR adds support for a new `iacCustomRules` feature flag that will enable the `--rules` flag. For orgs that do not have this feature enabled the flag will be rejected with an error.

#### Where should the reviewer start?

The implementation is all in test/local-exec/index.ts

I've also started migrating our Infrastructure as Code tests over to the `jest/acceptance` test folder. Most of our tests feel like they could live under here and talk to the fake backend. There are two files one containing the custom rules acceptance tests and the second a helper function that starts the fake server and returns a `run(cmd: string)` function for executing CLI commands and evaluating the output/exit code. The helper ensures that the CLI is configured (via environment variables) to talk to the correct backend with appropriate API token.

#### How should this be manually tested?

Test with feature flag disabled:

```
node ./dist/cli/index.js iac test --rules=test/fixtures/iac/custom-rules/custom.tar.gz test/fixtures/iac/terraform/sg_open_ssh.tf
```

<s>You should see an error. Enable the `iacCustomRules` feature flag for your org and run the command again.</s>
_EDIT: I've not implemented the Registry side of this yet_

