### PR TITLE
bug: extract line numbers if sarif-file-output or json-file-output [CC-887]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -41,7 +41,7 @@ const engineTypeToProjectType = {
 function formatScanResult(
   scanResult: IacFileScanResult,
   meta: TestMeta,
-  { severityThreshold, json, sarif }: IaCTestFlags,
+  options: IaCTestFlags,
 ): FormattedResult {
   const formattedIssues = scanResult.violatedPolicies.map((policy) => {
     const cloudConfigPath =
@@ -49,7 +49,15 @@ function formatScanResult(
         ? [`[DocId:${scanResult.docId}]`].concat(policy.msg.split('.'))
         : policy.msg.split('.');
 
-    const shouldExtractLineNumber = json || sarif;
+    const flagsRequiringLineNumber = [
+      'json',
+      'sarif',
+      'json-file-output',
+      'sarif-file-output',
+    ];
+    const shouldExtractLineNumber = flagsRequiringLineNumber.some(
+      (flag) => options[flag],
+    );
     const lineNumber: number = shouldExtractLineNumber
       ? extractLineNumber(scanResult, policy)
       : -1;
@@ -77,7 +85,7 @@ function formatScanResult(
     result: {
       cloudConfigResults: filterPoliciesBySeverity(
         formattedIssues,
-        severityThreshold,
+        options.severityThreshold,
       ),
       projectType: scanResult.projectType,
     },

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -1,0 +1,65 @@
+import { readFileSync, unlinkSync } from 'fs';
+import * as path from 'path';
+import * as sarif from 'sarif';
+import { v4 as uuidv4 } from 'uuid';
+import { startMockServer } from './helpers';
+import { MappedIacTestResponse } from '../../../../src/lib/snyk-test/iac-test-result';
+jest.setTimeout(50000);
+
+describe('iac test --json-file-output', () => {
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    ({ run, teardown } = await startMockServer());
+  });
+
+  afterAll(async () => teardown());
+
+  it('can save JSON output to file while sending human readable output to stdout', async () => {
+    const jsonOutputFilename = path.join(__dirname, `${uuidv4()}.json`);
+    const { stdout } = await run(
+      `snyk iac test ./iac/terraform/sg_open_ssh.tf --json-file-output=${jsonOutputFilename}`,
+    );
+    expect(stdout).toMatch('Organization:');
+
+    const outputFileContents = readFileSync(jsonOutputFilename, 'utf-8');
+    unlinkSync(jsonOutputFilename);
+    const jsonObj: MappedIacTestResponse = JSON.parse(outputFileContents);
+    const lineNumber = jsonObj?.infrastructureAsCodeIssues?.[0].lineNumber;
+    expect(lineNumber).not.toBeUndefined();
+    expect(lineNumber).not.toEqual(-1);
+  });
+});
+
+describe('iac test --sarif-file-output', () => {
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    ({ run, teardown } = await startMockServer());
+  });
+
+  afterAll(async () => teardown());
+
+  it('can save Sarif output to file while sending human readable output to stdout', async () => {
+    const sarifOutputFilename = path.join(__dirname, `${uuidv4()}.sarif`);
+    const { stdout } = await run(
+      `snyk iac test ./iac/terraform/sg_open_ssh.tf --sarif-file-output=${sarifOutputFilename}`,
+    );
+    expect(stdout).toMatch('Organization:');
+
+    const outputFileContents = readFileSync(sarifOutputFilename, 'utf-8');
+    unlinkSync(sarifOutputFilename);
+    const jsonObj: sarif.Log = JSON.parse(outputFileContents);
+    const startLine =
+      jsonObj?.runs?.[0].results?.[0].locations?.[0].physicalLocation?.region
+        ?.startLine;
+    expect(startLine).not.toBeUndefined();
+    expect(startLine).not.toEqual(-1);
+  });
+});

--- a/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.spec.ts
@@ -29,6 +29,14 @@ describe('formatScanResults', () => {
       { severityThreshold: SEVERITY.HIGH, json: true },
       expectedFormattedResultsWithLineNumber,
     ],
+    [
+      { severityThreshold: SEVERITY.HIGH, 'sarif-file-output': 'output.sarif' },
+      expectedFormattedResultsWithLineNumber,
+    ],
+    [
+      { severityThreshold: SEVERITY.HIGH, 'json-file-output': 'output.json' },
+      expectedFormattedResultsWithLineNumber,
+    ],
   ])(
     'given %p options object, returns the expected results',
     (optionsObject, expectedResult) => {

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -66,6 +66,7 @@ Describe "Snyk iac local test command"
       The status should equal 1
       The output should include '"id": "SNYK-CC-K8S-1",'
       The output should include '"ruleId": "SNYK-CC-K8S-1",'
+      The output should not include '"startLine": "-1",'
     End
 
     It "outputs the expected text when running with --json flag"
@@ -112,6 +113,7 @@ Describe "Snyk iac local test command"
       The status should equal 1
       The output should include '"id": "SNYK-CC-TF-1",'
       The output should include '"ruleId": "SNYK-CC-TF-1",'
+      The output should not include '"startLine": "-1",'
     End
 
     It "outputs the expected text when running with --json flag"
@@ -120,6 +122,7 @@ Describe "Snyk iac local test command"
       The output should include '"id": "SNYK-CC-TF-1",'
       The output should include '"packageManager": "terraformconfig",'
       The output should include '"projectType": "terraformconfig",'
+      The output should not include '"startLine": "-1",'
       The result of function check_valid_json should be success
     End
 
@@ -128,6 +131,7 @@ Describe "Snyk iac local test command"
       The status should equal 0 # no issues found
       The output should not include '"id": "SNYK-CC-TF-1",'
       The output should include '"packageManager": "terraformconfig",'
+      The output should not include '"startLine": "-1",'
       The result of function check_valid_json should be success
     End
   End
@@ -283,6 +287,7 @@ Describe "Snyk iac local test command"
       The status should equal 1
       The output should include '"packageManager": "terraformconfig",'
       The output should include '"projectType": "terraformconfig",'
+      The output should not include '"startLine": "-1",'
       The result of function check_valid_json should be success
     End
   End


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR enables the line number functionality for the `--sarif-file-output` and `--json-file-output` flags. Without this line number functionality, the GitHub action for IaC is broken because Sarif expects a non-negative `startLine`.

#### How should this be manually tested?
1. Run `npm run build`
2. Run `node ./dist/cli iac test test/fixtures/iac/terraform/sg_open_ssh.tf --sarif-file-output=snyk.sarif`
3. Run `cat snyk.sarif` and notice that the `startLine` is not -1 anymore.

#### Any background context you want to provide?
In https://github.com/snyk/snyk/pull/1901 we wanted to make sure we didn't run the line number functionality if we weren't going to display the line number to a user. This line number is only rendered when we output JSON or Sarif. We forgot about the `--json-file-output` and `--sarif-file-output` flags however.

#### What are the relevant tickets?
- [CC-887](https://snyksec.atlassian.net/browse/CC-887)

#### Screenshots
Before:
![Screenshot 2021-05-26 at 11 39 19](https://user-images.githubusercontent.com/81559517/119646402-06a60180-be17-11eb-8ab0-3859c5061ef4.png)

After:
![Screenshot 2021-05-25 at 19 06 39](https://user-images.githubusercontent.com/81559517/119638307-6d72ed00-be0e-11eb-9f04-c25613d5a8ce.png)
