### PR TITLE
fix: Analytics show correct number of issues by cloudformation

### DIFF
--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -9,13 +9,14 @@ export function addIacAnalytics(formattedResults: FormattedResult[]) {
   formattedResults.forEach((res) => {
     totalIssuesCount =
       (totalIssuesCount || 0) + res.result.cloudConfigResults.length;
-    packageManagers.push(res.packageManager);
+    const packageManagerConfig = res.packageManager;
+    packageManagers.push(packageManagerConfig);
 
     res.result.cloudConfigResults.forEach((policy) => {
-      const configType = policy.type + 'config';
-      issuesByType[configType] = issuesByType[configType] ?? {};
-      issuesByType[configType][policy.severity] =
-        (issuesByType[configType][policy.severity] || 0) + 1;
+      issuesByType[packageManagerConfig] =
+        issuesByType[packageManagerConfig] ?? {};
+      issuesByType[packageManagerConfig][policy.severity] =
+        (issuesByType[packageManagerConfig][policy.severity] || 0) + 1;
     });
   });
 


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
We were calculating the iac-type based on the `policy.type` field. 
However, we can no longer rely on the `type` field on its own for distinguishing between CloudFormation and Terraform. 
This PR changes from looking at the `policy.type` to the packageManager itself.

#### Where should the reviewer start?
For a single file:
```
  snyk analytics {
  "args": [
    "test/fixtures/iac/cloudformation/aurora-valid.yml",
    {
      "debug": true,
      "iac": true
    }
  ],
  "command": "test",
  "metadata": {
    "iac-terraform-plan": false,
    "packageManager": [
      "cloudformationconfig"
    ],
    "iac-issues-count": 1,
    "iac-type": {
      "cloudformationconfig": {
        "medium": 1
      }
    },
    "iac-metrics": {
      "cache-init-ms": 297,
      "file-loading-ms": 1,
      "file-parsing-ms": 26,
      "file-scanning-ms": 111,
      "org-settings-ms": 509,
      "custom-severities-ms": 2,
      "results-formatting-ms": 0,
      "cache-cleanup-ms": 4,
      "total-iac-ms": 951
    },
    "iac-test-count": 1,
    "error-message": "Vulnerabilities found",
    "error-code": "VULNS",
    "command": "test"
  },
  ...
}
```

For directory containing multiple configs:
```
...
"packageManager": [
      "cloudformationconfig",
      "terraformconfig",
      "k8sconfig"
    ],
    "iac-issues-count": 46,
    "iac-type": {
      "cloudformationconfig": {
        "medium": 1,
        "low": 2
      },
      "terraformconfig": {
        "medium": 4,
        "low": 5
      },
      "k8sconfig": {
        "medium": 12,
        "low": 20,
        "high": 2
      }
    },
...
```
#### How should this be manually tested?
Run `node ~/snyk-repos/snyk/dist/cli/index.js iac test test/fixtures/iac/cloudformation -d`

#### Screenshots

