### PR TITLE
fix: IaC SARIF output for GitHub Action [CC-957]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -128,7 +128,9 @@ function computePaths(
     // if the provided path points to a file, then the project starts at the parent folder of that file
     // and the target file was provided as the path argument
     projectPath = path.dirname(cmdPath);
-    targetFile = pathArg;
+    targetFile = path.isAbsolute(pathArg)
+      ? path.relative(process.cwd(), pathArg)
+      : pathArg;
   } else {
     // otherwise, the project starts at the provided path
     // and the target file must be the relative path from the project path to the path of the scanned file

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -133,6 +133,8 @@ export function createSarifOutputForIac(
     : pathLib.resolve('.');
   const issues = iacTestResponses.reduce((collect: ResponseIssues, res) => {
     if (res.result) {
+      // targetFile is the computed relative path of the scanned file
+      // so needs to be cleaned up before assigning to the URI
       const targetPath = res.targetFile.replace(/\\/g, '/');
       const mapped = res.result.cloudConfigResults.map((issue) => ({
         issue,

--- a/src/cli/commands/test/iac-output.ts
+++ b/src/cli/commands/test/iac-output.ts
@@ -133,7 +133,7 @@ export function createSarifOutputForIac(
     : pathLib.resolve('.');
   const issues = iacTestResponses.reduce((collect: ResponseIssues, res) => {
     if (res.result) {
-      const targetPath = pathLib.join(res.targetFile);
+      const targetPath = res.targetFile.replace(/\\/g, '/');
       const mapped = res.result.cloudConfigResults.map((issue) => ({
         issue,
         targetPath,
@@ -156,7 +156,7 @@ export function createSarifOutputForIac(
         // https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/sarif-v2.1.0-os.html#_Toc34317498
         originalUriBaseIds: {
           [PROJECT_ROOT_KEY]: {
-            uri: 'file://' + pathLib.join(basePath, '/'),
+            uri: 'file://' + pathLib.join(basePath, '/').replace(/\\/g, '/'),
             description: {
               text: 'The root directory for all project files.',
             },

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -135,33 +135,24 @@ describe('iac test --sarif-file-output', () => {
   [
     {
       location: './iac/file-output/sg_open_ssh.tf', // single file
-      expectedPhysicalLocation: path.join('iac/file-output/sg_open_ssh.tf'),
-      expectedProjectRoot:
-        'file://' + path.join(path.resolve('./test/fixtures/'), '/'),
+      expectedPhysicalLocation: 'iac/file-output/sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/',
     },
     {
       location: './iac/file-output/nested-folder', // folder with a single file
-      expectedPhysicalLocation: path.join(
-        'iac/file-output/nested-folder/sg_open_ssh.tf',
-      ),
-      expectedProjectRoot:
-        'file://' + path.join(path.resolve('./test/fixtures/'), '/'),
+      expectedPhysicalLocation: 'iac/file-output/nested-folder/sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/',
     },
     {
       location: './iac/file-output', // folder with a nested folder
-      expectedPhysicalLocation: path.join(
-        'iac/file-output/nested-folder/sg_open_ssh.tf',
-      ),
-      expectedProjectRoot:
-        'file://' + path.join(path.resolve('./test/fixtures/'), '/'),
+      expectedPhysicalLocation: 'iac/file-output/nested-folder/sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/',
     },
     {
       location: '../fixtures/iac/file-output/nested-folder', // folder nested outside running directory
-      expectedPhysicalLocation: path.join(
+      expectedPhysicalLocation:
         '../fixtures/iac/file-output/nested-folder/sg_open_ssh.tf',
-      ),
-      expectedProjectRoot:
-        'file://' + path.join(path.resolve('./test/fixtures/'), '/'),
+      expectedProjectRoot: './test/fixtures/',
     },
   ].forEach(({ location, expectedPhysicalLocation, expectedProjectRoot }) => {
     it(`returns the correct paths for provided path ${location}`, async () => {
@@ -174,13 +165,17 @@ describe('iac test --sarif-file-output', () => {
       const outputFileContents = readFileSync(sarifOutputFilename, 'utf-8');
       unlinkSync(sarifOutputFilename);
       const jsonObj = JSON.parse(outputFileContents);
-      const actualProjectRoot =
-        jsonObj?.runs?.[0].originalUriBaseIds.PROJECTROOT.uri;
-      const actualPhyisicalLocation =
+      const actualPhysicalLocation =
         jsonObj?.runs?.[0].results[0].locations[0].physicalLocation
           .artifactLocation.uri;
-      expect(actualProjectRoot).toEqual(expectedProjectRoot);
-      expect(actualPhyisicalLocation).toEqual(expectedPhysicalLocation);
+      const actualProjectRoot =
+        jsonObj?.runs?.[0].originalUriBaseIds.PROJECTROOT.uri;
+      expect(actualPhysicalLocation).toEqual(
+        path.join(expectedPhysicalLocation),
+      );
+      expect(actualProjectRoot).toEqual(
+        'file://' + path.join(path.resolve(expectedProjectRoot), '/'),
+      );
     });
   });
 });

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -135,7 +135,7 @@ describe('iac test --sarif-file-output', () => {
   [
     {
       location: './iac/file-output/sg_open_ssh.tf', // single file
-      expectedPhysicalLocation: 'iac/file-output/sg_open_ssh.tf',
+      expectedPhysicalLocation: './iac/file-output/sg_open_ssh.tf',
       expectedProjectRoot: './test/fixtures/',
     },
     {
@@ -169,11 +169,10 @@ describe('iac test --sarif-file-output', () => {
           .artifactLocation.uri;
       const actualProjectRoot =
         jsonObj?.runs?.[0].originalUriBaseIds.PROJECTROOT.uri;
-      expect(actualPhysicalLocation).toEqual(
-        path.join(expectedPhysicalLocation),
-      );
+      expect(actualPhysicalLocation).toEqual(expectedPhysicalLocation);
       expect(actualProjectRoot).toEqual(
-        'file://' + path.join(path.resolve(expectedProjectRoot), '/'),
+        'file://' +
+          path.join(path.resolve(expectedProjectRoot), '/').replace(/\\/g, '/'),
       );
     });
   });

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -140,19 +140,18 @@ describe('iac test --sarif-file-output', () => {
     },
     {
       location: './iac/file-output/nested-folder', // folder with a single file
-      expectedPhysicalLocation: 'iac/file-output/nested-folder/sg_open_ssh.tf',
-      expectedProjectRoot: './test/fixtures/',
+      expectedPhysicalLocation: 'sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/iac/file-output/nested-folder/',
     },
     {
       location: './iac/file-output', // folder with a nested folder
-      expectedPhysicalLocation: 'iac/file-output/nested-folder/sg_open_ssh.tf',
-      expectedProjectRoot: './test/fixtures/',
+      expectedPhysicalLocation: 'nested-folder/sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/iac/file-output/',
     },
     {
       location: '../fixtures/iac/file-output/nested-folder', // folder nested outside running directory
-      expectedPhysicalLocation:
-        '../fixtures/iac/file-output/nested-folder/sg_open_ssh.tf',
-      expectedProjectRoot: './test/fixtures/',
+      expectedPhysicalLocation: 'sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/iac/file-output/nested-folder/',
     },
   ].forEach(({ location, expectedPhysicalLocation, expectedProjectRoot }) => {
     it(`returns the correct paths for provided path ${location}`, async () => {

--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -134,6 +134,14 @@ describe('iac test --sarif-file-output', () => {
 
   [
     {
+      location: path.resolve(
+        './test/fixtures',
+        './iac/file-output/sg_open_ssh.tf',
+      ), // absolute location to file
+      expectedPhysicalLocation: 'iac/file-output/sg_open_ssh.tf',
+      expectedProjectRoot: './test/fixtures/',
+    },
+    {
       location: './iac/file-output/sg_open_ssh.tf', // single file
       expectedPhysicalLocation: './iac/file-output/sg_open_ssh.tf',
       expectedProjectRoot: './test/fixtures/',


### PR DESCRIPTION
#### What does this PR do?
In https://github.com/snyk/snyk/pull/1988 we fixed our GitHub Action by making the GA-ed SARIF output consistent with the legacy one. But there were still bugs left behind from the legacy output This PR completely removes all bugs to do with the file paths in the SARIF output.

#### Where should the reviewer start?
The tests have been refactored to make them easier to read, but also modified after implementing the fixes. Each commit contains its respective change to the functionality and tests, so to understand why these changes were made go through each `fix` commit.

#### How should this be manually tested?
Build using `npm run build` and clone https://github.com/teodora-sandu/test. Change directory into `nested` and run the following commands one by one. The result of these commands can be found in the attached ZIP.
```
snyk iac test --sarif-file-output=output-ga.sarif
snyk iac test --sarif-file-output=output-legacy.sarif --legacy
snyk iac test --sarif-file-output=output-ga-path.sarif .
snyk iac test --sarif-file-output=output-legacy-path.sarif --legacy .

snyk-dev iac test --sarif-file-output=output-ga.sarif
snyk-dev iac test --sarif-file-output=output-legacy.sarif --legacy
snyk-dev iac test --sarif-file-output=output-ga-path.sarif .
snyk-dev iac test --sarif-file-output=output-legacy-path.sarif --legacy .
```
If you compare the `output-ga.sarif` before and after, you'll see that the after looks exactly like the `output-ga-path.sarif`, which is the correct one, used by the GitHub action.

#### Any background context you want to provide?
- PR where the now removed FIXME was added: https://github.com/snyk/snyk/pull/1550/files
- thread explaining that URI's should use `/` in Windows instead of `\`: https://stackoverflow.com/questions/1589930/so-what-is-the-right-direction-of-the-paths-slash-or-under-windows

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CC-957

#### Screenshots
Before:
[before.zip](https://github.com/snyk/snyk/files/6702749/before.zip)
![Screenshot 2021-06-23 at 18 15 39](https://user-images.githubusercontent.com/81559517/123140418-2ac52480-d44f-11eb-8978-730e1052e5dc.png)
![Screenshot 2021-06-23 at 18 17 19](https://user-images.githubusercontent.com/81559517/123140502-44ff0280-d44f-11eb-93fc-777f49b6d392.png)
![Screenshot 2021-06-23 at 18 15 57](https://user-images.githubusercontent.com/81559517/123140426-2e58ab80-d44f-11eb-8e84-cbc5540524b4.png)

After:
[after.zip](https://github.com/snyk/snyk/files/6702750/after.zip)
![Screenshot 2021-06-23 at 18 15 16](https://user-images.githubusercontent.com/81559517/123140407-28fb6100-d44f-11eb-9e90-9be51e7f1081.png)
![Screenshot 2021-06-23 at 18 17 10](https://user-images.githubusercontent.com/81559517/123140497-43353f00-d44f-11eb-8b09-5ea7ec6e6ddf.png)
![Screenshot 2021-06-23 at 18 16 10](https://user-images.githubusercontent.com/81559517/123140432-2f89d880-d44f-11eb-9d0a-f2befe2d8e0c.png)



