### PR TITLE
fix(protect): handle package paths in quotes

### DIFF
--- a/packages/snyk-protect/src/lib/snyk-file.ts
+++ b/packages/snyk-protect/src/lib/snyk-file.ts
@@ -30,7 +30,8 @@ export function extractPatchMetadata(
               .substring(1)
               .split('>')
               .pop()
-              ?.trim();
+              ?.trim()
+              ?.replace(/['"]/g, '');
             if (!acc[writingTo].includes(destination)) {
               acc[writingTo].push(destination);
             }

--- a/packages/snyk-protect/test/fixtures/single-patchable-module/.snyk
+++ b/packages/snyk-protect/test/fixtures/single-patchable-module/.snyk
@@ -4,22 +4,22 @@ ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:
-    - tap > nyc > istanbul-lib-instrument > babel-types > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-generator > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-generator > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-traverse > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-traverse > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-template > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-template > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-generator > babel-types > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-generator > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-traverse > babel-types > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-traverse > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-template > babel-types > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-template > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > lodash':
         patched: '2021-02-17T13:43:51.857Z'
-    - tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash:
+    - 'tap > nyc > istanbul-lib-instrument > babel-template > babel-traverse > babel-types > lodash':
         patched: '2021-02-17T13:43:51.857Z'
 

--- a/packages/snyk-protect/test/unit/snyk-file.spec.ts
+++ b/packages/snyk-protect/test/unit/snyk-file.spec.ts
@@ -1,8 +1,9 @@
 import { extractPatchMetadata } from '../../src/lib/snyk-file';
 
 describe(extractPatchMetadata.name, () => {
-  it('extracts a direct dependency', () => {
-    const dotSnykFileContents = `
+  describe('extracts a single direct dependency', () => {
+    it('without quotes on package path', () => {
+      const dotSnykFileContents = `
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.19.0
 ignore: {}
@@ -12,17 +13,57 @@ patch:
     - lodash:
         patched: '2021-02-17T13:43:51.857Z'
 `;
-    const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
-    expect(snykFilePatchMetadata).toEqual([
-      {
-        vulnId: 'SNYK-JS-LODASH-567746',
-        packageName: 'lodash',
-      },
-    ]);
-  });
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
 
-  it('handles carriage returns in line endings', () => {
-    const dotSnykFileContents = `
+    it('with single quotes on package path', () => {
+      const dotSnykFileContents = `
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - 'lodash':
+        patched: '2021-02-17T13:43:51.857Z'
+`;
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
+
+    it('with double quotes on package path', () => {
+      const dotSnykFileContents = `
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - "lodash":
+        patched: '2021-02-17T13:43:51.857Z'
+`;
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
+
+    it('with carriage returns in line endings', () => {
+      const dotSnykFileContents = `
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.19.0
 ignore: {}
@@ -32,35 +73,78 @@ patch:
     - lodash:
         patched: '2021-02-17T13:43:51.857Z'
 `
-      .split('\n')
-      .join('\r\n');
-    const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
-    expect(snykFilePatchMetadata).toEqual([
-      {
-        vulnId: 'SNYK-JS-LODASH-567746',
-        packageName: 'lodash',
-      },
-    ]);
+        .split('\n')
+        .join('\r\n');
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
   });
 
-  it('extracts a transitive dependency', () => {
-    const dotSnykFileContents = `
+  describe('extracts a transitive dependency', () => {
+    it('without quotes on package path', () => {
+      const dotSnykFileContents = `
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.19.0
 ignore: {}
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-567746:
-    - tap > nyc > istanbul-lib-instrument > babel-types > lodash:
+    - 'tap > nyc > lodash':
         patched: '2021-02-17T13:43:51.857Z'
 `;
-    const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
-    expect(snykFilePatchMetadata).toEqual([
-      {
-        vulnId: 'SNYK-JS-LODASH-567746',
-        packageName: 'lodash',
-      },
-    ]);
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
+
+    it('with single quotes on package path', () => {
+      const dotSnykFileContents = `
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - 'tap > nyc > lodash':
+        patched: '2021-02-17T13:43:51.857Z'
+`;
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
+
+    it('with double quotes on package path', () => {
+      const dotSnykFileContents = `
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+ignore: {}
+# patches apply the minimum changes required to fix a vulnerability
+patch:
+  SNYK-JS-LODASH-567746:
+    - "tap > nyc > lodash":
+        patched: '2021-02-17T13:43:51.857Z'
+`;
+      const snykFilePatchMetadata = extractPatchMetadata(dotSnykFileContents);
+      expect(snykFilePatchMetadata).toEqual([
+        {
+          vulnId: 'SNYK-JS-LODASH-567746',
+          packageName: 'lodash',
+        },
+      ]);
+    });
   });
 
   it('extracts multiple transitive dependencies', () => {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Makes `@snyk/protect` handle `.snyk` files with package paths which are wrapped in either single or double quotes.

The reason for this is because our Snyk Fix PR generates `.snyk` files which have single quotes. For example: 
```
# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
version: v1.19.0
ignore: {}
# patches apply the minimum changes required to fix a vulnerability
patch:
  SNYK-JS-LODASH-567746:
    - '@snyk/patchable-dep-fixture > lodash':
        patched: '2021-06-14T22:42:43.116Z'
```
