### PR TITLE
Fix: partition Python projects by fixable earlier on in Snyk fix flow

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -40,7 +40,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
-    "@snyk/fix-pipenv-pipfile": "0.4.3",
+    "@snyk/fix-pipenv-pipfile": "0.5.3",
     "chalk": "4.1.1",
     "debug": "^4.3.1",
     "lodash.groupby": "4.6.0",

--- a/packages/snyk-fix/src/lib/errors/custom-error.ts
+++ b/packages/snyk-fix/src/lib/errors/custom-error.ts
@@ -16,4 +16,5 @@ export enum ERROR_CODES {
   MissingFileName = 'G12',
   FailedToParseManifest = 'G13',
   CommandFailed = 'G14',
+  NoFixesCouldBeApplied = 'G15',
 }

--- a/packages/snyk-fix/src/lib/errors/invalid-workspace.ts
+++ b/packages/snyk-fix/src/lib/errors/invalid-workspace.ts
@@ -1,7 +1,0 @@
-import { CustomError, ERROR_CODES } from './custom-error';
-
-export class MissingFileNameError extends CustomError {
-  public constructor() {
-    super('Filename is missing from test result', ERROR_CODES.MissingFileName);
-  }
-}

--- a/packages/snyk-fix/src/lib/errors/missing-remediation-data.ts
+++ b/packages/snyk-fix/src/lib/errors/missing-remediation-data.ts
@@ -4,7 +4,7 @@ export class MissingRemediationDataError extends CustomError {
   public constructor() {
     super(
       'Remediation data is required to apply fixes',
-      ERROR_CODES.UnsupportedTypeError,
+      ERROR_CODES.MissingRemediationData,
     );
   }
 }

--- a/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
+++ b/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
@@ -2,6 +2,6 @@ import { CustomError, ERROR_CODES } from './custom-error';
 
 export class NoFixesCouldBeAppliedError extends CustomError {
   public constructor() {
-    super('No fixes could be applied', ERROR_CODES.UnsupportedTypeError);
+    super('No fixes could be applied', ERROR_CODES.NoFixesCouldBeApplied);
   }
 }

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
@@ -13,7 +13,6 @@ import {
 } from '../../../../types';
 import { FixedCache, PluginFixResponse } from '../../../types';
 import { updateDependencies } from './update-dependencies';
-import { partitionByFixable } from './../is-supported';
 import { NoFixesCouldBeAppliedError } from '../../../../lib/errors/no-fixes-applied';
 import { extractProvenance } from './extract-version-provenance';
 import {
@@ -28,18 +27,15 @@ import { formatDisplayName } from '../../../../lib/output-formatters/format-disp
 const debug = debugLib('snyk-fix:python:requirements.txt');
 
 export async function pipRequirementsTxt(
-  entities: EntityToFix[],
+  fixable: EntityToFix[],
   options: FixOptions,
 ): Promise<PluginFixResponse> {
-  debug(`Preparing to fix ${entities.length} Python requirements.txt projects`);
+  debug(`Preparing to fix ${fixable.length} Python requirements.txt projects`);
   const handlerResult: PluginFixResponse = {
     succeeded: [],
     failed: [],
     skipped: [],
   };
-
-  const { fixable, skipped: notFixable } = await partitionByFixable(entities);
-  handlerResult.skipped.push(...notFixable);
 
   const ordered = sortByDirectory(fixable);
   let fixedFilesCache: FixedCache = {};


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- drop unused error
- correct error codes
- partition all items by fixable vs not before the handlers are called instead of repeating it in each
