### PR TITLE
fix: paths in json and sarif output [CC-563]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -137,6 +137,7 @@ export type IaCTestFlags = Pick<
   help?: 'help';
   q?: boolean;
   quiet?: boolean;
+  path?: string;
   // This flag is internal and is used merely to route the smoke tests of the old flow.
   // it should be removed together when the GA version completely deprecates the legacy remote processing flow.
   legacy?: boolean;

--- a/test/fixtures/iac/file-output/nested-folder/sg_open_ssh.tf
+++ b/test/fixtures/iac/file-output/nested-folder/sg_open_ssh.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/fixtures/iac/file-output/sg_open_ssh.tf
+++ b/test/fixtures/iac/file-output/sg_open_ssh.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -55,7 +55,11 @@ describe('iac test --json-file-output', () => {
       expectedTargetFilePath: path.resolve(
         './test/fixtures/iac/file-output/nested-folder/sg_open_ssh.tf',
       ),
-      expectedTargetFile: 'nested-folder/sg_open_ssh.tf',
+      expectedTargetFile: path.join(
+        'nested-folder',
+        path.sep,
+        'sg_open_ssh.tf',
+      ),
       expectedProjectName: 'file-output',
       isNested: true,
     },

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -38,6 +38,9 @@ const anotherPolicyStub: PolicyMetadata = {
   publicId: 'SNYK-CC-K8S-2',
 };
 
+const relativeFilePath = 'dont-care.yaml';
+const absoluteFilePath = path.resolve(relativeFilePath, '.');
+
 export function generateScanResults(): Array<IacFileScanResult> {
   return [
     {
@@ -47,7 +50,7 @@ export function generateScanResults(): Array<IacFileScanResult> {
       projectType: IacProjectType.K8S,
       engineType: EngineType.Kubernetes,
       fileContent: 'dont-care',
-      filePath: 'dont-care',
+      filePath: relativeFilePath,
       fileType: 'yaml',
     },
     {
@@ -57,7 +60,7 @@ export function generateScanResults(): Array<IacFileScanResult> {
       projectType: IacProjectType.K8S,
       engineType: EngineType.Kubernetes,
       fileContent: 'dont-care',
-      filePath: 'dont-care',
+      filePath: relativeFilePath,
       fileType: 'yaml',
     },
   ];
@@ -69,7 +72,7 @@ export const meta: TestMeta = {
   org: 'org-name',
 };
 
-function generateFormattedResults(withLineNumber: boolean = true) {
+function generateFormattedResults(withLineNumber = true) {
   return {
     result: {
       cloudConfigResults: [
@@ -95,8 +98,8 @@ function generateFormattedResults(withLineNumber: boolean = true) {
     },
     isPrivate: true,
     packageManager: IacProjectType.K8S,
-    targetFile: 'dont-care',
-    targetFilePath: path.resolve('dont-care', '.'),
+    targetFile: relativeFilePath,
+    targetFilePath: absoluteFilePath,
     vulnerabilities: [],
     dependencyCount: 0,
     ignoreSettings: null,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR fixes the logic for computing the `targetFile`, `targetFilePath`, and `projectName` for the outputs. The SARIF output for our GitHub action has been broken since making local exec GA and putting the legacy flow behind a flag. Comparing the legacy and GA output for SARIF, there was definitely a difference in the `physicalLocation` fields, **when** passing in the path to the folder as `.`.

The reason we are here today is we previously only tested the results returned by the CLI by scanning a single file, whereas now we've tested it for:
- a single file
- a folder which was passed in via the CLI by providing `.`
- a folder which was picked by default by the CLI by not providing any path to it
- a folder which is in a relative location to the current running directory

#### How should this be manually tested?
Build using `npm run build` and clone https://github.com/teodora-sandu/test. Change directory into `nested` and run the following commands one by one. The result of these commands can be found in the attached ZIP.
```
snyk iac test --json-file-output=output-ga.json
snyk iac test --json-file-output=output-legacy.json --legacy
snyk iac test --json-file-output=output-ga-path.json .
snyk iac test --json-file-output=output-legacy-path.json --legacy .

snyk iac test --sarif-file-output=output-ga.sarif
snyk iac test --sarif-file-output=output-legacy.sarif --legacy
snyk iac test --sarif-file-output=output-ga-path.sarif .
snyk iac test --sarif-file-output=output-legacy-path.sarif --legacy .

snyk-dev iac test --json-file-output=output-ga.json
snyk-dev iac test --json-file-output=output-legacy.json --legacy
snyk-dev iac test --json-file-output=output-ga-path.json .
snyk-dev iac test --json-file-output=output-legacy-path.json --legacy .

snyk-dev iac test --sarif-file-output=output-ga.sarif
snyk-dev iac test --sarif-file-output=output-legacy.sarif --legacy
snyk-dev iac test --sarif-file-output=output-ga-path.sarif .
snyk-dev iac test --sarif-file-output=output-legacy-path.sarif --legacy .
```

#### Any background context you want to provide?
We discussed in https://snyk.slack.com/archives/CS61093QC/p1622121809384500 how the GitHub action for IaC is broken because the `physicalLocation` in the SARIF output is not relative to the `PROJECT_ROOT`, as it should be.

This PR fixes that but also improves the output so that we now include the paths correctly when we have nested directories:
e.g. I have a `nested` folder, with a `nested` folder inside it, both of which have their own `test1.tf` files. As we can see from the attached screenshots, now we can differentiate between the two better.


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-563 - fixes this
https://snyksec.atlassian.net/browse/CC-679 - maintains this

#### Screenshots
Can find inside these ZIP files a before and after comparison of:
- SARIF output
    - for GA code
    - for legacy code (unchanged)
- JSON output
    - for GA code
    - for legacy code (unchanged)
- terminal results
    - for GA code
    - for legacy code (unchanged)
[before.zip](https://github.com/snyk/snyk/files/6584876/before.zip)
[after.zip](https://github.com/snyk/snyk/files/6593379/after.zip)

Quick screenshot of running against a folder with path provided as `.`:
![after-ga-path](https://user-images.githubusercontent.com/81559517/120688354-e0c5d000-c49a-11eb-8378-419d90a7fbd5.png)

Quick screenshot of running against a folder without a path provided:
![after-ga](https://user-images.githubusercontent.com/81559517/120688366-e58a8400-c49a-11eb-9b71-8cb3b13ec47a.png)

Quick screenshot of running against a folder which is located outside the current running directory:
![after-relative-folder-path](https://user-images.githubusercontent.com/81559517/120688382-e9b6a180-c49a-11eb-9daa-91894fa1bfc3.png)

Also quick screenshots of running against a single file (before vs after - no change):
![before-ga-single-file](https://user-images.githubusercontent.com/81559517/120515114-e8677500-c3c5-11eb-9959-6242a3cdb0a4.png)

![after-single-file](https://user-images.githubusercontent.com/81559517/120688404-ef13ec00-c49a-11eb-9326-ccdc6d7fa23d.png)

