### PR TITLE
feat: ignore unrecognised IaC types [CC-947]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/file-parser.ts
@@ -1,5 +1,6 @@
 import { detectConfigType } from './parsers/k8s-or-cloudformation-parser';
 import { tryParsingTerraformFile } from './parsers/terraform-file-parser';
+import { NoFilesToScanError } from './file-loader';
 import {
   isTerraformPlan,
   tryParsingTerraformPlan,
@@ -34,6 +35,10 @@ export async function parseFiles(
       }
       failedFiles.push(generateFailedParsedFile(fileData, err));
     }
+  }
+
+  if (parsedFiles.length === 0) {
+    throw new NoFilesToScanError();
   }
 
   return {

--- a/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/k8s-or-cloudformation-parser.ts
@@ -1,12 +1,5 @@
-import { CustomError } from '../../../../../lib/errors';
 import { IacProjectType } from '../../../../../lib/iac/constants';
-import { getErrorStringCode } from '../error-utils';
-import {
-  EngineType,
-  IaCErrorCodes,
-  IacFileData,
-  IacFileParsed,
-} from '../types';
+import { EngineType, IacFileData, IacFileParsed } from '../types';
 
 export const REQUIRED_K8S_FIELDS = ['apiVersion', 'kind', 'metadata'];
 export const REQUIRED_CLOUDFORMATION_FIELDS = ['Resources'];
@@ -15,79 +8,41 @@ export function detectConfigType(
   fileData: IacFileData,
   parsedIacFiles: any[],
 ): IacFileParsed[] {
-  return parsedIacFiles.map((parsedIaCFile, docId) => {
-    if (
-      checkRequiredFieldsMatch(parsedIaCFile, REQUIRED_CLOUDFORMATION_FIELDS)
-    ) {
-      return {
-        ...fileData,
-        jsonContent: parsedIaCFile,
-        projectType: IacProjectType.CLOUDFORMATION,
-        engineType: EngineType.CloudFormation,
-        docId,
-      };
-    } else if (checkRequiredFieldsMatch(parsedIaCFile, REQUIRED_K8S_FIELDS)) {
-      return {
-        ...fileData,
-        jsonContent: parsedIaCFile,
-        projectType: IacProjectType.K8S,
-        engineType: EngineType.Kubernetes,
-        docId,
-      };
-    } else {
-      if (fileData.fileType === 'json') {
-        throw new FailedToDetectJsonConfigError(fileData.filePath);
+  return parsedIacFiles
+    .map((parsedFile, docId): IacFileParsed | null => {
+      if (
+        checkRequiredFieldsMatch(parsedFile, REQUIRED_CLOUDFORMATION_FIELDS)
+      ) {
+        return {
+          ...fileData,
+          jsonContent: parsedFile,
+          projectType: IacProjectType.CLOUDFORMATION,
+          engineType: EngineType.CloudFormation,
+          docId,
+        };
+      } else if (checkRequiredFieldsMatch(parsedFile, REQUIRED_K8S_FIELDS)) {
+        return {
+          ...fileData,
+          jsonContent: parsedFile,
+          projectType: IacProjectType.K8S,
+          engineType: EngineType.Kubernetes,
+          docId,
+        };
       } else {
-        throw new FailedToDetectYamlConfigError(fileData.filePath);
+        return null;
       }
-    }
-  });
+    })
+    .filter((f): f is IacFileParsed => !!f);
 }
 
 export function checkRequiredFieldsMatch(
   parsedDocument: any,
   requiredFields: string[],
-) {
+): boolean {
+  if (!parsedDocument) {
+    return false;
+  }
   return requiredFields.every((requiredField) =>
     parsedDocument.hasOwnProperty(requiredField),
   );
-}
-
-export class MissingRequiredFieldsInKubernetesYamlError extends CustomError {
-  constructor(filename: string) {
-    super('Failed to detect Kubernetes file, missing required fields');
-    this.code = IaCErrorCodes.MissingRequiredFieldsInKubernetesYamlError;
-    this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to detect whether the YAML file "${filename}" is a valid Kubernetes file, it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
-      '", "',
-    )}"`;
-  }
-}
-
-export class FailedToDetectYamlConfigError extends CustomError {
-  constructor(filename: string) {
-    super(
-      'Failed to detect either a Kubernetes or CloudFormation file, missing required fields',
-    );
-    this.code = IaCErrorCodes.FailedToDetectYamlConfigError;
-    this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to detect whether the YAML file "${filename}" is a valid Kubernetes or CloudFormation file. For Kubernetes required fields are: "${REQUIRED_K8S_FIELDS.join(
-      '", "',
-    )}". For CloudFormation required fields are: "${REQUIRED_CLOUDFORMATION_FIELDS.join(
-      '", "',
-    )}". Please contact support@snyk.io, if possible with a redacted version of the file`;
-  }
-}
-
-export class FailedToDetectJsonConfigError extends CustomError {
-  constructor(filename: string) {
-    super(
-      'Failed to detect either a Kubernetes file, a CloudFormation file or a Terraform Plan, missing required fields',
-    );
-    this.code = IaCErrorCodes.FailedToDetectJsonConfigError;
-    this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `We were unable to detect whether the JSON file "${filename}" is either a valid Kubernetes file, CloudFormation file or a Terraform Plan. For Kubernetes it is missing the following fields: "${REQUIRED_K8S_FIELDS.join(
-      '", "',
-    )}".  For CloudFormation required fields are: "Resources". For Terraform Plan it was expected to contain fields "planned_values.root_module" and "resource_changes". Please contact support@snyk.io, if possible with a redacted version of the file`;
-  }
 }

