### PR TITLE
fix: latest @snyk/fix with engines 10+

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@snyk/cloud-config-parser": "^1.9.2",
     "@snyk/code-client": "3.5.1",
     "@snyk/dep-graph": "^1.27.1",
-    "@snyk/fix": "1.598.0",
+    "@snyk/fix": "1.601.0",
     "@snyk/gemfile": "1.2.0",
     "@snyk/graphlib": "^2.1.9-patch.3",
     "@snyk/inquirer": "^7.3.3-patch",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Use latest @snyk/fix packages that includes a fix for Yarn where node engines was set to 12+ in a transitive package @snyk/pipfile-fix