### PR TITLE
Feat: snyk fix output improvement

### DIFF
--- a/packages/snyk-fix/src/index.ts
+++ b/packages/snyk-fix/src/index.ts
@@ -2,7 +2,6 @@ import * as debugLib from 'debug';
 import * as pMap from 'p-map';
 import * as ora from 'ora';
 import * as chalk from 'chalk';
-import stripAnsi = require('strip-ansi');
 
 import * as outputFormatter from './lib/output-formatters/show-results-summary';
 import { loadPlugin } from './plugins/load-plugin';

--- a/packages/snyk-fix/src/index.ts
+++ b/packages/snyk-fix/src/index.ts
@@ -54,6 +54,7 @@ export async function fix(
   const fixSummary = await outputFormatter.showResultsSummary(
     resultsByPlugin,
     exceptionsByScanType,
+    options,
   );
   const meta = extractMeta(resultsByPlugin, exceptionsByScanType);
 
@@ -70,7 +71,7 @@ export async function fix(
   return {
     results: resultsByPlugin,
     exceptions: exceptionsByScanType,
-    fixSummary: options.stripAnsi ? stripAnsi(fixSummary) : fixSummary,
+    fixSummary,
     meta,
   };
 }

--- a/packages/snyk-fix/src/lib/errors/common.ts
+++ b/packages/snyk-fix/src/lib/errors/common.ts
@@ -1,4 +1,4 @@
 export const reTryMessage =
-  'Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>';
+  'Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>';
 export const contactSupportMessage =
   'If the issue persists contact support@snyk.io';

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -27,7 +27,11 @@ export async function showResultsSummary(
   const {
     summary: overallSummary,
     count: changedCount,
-  } = generateFixedAndFailedSummary(resultsByPlugin, exceptionsByScanType);
+  } = generateFixedAndFailedSummary(
+    resultsByPlugin,
+    exceptionsByScanType,
+    options,
+  );
 
   const vulnsSummary = generateIssueSummary(
     resultsByPlugin,
@@ -36,7 +40,7 @@ export async function showResultsSummary(
   const fixedIssuesSummary = `${chalk.bold(
     calculateFixedIssues(resultsByPlugin),
   )} fixed issues`;
-  const getHelpText = chalk.red(`\n${reTryMessage}. ${contactSupportMessage}`);
+  const getHelpText = `\n${reTryMessage}. ${contactSupportMessage}`;
 
   const fixSummary = `\n${successfulFixesSummary}${
     unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
@@ -128,14 +132,19 @@ export function generateUnresolvedSummary(
 export function generateFixedAndFailedSummary(
   resultsByPlugin: FixHandlerResultByPlugin,
   exceptionsByScanType: ErrorsByEcoSystem,
+  options: FixOptions,
 ): { summary: string; count: number } {
   const sectionTitle = 'Summary:';
   const formattedTitleHeader = `${chalk.bold(sectionTitle)}`;
   const fixed = calculateFixed(resultsByPlugin);
   const failed = calculateFailed(resultsByPlugin, exceptionsByScanType);
-
+  const dryRunText = options.dryRun
+    ? chalk.hex('#EDD55E')(
+        `${PADDING_SPACE}Command run in dry run mode. Fixes are not be applied.\n`,
+      )
+    : '';
   return {
-    summary: `${formattedTitleHeader}\n\n${PADDING_SPACE}${chalk.bold.red(
+    summary: `${formattedTitleHeader}\n\n${dryRunText}${PADDING_SPACE}${chalk.bold.red(
       failed,
     )} items were not fixed\n${PADDING_SPACE}${chalk.green.bold(
       fixed,

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -37,9 +37,9 @@ export async function showResultsSummary(
     resultsByPlugin,
     exceptionsByScanType,
   );
-  const fixedIssuesSummary = `${chalk.bold(
-    calculateFixedIssues(resultsByPlugin),
-  )} fixed issues`;
+  const fixedIssueCount = calculateFixedIssues(resultsByPlugin);
+  const fixedIssuesSummary =
+    fixedIssueCount > 0 ? `${chalk.bold(fixedIssueCount)} fixed issues` : '';
   const getHelpText = `\n${reTryMessage}. ${contactSupportMessage}`;
 
   const fixSummary = `\n${successfulFixesSummary}${
@@ -140,7 +140,9 @@ export function generateFixedAndFailedSummary(
   const failed = calculateFailed(resultsByPlugin, exceptionsByScanType);
   const dryRunText = options.dryRun
     ? chalk.hex('#EDD55E')(
-        `${PADDING_SPACE}Command run in dry run mode. Fixes are not be applied.\n`,
+        `${PADDING_SPACE}Command run in ${chalk.bold(
+          'dry run',
+        )} mode. Fixes are not applied.\n`,
       )
     : '';
   const notFixedMessage =

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -46,7 +46,7 @@ export async function showResultsSummary(
     unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
   }${
     unresolvedCount || changedCount
-      ? `\n\n${overallSummary}\n${vulnsSummary}\n${PADDING_SPACE}${fixedIssuesSummary}`
+      ? `\n\n${overallSummary}${vulnsSummary}${PADDING_SPACE}${fixedIssuesSummary}`
       : ''
   }${unresolvedSummary ? `\n\n${getHelpText}` : ''}`;
 
@@ -153,11 +153,11 @@ export function generateFixedAndFailedSummary(
     fixed > 0
       ? `${PADDING_SPACE}${chalk.green.bold(
           fixed,
-        )} items were successfully fixed`
+        )} items were successfully fixed\n`
       : '';
 
   return {
-    summary: `${formattedTitleHeader}\n\n${dryRunText}${notFixedMessage}${fixedMessage}`,
+    summary: `${formattedTitleHeader}\n\n${dryRunText}${notFixedMessage}${fixedMessage}\n`,
     count: fixed + failed,
   };
 }
@@ -309,7 +309,7 @@ export function generateIssueSummary(
 
   const { count: fixableCount } = hasFixableIssues(testResults);
   const fixableIssues =
-    fixableCount > 0 ? `${chalk.bold(fixableCount)} fixable issues` : '';
+    fixableCount > 0 ? `${chalk.bold(fixableCount)} fixable issues\n` : '';
 
   return `${PADDING_SPACE}${totalIssues}\n${PADDING_SPACE}${fixableIssues}`;
 }

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -39,7 +39,9 @@ export async function showResultsSummary(
   );
   const fixedIssueCount = calculateFixedIssues(resultsByPlugin);
   const fixedIssuesSummary =
-    fixedIssueCount > 0 ? `${chalk.bold(fixedIssueCount)} fixed issues` : '';
+    fixedIssueCount > 0
+      ? `${chalk.bold(fixedIssueCount)} issues were successfully fixed`
+      : '';
   const getHelpText = `\n${reTryMessage}. ${contactSupportMessage}`;
 
   const fixSummary = `\n${successfulFixesSummary}${
@@ -302,14 +304,14 @@ export function generateIssueSummary(
     issues.push(...result.issues);
   }
 
-  let totalIssues = `${chalk.bold(getTotalIssueCount(issueData))} total issues`;
+  let totalIssues = `${chalk.bold(getTotalIssueCount(issueData))} issues`;
   if (issuesBySeverityMessage) {
     totalIssues += `: ${issuesBySeverityMessage}`;
   }
 
   const { count: fixableCount } = hasFixableIssues(testResults);
   const fixableIssues =
-    fixableCount > 0 ? `${chalk.bold(fixableCount)} fixable issues\n` : '';
+    fixableCount > 0 ? `${chalk.bold(fixableCount)} issues are fixable\n` : '';
 
   return `${PADDING_SPACE}${totalIssues}\n${PADDING_SPACE}${fixableIssues}`;
 }

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -143,12 +143,19 @@ export function generateFixedAndFailedSummary(
         `${PADDING_SPACE}Command run in dry run mode. Fixes are not be applied.\n`,
       )
     : '';
+  const notFixedMessage =
+    failed > 0
+      ? `${PADDING_SPACE}${chalk.bold.red(failed)} items were not fixed\n`
+      : '';
+  const fixedMessage =
+    fixed > 0
+      ? `${PADDING_SPACE}${chalk.green.bold(
+          fixed,
+        )} items were successfully fixed`
+      : '';
+
   return {
-    summary: `${formattedTitleHeader}\n\n${dryRunText}${PADDING_SPACE}${chalk.bold.red(
-      failed,
-    )} items were not fixed\n${PADDING_SPACE}${chalk.green.bold(
-      fixed,
-    )} items were successfully fixed`,
+    summary: `${formattedTitleHeader}\n\n${dryRunText}${notFixedMessage}${fixedMessage}`,
     count: fixed + failed,
   };
 }
@@ -299,7 +306,8 @@ export function generateIssueSummary(
   }
 
   const { count: fixableCount } = hasFixableIssues(testResults);
-  const fixableIssues = `${chalk.bold(fixableCount)} fixable issues`;
+  const fixableIssues =
+    fixableCount > 0 ? `${chalk.bold(fixableCount)} fixable issues` : '';
 
   return `${PADDING_SPACE}${totalIssues}\n${PADDING_SPACE}${fixableIssues}`;
 }

--- a/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
+++ b/packages/snyk-fix/src/lib/output-formatters/show-results-summary.ts
@@ -1,7 +1,8 @@
 import * as chalk from 'chalk';
+import stripAnsi = require('strip-ansi');
 
 import { FixHandlerResultByPlugin } from '../../plugins/types';
-import { ErrorsByEcoSystem, Issue, TestResult } from '../../types';
+import { ErrorsByEcoSystem, FixOptions, Issue, TestResult } from '../../types';
 import { contactSupportMessage, reTryMessage } from '../errors/common';
 import { convertErrorToUserMessage } from '../errors/error-to-user-message';
 import { hasFixableIssues } from '../issues/fixable-issues';
@@ -14,6 +15,7 @@ export const PADDING_SPACE = '  '; // 2 spaces
 export async function showResultsSummary(
   resultsByPlugin: FixHandlerResultByPlugin,
   exceptionsByScanType: ErrorsByEcoSystem,
+  options: FixOptions,
 ): Promise<string> {
   const successfulFixesSummary = generateSuccessfulFixesSummary(
     resultsByPlugin,
@@ -35,13 +37,16 @@ export async function showResultsSummary(
     calculateFixedIssues(resultsByPlugin),
   )} fixed issues`;
   const getHelpText = chalk.red(`\n${reTryMessage}. ${contactSupportMessage}`);
-  return `\n${successfulFixesSummary}${
+
+  const fixSummary = `\n${successfulFixesSummary}${
     unresolvedSummary ? `\n\n${unresolvedSummary}` : ''
   }${
     unresolvedCount || changedCount
       ? `\n\n${overallSummary}\n${vulnsSummary}\n${PADDING_SPACE}${fixedIssuesSummary}`
       : ''
   }${unresolvedSummary ? `\n\n${getHelpText}` : ''}`;
+
+  return options.stripAnsi ? stripAnsi(fixSummary) : fixSummary;
 }
 
 export function generateSuccessfulFixesSummary(

--- a/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pip-requirements/index.ts
@@ -106,7 +106,7 @@ async function fixAll(
         throw new NoFixesCouldBeAppliedError();
       }
 
-      // keep fixed issues unique across files that are part of the same project
+      // keep issues were successfully fixed unique across files that are part of the same project
       // the test result is for 1 entry entity.
       const uniqueIssueIds = new Set<string>();
       for (const c of changes) {

--- a/packages/snyk-fix/src/plugins/python/index.ts
+++ b/packages/snyk-fix/src/plugins/python/index.ts
@@ -47,6 +47,8 @@ export async function pythonFix(
         return;
       }
       const processingMessage = `Processing ${projectsToFix.length} ${projectType} items`;
+      const processedMessage = `Processed ${projectsToFix.length} ${projectType} items`;
+
       spinner.text = processingMessage;
       spinner.render();
 
@@ -72,7 +74,7 @@ export async function pythonFix(
         );
       }
       spinner.stopAndPersist({
-        text: processingMessage,
+        text: processedMessage,
         symbol: chalk.green('✔'),
       });
     },

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -16,6 +16,7 @@ Successful fixes:
 Summary:
 
   2 items were successfully fixed
+
   6 total issues: 2 High | 2 Medium | 2 Low
   6 fixable issues
   6 fixed issues"
@@ -39,6 +40,7 @@ Successful fixes:
 Summary:
 
   3 items were successfully fixed
+
   6 total issues: 3 High | 3 Medium
   6 fixable issues
   6 fixed issues"

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -15,7 +15,6 @@ Successful fixes:
 
 Summary:
 
-  0 items were not fixed
   2 items were successfully fixed
   6 total issues: 2 High | 2 Medium | 2 Low
   6 fixable issues
@@ -39,7 +38,6 @@ Successful fixes:
 
 Summary:
 
-  0 items were not fixed
   3 items were successfully fixed
   6 total issues: 3 High | 3 Medium
   6 fixable issues

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pip-requirements/update-dependencies/__snapshots__/update-dependencies.spec.ts.snap
@@ -17,9 +17,9 @@ Summary:
 
   2 items were successfully fixed
 
-  6 total issues: 2 High | 2 Medium | 2 Low
-  6 fixable issues
-  6 fixed issues"
+  6 issues: 2 High | 2 Medium | 2 Low
+  6 issues are fixable
+  6 issues were successfully fixed"
 `;
 
 exports[`fix *req*.txt / *.txt Python projects fixes multiple files via -r with the same name (some were already fixed) 1`] = `
@@ -41,9 +41,9 @@ Summary:
 
   3 items were successfully fixed
 
-  6 total issues: 3 High | 3 Medium
-  6 fixable issues
-  6 fixed issues"
+  6 issues: 3 High | 3 Medium
+  6 issues are fixable
+  6 issues were successfully fixed"
 `;
 
 exports[`fix *req*.txt / *.txt Python projects retains python markers 1`] = `

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
@@ -172,8 +172,7 @@ describe('fix Pipfile Python projects', () => {
     expect(result.fixSummary).toContain(
       'Tip:     Try running `pipenv install django==2.0.1 transitive==1.1.1`',
     );
-    expect(result.fixSummary).toContain('0 items were successfully fixed');
-    expect(result.fixSummary).toContain('0 fixed issues');
+    expect(result.fixSummary).toContain('✖ No successful fixes');
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
     expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
       pathLib.resolve(workspacesPath, 'with-dev-deps'),

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
@@ -246,7 +246,7 @@ describe('fix Pipfile Python projects', () => {
       '✔ Upgraded django from 1.6.1 to 2.0.1',
     );
     expect(result.fixSummary).toContain('1 items were successfully fixed');
-    expect(result.fixSummary).toContain('1 fixed issues');
+    expect(result.fixSummary).toContain('1 issues were successfully fixed');
     expect(pipenvPipfileFixStub).toHaveBeenCalledTimes(1);
     expect(pipenvPipfileFixStub.mock.calls[0]).toEqual([
       pathLib.resolve(workspacesPath, 'with-django-upgrade'),
@@ -324,6 +324,6 @@ describe('fix Pipfile Python projects', () => {
       '✔ Upgraded django from 1.6.1 to 2.0.1',
     );
     expect(result.fixSummary).toContain('1 items were successfully fixed');
-    expect(result.fixSummary).toContain('1 fixed issues');
+    expect(result.fixSummary).toContain('1 issues were successfully fixed');
   });
 });

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -74,7 +74,7 @@ Unresolved items:
 Summary:
 
   1 items were not fixed
-  0 items were successfully fixed
+
   1 total issues: 1 High
   1 fixable issues
   0 fixed issues
@@ -100,7 +100,6 @@ Successful fixes:
 
 Summary:
 
-  0 items were not fixed
   1 items were successfully fixed
   1 total issues: 1 High
   1 fixable issues
@@ -202,7 +201,6 @@ Successful fixes:
 Summary:
 
   Command run in dry run mode. Fixes are not be applied.
-  0 items were not fixed
   2 items were successfully fixed
   2 total issues: 2 High
   2 fixable issues

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -75,8 +75,8 @@ Summary:
 
   1 items were not fixed
 
-  1 total issues: 1 High
-  1 fixable issues
+  1 issues: 1 High
+  1 issues are fixable
   
 
 
@@ -102,9 +102,9 @@ Summary:
 
   1 items were successfully fixed
 
-  1 total issues: 1 High
-  1 fixable issues
-  1 fixed issues",
+  1 issues: 1 High
+  1 issues are fixable
+  1 issues were successfully fixed",
   "meta": Object {
     "failed": 0,
     "fixed": 1,
@@ -204,9 +204,9 @@ Summary:
   Command run in dry run mode. Fixes are not applied.
   2 items were successfully fixed
 
-  2 total issues: 2 High
-  2 fixable issues
-  2 fixed issues",
+  2 issues: 2 High
+  2 issues are fixable
+  2 issues were successfully fixed",
   "meta": Object {
     "failed": 0,
     "fixed": 2,

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -101,6 +101,7 @@ Successful fixes:
 Summary:
 
   1 items were successfully fixed
+
   1 total issues: 1 High
   1 fixable issues
   1 fixed issues",
@@ -202,6 +203,7 @@ Summary:
 
   Command run in dry run mode. Fixes are not applied.
   2 items were successfully fixed
+
   2 total issues: 2 High
   2 fixable issues
   2 fixed issues",

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -80,7 +80,7 @@ Summary:
   0 fixed issues
 
 
-Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
+Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
   "meta": Object {
     "failed": 1,
     "fixed": 0,
@@ -201,6 +201,7 @@ Successful fixes:
 
 Summary:
 
+  Command run in dry run mode. Fixes are not be applied.
   0 items were not fixed
   2 items were successfully fixed
   2 total issues: 2 High

--- a/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/__snapshots__/fix.spec.ts.snap
@@ -77,7 +77,7 @@ Summary:
 
   1 total issues: 1 High
   1 fixable issues
-  0 fixed issues
+  
 
 
 Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io",
@@ -200,7 +200,7 @@ Successful fixes:
 
 Summary:
 
-  Command run in dry run mode. Fixes are not be applied.
+  Command run in dry run mode. Fixes are not applied.
   2 items were successfully fixed
   2 total issues: 2 High
   2 fixable issues

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`generateFixedAndFailedSummary has failed only 1`] = `
 
   Command run in dry run mode. Fixes are not applied.
   1 items were not fixed
+
 "
 `;
 
@@ -20,13 +21,17 @@ exports[`generateFixedAndFailedSummary has fixed & failed 1`] = `
 "Summary:
 
   1 items were not fixed
-  1 items were successfully fixed"
+  1 items were successfully fixed
+
+"
 `;
 
 exports[`generateFixedAndFailedSummary has fixed only 1`] = `
 "Summary:
 
-  1 items were successfully fixed"
+  1 items were successfully fixed
+
+"
 `;
 
 exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] = `
@@ -34,7 +39,9 @@ exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] 
 
   Command run in dry run mode. Fixes are not applied.
   2 items were not fixed
-  1 items were successfully fixed"
+  1 items were successfully fixed
+
+"
 `;
 
 exports[`generateSuccessfulFixesSummary has fixed & failed 1`] = `
@@ -81,6 +88,7 @@ Summary:
 
   2 items were not fixed
   1 items were successfully fixed
+
   3 total issues: 3 High
   3 fixable issues
   1 fixed issues

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -11,9 +11,9 @@ exports[`formatIssueCountBySeverity all vuln severities present 1`] = `"1 Critic
 exports[`generateFixedAndFailedSummary has failed only 1`] = `
 "Summary:
 
-Command run in dry run mode. Fixes are not be applied.
+  Command run in dry run mode. Fixes are not be applied.
   1 items were not fixed
-  0 items were successfully fixed"
+"
 `;
 
 exports[`generateFixedAndFailedSummary has fixed & failed 1`] = `
@@ -26,14 +26,13 @@ exports[`generateFixedAndFailedSummary has fixed & failed 1`] = `
 exports[`generateFixedAndFailedSummary has fixed only 1`] = `
 "Summary:
 
-  0 items were not fixed
   1 items were successfully fixed"
 `;
 
 exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] = `
 "Summary:
 
-Command run in dry run mode. Fixes are not be applied.
+  Command run in dry run mode. Fixes are not be applied.
   2 items were not fixed
   1 items were successfully fixed"
 `;
@@ -102,7 +101,7 @@ Unresolved items:
 Summary:
 
   1 items were not fixed
-  0 items were successfully fixed
+
   1 total issues: 1 High
   1 fixable issues
   0 fixed issues

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`formatIssueCountBySeverity all vuln severities present 1`] = `"1 Critic
 exports[`generateFixedAndFailedSummary has failed only 1`] = `
 "Summary:
 
+Command run in dry run mode. Fixes are not be applied.
   1 items were not fixed
   0 items were successfully fixed"
 `;
@@ -32,6 +33,7 @@ exports[`generateFixedAndFailedSummary has fixed only 1`] = `
 exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] = `
 "Summary:
 
+Command run in dry run mode. Fixes are not be applied.
   2 items were not fixed
   1 items were successfully fixed"
 `;
@@ -85,7 +87,7 @@ Summary:
   1 fixed issues
 
 
-Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
+Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
 `;
 
 exports[`showResultsSummary has unresolved only 1`] = `
@@ -106,5 +108,5 @@ Summary:
   0 fixed issues
 
 
-Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
+Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
 `;

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -89,9 +89,9 @@ Summary:
   2 items were not fixed
   1 items were successfully fixed
 
-  3 total issues: 3 High
-  3 fixable issues
-  1 fixed issues
+  3 issues: 3 High
+  3 issues are fixable
+  1 issues were successfully fixed
 
 
 Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"
@@ -110,8 +110,8 @@ Summary:
 
   1 items were not fixed
 
-  1 total issues: 1 High
-  1 fixable issues
+  1 issues: 1 High
+  1 issues are fixable
   
 
 

--- a/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/__snapshots__/show-results-summary.spec.ts.snap
@@ -11,7 +11,7 @@ exports[`formatIssueCountBySeverity all vuln severities present 1`] = `"1 Critic
 exports[`generateFixedAndFailedSummary has failed only 1`] = `
 "Summary:
 
-  Command run in dry run mode. Fixes are not be applied.
+  Command run in dry run mode. Fixes are not applied.
   1 items were not fixed
 "
 `;
@@ -32,7 +32,7 @@ exports[`generateFixedAndFailedSummary has fixed only 1`] = `
 exports[`generateFixedAndFailedSummary has skipped & failed & plugin errors 1`] = `
 "Summary:
 
-  Command run in dry run mode. Fixes are not be applied.
+  Command run in dry run mode. Fixes are not applied.
   2 items were not fixed
   1 items were successfully fixed"
 `;
@@ -104,7 +104,7 @@ Summary:
 
   1 total issues: 1 High
   1 fixable issues
-  0 fixed issues
+  
 
 
 Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io"

--- a/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
@@ -49,7 +49,7 @@ describe('generateFixedAndFailedSummary', () => {
         skipped: [],
       },
     };
-    const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
+    const res = await generateFixedAndFailedSummary(resultsByPlugin, {}, {});
     expect(stripAnsi(res.summary)).toMatchSnapshot();
   });
 
@@ -77,7 +77,7 @@ describe('generateFixedAndFailedSummary', () => {
         skipped: [],
       },
     };
-    const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
+    const res = await generateFixedAndFailedSummary(resultsByPlugin, {}, {});
     expect(stripAnsi(res.summary)).toMatchSnapshot();
     expect(res.count).toEqual(1);
   });
@@ -100,7 +100,11 @@ describe('generateFixedAndFailedSummary', () => {
         skipped: [],
       },
     };
-    const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
+    const res = await generateFixedAndFailedSummary(
+      resultsByPlugin,
+      {},
+      { dryRun: true },
+    );
     expect(stripAnsi(res.summary)).toMatchSnapshot();
     expect(res.count).toEqual(1);
   });
