### PR TITLE
Fix: total issue count

### DIFF
--- a/packages/snyk-fix/src/index.ts
+++ b/packages/snyk-fix/src/index.ts
@@ -84,7 +84,7 @@ export function groupEntitiesPerScanType(
     [type: string]: EntityToFix[];
   } = {};
   for (const entity of entities) {
-    const type = entity.scanResult?.identity?.type || 'missing-type';
+    const type = entity.scanResult?.identity?.type ?? 'missing-type';
     if (entitiesPerType[type]) {
       entitiesPerType[type].push(entity);
       continue;

--- a/packages/snyk-fix/src/lib/issues/total-issues-count.ts
+++ b/packages/snyk-fix/src/lib/issues/total-issues-count.ts
@@ -1,0 +1,11 @@
+import { IssuesData } from '../../types';
+
+export function getTotalIssueCount(issueData: IssuesData[]): number {
+  let total = 0;
+
+  for (const entry of issueData) {
+    total += Object.keys(entry).length;
+  }
+
+  return total;
+}

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -6,6 +6,7 @@ import { contactSupportMessage, reTryMessage } from '../errors/common';
 import { convertErrorToUserMessage } from '../errors/error-to-user-message';
 import { hasFixableIssues } from '../issues/fixable-issues';
 import { getIssueCountBySeverity } from '../issues/issues-by-severity';
+import { getTotalIssueCount } from '../issues/total-issues-count';
 import { formatChangesSummary } from './format-successful-item';
 import { formatUnresolved } from './format-unresolved-item';
 export const PADDING_SPACE = '  '; // 2 spaces
@@ -250,7 +251,7 @@ export const defaultSeverityColor = {
 };
 
 export function getSeveritiesColour(severity: string) {
-  return severitiesColourMapping[severity] || defaultSeverityColor;
+  return severitiesColourMapping[severity] ?? defaultSeverityColor;
 }
 
 export function generateIssueSummary(
@@ -264,6 +265,7 @@ export function generateIssueSummary(
 
   const issueData = testResults.map((i) => i.issuesData);
   const bySeverity = getIssueCountBySeverity(issueData);
+
   const issuesBySeverityMessage = formatIssueCountBySeverity({
     critical: bySeverity.critical.length,
     high: bySeverity.high.length,
@@ -277,7 +279,7 @@ export function generateIssueSummary(
     issues.push(...result.issues);
   }
 
-  let totalIssues = `${chalk.bold(issues.length)} total issues`;
+  let totalIssues = `${chalk.bold(getTotalIssueCount(issueData))} total issues`;
   if (issuesBySeverityMessage) {
     totalIssues += `: ${issuesBySeverityMessage}`;
   }

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/update-dependencies.spec.ts
@@ -1056,6 +1056,16 @@ describe('fix *req*.txt / *.txt Python projects', () => {
           },
         },
         {
+          pkgName: 'Jinja2@2.7.2',
+          issueId: 'SNYK-2',
+          fixInfo: {
+            upgradePaths: [],
+            isPatchable: false,
+            nearestFixedInVersion: '1.2.3',
+            isPinnable: true,
+          },
+        },
+        {
           pkgName: 'transitive@1.0.1',
           issueId: 'SNYK-3',
           fixInfo: {
@@ -1211,7 +1221,7 @@ describe('fix *req*.txt / *.txt Python projects', () => {
     expect(result.results.python.succeeded[1].changes).toEqual([
       {
         success: true,
-        issueIds: ['SNYK-1', 'SNYK-2', 'SNYK-3'],
+        issueIds: ['SNYK-1', 'SNYK-2', 'SNYK-2', 'SNYK-3'],
         userMessage: expect.stringContaining('requirements.txt'),
       },
     ]);

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -24,7 +24,7 @@ export function generateEntityToFix(
 
 function generateWorkspace(contents: string, path?: string) {
   return {
-    path: path || '.',
+    path: path ?? '.',
     readFile: async () => {
       return contents;
     },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- use nullish operator to ensure that fallback is only used when right hand side is `null` or `undefined`
- fix the issue count calculation as the Issues array is ungrouped issues and is not unique per scanned project

**before**

From this test result the total should have been 12 (unique issues) and not 42 which is vulnerable paths
```
Tested 93 dependencies for known issues, found 12 issues, 42 vulnerable paths.
```

<img width="671" alt="CleanShot 2021-05-17 at 13 35 43@2x" src="https://user-images.githubusercontent.com/2911613/118489500-cc50ac00-b714-11eb-8d76-858118c3a7e3.png">


**after**

<img width="560" alt="CleanShot 2021-05-17 at 13 35 57@2x" src="https://user-images.githubusercontent.com/2911613/118489516-d2df2380-b714-11eb-925d-87afe103bc9c.png">
