### PR TITLE
fix(@snyk/fix): drop prod prettier from fix packages

### DIFF
--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -40,8 +40,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@snyk/dep-graph": "^1.21.0",
-    "@snyk/fix-pipenv-pipfile": "0.5.3",
-    "@snyk/fix-poetry": "0.7.0",
+    "@snyk/fix-pipenv-pipfile": "0.5.4",
+    "@snyk/fix-poetry": "0.7.2",
     "chalk": "4.1.1",
     "debug": "^4.3.1",
     "lodash.groupby": "4.6.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bump fix packages to latest version without `prettier` listed as
a production dep
