### PR TITLE
fix: Skip empty files on IaC scanning [CC-589]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -41,7 +41,7 @@ export async function loadFiles(
   if (filesToScan.length === 0) {
     throw new NoFilesToScanError();
   }
-  return filesToScan;
+  return filesToScan.filter((file) => file.fileContent !== '');
 }
 
 function getFilePathsFromDirectory(
@@ -70,10 +70,6 @@ export async function tryLoadFileData(
   const fileContent = (
     await fs.readFile(pathToScan, DEFAULT_ENCODING)
   ).toString();
-
-  if (fileContent === '') {
-    return null;
-  }
 
   return {
     filePath: pathToScan,

--- a/test/jest/unit/iac-unit-tests/file-loader.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-loader.spec.ts
@@ -162,14 +162,13 @@ describe('loadFiles', () => {
     });
 
     describe('empty files', () => {
-      it('single empty file does not get scanned and throws an error', async () => {
+      it('single empty file gets scanned and returns no output', async () => {
         mockFs({
           [emptyFileStub.filePath]: emptyFileStub.fileContent,
         });
 
-        await expect(loadFiles(emptyFileStub.filePath)).rejects.toThrow(
-          NoFilesToScanError,
-        );
+        const loadedFiles = await loadFiles(emptyFileStub.filePath);
+        expect(loadedFiles).toEqual([]);
       });
 
       it('empty file in directory is skipped', async () => {


### PR DESCRIPTION
Co-authored-by: Teodora Sandu <teodora.sandu@snyk.io>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR skips empty files on an IaC scan instead of failing with a "Could not find any valid IaC files" error.
 
This implementation does not return any error or a message to indicate that the file is skipped. 
We decided to just skip for now as we have a wider discussion on refactoring our errors and messages.

#### Where should the reviewer start?
- In `file.loader.ts`: we filter out files with empty content. The file will never be scanned for issues going down the flow.

#### How should this be manually tested?
```
touch empty.tf
node ~/snyk-repos/snyk/dist/cli/index.js iac test empty.tf
```

#### What are the relevant tickets?
[CC-589]

#### Screenshots
![image](https://user-images.githubusercontent.com/6989529/119847633-0c791100-bf03-11eb-8c20-01455a70c0aa.png)

[CC-589]: https://snyksec.atlassian.net/browse/CC-589