### PR TITLE
fix(protect): correctly extract patches from direct dependencies

### DIFF
--- a/packages/snyk-protect/src/lib/snyk-file.ts
+++ b/packages/snyk-protect/src/lib/snyk-file.ts
@@ -25,6 +25,7 @@ export function extractPatchMetadata(
         } else {
           if (key.startsWith('-')) {
             const destination = key
+              .substring(1)
               .split('>')
               .pop()
               ?.trim();


### PR DESCRIPTION
When splitting the dependency path in the `.snyk`'s `patch` section, we weren't removing the array indicator, `-`, so the first dependency became `- lodash` rather than just `lodash`.

Also, because we `trim` after, it's good enough to only remove the `-` and not the whitespace after which, given how loose our parsing is, may or may not exist.

I've also reworded test cases to better fit with what the function does, "it extracts", rather than just "it works".