### PR TITLE
test(protect): increase timeout for network test

### DIFF
--- a/packages/snyk-protect/test/unit/fetch-patches.spec.ts
+++ b/packages/snyk-protect/test/unit/fetch-patches.spec.ts
@@ -11,6 +11,8 @@ const getExpectedPatchDiff = (): Promise<string> => {
   return fse.readFile(patchedLodashPath, 'utf-8');
 };
 
+jest.setTimeout(1000 * 60);
+
 describe('fetchPatches', () => {
   it('can fetch patches for valid request params', async () => {
     const expectedLodashPatch = await getExpectedPatchDiff();


### PR DESCRIPTION
These tests make network calls so it can take longer than 5 seconds. Wait max 60 seconds.
