### PR TITLE
fix(protect): handle carriage returns

### DIFF
--- a/packages/snyk-protect/src/lib/snyk-file.ts
+++ b/packages/snyk-protect/src/lib/snyk-file.ts
@@ -10,7 +10,7 @@ export function extractPatchMetadata(
   const patches = dotSnykFileContent
     .split('\n')
     .filter((l) => l.length && !l.trimStart().startsWith('#'))
-    .map((line) => lineRegex.exec(line))
+    .map((line) => lineRegex.exec(line.trimEnd()))
     .filter(Boolean)
     .reduce((acc, thing) => {
       const [, prefix, key, value] = thing as RegExpExecArray;

--- a/packages/snyk-protect/test/unit/patch.spec.ts
+++ b/packages/snyk-protect/test/unit/patch.spec.ts
@@ -32,7 +32,38 @@ describe(patchString.name, () => {
       'utf-8',
     );
     expect(patchedContents).toBe(expectedPatchedContents);
-    expect(0).toBe(0);
+  });
+
+  it('keeps the same line endings', () => {
+    const fixtureFolder = path.join(
+      __dirname,
+      '../fixtures/patchable-file-lodash',
+    );
+    const patchFilePath = path.join(fixtureFolder, 'lodash.patch');
+
+    const patchContents = fs.readFileSync(patchFilePath, 'utf-8');
+
+    const targetFilePath = path.join(
+      fixtureFolder,
+      extractTargetFilePathFromPatch(patchContents),
+    );
+    const contentsToPatch = fs
+      .readFileSync(targetFilePath, 'utf-8')
+      .split('\n')
+      .join('\r\n');
+
+    const patchedContents = patchString(patchContents, contentsToPatch);
+
+    const expectedPatchedContentsFilePath = path.join(
+      fixtureFolder,
+      'lodash-expected-patched.js',
+    );
+
+    const expectedPatchedContents = fs
+      .readFileSync(expectedPatchedContentsFilePath, 'utf-8')
+      .split('\n')
+      .join('\r\n');
+    expect(patchedContents).toBe(expectedPatchedContents);
   });
 
   // if the patch is not compatible with the target, make sure we throw an Error and do patch

--- a/packages/snyk-protect/test/unit/snyk-file.spec.ts
+++ b/packages/snyk-protect/test/unit/snyk-file.spec.ts
@@ -27,6 +27,34 @@ patch:
     expect(packageNames).toEqual(['lodash']);
   });
 
+  it('handles carriage returns in line endings', () => {
+    const dotSnykFileContents = `
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - lodash:
+        patched: '2021-02-17T13:43:51.857Z'
+`
+      .split('\n')
+      .join('\r\n');
+    const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+    const vulnIds = Object.keys(snykFilePatchMetadata);
+
+    // can't use .flat() because it's not supported in Node 10
+    const packageNames: string[] = [];
+    for (const nextArrayOfPackageNames of Object.values(
+      snykFilePatchMetadata,
+    )) {
+      packageNames.push(...nextArrayOfPackageNames);
+    }
+
+    expect(vulnIds).toEqual(['SNYK-JS-LODASH-567746']);
+    expect(packageNames).toEqual(['lodash']);
+  });
+
   it('extracts a transitive dependency', () => {
     const dotSnykFileContents = `
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.


### PR DESCRIPTION
This came up while working on smoke tests. We don't handle carriage returns, which isn't specific to Windows but is most common. Various applications like `git` may automatically translate line endings so we should try our best to keep things as they are. That means:

- Ignore `\r` when parsing `.snyk` file for patches.
- Keep `\r` when patching files.