### PR TITLE
fix: Skip specific errors when parsing yaml IaC files

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -23,6 +23,7 @@ import {
 import * as analytics from '../../../../lib/analytics';
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
+import { shouldThrowErrorFor } from './file-utils';
 
 export async function parseFiles(
   filesData: IacFileData[],
@@ -69,7 +70,7 @@ function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
     // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
     // by using this library we don't have to disambiguate between these different contents ourselves
     yamlDocuments = YAML.parseAllDocuments(fileData.fileContent).map((doc) => {
-      if (doc.errors.length !== 0) {
+      if (shouldThrowErrorFor(doc)) {
         throw doc.errors[0];
       }
       return doc.toJSON();

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as tar from 'tar';
 import * as path from 'path';
 import { FailedToInitLocalCacheError } from './local-cache';
+import * as YAML from 'yaml';
 
 export function createIacDir(): void {
   // this path will be able to be customised by the user in the future
@@ -28,4 +29,19 @@ export function extractBundle(response: NodeJS.ReadableStream): Promise<void> {
       .on('finish', resolve)
       .on('error', reject);
   });
+}
+
+const errorsToSkip = [
+  'Insufficient indentation in flow collection',
+  'Map keys must be unique',
+];
+
+// the YAML Parser is more strict than the Golang one in Policy Engine,
+// so we decided to skip specific errors in order to be consistent.
+// this function checks if the current error is one them
+export function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
+  return (
+    doc.errors.length !== 0 &&
+    !errorsToSkip.some((e) => doc.errors[0].message.includes(e))
+  );
 }

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -14,6 +14,7 @@ import {
   IacValidateTerraformResponse,
   IacValidationResponse,
 } from './constants';
+import { shouldThrowErrorFor } from '../../cli/commands/test/iac-local-execution/file-utils';
 
 const debug = debugLib('snyk-detect');
 
@@ -31,7 +32,7 @@ function parseYamlOrJson(fileContent: string, filePath: string): any {
     case 'yml':
       try {
         return YAML.parseAllDocuments(fileContent).map((doc) => {
-          if (doc.errors.length !== 0) {
+          if (shouldThrowErrorFor(doc)) {
             throw doc.errors[0];
           }
           return doc.toJSON();

--- a/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.fixtures.ts
@@ -83,6 +83,73 @@ const invalidYamlFile = `
 foo: "bar
 `;
 
+const semanticYamlWithDuplicateKeyFile = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: myapp-pod
+spec:
+  containers:
+  something: here
+metadata:
+  another: thing
+`;
+
+const semanticYamlErrorFileJSON = {
+  apiVersion: 'v1',
+  kind: 'Pod',
+  metadata: {
+    another: 'thing', //in a case of a duplicate key, the last one will be the one used when parsed
+  },
+  spec: {
+    containers: null,
+    something: 'here',
+  },
+};
+
+const yamlWithInsufficientIndentationFile = `
+Resources:
+ Denied:
+   Type: "AWS::IAM::Role"
+   Properties:
+     AssumeRolePolicyDocument: {
+ "Version": "2012-10-17",
+ "Statement": [
+   {
+     "Action": "sts:AssumeRole",
+     "Principal": {
+       "AWS": "arn:aws:iam::123456789012:root"
+     },
+     "Effect": "Allow",
+     "Sid": ""
+   }
+ ]
+}
+`;
+
+const yamlWithInsufficientIndentationFileJSON = {
+  Resources: {
+    Denied: {
+      Type: 'AWS::IAM::Role',
+      Properties: {
+        AssumeRolePolicyDocument: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Action: 'sts:AssumeRole',
+              Principal: {
+                AWS: 'arn:aws:iam::123456789012:root',
+              },
+              Effect: 'Allow',
+              Sid: '',
+            },
+          ],
+        },
+      },
+    },
+  },
+};
+
 export const kubernetesYamlFileDataStub: IacFileData = {
   fileContent: kubernetesYamlFileContent,
   filePath: 'dont-care',
@@ -117,6 +184,33 @@ export const invalidYamlFileDataStub: IacFileData = {
   fileContent: invalidYamlFile,
   filePath: 'dont-care',
   fileType: 'yml',
+};
+
+export const duplicateKeyYamlErrorFileDataStub: IacFileData = {
+  fileContent: semanticYamlWithDuplicateKeyFile,
+  filePath: 'dont-care',
+  fileType: 'yml',
+};
+
+export const expectedDuplicateKeyYamlErrorFileParsingResult: IacFileParsed = {
+  ...duplicateKeyYamlErrorFileDataStub,
+  docId: 0,
+  projectType: IacProjectType.K8S,
+  engineType: EngineType.Kubernetes,
+  jsonContent: semanticYamlErrorFileJSON,
+};
+
+export const insufficientIndentationYamlErrorFileDataStub: IacFileData = {
+  fileContent: yamlWithInsufficientIndentationFile,
+  filePath: 'dont-care',
+  fileType: 'yml',
+};
+export const expectedInsufficientIndentationYamlErrorFileParsingResult: IacFileParsed = {
+  ...insufficientIndentationYamlErrorFileDataStub,
+  docId: 0,
+  projectType: IacProjectType.CLOUDFORMATION,
+  engineType: EngineType.CloudFormation,
+  jsonContent: yamlWithInsufficientIndentationFileJSON,
 };
 
 export const expectedKubernetesYamlParsingResult: IacFileParsed = {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

We identified a few cases that our services parse the yaml files in a different way. The node 'yaml' library is too 'strict', returning errors for validation of the YAML as well. 

In this PR we focus on two specific errors: bad indentation and duplicate keys. 
These two examples are not consistent with what Policy Engine returns so in this commit we intentionally skip errors for these cases, and return the parsed YAML document instead.

This will improve the consistency between the two parsers.

#### Where should the reviewer start?
The changes are in `file-parser.ts` and `iac-parser.ts` where we check if the error is one of the two error strings.

#### How should this be manually tested?
- Create a file with a SemanticError, e.g. duplicate keys:
```
apiVersion: v1
kind: Pod
metadata:
  name: myapp-pod
spec:
  containers:
  something: here
metadata:
  another: thing
```

Run `snyk-dev iac test duplicate_keys.yaml`
See that it is no longer failing but showing results (if any).

#### What are the relevant tickets?
[CC-927]

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/6989529/120799626-e96be400-c536-11eb-854c-2deadb406caf.png)

After:
![image](https://user-images.githubusercontent.com/6989529/120799647-eec92e80-c536-11eb-980d-74507269a59f.png)


#### Additional questions


[CC-927]: https://snyksec.atlassian.net/browse/CC-927