### PR TITLE
feat(protect): add successful message for protect

### DIFF
--- a/packages/snyk-protect/src/lib/index.ts
+++ b/packages/snyk-protect/src/lib/index.ts
@@ -84,6 +84,8 @@ async function protect(projectFolderPath: string) {
     });
   });
 
+  console.log('Successfully applied Snyk patches');
+
   sendAnalytics({
     type: ProtectResultType.APPLIED_PATCHES,
     patchedModules,

--- a/packages/snyk-protect/test/acceptance/protect.spec.ts
+++ b/packages/snyk-protect/test/acceptance/protect.spec.ts
@@ -16,6 +16,7 @@ describe('@snyk/protect', () => {
 
   describe('applies patch(es)', () => {
     it('works for project with a single patchable module', async () => {
+      const log = jest.spyOn(global.console, 'log');
       const postJsonSpy = jest.spyOn(http, 'postJson');
       const project = await createProject('single-patchable-module');
       const patchedLodash = await getPatchedLodash();
@@ -26,6 +27,7 @@ describe('@snyk/protect', () => {
         project.read('node_modules/nyc/node_modules/lodash/lodash.js'),
       ).resolves.toEqual(patchedLodash);
 
+      expect(log).toHaveBeenCalledWith('Successfully applied Snyk patches');
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({
         data: {
@@ -50,6 +52,7 @@ describe('@snyk/protect', () => {
     });
 
     it('works for project with multiple patchable modules', async () => {
+      const log = jest.spyOn(global.console, 'log');
       const postJsonSpy = jest.spyOn(http, 'postJson');
       const project = await createProject('multiple-matching-paths');
       const patchedLodash = await getPatchedLodash();
@@ -63,6 +66,7 @@ describe('@snyk/protect', () => {
         project.read('node_modules/lodash/lodash.js'),
       ).resolves.toEqual(patchedLodash);
 
+      expect(log).toHaveBeenCalledWith('Successfully applied Snyk patches');
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({
         data: {


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Adds the message `Successfully applied Snyk patches`, like the original protect implementation.
