### PR TITLE
Feat: Poetry support for @snyk/fix

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -41,13 +41,15 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
     "@snyk/fix-pipenv-pipfile": "0.5.3",
+    "@snyk/fix-poetry": "0.6.0",
     "chalk": "4.1.1",
     "debug": "^4.3.1",
     "lodash.groupby": "4.6.0",
     "lodash.sortby": "^4.7.0",
     "ora": "5.4.0",
     "p-map": "^4.0.0",
-    "strip-ansi": "6.0.0"
+    "strip-ansi": "6.0.0",
+    "toml": "3.0.0"
   },
   "devDependencies": {
     "@types/jest": "26.0.20",

--- a/packages/snyk-fix/src/plugins/load-plugin.ts
+++ b/packages/snyk-fix/src/plugins/load-plugin.ts
@@ -7,6 +7,9 @@ export function loadPlugin(type: string): FixHandler {
     case 'pip': {
       return pythonFix;
     }
+    case 'poetry': {
+      return pythonFix;
+    }
     default: {
       throw new UnsupportedTypeError(type);
     }

--- a/packages/snyk-fix/src/plugins/package-tool-supported.ts
+++ b/packages/snyk-fix/src/plugins/package-tool-supported.ts
@@ -1,6 +1,7 @@
 import * as chalk from 'chalk';
 
 import * as pipenvPipfileFix from '@snyk/fix-pipenv-pipfile';
+import * as poetryFix from '@snyk/fix-poetry';
 
 import * as ora from 'ora';
 
@@ -12,10 +13,15 @@ const supportFunc = {
     isSupportedVersion: (version) =>
       pipenvPipfileFix.isPipenvSupportedVersion(version),
   },
+  poetry: {
+    isInstalled: () => poetryFix.isPoetryInstalled(),
+    isSupportedVersion: (version) =>
+      poetryFix.isPoetrySupportedVersion(version),
+  },
 };
 
 export async function checkPackageToolSupported(
-  packageManager: 'pipenv',
+  packageManager: 'pipenv' | 'poetry',
   options: FixOptions,
 ): Promise<void> {
   const { version } = await supportFunc[packageManager].isInstalled();

--- a/packages/snyk-fix/src/plugins/python/get-handler-type.ts
+++ b/packages/snyk-fix/src/plugins/python/get-handler-type.ts
@@ -15,6 +15,8 @@ export function getHandlerType(
     return SUPPORTED_HANDLER_TYPES.REQUIREMENTS;
   } else if (['Pipfile'].includes(path.base)) {
     return SUPPORTED_HANDLER_TYPES.PIPFILE;
+  } else if (['pyproject.toml', 'poetry.lock'].includes(path.base)) {
+    return SUPPORTED_HANDLER_TYPES.POETRY;
   }
   return null;
 }

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/index.ts
@@ -1,0 +1,42 @@
+import * as debugLib from 'debug';
+import * as ora from 'ora';
+
+import { EntityToFix, FixOptions } from '../../../../types';
+import { checkPackageToolSupported } from '../../../package-tool-supported';
+import { PluginFixResponse } from '../../../types';
+import { updateDependencies } from './update-dependencies';
+
+const debug = debugLib('snyk-fix:python:Poetry');
+
+export async function poetry(
+  fixable: EntityToFix[],
+  options: FixOptions,
+): Promise<PluginFixResponse> {
+  debug(`Preparing to fix ${fixable.length} Python Poetry projects`);
+  const handlerResult: PluginFixResponse = {
+    succeeded: [],
+    failed: [],
+    skipped: [],
+  };
+
+  await checkPackageToolSupported('poetry', options);
+  for (const [index, entity] of fixable.entries()) {
+    const spinner = ora({ isSilent: options.quiet, stream: process.stdout });
+    const spinnerMessage = `Fixing pyproject.toml ${index + 1}/${
+      fixable.length
+    }`;
+    spinner.text = spinnerMessage;
+    spinner.start();
+
+    const { failed, succeeded, skipped } = await updateDependencies(
+      entity,
+      options,
+    );
+    handlerResult.succeeded.push(...succeeded);
+    handlerResult.failed.push(...failed);
+    handlerResult.skipped.push(...skipped);
+    spinner.stop();
+  }
+
+  return handlerResult;
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -1,0 +1,175 @@
+import * as pathLib from 'path';
+import * as toml from 'toml';
+
+import * as debugLib from 'debug';
+import * as poetryFix from '@snyk/fix-poetry';
+
+import { PluginFixResponse } from '../../../../types';
+import {
+  DependencyPins,
+  EntityToFix,
+  FixChangesSummary,
+  FixOptions,
+} from '../../../../../types';
+import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
+import { CommandFailedError } from '../../../../../lib/errors/command-failed-to-run-error';
+import { validateRequiredData } from '../../validate-required-data';
+import { standardizePackageName } from '../../../standardize-package-name';
+
+const debug = debugLib('snyk-fix:python:Poetry');
+
+interface PyProjectToml {
+  tool: {
+    poetry: {
+      name: string;
+      version: string;
+      description: string;
+      authors: string[];
+      dependencies?: object;
+      'dev-dependencies'?: object;
+    };
+  };
+}
+export async function updateDependencies(
+  entity: EntityToFix,
+  options: FixOptions,
+): Promise<PluginFixResponse> {
+  const handlerResult: PluginFixResponse = {
+    succeeded: [],
+    failed: [],
+    skipped: [],
+  };
+  let poetryCommand;
+  try {
+    const { upgrades, devUpgrades } = await generateUpgrades(entity);
+    const { remediation, targetFile } = validateRequiredData(entity);
+    const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
+    const { dir } = pathLib.parse(targetFilePath);
+    // TODO: for better support we need to:
+    // 1. parse the manifest and extract original requirements, version spec etc
+    // 2. swap out only the version and retain original spec
+    // 3. re-lock the lockfile
+
+    // update prod dependencies first
+    if (!options.dryRun && upgrades.length) {
+      const res = await poetryFix.poetryAdd(dir, upgrades, {});
+      if (res.exitCode !== 0) {
+        poetryCommand = res.command;
+        throwPoetryError(res.stderr ? res.stderr : res.stdout, res.command);
+      }
+    }
+
+    // update dev dependencies second
+    if (!options.dryRun && devUpgrades.length) {
+      const res = await poetryFix.poetryAdd(dir, devUpgrades, {
+        dev: true,
+      });
+      if (res.exitCode !== 0) {
+        poetryCommand = res.command;
+        throwPoetryError(res.stderr ? res.stderr : res.stdout, res.command);
+      }
+    }
+    const changes = generateSuccessfulChanges(remediation.pin);
+    handlerResult.succeeded.push({ original: entity, changes });
+  } catch (error) {
+    debug(
+      `Failed to fix ${entity.scanResult.identity.targetFile}.\nERROR: ${error}`,
+    );
+    handlerResult.failed.push({
+      original: entity,
+      error,
+      tip: poetryCommand ? `Try running \`${poetryCommand}\`` : undefined,
+    });
+  }
+  return handlerResult;
+}
+
+export function generateSuccessfulChanges(
+  pins: DependencyPins,
+): FixChangesSummary[] {
+  const changes: FixChangesSummary[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    const updatedMessage = pin.isTransitive ? 'Pinned' : 'Upgraded';
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName, version] = pkgAtVersion.split('@');
+
+    changes.push({
+      success: true,
+      userMessage: `${updatedMessage} ${pkgName} from ${version} to ${newVersion}`,
+      issueIds: pin.vulns,
+      from: pkgAtVersion,
+      to: `${pkgName}@${newVersion}`,
+    });
+  }
+  return changes;
+}
+
+export async function generateUpgrades(
+  entity: EntityToFix,
+): Promise<{ upgrades: string[]; devUpgrades: string[] }> {
+  const { remediation, targetFile } = validateRequiredData(entity);
+  const pins = remediation.pin;
+
+  const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
+  const { dir } = pathLib.parse(targetFilePath);
+  const pyProjectTomlRaw = await entity.workspace.readFile(
+    pathLib.resolve(dir, 'pyproject.toml'),
+  );
+  const pyProjectToml: PyProjectToml = toml.parse(pyProjectTomlRaw);
+
+  const prodTopLevelDeps = Object.keys(
+    pyProjectToml.tool.poetry.dependencies ?? {},
+  );
+  const devTopLevelDeps = Object.keys(
+    pyProjectToml.tool.poetry['dev-dependencies'] ?? {},
+  );
+
+  const upgrades: string[] = [];
+  const devUpgrades: string[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName] = pkgAtVersion.split('@');
+
+    const upgrade = `${standardizePackageName(pkgName)}==${newVersion}`;
+
+    if (pin.isTransitive) {
+      // transitive and it could have come from a dev or prod dep
+      // since we can't tell right now let be pinned into production deps
+      upgrades.push(upgrade);
+    } else if (prodTopLevelDeps.includes(pkgName)) {
+      upgrades.push(upgrade);
+    } else if (entity.options.dev && devTopLevelDeps.includes(pkgName)) {
+      devUpgrades.push(upgrade);
+    } else {
+      debug(
+        `Could not determine what type of upgrade ${upgrade} is. When choosing between: transitive upgrade, production or dev direct upgrade. `,
+      );
+    }
+  }
+  return { upgrades, devUpgrades };
+}
+
+function throwPoetryError(stderr: string, command?: string) {
+  const ALREADY_UP_TO_DATE = 'No dependencies to install or update';
+  const INCOMPATIBLE_PYTHON = new RegExp(
+    /Python requirement (.*) is not compatible/g,
+    'gm',
+  );
+  const match = INCOMPATIBLE_PYTHON.exec(stderr);
+  if (match) {
+    throw new CommandFailedError(
+      `The current project's Python requirement ${match[1]} is not compatible with some of the required packages`,
+      command,
+    );
+  }
+  // TODO: test this
+  if (stderr.includes(ALREADY_UP_TO_DATE)) {
+    throw new CommandFailedError(
+      'No dependencies could be updated as they seem to be at the correct versions. Make sure installed dependencies in the environment match those in the lockfile by running `poetry update`',
+      command,
+    );
+  }
+  throw new NoFixesCouldBeAppliedError();
+}

