### PR TITLE
feat: support --command for Poetry fix

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
     "@snyk/fix-pipenv-pipfile": "0.5.3",
-    "@snyk/fix-poetry": "0.6.0",
+    "@snyk/fix-poetry": "0.7.0",
     "chalk": "4.1.1",
     "debug": "^4.3.1",
     "lodash.groupby": "4.6.0",

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -52,7 +52,9 @@ export async function updateDependencies(
 
     // update prod dependencies first
     if (!options.dryRun && upgrades.length) {
-      const res = await poetryFix.poetryAdd(dir, upgrades, {});
+      const res = await poetryFix.poetryAdd(dir, upgrades, {
+        python: entity.options.command ?? undefined,
+      });
       if (res.exitCode !== 0) {
         poetryCommand = res.command;
         throwPoetryError(res.stderr ? res.stderr : res.stdout, res.command);
@@ -63,6 +65,7 @@ export async function updateDependencies(
     if (!options.dryRun && devUpgrades.length) {
       const res = await poetryFix.poetryAdd(dir, devUpgrades, {
         dev: true,
+        python: entity.options.command ?? undefined,
       });
       if (res.exitCode !== 0) {
         poetryCommand = res.command;

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
@@ -177,7 +177,9 @@ describe('fix Poetry Python projects', () => {
     expect(poetryFixStub.mock.calls[0]).toEqual([
       pathLib.resolve(workspacesPath, 'simple'),
       ['six==2.0.1', 'transitive==1.1.1'],
-      {},
+      {
+        python: 'python3',
+      },
     ]);
   });
 
@@ -276,7 +278,7 @@ describe('fix Poetry Python projects', () => {
       },
     ]);
   });
-  it('pins a transitive dep', async () => {
+  it('pins a transitive dep with custom python interpreter via --command', async () => {
     jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
       exitCode: 0,
       stdout: '',
@@ -308,7 +310,9 @@ describe('fix Poetry Python projects', () => {
       workspacesPath,
       targetFile,
       testResult,
-      {},
+      {
+        command: 'python2',
+      },
     );
 
     // Act
@@ -341,10 +345,11 @@ describe('fix Poetry Python projects', () => {
     expect(poetryFixStub.mock.calls[0]).toEqual([
       pathLib.resolve(workspacesPath, 'simple'),
       ['markupsafe==2.1.0'],
-      {},
+      {
+        python: 'python2',
+      },
     ]);
   });
-  it.todo('--command support');
   it('shows expected changes when updating a dev dep', async () => {
     jest.spyOn(poetryFix, 'poetryAdd').mockResolvedValue({
       exitCode: 0,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Snyk users can provide a Python interpreter to be used for all
Python opetations via --command parameter to `snyk test` and `snyk fix`

Latest @snyk/fix-poetry package version nos supports it and expects it to be passed through as `python` parameter.

#### Screenshots

