### PR TITLE
Feat/adding cloudformation support [CC-850]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-scanner.ts
+++ b/src/cli/commands/test/iac-local-execution/file-scanner.ts
@@ -39,6 +39,7 @@ export function clearPolicyEngineCache() {
   policyEngineCache = {
     [EngineType.Kubernetes]: null,
     [EngineType.Terraform]: null,
+    [EngineType.CloudFormation]: null,
     [EngineType.Custom]: null,
   };
 }
@@ -46,6 +47,7 @@ export function clearPolicyEngineCache() {
 let policyEngineCache: { [key in EngineType]: PolicyEngine | null } = {
   [EngineType.Kubernetes]: null,
   [EngineType.Terraform]: null,
+  [EngineType.CloudFormation]: null,
   [EngineType.Custom]: null,
 };
 

--- a/src/cli/commands/test/iac-local-execution/local-cache.ts
+++ b/src/cli/commands/test/iac-local-execution/local-cache.ts
@@ -30,6 +30,14 @@ const TERRAFORM_POLICY_ENGINE_DATA_PATH = path.join(
   LOCAL_POLICY_ENGINE_DIR,
   'tf_data.json',
 );
+const CLOUDFORMATION_POLICY_ENGINE_WASM_PATH = path.join(
+  LOCAL_POLICY_ENGINE_DIR,
+  'cloudformation_policy.wasm',
+);
+const CLOUDFORMATION_POLICY_ENGINE_DATA_PATH = path.join(
+  LOCAL_POLICY_ENGINE_DIR,
+  'cloudformation_data.json',
+);
 
 // NOTE: The filenames used for the custom policy bundles match those output
 // by the `opa` CLI tool, which is why they are very generic.
@@ -59,6 +67,11 @@ export function getLocalCachePath(engineType: EngineType) {
       return [
         `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_WASM_PATH}`,
         `${process.cwd()}/${TERRAFORM_POLICY_ENGINE_DATA_PATH}`,
+      ];
+    case EngineType.CloudFormation:
+      return [
+        `${process.cwd()}/${CLOUDFORMATION_POLICY_ENGINE_WASM_PATH}`,
+        `${process.cwd()}/${CLOUDFORMATION_POLICY_ENGINE_DATA_PATH}`,
       ];
     case EngineType.Custom:
       return [

--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -35,6 +35,7 @@ export function formatScanResults(
 const engineTypeToProjectType = {
   [EngineType.Kubernetes]: IacProjectType.K8S,
   [EngineType.Terraform]: IacProjectType.TERRAFORM,
+  [EngineType.CloudFormation]: IacProjectType.CLOUDFORMATION,
   [EngineType.Custom]: IacProjectType.CUSTOM,
 };
 

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -93,6 +93,7 @@ export type SafeAnalyticsOutput = Omit<
 export enum EngineType {
   Kubernetes,
   Terraform,
+  CloudFormation,
   Custom,
 }
 
@@ -232,7 +233,8 @@ export enum IaCErrorCodes {
   UnsupportedFileTypeError = 1020,
   InvalidJsonFileError = 1021,
   InvalidYamlFileError = 1022,
-  FailedToDetectJsonFileError = 1023,
+  FailedToDetectJsonConfigError = 1023,
+  FailedToDetectYamlConfigError = 1024,
 
   // kubernetes-parser errors
   MissingRequiredFieldsInKubernetesYamlError = 1031,

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -108,6 +108,9 @@ export function capitalizePackageManager(type: string | undefined) {
     case 'terraformconfig': {
       return 'Terraform';
     }
+    case 'cloudformationconfig': {
+      return 'CloudFormation';
+    }
     default: {
       return 'Infrastracture as Code';
     }

--- a/src/lib/iac/constants.ts
+++ b/src/lib/iac/constants.ts
@@ -1,6 +1,7 @@
 export type IacProjectTypes =
   | 'k8sconfig'
   | 'terraformconfig'
+  | 'cloudformationconfig'
   | 'customconfig'
   | 'multiiacconfig';
 export type IacFileTypes = 'yaml' | 'yml' | 'json' | 'tf';
@@ -8,6 +9,7 @@ export type IacFileTypes = 'yaml' | 'yml' | 'json' | 'tf';
 export enum IacProjectType {
   K8S = 'k8sconfig',
   TERRAFORM = 'terraformconfig',
+  CLOUDFORMATION = 'cloudformationconfig',
   CUSTOM = 'customconfig',
   MULTI_IAC = 'multiiacconfig',
 }
@@ -15,6 +17,7 @@ export enum IacProjectType {
 export const TEST_SUPPORTED_IAC_PROJECTS: IacProjectTypes[] = [
   IacProjectType.K8S,
   IacProjectType.TERRAFORM,
+  IacProjectType.CLOUDFORMATION,
   IacProjectType.MULTI_IAC,
   IacProjectType.CUSTOM,
 ];

--- a/test/fixtures/iac/cloudformation/aurora-valid.yml
+++ b/test/fixtures/iac/cloudformation/aurora-valid.yml
@@ -1,0 +1,408 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+
+Description: SASKV5N Aurora
+
+# Create the Aurora MySQL or PostgreSQL database(s). Currently, this template only supports alarms for Aurora MySQL.
+
+Parameters:
+
+  NetworkStackName:
+    Description: Name of an active CloudFormation stack that contains networking resources
+    Type: String
+    MinLength: 1
+    MaxLength: 255
+    AllowedPattern: "^[a-zA-Z][-a-zA-Z0-9]*$"
+
+  DatabaseUser:
+    Default: startupadmin
+    Type: String
+    Description: Database admin account name
+    MinLength: 5
+    MaxLength: 16
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
+
+  DatabasePassword:
+    NoEcho: true
+    Type: String
+    Description: Database admin account password
+    MinLength: 6
+    MaxLength: 41
+    AllowedPattern: "[a-zA-Z0-9]*"
+    ConstraintDescription: Password must contain only alphanumeric characters
+
+  DatabaseName:
+    Default: StartupDB
+    Type: String
+    Description: Database name
+    MinLength: 1
+    MaxLength: 30
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
+
+  DatabaseEngine:
+    Default: aurora
+    Type: String
+    Description: Database engines - Aurora MySQL or Aurora PostgreSQL
+    ConstraintDescription: Choose an engine from the drop down
+    AllowedValues:
+      - aurora
+      - aurora-postgresql
+
+  EncryptionAtRest:
+    Default: false
+    Type: String
+    Description: The optional flag for encryption at rest (db.t2.small and above)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  DatabaseInstanceClass:
+    Default: db.t2.small
+    Type: String
+    Description: "Database instance class, e.g. db.t2.micro (free tier) - Engine support: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.html"
+    ConstraintDescription: DB instance class not supported
+    AllowedValues:
+      - db.t2.small
+      - db.t2.medium
+      - db.t2.xlarge
+      - db.r4.large
+      - db.r4.xlarge
+      - db.r4.2xlarge
+      - db.r4.4xlarge
+      - db.r4.8xlarge
+      - db.r4.16xlarge
+
+  EnvironmentName:
+    Description: Environment name - dev or prod
+    Type: String
+    Default: dev
+    AllowedValues:
+      - dev
+      - prod
+    ConstraintDescription: Specify either dev or prod
+
+  # The database alarm configuration, currently not supported for Aurora PostgreSQL
+  DatabaseAlarmMaxCpuPercent:
+    Description: Database CPU % max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 99
+    ConstraintDescription: Must be a percentage between 1-99%
+
+  DatabaseAlarmReadLatencyMaxSeconds:
+    Description: Read latency max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmWriteLatencyMaxSeconds:
+    Description: Write latency max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmEvaluationPeriods:
+    Description: The number of periods over which data is compared to the specified threshold (currently, Aurora MySQL only)
+    Type: Number
+    Default: 2
+    MinValue: 2
+
+  DatabaseAlarmEvaluationPeriodSeconds:
+    Description: The time over which the specified statistic is applied. Specify time in seconds, in multiples of 60. Enhanced monitoring must be enabled if less than 500 seconds (currently, Aurora MySQL only)
+    Type: Number
+    Default: 300
+    MinValue: 60
+    ConstraintDescription: Must be at least 60 seconds
+
+  EnhancedMonitoring:
+    Default: false
+    Type: String
+    Description: The optional flag for enhanced monitoring (additional charges apply - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html) (currently, Aurora MySQL only)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  # Default is 200 MB
+  DatabaseAlarmSwapUsageInBytes:
+    Default: 209715200
+    Type: Number
+    Description: Number of swap usage bytes for alarm (if enabled - Aurora MySQL only)
+    MinValue: 1
+    ConstraintDescription: Enter a value of at least one byte
+
+  EnableAlarms:
+    Default: false
+    Type: String
+    Description: Set to true to enable (additional charges - https://aws.amazon.com/cloudwatch/pricing/ - currently, Aurora MySQL only)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+
+Conditions:
+
+  IsProd: !Equals [ !Ref EnvironmentName, prod ]
+
+  IsAuroraMySQL: !Equals [ !Ref DatabaseEngine, aurora ]
+
+  AlarmsEnabled: !And
+    - !Condition IsAuroraMySQL
+    - !Equals [ !Ref EnableAlarms, true ]
+
+  EnhancedMonitoringSupprtedAndEnabled: !And
+    - !Condition AlarmsEnabled
+    - !Equals [ !Ref EnhancedMonitoring, true ]
+
+
+Resources:
+
+  EnhancedMonitoringRole:
+    Type: AWS::IAM::Role
+    Condition: EnhancedMonitoringSupprtedAndEnabled
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: monitoring.rds.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
+
+  DatabaseAlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: AlarmsEnabled
+    Properties:
+      DisplayName: Database Alarm Topic
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Database subnet group
+      SubnetIds:
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet1ID
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet2ID
+      Tags:
+      - Key: Name
+        Value: !Ref AWS::StackName
+
+  AuroraCluster:
+    Type: AWS::RDS::DBCluster
+    Properties:
+      Engine: !Ref DatabaseEngine
+      MasterUsername: !Ref DatabaseUser
+      MasterUserPassword: !Ref DatabasePassword
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      StorageEncrypted: !Ref EncryptionAtRest
+      DatabaseName: !Ref DatabaseName
+      DBClusterParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
+      Port: !If [ IsAuroraMySQL,  3306, 5432 ]
+      VpcSecurityGroupIds:
+        - Fn::ImportValue: !Sub ${NetworkStackName}-DatabaseGroupID
+    DependsOn: DatabaseSubnetGroup
+
+  AuroraInstance0:
+    Type: AWS::RDS::DBInstance
+    Properties:
+      Engine: !Ref DatabaseEngine
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: !Ref DatabaseInstanceClass
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      StorageEncrypted: !Ref EncryptionAtRest
+      DBParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
+      MonitoringInterval: !If [ EnhancedMonitoringSupprtedAndEnabled, 60, 0 ]
+      MonitoringRoleArn: !If [ EnhancedMonitoringSupprtedAndEnabled, !GetAtt EnhancedMonitoringRole.Arn, !Ref "AWS::NoValue" ]
+      CopyTagsToSnapshot: true
+      Tags:
+      - Key: Name
+        Value: !Ref AWS::StackName
+    DependsOn: AuroraCluster
+
+  AuroraInstance1:
+    Type: AWS::RDS::DBInstance
+    Condition: IsProd
+    Properties:
+      Engine: !Ref DatabaseEngine
+      DBClusterIdentifier: !Ref AuroraCluster
+      DBInstanceClass: !Ref DatabaseInstanceClass
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      StorageEncrypted: !Ref EncryptionAtRest
+      DBParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
+      MonitoringInterval: !If [ EnhancedMonitoringSupprtedAndEnabled, 60, 0 ]
+      MonitoringRoleArn: !If [ EnhancedMonitoringSupprtedAndEnabled, !GetAtt EnhancedMonitoringRole.Arn, !Ref "AWS::NoValue" ]
+      CopyTagsToSnapshot: true
+      Tags:
+      - Key: Name
+        Value: !Ref AWS::StackName
+    DependsOn: AuroraCluster
+
+  DatabaseCpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB CPU utilization is over ${DatabaseAlarmMaxCpuPercent}% for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      Unit: Percent
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmMaxCpuPercent
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseSelectLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB read latency is over ${DatabaseAlarmReadLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: SelectLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmReadLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseInsertLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB insert latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: InsertLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseUpdateLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB update latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: UpdateLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseDeleteLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB update latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: DeleteLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+
+Outputs:
+
+  Name:
+    Description: Aurora Stack Name
+    Value: !Ref AWS::StackName
+    Export:
+      Name: !Sub ${AWS::StackName}-Name
+
+  AuroraClusterId:
+    Description: Aurora Cluster ID
+    Value: !Ref AuroraCluster
+    Export:
+      Name: !Sub ${AWS::StackName}-AuroraClusterID
+
+  AuroraDbURL:
+    Description: Aurora Database URL
+    Value: !GetAtt AuroraCluster.Endpoint.Address
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseURL
+
+  AuroraReadDbURL:
+    Description: Aurora Database Read URL
+    Value: !GetAtt AuroraCluster.ReadEndpoint.Address
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseReadURL
+
+  DbUser:
+    Description: RDS Database admin account user
+    Value: !Ref DatabaseUser
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseUser
+
+  DatabaseAlarmTopicArn:
+    Description: Database Alarm Topic ARN
+    Condition: AlarmsEnabled
+    Value: !Ref DatabaseAlarmTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicArn
+
+  DatabaseAlarmTopicName:
+    Description: Database Alarm Topic Name
+    Condition: AlarmsEnabled
+    Value: !GetAtt DatabaseAlarmTopic.TopicName
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicName
+

--- a/test/fixtures/iac/cloudformation/fargate-valid.json
+++ b/test/fixtures/iac/cloudformation/fargate-valid.json
@@ -1,0 +1,38 @@
+{
+  "Description": "Fargate",
+  "Parameters": {
+    "NetworkStackName": {
+      "Type": "String",
+      "Description": "Name of an active Startup Kit CloudFormation stack that contains networking resources",
+      "MinLength": 1,
+      "MaxLength": 255,
+      "AllowedPattern": "^[a-zA-Z][-a-zA-Z0-9]*$"
+    },
+    "HostedZoneName": {
+      "Type": "String",
+      "Description": "The Amazon Route 53 Hosted Zone Name for the optional load balancer alias record - do not include a period at the end",
+      "Default": "",
+      "AllowedPattern": "(^$|^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$)",
+      "ConstraintDescription": "Please enter a valid Route 53 Hosted Zone Name"
+    },
+    "LoadBalancerDomainName": {
+      "Type": "String",
+      "Description": "Domain name to create an Amazon Route 53 alias record for the load balancer",
+      "Default": "",
+      "AllowedPattern": "(^$|^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\\.)+[A-Za-z]{2,6}$)",
+      "ConstraintDescription": "Please enter a valid domain name"
+    }
+  },
+  "Conditions": {
+    "IsTlsEnabled": null
+  },
+  "Resources": {
+    "DefaultContainerBucket": {
+      "Type": "AWS::S3::Bucket"
+    },
+    "CodePipelineArtifactBucket": {
+      "Type": "AWS::S3::Bucket",
+      "DeletionPolicy": "Delete"
+    }
+  }
+}

--- a/test/fixtures/iac/cloudformation/invalid-cfn.yml
+++ b/test/fixtures/iac/cloudformation/invalid-cfn.yml
@@ -1,0 +1,20 @@
+---
+Description: Invalid Aurora
+
+Parameters:
+
+            NetworkStackName:
+  Description: Name of an active CloudFormation stack that contains networking resources
+      Type: String
+  MinLength: 1
+  MaxLength: 255
+    AllowedPattern: "^[a-zA-Z][-a-zA-Z0-9]*$"
+
+  DatabaseUser:
+    Default: startupadmin
+    Type: String
+    Description: Database admin account name
+    MinLength: 5
+    MaxLength: 16
+    AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters

--- a/test/fixtures/iac/kubernetes/pod-valid.json
+++ b/test/fixtures/iac/kubernetes/pod-valid.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+    "name": "example"
+  },
+  "spec": {
+    "containers": [
+      {
+        "name": "example",
+        "image": "example:latest",
+        "securityContext": {
+          "privileged": true
+        }
+      }
+    ]
+  }
+}

--- a/test/jest/unit/iac-unit-tests/file-parser.cloudformation.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.cloudformation.fixtures.ts
@@ -1,0 +1,82 @@
+import {
+  EngineType,
+  IacFileData,
+  IacFileParsed,
+} from '../../../../src/cli/commands/test/iac-local-execution/types';
+import { IacProjectType } from '../../../../src/lib/iac/constants';
+
+const cloudFormationYAMLFileContent = `
+Description:  Aurora
+
+# Create the Aurora MySQL DB
+
+Parameters:
+
+  NetworkStackName:
+    Description: Name of an active CloudFormation stack that contains networking resources
+    Type: String
+    MinLength: 1
+    MaxLength: 255
+    AllowedPattern: "^[a-zA-Z][-a-zA-Z0-9]*$"
+
+Resources:
+
+  DatabaseAlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: AlarmsEnabled
+    Properties:
+      DisplayName: Database Alarm Topic
+`;
+
+const cloudFormationJSON = {
+  Description: 'Aurora',
+  Parameters: {
+    NetworkStackName: {
+      Description:
+        'Name of an active CloudFormation stack that contains networking resources',
+      Type: 'String',
+      MinLength: 1,
+      MaxLength: 255,
+      AllowedPattern: '^[a-zA-Z][-a-zA-Z0-9]*$',
+    },
+  },
+  Resources: {
+    DatabaseAlarmTopic: {
+      Type: 'AWS::SNS::Topic',
+      Condition: 'AlarmsEnabled',
+      Properties: {
+        DisplayName: 'Database Alarm Topic',
+      },
+    },
+  },
+};
+
+export const cloudFormationJSONFileContent = JSON.stringify(cloudFormationJSON);
+
+export const cloudFormationYAMLFileDataStub: IacFileData = {
+  fileContent: cloudFormationYAMLFileContent,
+  filePath: 'dont-care',
+  fileType: 'yml',
+};
+
+export const cloudFormationJSONFileDataStub: IacFileData = {
+  fileContent: cloudFormationJSONFileContent,
+  filePath: 'dont-care',
+  fileType: 'json',
+};
+
+export const expectedCloudFormationYAMLParsingResult: IacFileParsed = {
+  ...cloudFormationYAMLFileDataStub,
+  docId: 0,
+  projectType: IacProjectType.CLOUDFORMATION,
+  engineType: EngineType.CloudFormation,
+  jsonContent: cloudFormationJSON,
+};
+
+export const expectedCloudFormationJSONParsingResult: IacFileParsed = {
+  ...cloudFormationJSONFileDataStub,
+  docId: 0,
+  projectType: IacProjectType.CLOUDFORMATION,
+  engineType: EngineType.CloudFormation,
+  jsonContent: cloudFormationJSON,
+};

--- a/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
@@ -5,7 +5,7 @@ import {
   IacFileData,
   IacFileParsed,
 } from '../../../../src/cli/commands/test/iac-local-execution/types';
-import { MissingRequiredFieldsInKubernetesYamlError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/kubernetes-parser';
+import { FailedToDetectYamlConfigError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser';
 import {
   getExpectedResult,
   PlanOutputCase,
@@ -144,10 +144,9 @@ export const expectedMultipleKubernetesYamlsParsingResult: IacFileParsed = {
 };
 
 export const expectedKubernetesYamlInvalidParsingResult = {
-  err: new MissingRequiredFieldsInKubernetesYamlError(
-    'Failed to detect Kubernetes file, missing required fields',
-  ),
-  failureReason: 'Failed to detect Kubernetes file, missing required fields',
+  err: new FailedToDetectYamlConfigError('filename'),
+  failureReason:
+    'Failed to detect either a Kubernetes or CloudFormation file, missing required fields',
   fileType: 'yml',
   filePath: 'dont-care',
   fileContent: kubernetesYamlInvalidFileDataStub.fileContent,

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -27,7 +27,7 @@ Describe "Snyk iac local test command"
   End
 
   Describe "k8s single file scan"
-    It "finds issues in k8s file"
+    It "finds issues in k8s YAML file"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml
       The status should equal 1 # issues found
       The output should include "Testing pod-privileged.yaml..."
@@ -37,6 +37,17 @@ Describe "Snyk iac local test command"
       The output should include "✗ Container is running in privileged mode"
       The output should include "  introduced by"
     End
+
+    It "finds issues in k8s JSON file"
+          When run snyk iac test ../fixtures/iac/kubernetes/pod-valid.json
+          The status should equal 1 # issues found
+          The output should include "Testing pod-valid.json..."
+
+          # Outputs issues
+          The output should include "Infrastructure as code issues:"
+          The output should include "✗ Container is running in privileged mode"
+          The output should include "  introduced by"
+        End
 
     It "filters out issues when using severity threshold"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-privileged.yaml  --severity-threshold=high
@@ -77,6 +88,61 @@ Describe "Snyk iac local test command"
       The result of function check_valid_json should be success
     End
   End
+
+  Describe "CloudFormation single file scan"
+      It "finds issues in CloudFormation YAML file"
+        When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml
+        The status should equal 1 # issues found
+        The output should include "Testing aurora-valid.yml..."
+
+        # Outputs issues
+        The output should include "Infrastructure as code issues:"
+        The output should include "✗ Non-Encrypted SNS Topic"
+        The output should include "  introduced by"
+      End
+
+      It "finds issues in CloudFormation JSON file"
+              When run snyk iac test ../fixtures/iac/cloudformation/fargate-valid.json
+              The status should equal 1 # issues found
+              The output should include "Testing fargate-valid.json..."
+
+              # Outputs issues
+              The output should include "Infrastructure as code issues:"
+              The output should include "✗ S3 bucket versioning disabled"
+              The output should include "  introduced by"
+            End
+
+      It "filters out issues when using severity threshold"
+        When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml  --severity-threshold=high
+        The status should equal 0 # no issues found
+        The output should include "Testing aurora-valid.yml..."
+
+        The output should include "Infrastructure as code issues:"
+        The output should include "Tested aurora-valid.yml for known issues, found"
+      End
+
+      It "outputs an error for files with no valid YAML"
+        When run snyk iac test ../fixtures/iac/cloudformation/invalid-cfn.yml
+        The status should equal 2
+        The output should include "We were unable to parse the YAML file"
+      End
+
+      It "outputs the expected text when running with --sarif flag"
+        When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml --sarif
+        The status should equal 1
+        The output should include '"id": "SNYK-CC-TF-55",'
+        The output should include '"ruleId": "SNYK-CC-TF-55",'
+      End
+
+      It "outputs the expected text when running with --json flag"
+        When run snyk iac test ../fixtures/iac/cloudformation/aurora-valid.yml --json
+        The status should equal 1
+        The output should include '"id": "SNYK-CC-TF-55",'
+        The output should include '"packageManager": "cloudformationconfig",'
+        The output should include '"projectType": "cloudformationconfig",'
+        The result of function check_valid_json should be success
+      End
+    End
 
   Describe "terraform single file scan"
     It "finds issues in terraform file"
@@ -160,7 +226,7 @@ Describe "Snyk iac local test command"
 
       # Second File
       The output should include "Testing pod-invalid.yaml..."
-      The output should include "Failed to detect Kubernetes file, missing required fields"
+      The output should include "Failed to detect either a Kubernetes or CloudFormation file, missing required fields"
     End
 
     It "limits the depth of the directories"


### PR DESCRIPTION
#### What does this PR do?

This PR enables users to scan CloudFormation files (both with `yaml` and `json` extenstions) via CLI. For this purpose it:

1. Adds EngineType for CloudFormation, packagemanager: cloudformationconfig.
2. Adds support for the new wasm bundle for CloudFormation files.
3. Extends the engineTypeToProjectType with the new EngineType=cloudformationconfig.
4. Implements the soultion for the detection of CloudFormation files in a new `k8s-or-cloudformation-parser.ts` by checking whether a file has a top-level `Resourses` field which is the only required field for ClodFormation templates. 
5. Introduces new unit tests and smoke tests for CloudFormation.

#### Where should the reviewer start?

The reviewer should start with `src/cli/commands/test/iac-local-execution/file-parser.ts` file.

#### How should this be manually tested?

It can by manually tested by running `snyk-dev iac test test/fixtures/iac/cloudformation` command for testing a folder containing different CloudFormation templates for testing. Or by specifying CloudFormation file name in the same command for testing files individually.

#### What are the relevant tickets?

https://snyksec.atlassian.net/jira/software/projects/CC/boards/93?selectedIssue=CC-850

#### Screenshots

1. Testing valid CloudFormation file with 1 issue.

![Screen Shot 2021-05-25 at 11 18 23](https://user-images.githubusercontent.com/61270579/119463951-f0327400-bd4a-11eb-835b-9a54e2ba6482.png)

2. Testing valid CloudFormation file with 1 issue, adding `--json` at the end of the command

![Screen Shot 2021-05-25 at 11 25 16](https://user-images.githubusercontent.com/61270579/119464994-f2e19900-bd4b-11eb-9379-baedc6c487fd.png)
![Screen Shot 2021-05-25 at 10 59 55](https://user-images.githubusercontent.com/61270579/119461425-5b2e7b80-bd48-11eb-92ba-210d48742a1a.png)

3. Testing invalid CloudFormation file.

![Screen Shot 2021-05-25 at 11 19 06](https://user-images.githubusercontent.com/61270579/119464048-0d674280-bd4b-11eb-90a8-ca67256deff8.png)

4. Testing valid CloudFormation file with no `Resources` field.

![Screen Shot 2021-05-25 at 11 19 55](https://user-images.githubusercontent.com/61270579/119464181-28d24d80-bd4b-11eb-9e0f-99aa7e19729f.png)

5. Testing CloudFormation file with `json` extension.

![Screen Shot 2021-05-25 at 11 21 01](https://user-images.githubusercontent.com/61270579/119464333-4d2e2a00-bd4b-11eb-8a75-56e63578a7ad.png)

#### Additional questions

1. Before changes there was a specific error for k8s files that did not contain required fields - `MissingRequiredFieldsInKubernetesYamlError` saying `We were unable to detect whether the YAML file "${filename}" is a valid Kubernetes file, it is missing the following fields:...` Now CloudFormation and Kubernetes files which do not have required fields get the shared output error message in `FailedToDetectYamlFileError` saying `We were unable to detect whether the YAML file "${filename}" is a valid Kubernetes or CloudFormation file. For Kubernetes required fields are... For CloudFormation required fields are: ...` However, we did not remove `MissingRequiredFieldsInKubernetesYamlError` for now
to be able to use it in case we would like to have a specific error for k8s files. 
2. We renamed the `kubernetes-parser.ts` file to `k8s-or-cloudformation-parser.ts` to be consistent with the namings we had before. However, we think that a further renaming of the files is required (in a future PR) to be more consistent with the file content as in`k8s-or-cloudformation-parser.ts` we rather detect a config type after file parsing.