### PR TITLE
chore(protect): drop node 8 in engines

### DIFF
--- a/packages/snyk-protect/package.json
+++ b/packages/snyk-protect/package.json
@@ -19,7 +19,7 @@
     "snyk-protect": "dist/index.js"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
We dropped Node 8 support a while back but didn't update @snyk/protect's package.json.