### PR TITLE
chore: get timings for tap tests in circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,8 +268,13 @@ jobs:
             - run:
                 name: Run "Root" tap tests
                 command: |
-                  npm run test:test -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-test
+                  mkdir -p test-results/tap-test-test
+                  npm run --silent test:test -- -Rxunit > test-results/tap-test-test/tap.xml
+            - run:
+                name: Run "Root" tap tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-test/tap.xml --console --clear=false --output=false
       - when:
           condition: << parameters.jest_tests >>
           steps:
@@ -303,16 +308,26 @@ jobs:
             - run:
                 name: Run Acceptance tests
                 command: |
-                  npm run test:acceptance-windows -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-acceptance-windows
+                  mkdir -p test-results/tap-test-acceptance-windows
+                  npm run --silent test:acceptance-windows -- -Rxunit > test-results/tap-test-acceptance-windows/tap.xml
+            - run:
+                name: Run Acceptance tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-acceptance-windows/tap.xml --console --clear=false --output=false
       - when:
           condition: << parameters.system_tests >>
           steps:
             - run:
                 name: Run System tests
                 command: |
-                  npm run test:system -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-system
+                  mkdir -p test-results/tap-test-system
+                  npm run --silent test:system -- -Rxunit > test-results/tap-test-system/tap.xml
+            - run:
+                name: Run System tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-system/tap.xml --console --clear=false --output=false
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -367,8 +382,13 @@ jobs:
             - run:
                 name: Run "Root" tap tests
                 command: |
-                  npm run test:test -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-test
+                  mkdir -p test-results/tap-test-test
+                  npm run --silent test:test -- -Rxunit > test-results/tap-test-test/tap.xml
+            - run:
+                name: Run "Root" tap tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-test/tap.xml --console --clear=false --output=false
       - when:
           condition: << parameters.jest_tests >>
           steps:
@@ -402,16 +422,26 @@ jobs:
             - run:
                 name: Run Acceptance tests
                 command: |
-                  npm run test:acceptance -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-acceptance
+                  mkdir -p test-results/tap-test-acceptance
+                  npm run --silent test:acceptance -- -Rxunit > test-results/tap-test-acceptance/tap.xml
+            - run:
+                name: Run Acceptance tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-acceptance/tap.xml --console --clear=false --output=false
       - when:
           condition: << parameters.system_tests >>
           steps:
             - run:
                 name: Run System tests
                 command: |
-                  npm run test:system -- --output-file tap-output
-                  npx tap-junit --input tap-output --output test-results/tap-test-system
+                  mkdir -p test-results/tap-test-system
+                  npm run --silent test:system -- -Rxunit > test-results/tap-test-system/tap.xml
+            - run:
+                name: Run System tests output
+                when: always
+                command: |
+                  npx xunit-viewer -r test-results/tap-test-system/tap.xml --console --clear=false --output=false
       - store_test_results:
           path: test-results
       - store_artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ test/**/.gradle
 !test/smoke/.iac-data
 test-output
 test-results
-tap-output
 
 # Jest
 coverage

--- a/check-dependencies.config.ts
+++ b/check-dependencies.config.ts
@@ -5,7 +5,7 @@ export const config: Options = {
     'sarif', // we only use @types/sarif. https://github.com/depcheck/depcheck/issues/640
     '@types/jest', // jest is a global so impossible to detect usage of types
     'jest-junit', // used in circleci
-    'tap-junit' // used in circleci
+    'xunit-viewer', // used in circleci
   ],
   ignoreDirs: ['node_modules', 'dist', 'fixtures', 'test-output'],
 };

--- a/package.json
+++ b/package.json
@@ -173,11 +173,11 @@
     "restify": "^8.5.1",
     "sinon": "^4.0.0",
     "tap": "^12.6.1",
-    "tap-junit": "^4.2.0",
     "ts-jest": "^26.5.2",
     "ts-node": "^8.0.0",
     "tslint": "^5.14.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.4.1",
+    "xunit-viewer": "7.1.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As mentioned in #1951 , tap has an awkward interface for getting junit XML files out. Enabling it disables pretty output. Using something else removes timing data. So I've made this compromise to get timing data and still have somewhat pretty output.

tap test under CI will now output junit xml for CircleCI to consume. This then gets rendered pretty as a separate step.

Yes, this is pretty ugly, but getting this data will help remove tap tests entirely and remove this ugliness in the future.

# To Do

- The timings providing by tap's xunit reporter per `testcase` are `0`, only timings available for `testsuite`. So this isn't good enough.
- The only solution seems to be to improve `tap-junit` to parse and include timings from tap's TAP output.