### PR TITLE
test(protect): increase timeout for network-dependent tests

### DIFF
--- a/packages/snyk-protect/test/acceptance/protect.spec.ts
+++ b/packages/snyk-protect/test/acceptance/protect.spec.ts
@@ -17,6 +17,8 @@ const getPatchedLodash = (): Promise<string> => {
   return fse.readFile(patchedLodashPath, 'utf-8');
 };
 
+jest.setTimeout(1000 * 60);
+
 describe('@snyk/protect', () => {
   let tempFolder: string;
 


### PR DESCRIPTION
Jest defaults to 5 seconds and these tests can take longer than that. Since networks are unreliable, a minute is good enough. 

Ideally we should decouple ourselves from external networks in our acceptance tests to avoid slowing us down but that's a future step.