--- a/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
+++ b/test/smoke/spec/iac/snyk_test_local_exec_spec.sh
@@ -59,10 +59,10 @@ Describe "Snyk iac local test command"
       The output should include "introduced by"
     End
 
-    It "outputs an error for files with no valid k8s objects"
+    It "ignores files with no recognised config types"
       When run snyk iac test ../fixtures/iac/kubernetes/pod-invalid.yaml
       The status should equal 2
-      The output should include "We were unable to detect whether the YAML file"
+      The output should include "Could not find any valid infrastructure as code files."
     End
 
     It "outputs an error for Helm files"
@@ -218,7 +218,7 @@ Describe "Snyk iac local test command"
       The output should include "Failed to parse Terraform file"
     End
 
-    It "finds issues in a directory with Kubernetes files"
+    It "finds issues in a directory with Kubernetes files, ignoring unrecognised config types"
       When run snyk iac test ../fixtures/iac/kubernetes/
       The status should equal 1 # issues found
       # First File
@@ -228,9 +228,8 @@ Describe "Snyk iac local test command"
       The output should include "introduced by"
       The output should include "Tested pod-privileged.yaml for known issues, found"
 
-      # Second File
-      The output should include "Testing pod-invalid.yaml..."
-      The output should include "Failed to detect either a Kubernetes or CloudFormation file, missing required fields"
+      # pod-invalid.yaml, in the fixture directory, is not detected as
+      # Kubernetes and produces no output.
     End
 
     It "limits the depth of the directories"


### PR DESCRIPTION

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

ignore unrecognised IaC types

No longer return an error when scanning YAML or JSON files that do not
contain recognised infrastructure as code schemas, e.g. Kubernetes or
CloudFormation. Instead, ignore these files.

In YAML files that contain multiple documents, ignore documents that
contain unrecognised schemas. This includes empty documents.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?

I discovered while implementing this that mixed-recognised-config-type multi-doc yaml files were already supported: e.g. when scanning a 2-doc yaml file that contains a valid kubernetes manifest in 1 doc, and a valid cloudformation config in the other, issues are returned for both. This PR does not break this behaviour, although I suspect it was always undefined and I haven't added a test case for it.

In https://snyksec.atlassian.net/browse/CC-947 and https://docs.google.com/document/d/1IX6il8FN50Tv1bzEg9VvLfkvNTLz2jcyVbl4ceYscWo/edit#, we've had a fair amount of back and forth on what to do about unrecognised config types. This PR just moves such files from error cases to ignored, it doesn't print out a list/count of skipped json/yaml files.

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CC-947

#### Screenshots


#### Additional questions