--- a/packages/snyk-fix/src/plugins/python/load-handler.ts
+++ b/packages/snyk-fix/src/plugins/python/load-handler.ts
@@ -1,5 +1,6 @@
 import { pipRequirementsTxt } from './handlers/pip-requirements';
 import { pipenvPipfile } from './handlers/pipenv-pipfile';
+import { poetry } from './handlers/poetry';
 
 import { SUPPORTED_HANDLER_TYPES } from './supported-handler-types';
 
@@ -10,6 +11,9 @@ export function loadHandler(type: SUPPORTED_HANDLER_TYPES) {
     }
     case SUPPORTED_HANDLER_TYPES.PIPFILE: {
       return pipenvPipfile;
+    }
+    case SUPPORTED_HANDLER_TYPES.POETRY: {
+      return poetry;
     }
     default: {
       throw new Error('No handler available for requested project type');

--- a/packages/snyk-fix/src/plugins/python/map-entities-per-handler-type.ts
+++ b/packages/snyk-fix/src/plugins/python/map-entities-per-handler-type.ts
@@ -19,6 +19,7 @@ export function mapEntitiesPerHandlerType(
   } = {
     [SUPPORTED_HANDLER_TYPES.REQUIREMENTS]: [],
     [SUPPORTED_HANDLER_TYPES.PIPFILE]: [],
+    [SUPPORTED_HANDLER_TYPES.POETRY]: [],
   };
 
   const skipped: Array<WithUserMessage<EntityToFix>> = [];

--- a/packages/snyk-fix/src/plugins/python/supported-handler-types.ts
+++ b/packages/snyk-fix/src/plugins/python/supported-handler-types.ts
@@ -2,4 +2,5 @@ export enum SUPPORTED_HANDLER_TYPES {
   // shortname = display name
   REQUIREMENTS = 'requirements.txt',
   PIPFILE = 'Pipfile',
+  POETRY = 'pyproject.toml',
 }

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -193,6 +193,7 @@ export interface EntityToFix {
 // add more as needed
 export interface PythonTestOptions {
   command?: string; // python interpreter to use for python tests
+  dev?: boolean;
 }
 export type CliTestOptions = PythonTestOptions;
 export interface WithError<Original> {

--- a/packages/snyk-fix/test/acceptance/plugins/package-tool-supported.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/package-tool-supported.spec.ts
@@ -1,7 +1,10 @@
 import * as pipenvPipfileFix from '@snyk/fix-pipenv-pipfile';
+import * as poetryFix from '@snyk/fix-poetry';
+
 import { checkPackageToolSupported } from '../../../src/plugins/package-tool-supported';
 
 jest.mock('@snyk/fix-pipenv-pipfile');
+jest.mock('@snyk/fix-poetry');
 
 describe('checkPackageToolSupported', () => {
   it('pipenv fix package called with correct data', async () => {
@@ -27,5 +30,29 @@ describe('checkPackageToolSupported', () => {
 
     expect(isPipenvSupportedVersionSpy).toHaveBeenCalled();
     expect(isPipenvSupportedVersionSpy).toHaveBeenCalledWith('123.123.123');
+  });
+  it('poetry fix package called with correct data', async () => {
+    // Arrange
+    const isPipenvSupportedVersionSpy = jest
+      .spyOn(poetryFix, 'isPoetrySupportedVersion')
+      .mockReturnValue({
+        supported: true,
+        versions: ['1', '2'],
+      });
+    const isPipenvInstalledSpy = jest
+      .spyOn(poetryFix, 'isPoetryInstalled')
+      .mockResolvedValue({
+        version: '3',
+      });
+
+    // Act
+    await checkPackageToolSupported('poetry', {});
+
+    // Assert
+    expect(isPipenvInstalledSpy).toHaveBeenCalled();
+    expect(isPipenvInstalledSpy).toHaveBeenNthCalledWith(1);
+
+    expect(isPipenvSupportedVersionSpy).toHaveBeenCalled();
+    expect(isPipenvSupportedVersionSpy).toHaveBeenCalledWith('3');
   });
 });

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
@@ -1,0 +1,426 @@
+import * as pathLib from 'path';
+import * as poetryFix from '@snyk/fix-poetry';
+
+import * as snykFix from '../../../../../../src';
+import {
+  generateEntityToFixWithFileReadWrite,
+  generateTestResult,
+} from '../../../../../helpers/generate-entity-to-fix';
+
+jest.mock('@snyk/fix-poetry');
+
+describe('fix Poetry Python projects', () => {
+  let poetryFixStub: jest.SpyInstance;
+  beforeAll(() => {
+    jest.spyOn(poetryFix, 'isPoetrySupportedVersion').mockReturnValue({
+      supported: true,
+      versions: ['1.1.1'],
+    });
+    jest.spyOn(poetryFix, 'isPoetryInstalled').mockResolvedValue({
+      version: '1.1.1',
+    });
+  });
+
+  beforeEach(() => {
+    poetryFixStub = jest.spyOn(poetryFix, 'poetryAdd');
+  });
+
+  afterEach(() => {
+    poetryFixStub.mockClear();
+  });
+
+  const workspacesPath = pathLib.resolve(__dirname, 'workspaces');
+
+  it('shows expected changes with lockfile in --dry-run mode', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+      dryRun: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(0);
+  });
+
+  it('Calls the plugin with expected parameters (upgrade & pin)', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: [],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(1);
+    expect(poetryFixStub.mock.calls[0]).toEqual([
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['six==2.0.1', 'transitive==1.1.1'],
+      {},
+    ]);
+  });
+
+  it('Calls the plugin with expected parameters with --dev (upgrade & pin)', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'six@1.1.6': {
+            upgradeTo: 'six@2.0.1',
+            vulns: ['VULN-six'],
+            isTransitive: false,
+          },
+          'transitive@1.0.0': {
+            upgradeTo: 'transitive@1.1.1',
+            vulns: ['vuln-transitive'],
+            isTransitive: true,
+          },
+          'json-api@0.1.21': {
+            upgradeTo: 'json-api@0.1.22',
+            vulns: ['SNYK-1'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {
+        dev: true,
+      },
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
+                },
+                {
+                  success: true,
+                  userMessage: 'Upgraded json-api from 0.1.21 to 0.1.22',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(2);
+    expect(poetryFixStub.mock.calls[0]).toEqual([
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['six==2.0.1', 'transitive==1.1.1'],
+      {},
+    ]);
+    expect(poetryFixStub.mock.calls[1]).toEqual([
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['json-api==0.1.22'],
+      {
+        dev: true,
+      },
+    ]);
+  });
+  it('pins a transitive dep', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'simple/poetry.lock';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'markupsafe@2.0.1': {
+            upgradeTo: 'markupsafe@2.1.0',
+            vulns: ['SNYK-1'],
+            isTransitive: true,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {},
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Pinned markupsafe from 2.0.1 to 2.1.0',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(1);
+    expect(poetryFixStub.mock.calls[0]).toEqual([
+      pathLib.resolve(workspacesPath, 'simple'),
+      ['markupsafe==2.1.0'],
+      {},
+    ]);
+  });
+  it.todo('--command support');
+  it('shows expected changes when updating a dev dep', async () => {
+    jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+      command: 'poetry install',
+      duration: 123,
+    });
+    // Arrange
+    const targetFile = 'with-dev-deps/pyproject.toml';
+
+    const testResult = {
+      ...generateTestResult(),
+      remediation: {
+        unresolved: [],
+        upgrade: {},
+        patch: {},
+        ignore: {},
+        pin: {
+          'json-api@0.1.21': {
+            upgradeTo: 'json-api@0.1.22',
+            vulns: ['SNYK-1'],
+            isTransitive: false,
+          },
+        },
+      },
+    };
+
+    const entityToFix = generateEntityToFixWithFileReadWrite(
+      workspacesPath,
+      targetFile,
+      testResult,
+      {
+        dev: true,
+      },
+    );
+
+    // Act
+    const result = await snykFix.fix([entityToFix], {
+      quiet: true,
+      stripAnsi: true,
+    });
+    // Assert
+    expect(result).toMatchObject({
+      exceptions: {},
+      results: {
+        python: {
+          failed: [],
+          skipped: [],
+          succeeded: [
+            {
+              original: entityToFix,
+              changes: [
+                {
+                  success: true,
+                  userMessage: 'Upgraded json-api from 0.1.21 to 0.1.22',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    expect(poetryFixStub.mock.calls).toHaveLength(1);
+    expect(poetryFixStub.mock.calls[0]).toEqual([
+      pathLib.resolve(workspacesPath, 'with-dev-deps'),
+      ['json-api==0.1.22'],
+      {
+        dev: true,
+      },
+    ]);
+  });
+
+  it.todo(
+    'upgrade fails since the env already has the right versions (full failure)',
+  );
+
+  it.todo('upgrade of dev deps fails (partial failure)');
+});

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/fails-to-lock/poetry.lock
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/fails-to-lock/poetry.lock
@@ -1,0 +1,342 @@
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
+name = "backports.functools-lru-cache"
+version = "1.6.4"
+description = "Backport of functools.lru_cache"
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-checkdocs (>=2.4)"]
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "configparser"
+version = "4.0.2"
+description = "Updated configparser from Python 3.7 for Python 2.6+."
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
+
+[[package]]
+name = "contextlib2"
+version = "0.6.0.post1"
+description = "Backports and enhancements for the contextlib module"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "django"
+version = "1.11.0"
+description = "A high-level Python Web framework that encourages rapid development and clean, pragmatic design."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pytz = "*"
+
+[package.extras]
+argon2 = ["argon2-cffi (>=16.1.0)"]
+bcrypt = ["bcrypt"]
+
+[[package]]
+name = "funcsigs"
+version = "1.0.2"
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "2.1.1"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+configparser = {version = ">=3.5", markers = "python_version < \"3\""}
+contextlib2 = {version = "*", markers = "python_version < \"3\""}
+pathlib2 = {version = "*", markers = "python_version < \"3\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+
+[[package]]
+name = "more-itertools"
+version = "5.0.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.0.0,<2.0.0"
+
+[[package]]
+name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+
+[[package]]
+name = "pathlib2"
+version = "2.3.5"
+description = "Object-oriented filesystem paths"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+scandir = {version = "*", markers = "python_version < \"3.5\""}
+six = "*"
+
+[[package]]
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pytest"
+version = "4.6.11"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\" and python_version != \"3.4\""}
+funcsigs = {version = ">=1.0", markers = "python_version < \"3.0\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+more-itertools = {version = ">=4.0.0,<6.0.0", markers = "python_version <= \"2.7\""}
+packaging = "*"
+pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+six = ">=1.10.0"
+wcwidth = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "nose", "requests", "mock"]
+
+[[package]]
+name = "pytz"
+version = "2021.1"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "scandir"
+version = "1.10.0"
+description = "scandir, a better directory iterator and faster os.walk()"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"backports.functools-lru-cache" = {version = ">=1.2.1", markers = "python_version < \"3.2\""}
+
+[[package]]
+name = "zipp"
+version = "1.2.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+contextlib2 = {version = "*", markers = "python_version < \"3.4\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "2.7"
+content-hash = "2812ca5546665a9640b6c0e9e5edaefa850f806fa09a23b35e30f395b446070c"
+
+[metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
+]
+"backports.functools-lru-cache" = [
+    {file = "backports.functools_lru_cache-1.6.4-py2.py3-none-any.whl", hash = "sha256:dbead04b9daa817909ec64e8d2855fb78feafe0b901d4568758e3a60559d8978"},
+    {file = "backports.functools_lru_cache-1.6.4.tar.gz", hash = "sha256:d5ed2169378b67d3c545e5600d363a923b09c456dab1593914935a68ad478271"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+configparser = [
+    {file = "configparser-4.0.2-py2.py3-none-any.whl", hash = "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c"},
+    {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
+]
+contextlib2 = [
+    {file = "contextlib2-0.6.0.post1-py2.py3-none-any.whl", hash = "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"},
+    {file = "contextlib2-0.6.0.post1.tar.gz", hash = "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e"},
+]
+django = [
+    {file = "Django-1.11.29-py2.py3-none-any.whl", hash = "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f"},
+    {file = "Django-1.11.29.tar.gz", hash = "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"},
+]
+funcsigs = [
+    {file = "funcsigs-1.0.2-py2.py3-none-any.whl", hash = "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"},
+    {file = "funcsigs-1.0.2.tar.gz", hash = "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-2.1.1-py2.py3-none-any.whl", hash = "sha256:c2d6341ff566f609e89a2acb2db190e5e1d23d5409d6cc8d2fe34d72443876d4"},
+    {file = "importlib_metadata-2.1.1.tar.gz", hash = "sha256:b8de9eff2b35fb037368f28a7df1df4e6436f578fa74423505b6c6a778d5b5dd"},
+]
+more-itertools = [
+    {file = "more-itertools-5.0.0.tar.gz", hash = "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4"},
+    {file = "more_itertools-5.0.0-py2-none-any.whl", hash = "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc"},
+    {file = "more_itertools-5.0.0-py3-none-any.whl", hash = "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"},
+]
+packaging = [
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+]
+pathlib2 = [
+    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
+    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-4.6.11-py2.py3-none-any.whl", hash = "sha256:a00a7d79cbbdfa9d21e7d0298392a8dd4123316bfac545075e6f8f24c94d8c97"},
+    {file = "pytest-4.6.11.tar.gz", hash = "sha256:50fa82392f2120cc3ec2ca0a75ee615be4c479e66669789771f1758332be4353"},
+]
+pytz = [
+    {file = "pytz-2021.1-py2.py3-none-any.whl", hash = "sha256:eb10ce3e7736052ed3623d49975ce333bcd712c7bb19a58b9e2089d4057d0798"},
+    {file = "pytz-2021.1.tar.gz", hash = "sha256:83a4a90894bf38e243cf052c8b58f381bfe9a7a483f6a9cab140bc7f702ac4da"},
+]
+scandir = [
+    {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
+    {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
+    {file = "scandir-1.10.0-cp34-cp34m-win32.whl", hash = "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"},
+    {file = "scandir-1.10.0-cp34-cp34m-win_amd64.whl", hash = "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"},
+    {file = "scandir-1.10.0-cp35-cp35m-win32.whl", hash = "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"},
+    {file = "scandir-1.10.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"},
+    {file = "scandir-1.10.0-cp36-cp36m-win32.whl", hash = "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"},
+    {file = "scandir-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"},
+    {file = "scandir-1.10.0-cp37-cp37m-win32.whl", hash = "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"},
+    {file = "scandir-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"},
+    {file = "scandir-1.10.0.tar.gz", hash = "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+zipp = [
+    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
+    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+]

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/fails-to-lock/pyproject.toml
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/fails-to-lock/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "fails-to-lock"
+version = "0.1.0"
+description = ""
+authors = ["ghe <lili@snyk.io>"]
+
+[tool.poetry.dependencies]
+python = "^2.7"
+Django = "1.11.0"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/non-existent/poetry.lock
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/non-existent/poetry.lock
@@ -1,0 +1,337 @@
+[[package]]
+name = "atomicwrites"
+version = "1.4.0"
+description = "Atomic file writes."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "attrs"
+version = "21.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
+name = "backports.functools-lru-cache"
+version = "1.6.4"
+description = "Backport of functools.lru_cache"
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-checkdocs (>=2.4)"]
+
+[[package]]
+name = "colorama"
+version = "0.4.1"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "configparser"
+version = "4.0.2"
+description = "Updated configparser from Python 3.7 for Python 2.6+."
+category = "dev"
+optional = false
+python-versions = ">=2.6"
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2)", "pytest-flake8", "pytest-black-multipy"]
+
+[[package]]
+name = "contextlib2"
+version = "0.6.0.post1"
+description = "Backports and enhancements for the contextlib module"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "funcsigs"
+version = "1.0.2"
+description = "Python function signatures from PEP362 for Python 2.6, 2.7 and 3.2+"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "importlib-metadata"
+version = "1.1.3"
+description = "Read metadata from Python packages"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+configparser = {version = ">=3.5", markers = "python_version < \"3\""}
+contextlib2 = {version = "*", markers = "python_version < \"3\""}
+pathlib2 = {version = "*", markers = "python_version == \"3.4.*\" or python_version < \"3\""}
+zipp = ">=0.5"
+
+[package.extras]
+docs = ["sphinx", "rst.linker"]
+testing = ["packaging", "importlib-resources"]
+
+[[package]]
+name = "more-itertools"
+version = "5.0.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+six = ">=1.0.0,<2.0.0"
+
+[[package]]
+name = "more-itertools"
+version = "7.2.0"
+description = "More routines for operating on iterables, beyond itertools"
+category = "dev"
+optional = false
+python-versions = ">=3.4"
+
+[[package]]
+name = "packaging"
+version = "20.9"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+pyparsing = ">=2.0.2"
+
+[[package]]
+name = "pathlib2"
+version = "2.3.5"
+description = "Object-oriented filesystem paths"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+scandir = {version = "*", markers = "python_version < \"3.5\""}
+six = "*"
+
+[[package]]
+name = "pluggy"
+version = "0.13.1"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.dependencies]
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+
+[[package]]
+name = "py"
+version = "1.10.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyparsing"
+version = "2.4.7"
+description = "Python parsing module"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "pytest"
+version = "4.6.11"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
+
+[package.dependencies]
+atomicwrites = ">=1.0"
+attrs = ">=17.4.0"
+colorama = [
+    {version = "*", markers = "sys_platform == \"win32\" and python_version != \"3.4\""},
+    {version = "<=0.4.1", markers = "sys_platform == \"win32\" and python_version == \"3.4\""},
+]
+funcsigs = {version = ">=1.0", markers = "python_version < \"3.0\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+more-itertools = [
+    {version = ">=4.0.0,<6.0.0", markers = "python_version <= \"2.7\""},
+    {version = ">=4.0.0", markers = "python_version > \"2.7\""},
+]
+packaging = "*"
+pathlib2 = {version = ">=2.2.0", markers = "python_version < \"3.6\""}
+pluggy = ">=0.12,<1.0"
+py = ">=1.5.0"
+six = ">=1.10.0"
+wcwidth = "*"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "nose", "requests", "mock"]
+
+[[package]]
+name = "scandir"
+version = "1.10.0"
+description = "scandir, a better directory iterator and faster os.walk()"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "wcwidth"
+version = "0.2.5"
+description = "Measures the displayed width of unicode strings in a terminal"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+"backports.functools-lru-cache" = {version = ">=1.2.1", markers = "python_version < \"3.2\""}
+
+[[package]]
+name = "zipp"
+version = "1.2.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "dev"
+optional = false
+python-versions = ">=2.7"
+
+[package.dependencies]
+contextlib2 = {version = "*", markers = "python_version < \"3.4\""}
+
+[package.extras]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "a180db292c7a500bc869ebe797d2cad708efae3e81482d2f7956cb80ac022446"
+
+[metadata.files]
+atomicwrites = [
+    {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
+    {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
+]
+attrs = [
+    {file = "attrs-21.1.0-py2.py3-none-any.whl", hash = "sha256:8ee1e5f5a1afc5b19bdfae4fdf0c35ed324074bdce3500c939842c8f818645d9"},
+    {file = "attrs-21.1.0.tar.gz", hash = "sha256:3901be1cb7c2a780f14668691474d9252c070a756be0a9ead98cfeabfa11aeb8"},
+]
+"backports.functools-lru-cache" = [
+    {file = "backports.functools_lru_cache-1.6.4-py2.py3-none-any.whl", hash = "sha256:dbead04b9daa817909ec64e8d2855fb78feafe0b901d4568758e3a60559d8978"},
+    {file = "backports.functools_lru_cache-1.6.4.tar.gz", hash = "sha256:d5ed2169378b67d3c545e5600d363a923b09c456dab1593914935a68ad478271"},
+]
+colorama = [
+    {file = "colorama-0.4.1-py2.py3-none-any.whl", hash = "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"},
+    {file = "colorama-0.4.1.tar.gz", hash = "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+configparser = [
+    {file = "configparser-4.0.2-py2.py3-none-any.whl", hash = "sha256:254c1d9c79f60c45dfde850850883d5aaa7f19a23f13561243a050d5a7c3fe4c"},
+    {file = "configparser-4.0.2.tar.gz", hash = "sha256:c7d282687a5308319bf3d2e7706e575c635b0a470342641c93bea0ea3b5331df"},
+]
+contextlib2 = [
+    {file = "contextlib2-0.6.0.post1-py2.py3-none-any.whl", hash = "sha256:3355078a159fbb44ee60ea80abd0d87b80b78c248643b49aa6d94673b413609b"},
+    {file = "contextlib2-0.6.0.post1.tar.gz", hash = "sha256:01f490098c18b19d2bd5bb5dc445b2054d2fa97f09a4280ba2c5f3c394c8162e"},
+]
+funcsigs = [
+    {file = "funcsigs-1.0.2-py2.py3-none-any.whl", hash = "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca"},
+    {file = "funcsigs-1.0.2.tar.gz", hash = "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-1.1.3-py2.py3-none-any.whl", hash = "sha256:7c7f8ac40673f507f349bef2eed21a0e5f01ddf5b2a7356a6c65eb2099b53764"},
+    {file = "importlib_metadata-1.1.3.tar.gz", hash = "sha256:7a99fb4084ffe6dae374961ba7a6521b79c1d07c658ab3a28aa264ee1d1b14e3"},
+]
+more-itertools = [
+    {file = "more-itertools-5.0.0.tar.gz", hash = "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4"},
+    {file = "more_itertools-5.0.0-py2-none-any.whl", hash = "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc"},
+    {file = "more_itertools-5.0.0-py3-none-any.whl", hash = "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"},
+    {file = "more-itertools-7.2.0.tar.gz", hash = "sha256:409cd48d4db7052af495b09dec721011634af3753ae1ef92d2b32f73a745f832"},
+    {file = "more_itertools-7.2.0-py3-none-any.whl", hash = "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"},
+]
+packaging = [
+    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
+    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+]
+pathlib2 = [
+    {file = "pathlib2-2.3.5-py2.py3-none-any.whl", hash = "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db"},
+    {file = "pathlib2-2.3.5.tar.gz", hash = "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"},
+]
+pluggy = [
+    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
+    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+]
+py = [
+    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
+    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pyparsing = [
+    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
+    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+]
+pytest = [
+    {file = "pytest-4.6.11-py2.py3-none-any.whl", hash = "sha256:a00a7d79cbbdfa9d21e7d0298392a8dd4123316bfac545075e6f8f24c94d8c97"},
+    {file = "pytest-4.6.11.tar.gz", hash = "sha256:50fa82392f2120cc3ec2ca0a75ee615be4c479e66669789771f1758332be4353"},
+]
+scandir = [
+    {file = "scandir-1.10.0-cp27-cp27m-win32.whl", hash = "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188"},
+    {file = "scandir-1.10.0-cp27-cp27m-win_amd64.whl", hash = "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"},
+    {file = "scandir-1.10.0-cp34-cp34m-win32.whl", hash = "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f"},
+    {file = "scandir-1.10.0-cp34-cp34m-win_amd64.whl", hash = "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e"},
+    {file = "scandir-1.10.0-cp35-cp35m-win32.whl", hash = "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f"},
+    {file = "scandir-1.10.0-cp35-cp35m-win_amd64.whl", hash = "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32"},
+    {file = "scandir-1.10.0-cp36-cp36m-win32.whl", hash = "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022"},
+    {file = "scandir-1.10.0-cp36-cp36m-win_amd64.whl", hash = "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4"},
+    {file = "scandir-1.10.0-cp37-cp37m-win32.whl", hash = "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173"},
+    {file = "scandir-1.10.0-cp37-cp37m-win_amd64.whl", hash = "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d"},
+    {file = "scandir-1.10.0.tar.gz", hash = "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]
+wcwidth = [
+    {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
+    {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
+]
+zipp = [
+    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
+    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+]

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/non-existent/pyproject.toml
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/non-existent/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "fails-to-lock"
+version = "0.1.0"
+description = ""
+authors = ["ghe <lili@snyk.io>"]
+
+[tool.poetry.dependencies]
+python = "*"
+
+[tool.poetry.dev-dependencies]
+pytest = "*"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/simple/poetry.lock
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/simple/poetry.lock
@@ -1,0 +1,91 @@
+[[package]]
+name = "jinja2"
+version = "2.11.2"
+description = "A very fast and expressive template engine."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.dependencies]
+MarkupSafe = ">=0.23"
+
+[package.extras]
+i18n = ["Babel (>=0.8)"]
+
+[[package]]
+name = "markupsafe"
+version = "2.0.1"
+description = "Safely add untrusted strings to HTML/XML markup."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "json-api"
+version = "0.1.21"
+description = "Make you focus on writting business logic code, just return dict data for API, or other Response directly."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6"
+content-hash = "951c297f4767e668994eeb81b2f1fd10869d12496b2a3ebb6f4a6c6d86b4fdfa"
+
+[metadata.files]
+jinja2 = [
+    {file = "Jinja2-2.11.2-py2.py3-none-any.whl", hash = "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"},
+    {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
+]
+json-api = [
+    {file = "json_api-0.1.21-py3-none-any.whl", hash = "sha256:f5e4c369e815e70a59596ce1b4921683d966bbe7a38ec8d0df57bf74492eeefb"},
+]
+markupsafe = [
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
+    {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
+    {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
+    {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
+    {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
+    {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+]

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/simple/pyproject.toml
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/simple/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.poetry]
+name = "my-package"
+version = "0.1.0"
+description = ""
+authors = ["ghe <email@email.io>"]
+
+[tool.poetry.dependencies]
+python = "*"
+six = "1.16.0"
+
+[tool.poetry.dev-dependencies]
+json-api = "0.1.21"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/with-dev-deps/poetry.lock
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/with-dev-deps/poetry.lock
@@ -1,0 +1,17 @@
+[[package]]
+name = "json-api"
+version = "0.1.21"
+description = "Make you focus on writting business logic code, just return dict data for API, or other Response directly."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "*"
+content-hash = "b032690f346f78dfe91bb1b8fcb583abcaf51fc2c3259da47f8759169bfa758d"
+
+[metadata.files]
+json-api = [
+    {file = "json_api-0.1.21-py3-none-any.whl", hash = "sha256:f5e4c369e815e70a59596ce1b4921683d966bbe7a38ec8d0df57bf74492eeefb"},
+]

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/with-dev-deps/pyproject.toml
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/workspaces/with-dev-deps/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "my-package"
+version = "0.1.0"
+description = ""
+authors = ["ghe <email@email.io>"]
+
+[tool.poetry.dependencies]
+python = "*"
+
+[tool.poetry.dev-dependencies]
+json-api = "0.1.21"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
+++ b/packages/snyk-fix/test/helpers/generate-entity-to-fix.ts
@@ -31,11 +31,14 @@ export function generateEntityToFixWithFileReadWrite(
   workspacesPath: string,
   targetFile: string,
   testResult: TestResult,
+  options: {
+    command?: string;
+    dev?: boolean;
+  } = {
+    command: 'python3',
+  },
 ): EntityToFix {
   const scanResult = generateScanResult('pip', targetFile);
-  const cliTestOptions = {
-    command: 'python3',
-  };
 
   const workspace = {
     path: workspacesPath,
@@ -52,7 +55,7 @@ export function generateEntityToFixWithFileReadWrite(
       fs.writeFileSync(fixedPath, contents, 'utf-8');
     },
   };
-  return { scanResult, testResult, workspace, options: cliTestOptions };
+  return { scanResult, testResult, workspace, options };
 }
 
 function generateWorkspace(contents: string, path?: string) {

--- a/packages/snyk-fix/test/unit/fix.spec.ts
+++ b/packages/snyk-fix/test/unit/fix.spec.ts
@@ -185,7 +185,7 @@ describe('Snyk fix', () => {
       'django===1.6.1',
     );
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore: The operand of a 'delete' operator must be optional
+    // @ts-ignore: for test purpose only
     delete txtProdProjectTestResult.testResult.remediation;
 
     // Act
@@ -258,17 +258,25 @@ describe('groupEntitiesPerScanType', () => {
       'django===1.6.1',
     );
 
+    const poetryProjectTestResult = generateEntityToFix(
+      'poetry',
+      'poetry.lock',
+      'django===1.6.1',
+    );
+
     // Act
     const res = snykFix.groupEntitiesPerScanType([
       txtProdProjectTestResult,
       txtDevProjectTestResult,
       npmProjectTestResult,
+      poetryProjectTestResult,
     ]);
 
     // Assert
-    expect(Object.keys(res).sort()).toEqual(['npm', 'pip']);
+    expect(Object.keys(res).sort()).toEqual(['npm', 'pip', 'poetry']);
     expect(res.npm).toHaveLength(1);
     expect(res.pip).toHaveLength(2);
+    expect(res.poetry).toHaveLength(1);
   });
 
   it('It correctly groups related entities per handler type with missing type', () => {
@@ -289,7 +297,7 @@ describe('groupEntitiesPerScanType', () => {
       'django===1.6.1',
     );
     // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore: The operand of a 'delete' operator must be optional
+    // @ts-ignore: for test purpose only
     delete missingProjectTestResult.scanResult.identity.type;
 
     // Act

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/get-handler-type.spec.ts
@@ -24,6 +24,15 @@ describe('getHandlerType', () => {
     const entity = generateEntityToFix('pip', 'Pipfile', '');
     expect(getHandlerType(entity)).toBe(SUPPORTED_HANDLER_TYPES.PIPFILE);
   });
+
+  it('poetry + pyproject.toml is supported project type `pyproject.toml`', () => {
+    const entity = generateEntityToFix('poetry', 'pyproject.toml', '');
+    expect(getHandlerType(entity)).toBe(SUPPORTED_HANDLER_TYPES.POETRY);
+  });
+  it('poetry + poetry.lock is supported project type `pyproject.toml`', () => {
+    const entity = generateEntityToFix('poetry', 'poetry.lock', '');
+    expect(getHandlerType(entity)).toBe(SUPPORTED_HANDLER_TYPES.POETRY);
+  });
 });
 
 describe('isRequirementsTxtManifest', () => {

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/map-entities-per-handler-type.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/pip-requirements/map-entities-per-handler-type.spec.ts
@@ -56,4 +56,31 @@ describe('getHandlerType', () => {
     ]);
     expect(res.skipped).toStrictEqual([]);
   });
+  it('Poetry pyproject.toml is supported', () => {
+    // Arrange
+    const entity = generateEntityToFix('pip', 'pyproject.toml', '');
+    // Act
+    const res = mapEntitiesPerHandlerType([entity]);
+
+    // Assert
+    expect(res.entitiesPerType[SUPPORTED_HANDLER_TYPES.POETRY]).toHaveLength(1);
+    expect(res.entitiesPerType[SUPPORTED_HANDLER_TYPES.POETRY]).toStrictEqual([
+      entity,
+    ]);
+    expect(res.skipped).toStrictEqual([]);
+  });
+
+  it('Poetry poetry.lock is supported', () => {
+    // Arrange
+    const entity = generateEntityToFix('pip', 'poetry.lock', '');
+    // Act
+    const res = mapEntitiesPerHandlerType([entity]);
+
+    // Assert
+    expect(res.entitiesPerType[SUPPORTED_HANDLER_TYPES.POETRY]).toHaveLength(1);
+    expect(res.entitiesPerType[SUPPORTED_HANDLER_TYPES.POETRY]).toStrictEqual([
+      entity,
+    ]);
+    expect(res.skipped).toStrictEqual([]);
+  });
 });

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
@@ -1,0 +1,252 @@
+import { generateUpgrades } from '../../../../../../src/plugins/python/handlers/poetry/update-dependencies';
+import { generateEntityToFix } from '../../../../../helpers/generate-entity-to-fix';
+describe('generateUpgrades', () => {
+  it('returns empty if no upgrades could be generated', async () => {
+    const manifestContents = `[tool.poetry]
+    name = "my-package"
+    version = "0.1.0"
+    description = ""
+    authors = ["ghe <email@email.io>"]
+
+    [tool.poetry.dependencies]
+    python = "*"
+
+    [tool.poetry.dev-dependencies]
+    json-api = "0.1.21"
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    `;
+
+    const entityToFix = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      manifestContents,
+    );
+
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.testResult.remediation = {
+      ignore: {},
+      patch: {},
+      pin: {},
+      unresolved: [],
+      // only pins are supported for Python
+      upgrade: {
+        'json-api@0.1.21': {
+          upgradeTo: 'json-api@0.1.22',
+          upgrades: ['json-api@0.1.22'],
+          vulns: ['pip:json-api:20170213'],
+          isTransitive: false,
+        },
+      },
+    };
+
+    const { upgrades, devUpgrades } = await generateUpgrades(entityToFix);
+    expect(devUpgrades).toEqual([]);
+    expect(upgrades).toEqual([]);
+  });
+
+  it('returns dev upgrades as expected with tested with --dev', async () => {
+    const manifestContents = `[tool.poetry]
+    name = "my-package"
+    version = "0.1.0"
+    description = ""
+    authors = ["ghe <email@email.io>"]
+
+    [tool.poetry.dependencies]
+    python = "*"
+
+    [tool.poetry.dev-dependencies]
+    json-api = "0.1.21"
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    `;
+
+    const entityToFix = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      manifestContents,
+    );
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.options = {
+      dev: true,
+    };
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.testResult.remediation = {
+      ignore: {},
+      patch: {},
+      pin: {
+        // dev dep remediation mentioned but no `--dev` options passed during test
+        'json-api@0.1.21': {
+          upgradeTo: 'json-api@0.1.22',
+          upgrades: ['json-api@0.1.22'],
+          vulns: ['pip:json-api:20170213'],
+          isTransitive: false,
+        },
+      },
+      unresolved: [],
+      upgrade: {},
+    };
+
+    const { upgrades, devUpgrades } = await generateUpgrades(entityToFix);
+    expect(devUpgrades).toEqual(['json-api==0.1.22']);
+    expect(upgrades).toEqual([]);
+  });
+
+  it('returns production upgrades only', async () => {
+    const manifestContents = `[tool.poetry]
+    name = "my-package"
+    version = "0.1.0"
+    description = ""
+    authors = ["ghe <email@email.io>"]
+
+    [tool.poetry.dependencies]
+    python = "*"
+    django = "1.1.1"
+
+    [tool.poetry.dev-dependencies]
+    json-api = "0.1.21"
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    `;
+
+    const entityToFix = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      manifestContents,
+    );
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.testResult.remediation = {
+      ignore: {},
+      patch: {},
+      pin: {
+        // dev dep remediation mentioned but no `--dev` options passed during test
+        'django@1.1.1': {
+          upgradeTo: 'django@1.3.4',
+          upgrades: ['django@1.1.1'],
+          vulns: ['pip:django:20170213'],
+          isTransitive: false,
+        },
+      },
+      unresolved: [],
+      upgrade: {},
+    };
+
+    const { upgrades, devUpgrades } = await generateUpgrades(entityToFix);
+    expect(devUpgrades).toEqual([]);
+    expect(upgrades).toEqual(['django==1.3.4']);
+  });
+
+  it('adds transitive upgrades to production upgrades', async () => {
+    const manifestContents = `[tool.poetry]
+    name = "my-package"
+    version = "0.1.0"
+    description = ""
+    authors = ["ghe <email@email.io>"]
+
+    [tool.poetry.dependencies]
+    python = "*"
+
+    [tool.poetry.dev-dependencies]
+    json-api = "0.1.21"
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    `;
+
+    const entityToFix = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      manifestContents,
+    );
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.testResult.remediation = {
+      ignore: {},
+      patch: {},
+      pin: {
+        // dev dep remediation mentioned but no `--dev` options passed during test
+        'transitive@1.1.1': {
+          upgradeTo: 'transitive@1.3.4',
+          upgrades: ['transitive@1.1.1'],
+          vulns: ['pip:django:20170213'],
+          isTransitive: true,
+        },
+      },
+      unresolved: [],
+      upgrade: {},
+    };
+
+    const { upgrades, devUpgrades } = await generateUpgrades(entityToFix);
+    expect(devUpgrades).toEqual([]);
+    expect(upgrades).toEqual(['transitive==1.3.4']);
+  });
+
+  it('correctly generated production, dev & transitive upgrades', async () => {
+    const manifestContents = `[tool.poetry]
+    name = "my-package"
+    version = "0.1.0"
+    description = ""
+    authors = ["ghe <email@email.io>"]
+
+    [tool.poetry.dependencies]
+    python = "*"
+    django = "1.1.1"
+
+
+    [tool.poetry.dev-dependencies]
+    json-api = "0.1.21"
+
+    [build-system]
+    requires = ["poetry-core>=1.0.0"]
+    build-backend = "poetry.core.masonry.api"
+    `;
+
+    const entityToFix = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      manifestContents,
+    );
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.options = {
+      dev: true,
+    };
+    // @ts-ignore: for test purpose need specific remediation
+    entityToFix.testResult.remediation = {
+      ignore: {},
+      patch: {},
+      pin: {
+        // dev dep remediation mentioned but no `--dev` options passed during test
+        'transitive@1.1.1': {
+          upgradeTo: 'transitive@1.3.4',
+          upgrades: ['transitive@1.1.1'],
+          vulns: ['pip:django:20170213'],
+          isTransitive: true,
+        },
+        'django@1.1.1': {
+          upgradeTo: 'django@1.3.4',
+          upgrades: ['django@1.1.1'],
+          vulns: ['pip:django:20170213'],
+          isTransitive: false,
+        },
+        'json-api@0.1.21': {
+          upgradeTo: 'json-api@0.1.22',
+          upgrades: ['json-api@0.1.22'],
+          vulns: ['pip:json-api:20170213'],
+          isTransitive: false,
+        },
+      },
+      unresolved: [],
+      upgrade: {},
+    };
+
+    const { upgrades, devUpgrades } = await generateUpgrades(entityToFix);
+    expect(devUpgrades).toEqual(['json-api==0.1.22']);
+    expect(upgrades).toEqual(['transitive==1.3.4', 'django==1.3.4']);
+  });
+});

--- a/packages/snyk-fix/test/unit/plugins/python/is-supported.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/is-supported.spec.ts
@@ -14,6 +14,33 @@ describe('isSupported', () => {
     const res = await isSupported(entity);
     expect(res.supported).toBeFalsy();
   });
+
+  it('with empty Pins is not supported', async () => {
+    const entity = generateEntityToFix(
+      'poetry',
+      'pyproject.toml',
+      JSON.stringify({}),
+    );
+    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
+    // @ts-ignore: for test purpose only
+    delete entity.testResult.remediation;
+    // @ts-ignore: for test purpose only
+    entity.testResult.remediation = {
+      unresolved: [],
+      upgrade: {
+        'django@1.6.1': {
+          upgradeTo: 'django@2.0.1',
+          vulns: ['vuln-id'],
+          isTransitive: false,
+        },
+      },
+      patch: {},
+      ignore: {},
+      pin: {},
+    };
+    const res = await isSupported(entity);
+    expect(res.supported).toBeFalsy();
+  });
   it('with -r directive in the manifest is supported', async () => {
     const entity = generateEntityToFix(
       'pip',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- introduce Poetry fix support to @snyk/fix
- production & development dependencies are updated separately as `poetry` is called directly to apply changes and requires a `--dev` flag to change the correct dependency section.
- `--command` is not yet supported, this is coming next (currently `snyk test` does not use any python interpreter to get to dependencies, but require using it potentially to fix issues since we invoke poetry)

#### Where should the reviewer start?
`packages/snyk-fix/src/plugins/load-plugin.ts`

#### How should this be manually tested?
`snyk fix --all-projects` on


#### Screenshots

<img width="1436" alt="CleanShot 2021-06-15 at 15 42 31@2x" src="https://user-images.githubusercontent.com/2911613/122073448-55c8cc00-cdf0-11eb-9437-4edbd8a1bbf4.png">
