### PR TITLE
refactor: yaml parsing for IaC scans [CC-943] 

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -38,7 +38,7 @@ export async function parseFiles(
       if (filesData.length === 1) {
         throw err;
       }
-      failedFiles.push(generateFailedParsedFile(fileData, err));
+      failedFiles.push(generateFailedParsedFile(fileData, err as Error));
     }
   }
 

--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -1,4 +1,3 @@
-import * as YAML from 'yaml';
 import {
   REQUIRED_K8S_FIELDS,
   detectConfigType,
@@ -23,7 +22,7 @@ import {
 import * as analytics from '../../../../lib/analytics';
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
-import { shouldThrowErrorFor } from './file-utils';
+import { parseYAMLOrJSON } from '../../../../lib/iac/iac-parser';
 
 export async function parseFiles(
   filesData: IacFileData[],
@@ -67,14 +66,7 @@ function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
   let yamlDocuments;
 
   try {
-    // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
-    // by using this library we don't have to disambiguate between these different contents ourselves
-    yamlDocuments = YAML.parseAllDocuments(fileData.fileContent).map((doc) => {
-      if (shouldThrowErrorFor(doc)) {
-        throw doc.errors[0];
-      }
-      return doc.toJSON();
-    });
+    yamlDocuments = parseYAMLOrJSON(fileData.fileContent);
   } catch (e) {
     if (fileData.fileType === 'json') {
       throw new InvalidJsonFileError(fileData.filePath);

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -2,7 +2,6 @@ import * as fs from 'fs';
 import * as tar from 'tar';
 import * as path from 'path';
 import { FailedToInitLocalCacheError } from './local-cache';
-import * as YAML from 'yaml';
 
 export function createIacDir(): void {
   // this path will be able to be customised by the user in the future
@@ -29,19 +28,4 @@ export function extractBundle(response: NodeJS.ReadableStream): Promise<void> {
       .on('finish', resolve)
       .on('error', reject);
   });
-}
-
-const errorsToSkip = [
-  'Insufficient indentation in flow collection',
-  'Map keys must be unique',
-];
-
-// the YAML Parser is more strict than the Golang one in Policy Engine,
-// so we decided to skip specific errors in order to be consistent.
-// this function checks if the current error is one them
-export function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
-  return (
-    doc.errors.length !== 0 &&
-    !errorsToSkip.some((e) => doc.errors[0].message.includes(e))
-  );
 }

--- a/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
@@ -48,7 +48,11 @@ export function detectConfigType(
         docId,
       };
     } else {
-      throw new FailedToDetectYamlConfigError(fileData.filePath);
+      if (fileData.fileType === 'json') {
+        throw new FailedToDetectJsonConfigError(fileData.filePath);
+      } else {
+        throw new FailedToDetectYamlConfigError(fileData.filePath);
+      }
     }
   });
 }
@@ -94,5 +98,18 @@ export class FailedToDetectYamlConfigError extends CustomError {
     )}". For CloudFormation required fields are: "${REQUIRED_CLOUDFORMATION_FIELDS.join(
       '", "',
     )}". Please contact support@snyk.io, if possible with a redacted version of the file`;
+  }
+}
+
+export class FailedToDetectJsonConfigError extends CustomError {
+  constructor(filename: string) {
+    super(
+      'Failed to detect either a Kubernetes file, a CloudFormation file or a Terraform Plan, missing required fields',
+    );
+    this.code = IaCErrorCodes.FailedToDetectJsonConfigError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `We were unable to detect whether the JSON file "${filename}" is either a valid Kubernetes file, CloudFormation file or a Terraform Plan. For Kubernetes it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
+      '", "',
+    )}".  For CloudFormation required fields are: "Resources". For Terraform Plan it was expected to contain fields "planned_values.root_module" and "resource_changes". Please contact support@snyk.io, if possible with a redacted version of the file`;
   }
 }

--- a/src/cli/commands/test/iac-local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/yaml-parser.ts
@@ -1,0 +1,60 @@
+import * as YAML from 'yaml';
+import { CustomError } from '../../../../lib/errors';
+import { getErrorStringCode } from './error-utils';
+import { IaCErrorCodes, IacFileData } from './types';
+
+export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
+  try {
+    return parseYAMLOrJSON(fileData.fileContent);
+  } catch (e) {
+    if (fileData.fileType === 'json') {
+      throw new InvalidJsonFileError(fileData.filePath);
+    } else {
+      throw new InvalidYamlFileError(fileData.filePath);
+    }
+  }
+}
+
+const errorsToSkip = [
+  'Insufficient indentation in flow collection',
+  'Map keys must be unique',
+];
+
+// the YAML Parser is more strict than the Golang one in Policy Engine,
+// so we decided to skip specific errors in order to be consistent.
+// this function checks if the current error is one them
+export function shouldThrowErrorFor(doc: YAML.Document.Parsed) {
+  return (
+    doc.errors.length !== 0 &&
+    !errorsToSkip.some((e) => doc.errors[0].message.includes(e))
+  );
+}
+
+export function parseYAMLOrJSON(fileContent: string): any[] {
+  // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
+  // by using this library we don't have to disambiguate between these different contents ourselves
+  return YAML.parseAllDocuments(fileContent).map((doc) => {
+    if (shouldThrowErrorFor(doc)) {
+      throw doc.errors[0];
+    }
+    return doc.toJSON();
+  });
+}
+
+export class InvalidJsonFileError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse JSON file');
+    this.code = IaCErrorCodes.InvalidJsonFileError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `We were unable to parse the JSON file "${filename}". Please ensure that it contains properly structured JSON`;
+  }
+}
+
+export class InvalidYamlFileError extends CustomError {
+  constructor(filename: string) {
+    super('Failed to parse YAML file');
+    this.code = IaCErrorCodes.InvalidYamlFileError;
+    this.strCode = getErrorStringCode(this.code);
+    this.userMessage = `We were unable to parse the YAML file "${filename}". Please ensure that it contains properly structured YAML`;
+  }
+}

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -1,5 +1,4 @@
 //TODO(orka): take out into a new lib