@@ -146,7 +150,11 @@ describe('generateFixedAndFailedSummary', () => {
         ],
       },
     };
-    const res = await generateFixedAndFailedSummary(resultsByPlugin, {});
+    const res = await generateFixedAndFailedSummary(
+      resultsByPlugin,
+      {},
+      { dryRun: true },
+    );
     expect(stripAnsi(res.summary)).toMatchSnapshot();
     expect(res.count).toEqual(3);
   });

--- a/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
+++ b/packages/snyk-fix/test/unit/lib/output-formatters/show-results-summary.spec.ts
@@ -332,8 +332,12 @@ describe('showResultsSummary', () => {
       },
     };
 
-    const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
-    expect(stripAnsi(res)).toMatchSnapshot();
+    const res = await showResultsSummary(
+      resultsByPlugin,
+      exceptionsByScanType,
+      { stripAnsi: true },
+    );
+    expect(res).toMatchSnapshot();
   });
   it('has unresolved only', async () => {
     const entityFailed = generateEntityToFix(
@@ -355,8 +359,12 @@ describe('showResultsSummary', () => {
       },
     };
 
-    const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
-    expect(stripAnsi(res)).toMatchSnapshot();
+    const res = await showResultsSummary(
+      resultsByPlugin,
+      exceptionsByScanType,
+      { stripAnsi: true },
+    );
+    expect(res).toMatchSnapshot();
   });
   it('called with nothing to fix', async () => {
     const resultsByPlugin: FixHandlerResultByPlugin = {
@@ -368,7 +376,11 @@ describe('showResultsSummary', () => {
     };
     const exceptionsByScanType: ErrorsByEcoSystem = {};
 
-    const res = await showResultsSummary(resultsByPlugin, exceptionsByScanType);
-    expect(stripAnsi(res)).toMatchSnapshot();
+    const res = await showResultsSummary(
+      resultsByPlugin,
+      exceptionsByScanType,
+      { stripAnsi: true },
+    );
+    expect(res).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- only show summary items if at least 1 item is fixed/skipped/etc (no 0s)
- show a warning when running in `--dry-run` mode to make it clear no changes were applied
- if any items are unresolved the retry help text was showing in red, changed it to white & prefix with `Tip:`

#### Screenshots

<img width="1035" alt="CleanShot 2021-06-18 at 13 05 38@2x" src="https://user-images.githubusercontent.com/2911613/122595543-8ca51900-d060-11eb-9e4d-e6b9b530c064.png">
<img width="1037" alt="CleanShot 2021-06-24 at 11 34 15@2x" src="https://user-images.githubusercontent.com/2911613/123249254-ade28b00-d4e0-11eb-8c78-94de82962955.png">
