### PR TITLE
fix: yaml parsing for IaC scans [CC-943]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -1,8 +1,4 @@
-import {
-  detectConfigType,
-  FailedToDetectYamlConfigError,
-  HelmFileNotSupportedError,
-} from './parsers/k8s-or-cloudformation-parser';
+import { detectConfigType } from './parsers/k8s-or-cloudformation-parser';
 import { tryParsingTerraformFile } from './parsers/terraform-file-parser';
 import {
   isTerraformPlan,
@@ -70,15 +66,7 @@ export function tryParseIacFile(
     case 'yaml':
     case 'yml': {
       const parsedIacFile = parseYAMLOrJSONFileData(fileData);
-      try {
-        return detectConfigType(fileData, parsedIacFile);
-      } catch (e) {
-        if (e instanceof HelmFileNotSupportedError) {
-          throw new HelmFileNotSupportedError(fileData.filePath);
-        } else {
-          throw new FailedToDetectYamlConfigError(fileData.filePath);
-        }
-      }
+      return detectConfigType(fileData, parsedIacFile);
     }
     case 'json': {
       const parsedIacFile = parseYAMLOrJSONFileData(fileData);

--- a/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
@@ -11,23 +11,10 @@ import {
 export const REQUIRED_K8S_FIELDS = ['apiVersion', 'kind', 'metadata'];
 export const REQUIRED_CLOUDFORMATION_FIELDS = ['Resources'];
 
-export function assertHelmAndThrow(fileData: IacFileData) {
-  const lines: string[] = fileData.fileContent.split(/\r\n|\r|\n/);
-
-  lines.forEach((line) => {
-    const isHelmFile = line.includes('{{') && line.includes('}}');
-    if (isHelmFile) {
-      throw new HelmFileNotSupportedError(fileData.filePath);
-    }
-  });
-}
-
 export function detectConfigType(
   fileData: IacFileData,
   parsedIacFiles: any[],
 ): IacFileParsed[] {
-  assertHelmAndThrow(fileData);
-
   return parsedIacFiles.map((parsedIaCFile, docId) => {
     if (
       checkRequiredFieldsMatch(parsedIaCFile, REQUIRED_CLOUDFORMATION_FIELDS)
@@ -64,15 +51,6 @@ export function checkRequiredFieldsMatch(
   return requiredFields.every((requiredField) =>
     parsedDocument.hasOwnProperty(requiredField),
   );
-}
-
-export class HelmFileNotSupportedError extends CustomError {
-  constructor(filename: string) {
-    super('Failed to parse Helm file');
-    this.code = IaCErrorCodes.FailedToParseHelmError;
-    this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to parse the YAML file "${filename}" as we currently do not support scanning of Helm files. More information can be found through our documentation:\nhttps://support.snyk.io/hc/en-us/articles/360012429477-Test-your-Kubernetes-files-with-our-CLI-tool`;
-  }
 }
 
 export class MissingRequiredFieldsInKubernetesYamlError extends CustomError {

--- a/src/cli/commands/test/iac-local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/yaml-parser.ts
@@ -19,7 +19,6 @@ const errorsToSkip = [
   'Insufficient indentation in flow collection',
   'Map keys must be unique',
 ];
-
 // the YAML Parser is more strict than the Golang one in Policy Engine,
 // so we decided to skip specific errors in order to be consistent.
 // this function checks if the current error is one them
@@ -30,12 +29,28 @@ export function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
   );
 }
 
+const warningsToInclude = [
+  'Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.',
+];
+// The YAML Parser is less strict than the Golang one when it comes to templating directives
+// instead it returns them as warnings
+// which we now throw on
+function shouldThrowWarningFor(doc: YAML.Document.Parsed) {
+  return (
+    doc.warnings.length !== 0 &&
+    warningsToInclude.some((e) => doc.warnings[0].message.includes(e))
+  );
+}
+
 export function parseYAMLOrJSON(fileContent: string): any[] {
   // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
   // by using this library we don't have to disambiguate between these different contents ourselves
   return YAML.parseAllDocuments(fileContent).map((doc) => {
     if (shouldThrowErrorFor(doc)) {
       throw doc.errors[0];
+    }
+    if (shouldThrowWarningFor(doc)) {
+      throw doc.warnings[0];
     }
     return doc.toJSON();
   });
@@ -55,6 +70,6 @@ export class InvalidYamlFileError extends CustomError {
     super('Failed to parse YAML file');
     this.code = IaCErrorCodes.InvalidYamlFileError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML`;
+    this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML, without any template directives`;
   }
 }

--- a/test/jest/unit/iac-unit-tests/file-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.spec.ts
@@ -34,7 +34,6 @@ import {
 } from './file-parser.fixtures';
 import { IacFileData } from '../../../../src/cli/commands/test/iac-local-execution/types';
 import { IacFileTypes } from '../../../../dist/lib/iac/constants';
-import { detectConfigType } from '../../../../src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser';
 import {
   cloudFormationJSONFileDataStub,
   cloudFormationYAMLFileDataStub,
@@ -155,18 +154,6 @@ describe('parseFiles', () => {
       expect(parsedFiles[0]).toEqual(expectedParsingResult);
     },
   );
-
-  it('throws an error for a Helm file', async () => {
-    const helmFileData: IacFileData = {
-      fileContent: ' {{ something }}',
-      filePath: 'path/to/file',
-      fileType: 'yaml',
-    };
-
-    expect(() => detectConfigType(helmFileData, [{}])).toThrowError(
-      'Failed to parse Helm file',
-    );
-  });
 
   it('throws an error for an invalid HCL file', async () => {
     expect(() => tryParsingTerraformFile(invalidTerraformFileDataStub)).toThrow(

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -69,7 +69,7 @@ Describe "Snyk iac local test command"
       When run snyk iac test ../fixtures/iac/kubernetes/helm-config.yaml
       The status should equal 2
       The output should include "We were unable to parse the YAML file"
-      The output should include "do not support scanning of Helm files"
+      The output should include "without any template directives"
     End
 
     It "outputs the expected text when running with --sarif flag"


### PR DESCRIPTION
#### What does this PR do?
This PR builds on top of https://github.com/snyk/snyk/pull/2041 and makes the yaml parser consistent with `registry`, since https://github.com/snyk/registry/pull/21629.

#### Where should the reviewer start?
The PR technically shouldn't add any new functionality other than if someone were to scan the following file (notice that the template directive is `{ {` rather than `{{`) then we now would throw an error and not allow the CLI to scan it as valid YAML. This check now makes the `assertHelmAndThrow` function redundant. The difference now is if someone uses `{{` we don't tell them we don't support Helm, only that their YAML shouldn't contain template directives.


```
apiVersion: authentication.istio.io/v1alpha1
kind: Policy
metadata:
  name: auth-policy
  namespace: istio-system
spec:
  targets:
    - name: catalog
      ports:
        - number: 5002
    - name: cart
      ports:
        - number: 5003
    - name: inventory
      ports:
        - number: 5004
    - name: rating
      ports:
        - number: 5007
  origins:
    - jwt:
        issuer: { { .Values.idp.issuer } }
        jwksUri: { { .Values.idp.jwks_uri } }
        audiences:
          - api
  principalBinding: USE_ORIGIN
---
```

#### What are the relevant tickets?

- [CC-943](https://snyksec.atlassian.net/browse/CC-943)


### Screenshots
Before:
![Screenshot 2021-06-17 at 19 21 57](https://user-images.githubusercontent.com/81559517/122452605-5785c180-cfa1-11eb-8c99-ab3d2c087d09.png)

After:
![Screenshot 2021-06-17 at 19 21 33](https://user-images.githubusercontent.com/81559517/122452615-5a80b200-cfa1-11eb-9164-e3195e5d3189.png)