-import * as YAML from 'yaml';
 import * as debugLib from 'debug';
 import {
   IllegalIacFileErrorMsg,
@@ -14,7 +13,7 @@ import {
   IacValidateTerraformResponse,
   IacValidationResponse,
 } from './constants';
-import { shouldThrowErrorFor } from '../../cli/commands/test/iac-local-execution/file-utils';
+import { parseYAMLOrJSON } from '../../cli/commands/test/iac-local-execution/yaml-parser';
 
 const debug = debugLib('snyk-detect');
 
@@ -23,17 +22,6 @@ const requiredK8SObjectFields = ['apiVersion', 'kind', 'metadata'];
 export function getFileType(filePath: string): string {
   const filePathSplit = filePath.split('.');
   return filePathSplit[filePathSplit.length - 1].toLowerCase();
-}
-
-export function parseYAMLOrJSON(fileContent: string): any[] {
-  // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
-  // by using this library we don't have to disambiguate between these different contents ourselves
-  return YAML.parseAllDocuments(fileContent).map((doc) => {
-    if (shouldThrowErrorFor(doc)) {
-      throw doc.errors[0];
-    }
-    return doc.toJSON();
-  });
 }
 
 function parseFileContent(fileContent: string, filePath: string): any {

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -25,6 +25,17 @@ export function getFileType(filePath: string): string {
   return filePathSplit[filePathSplit.length - 1].toLowerCase();
 }
 
+export function parseYAMLOrJSON(fileContent: string): any[] {
+  // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
+  // by using this library we don't have to disambiguate between these different contents ourselves
+  return YAML.parseAllDocuments(fileContent).map((doc) => {
+    if (shouldThrowErrorFor(doc)) {
+      throw doc.errors[0];
+    }
+    return doc.toJSON();
+  });
+}
+
 function parseFileContent(fileContent: string, filePath: string): any {
   const fileType = getFileType(filePath);
   switch (fileType) {
@@ -32,14 +43,7 @@ function parseFileContent(fileContent: string, filePath: string): any {
     case 'yml':
     case 'json':
       try {
-        // the YAML library can parse both YAML and JSON content, as well as content with singe/multiple YAMLs
-        // by using this library we don't have to disambiguate between these different contents ourselves
-        return YAML.parseAllDocuments(fileContent).map((doc) => {
-          if (shouldThrowErrorFor(doc)) {
-            throw doc.errors[0];
-          }
-          return doc.toJSON();
-        });
+        return parseYAMLOrJSON(fileContent);
       } catch (e) {
         if (fileType === 'json') {
           debug('Failed to parse iac config as a JSON');

--- a/test/jest/unit/iac-unit-tests/file-parser.spec.ts
+++ b/test/jest/unit/iac-unit-tests/file-parser.spec.ts
@@ -1,11 +1,11 @@
 import {
-  FailedToDetectJsonConfigError,
-  InvalidJsonFileError,
-  InvalidYamlFileError,
   UnsupportedFileTypeError,
   parseFiles,
 } from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
-import { FailedToDetectYamlConfigError } from '../../../../src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser';
+import {
+  FailedToDetectJsonConfigError,
+  FailedToDetectYamlConfigError,
+} from '../../../../src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser';
 import {
   FailedToParseTerraformFileError,
   tryParsingTerraformFile,
@@ -41,6 +41,10 @@ import {
   expectedCloudFormationJSONParsingResult,
   expectedCloudFormationYAMLParsingResult,
 } from './file-parser.cloudformation.fixtures';
+import {
+  InvalidJsonFileError,
+  InvalidYamlFileError,
+} from '../../../../src/cli/commands/test/iac-local-execution/yaml-parser';
 
 const filesToParse: IacFileData[] = [
   kubernetesYamlFileDataStub,


### PR DESCRIPTION
#### What does this PR do?
This PR is refactoring the YAML/JSON parsing logic, so it's easier to update in the future.

#### Where should the reviewer start?
The PR contains multiple commits, per type of change. The easiest way to understand the changes is by looking at each commit in order.

There are a few related changes in this PR:
1. Creating a `src/cli/commands/test/iac-local-execution/yaml-parser.ts` file to put all YAML parsing related code in, to improve readability and remove duplication.
2. Refactoring the legacy parser so it parses YAML and JSON using the same library (`yaml`), as we discovered previously that they are dealt with the same. This change was done by using the same YAML parser from stage 1.
3. Moving the Helm validation earlier, to the YALM parser, so that we don't parse unnecessarily.

#### What are the relevant tickets?

- [CC-943](https://snyksec.atlassian.net/browse/CC-943)

