### PR TITLE
feat: support c++ unmanaged scanning

### DIFF
--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -7,10 +7,10 @@ interface ModeData {
 }
 
 const modes: Record<string, ModeData> = {
-  source: {
+  unmanaged: {
     allowedCommands: ['test', 'monitor'],
     config: (args): [] => {
-      args['source'] = true;
+      args['unmanaged'] = true;
       return args;
     },
   },

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,160 @@
+import { v4 as uuidv4 } from 'uuid';
+const snyk = require('../lib');
+const config = require('./config');
+const version = require('./version');
+const request = require('./request');
+const {
+  getIntegrationName,
+  getIntegrationVersion,
+  getIntegrationEnvironment,
+  getIntegrationEnvironmentVersion,
+  getCommandVersion,
+} = require('./analytics-sources');
+const isCI = require('./is-ci').isCI;
+const debug = require('debug')('snyk');
+const os = require('os');
+const osName = require('os-name');
+const crypto = require('crypto');
+const stripAnsi = require('strip-ansi');
+import * as needle from 'needle';
+const { MetricsCollector } = require('./metrics');
+
+const metadata = {};
+// analytics module is required at the beginning of the CLI run cycle
+const startTime = Date.now();
+
+/**
+ *
+ * @param data the data to merge into that data which has been staged thus far (with the {@link add} function)
+ * and then sent to the backend.
+ */
+export function addDataAndSend(
+  data,
+): Promise<void | { res: needle.NeedleResponse; body: any }> {
+  if (!data) {
+    data = {};
+  }
+
+  // merge any new data with data we picked up along the way
+  if (Array.isArray(data.args)) {
+    // this is an overhang from the cli/args.js and we don't want it
+    delete (data.args.slice(-1).pop() || {})._;
+  }
+
+  if (Object.keys(metadata).length) {
+    data.metadata = metadata;
+  }
+
+  return postAnalytics(data);
+}
+
+export function allowAnalytics(): boolean {
+  if (snyk.config.get('disable-analytics') || config.DISABLE_ANALYTICS) {
+    return false;
+  } else {
+    return true;
+  }
+}
+
+/**
+ * Actually send the analytics to the backend. This can be used standalone to send only the data
+ * given by the data parameter, or called from {@link addDataAndSend}.
+ * @param data the analytics data to send to the backend.
+ */
+export function postAnalytics(
+  data,
+): Promise<void | { res: needle.NeedleResponse; body: any }> {
+  // if the user opt'ed out of analytics, then let's bail out early
+  // ths applies to all sending to protect user's privacy
+
+  const isStandalone = version.isStandaloneBuild();
+
+  // get snyk version
+  return version
+    .getVersion()
+    .then(async (version) => {
+      data.version = version;
+      data.os = osName(os.platform(), os.release());
+      data.nodeVersion = process.version;
+      data.standalone = isStandalone;
+      data.integrationName = getIntegrationName(data.args);
+      data.integrationVersion = getIntegrationVersion(data.args);
+      data.integrationEnvironment = getIntegrationEnvironment(data.args);
+      data.integrationEnvironmentVersion = getIntegrationEnvironmentVersion(
+        data.args,
+      );
+
+      const seed = uuidv4();
+      const shasum = crypto.createHash('sha1');
+      data.id = shasum.update(seed).digest('hex');
+
+      const headers = {};
+      if (snyk.api) {
+        headers['authorization'] = 'token ' + snyk.api;
+      }
+
+      data.ci = isCI();
+
+      data.environment = {};
+      if (!isStandalone) {
+        data.environment.npmVersion = await getCommandVersion('npm');
+      }
+
+      data.durationMs = Date.now() - startTime;
+
+      try {
+        const networkTime = MetricsCollector.NETWORK_TIME.getTotal();
+        const cpuTime = data.durationMs - networkTime;
+        MetricsCollector.CPU_TIME.createInstance().setValue(cpuTime);
+        data.metrics = MetricsCollector.getAllMetrics();
+      } catch (err) {
+        debug('Error with metrics', err);
+      }
+
+      const queryStringParams = {};
+      if (data.org) {
+        queryStringParams['org'] = data.org;
+      }
+
+      debug('analytics', JSON.stringify(data, null, '  '));
+
+      const queryString =
+        Object.keys(queryStringParams).length > 0
+          ? queryStringParams
+          : undefined;
+
+      return request({
+        body: {
+          data: data,
+        },
+        qs: queryString,
+        url: config.API + '/analytics/cli',
+        json: true,
+        method: 'post',
+        headers: headers,
+      });
+    })
+    .catch((error) => {
+      debug('analytics', error); // this swallows the analytics error
+    });
+}
+
+/**
+ * Adds a key-value pair to the analytics data `metadata` field. This doesn't send the analytis, just stages it for
+ * sending later (via the {@link addDataAndSend} function).
+ * @param key
+ * @param value
+ */
+export function add(key, value) {
+  if (typeof value === 'string') {
+    value = stripAnsi(value);
+  }
+  if (metadata[key]) {
+    if (!Array.isArray(metadata[key])) {
+      metadata[key] = [metadata[key]];
+    }
+    metadata[key].push(value);
+  } else {
+    metadata[key] = value;
+  }
+}

--- a/src/lib/ecosystems/index.ts
+++ b/src/lib/ecosystems/index.ts
@@ -14,7 +14,7 @@ export { getPlugin } from './plugins';
  * hence this is in a separate function from getEcosystem().
  */
 export function getEcosystemForTest(options: Options): Ecosystem | null {
-  if (options.source) {
+  if (options.unmanaged) {
     return 'cpp';
   }
   if (options.code) {
@@ -24,7 +24,7 @@ export function getEcosystemForTest(options: Options): Ecosystem | null {
 }
 
 export function getEcosystem(options: Options): Ecosystem | null {
-  if (options.source) {
+  if (options.unmanaged) {
     return 'cpp';
   }
 

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -219,7 +219,8 @@ export async function getFormattedMonitorOutput(
           : 'Unknown error occurred.';
 
       return (
-        chalk.bold.white('\nMonitoring ' + res.path + '...\n\n') + errorMessage
+        chalk.bold.white('\nCould not monitor your project...\n\n') +
+        errorMessage
       );
     })
     .join('\n' + SEPARATOR);

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -25,6 +25,7 @@ import {
 } from './types';
 import { findAndLoadPolicyForScanResult } from './policy';
 import { getAuthHeader } from '../api-token';
+import { resolveAndMonitorFacts } from './resolve-monitor-facts';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -58,14 +59,30 @@ export async function monitorEcosystem(
       spinner.clearAll();
     }
   }
-  const [monitorResults, errors] = await monitorDependencies(
+
+  const [
+    monitorResults,
+    errors,
+  ] = await selectAndTriggerMonitorDependenciesStrategy(
+    ecosystem,
     scanResultsByPath,
     options,
   );
+
   return [monitorResults, errors];
 }
 
-async function generateMonitorDependenciesRequest(
+async function selectAndTriggerMonitorDependenciesStrategy(
+  ecosystem: Ecosystem,
+  scanResultsByPath: { [dir: string]: ScanResult[] },
+  options: Options,
+) {
+  return ecosystem === 'cpp'
+    ? await resolveAndMonitorFacts(ecosystem, scanResultsByPath, options)
+    : await monitorDependencies(scanResultsByPath, options);
+}
+
+export async function generateMonitorDependenciesRequest(
   scanResult: ScanResult,
   options: Options,
 ): Promise<MonitorDependenciesRequest> {

--- a/src/lib/ecosystems/plugin-analytics.ts
+++ b/src/lib/ecosystems/plugin-analytics.ts
@@ -1,8 +1,18 @@
 import { Analytics } from './types';
 import * as analytics from '../../lib/analytics';
 
-export function extractAndApplyPluginAnalytics(pluginAnalytics: Analytics[]) {
+export function extractAndApplyPluginAnalytics(
+  pluginAnalytics: Analytics[],
+  asyncRequestToken?: string,
+) {
+  trackAsyncRequestAnalytics(asyncRequestToken);
   for (const { name, data } of pluginAnalytics) {
     analytics.add(name, data);
+  }
+}
+
+async function trackAsyncRequestAnalytics(asyncRequestToken?: string) {
+  if (asyncRequestToken) {
+    analytics.add('asyncRequestToken', asyncRequestToken);
   }
 }

--- a/src/lib/ecosystems/plugin-analytics.ts
+++ b/src/lib/ecosystems/plugin-analytics.ts
@@ -1,0 +1,8 @@
+import { Analytics } from './types';
+import * as analytics from '../../lib/analytics';
+
+export function extractAndApplyPluginAnalytics(pluginAnalytics: Analytics[]) {
+  for (const { name, data } of pluginAnalytics) {
+    analytics.add(name, data);
+  }
+}

--- a/src/lib/ecosystems/polling/polling-monitor.ts
+++ b/src/lib/ecosystems/polling/polling-monitor.ts
@@ -1,0 +1,103 @@
+import * as config from '../../config';
+import { isCI } from '../../is-ci';
+import { makeRequest } from '../../request/promise';
+import { Options } from '../../types';
+
+import { assembleQueryString } from '../../snyk-test/common';
+import { getAuthHeader } from '../../api-token';
+import { ScanResult } from '../types';
+import { sleep } from '../../common';
+import { ResolveAndMonitorFactsResponse } from './types';
+
+export async function requestMonitorPollingToken(
+  options: Options,
+  isAsync: boolean,
+  scanResult: ScanResult,
+): Promise<ResolveAndMonitorFactsResponse> {
+  if (scanResult?.target && scanResult.target['remoteUrl'] === '') {
+    scanResult.target['remoteUrl'] = scanResult.name;
+  }
+  const payload = {
+    method: 'PUT',
+    url: `${config.API}/monitor-dependencies`,
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: getAuthHeader(),
+    },
+    body: {
+      isAsync,
+      scanResult,
+    },
+    qs: assembleQueryString(options),
+  };
+  const response = await makeRequest<ResolveAndMonitorFactsResponse>(payload);
+  return response;
+}
+
+export async function pollingMonitorWithTokenUntilDone(
+  token: string,
+  type: string,
+  options: Options,
+  pollInterval: number,
+  attemptsCount: number,
+  maxAttempts = Infinity,
+  resolutionMeta,
+): Promise<ResolveAndMonitorFactsResponse> {
+  const payload = {
+    method: 'PUT',
+    url: `${config.API}/monitor-dependencies/${token}`,
+    json: true,
+    headers: {
+      'x-is-ci': isCI(),
+      authorization: getAuthHeader(),
+    },
+    qs: { ...assembleQueryString(options), type },
+    body: {
+      resolutionMeta,
+      method: 'cli',
+      projectName:
+        resolutionMeta?.meta ||
+        options['project-name'] ||
+        config.PROJECT_NAME ||
+        undefined, // // move to plugin
+    },
+  };
+
+  const response = await makeRequest<ResolveAndMonitorFactsResponse>(payload);
+
+  const taskCompleted = (response as any).ok && (response as any).isMonitored;
+  if (taskCompleted) {
+    return response;
+  }
+
+  attemptsCount++;
+  checkPollingAttempts(maxAttempts)(attemptsCount);
+  await sleep(pollInterval);
+  return await pollingMonitorWithTokenUntilDone(
+    token,
+    type,
+    options,
+    pollInterval,
+    attemptsCount,
+    maxAttempts,
+    resolutionMeta,
+  );
+}
+
+function checkPollingAttempts(maxAttempts: number) {
+  return (attemptsCount: number) => {
+    if (attemptsCount > maxAttempts) {
+      throw new Error('Exceeded Polling maxAttempts');
+    }
+  };
+}
+
+function pollingMonitorRequestHasFailed(
+  response: ResolveAndMonitorFactsResponse,
+): boolean {
+  const { token, result, meta, status, error, code, message } = response;
+  const hasError = !!error && !!code && !!message;
+  const pollingContextIsMissing = !token && !result && !meta && !status;
+  return !!pollingContextIsMissing || hasError;
+}

--- a/src/lib/ecosystems/polling/types.ts
+++ b/src/lib/ecosystems/polling/types.ts
@@ -1,0 +1,50 @@
+import {
+  TestDepGraphMeta,
+  TestDependenciesResult,
+} from '../../snyk-test/legacy';
+import {
+  MonitorDependenciesResponse,
+  GitTarget,
+  ContainerTarget,
+} from '../types';
+
+type ResolveFactsStatus = 'CANCELLED' | 'ERROR' | 'PENDING' | 'RUNNING' | 'OK';
+
+interface PollingTask {
+  pollInterval: number;
+  maxAttempts: number;
+}
+
+export interface ResolveAndTestFactsResponse {
+  token: string;
+  pollingTask: PollingTask;
+  result?: TestDependenciesResult;
+  meta?: TestDepGraphMeta;
+  status?: ResolveFactsStatus;
+  code?: number;
+  error?: string;
+  message?: string;
+  userMessage?: string;
+  resolutionMeta?: ResolutionMeta | undefined;
+}
+
+export interface ResolveAndMonitorFactsResponse {
+  token: string;
+  pollingTask: PollingTask;
+  result?: MonitorDependenciesResponse;
+  meta?: TestDepGraphMeta;
+  status?: ResolveFactsStatus;
+  code?: number;
+  error?: string;
+  message?: string;
+  userMessage?: string;
+  resolutionMeta?: ResolutionMeta | undefined;
+}
+
+export interface ResolutionMeta {
+  name: string | undefined;
+  identity: {
+    type: string;
+  };
+  target?: GitTarget | ContainerTarget;
+}

--- a/src/lib/ecosystems/resolve-monitor-facts.ts
+++ b/src/lib/ecosystems/resolve-monitor-facts.ts
@@ -1,0 +1,68 @@
+import { Options } from '../types';
+import * as spinner from '../../lib/spinner';
+import {
+  Ecosystem,
+  ScanResult,
+  EcosystemMonitorError,
+  EcosystemMonitorResult,
+} from './types';
+import {
+  requestMonitorPollingToken,
+  pollingMonitorWithTokenUntilDone,
+} from './polling/polling-monitor';
+import { extractAndApplyPluginAnalytics } from './plugin-analytics';
+import { AuthFailedError, MonitorError } from '../errors';
+
+export async function resolveAndMonitorFacts(
+  ecosystem: Ecosystem,
+  scans: {
+    [dir: string]: ScanResult[];
+  },
+  options: Options,
+): Promise<[EcosystemMonitorResult[], EcosystemMonitorError[]]> {
+  const results: EcosystemMonitorResult[] = [];
+  const errors: EcosystemMonitorError[] = [];
+
+  for (const [path, scanResults] of Object.entries(scans)) {
+    await spinner(`Resolving and Monitoring fileSignatures in ${path}`);
+    for (const scanResult of scanResults) {
+      try {
+        if (scanResult.analytics) {
+          extractAndApplyPluginAnalytics(scanResult.analytics);
+        }
+        const res = await requestMonitorPollingToken(options, true, scanResult);
+        const { maxAttempts, pollInterval } = res.pollingTask;
+        const attemptsCount = 0;
+
+        const response = await pollingMonitorWithTokenUntilDone(
+          res.token,
+          ecosystem,
+          options,
+          pollInterval,
+          attemptsCount,
+          maxAttempts,
+          res.resolutionMeta,
+        );
+
+        if (response) {
+          results.push({ ...(response as any), path, scanResult });
+        }
+      } catch (error) {
+        if (error.code === 401) {
+          throw AuthFailedError();
+        }
+        if (error.code >= 400 && error.code < 500) {
+          throw new MonitorError(error.code, error.message);
+        }
+
+        errors.push({
+          error: 'Could not monitor dependencies in ' + path,
+          path,
+          scanResult,
+        });
+      }
+    }
+  }
+  spinner.clearAll();
+  return [results, errors];
+}

--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -2,6 +2,7 @@ import { Options } from '../types';
 import * as spinner from '../../lib/spinner';
 import { Ecosystem, ScanResult, TestResult } from './types';
 import { pollingWithTokenUntilDone, requestPollingToken } from './polling';
+import { extractAndApplyPluginAnalytics } from './plugin-analytics';
 
 export async function resolveAndTestFacts(
   ecosystem: Ecosystem,
@@ -17,6 +18,9 @@ export async function resolveAndTestFacts(
     await spinner(`Resolving and Testing fileSignatures in ${path}`);
     for (const scanResult of scanResults) {
       try {
+        if (scanResult.analytics) {
+          extractAndApplyPluginAnalytics(scanResult.analytics);
+        }
         const res = await requestPollingToken(options, true, scanResult);
         const { maxAttempts, pollInterval } = res.pollingTask;
         const attemptsCount = 0;

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -1,6 +1,6 @@
 import { DepGraphData } from '@snyk/dep-graph';
 import { SEVERITY } from '../snyk-test/common';
-import { RemediationChanges } from '../snyk-test/legacy';
+import { DepsFilePaths, RemediationChanges } from '../snyk-test/legacy';
 import { Options } from '../types';
 
 export type Ecosystem = 'cpp' | 'docker' | 'code';
@@ -80,6 +80,7 @@ export interface TestResult {
   issues: Issue[];
   issuesData: IssuesData;
   depGraphData: DepGraphData;
+  depsFilePaths?: DepsFilePaths;
   remediation?: RemediationChanges;
 }
 

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -24,6 +24,7 @@ export interface ScanResult {
   name?: string;
   policy?: string;
   target?: GitTarget | ContainerTarget;
+  analytics?: Analytics[];
 }
 
 export interface Identity {
@@ -35,6 +36,12 @@ export interface Identity {
 export interface Facts {
   type: string;
   data: any;
+}
+
+//TODO (@snyk/tundra): maybe PluginAnalytics?
+export interface Analytics {
+  name: string;
+  data: unknown;
 }
 
 interface UpgradePathItem {

--- a/src/lib/plugins/get-extra-project-count.ts
+++ b/src/lib/plugins/get-extra-project-count.ts
@@ -8,7 +8,7 @@ export async function getExtraProjectCount(
   options: Options,
   inspectResult: pluginApi.InspectResult,
 ): Promise<number | undefined> {
-  if (options.docker || options.source) {
+  if (options.docker || options.unmanaged) {
     return undefined;
   }
   if (

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -238,6 +238,10 @@ interface Issue {
   fixInfo: FixInfo;
 }
 
+export interface DepsFilePaths {
+  [pkgKey: string]: string[];
+}
+
 export interface TestDependenciesResult {
   issuesData: {
     [issueId: string]: IssueData;
@@ -250,6 +254,7 @@ export interface TestDependenciesResult {
   };
   remediation?: RemediationChanges;
   depGraphData: depGraphLib.DepGraphData;
+  depsFilePaths?: DepsFilePaths;
 }
 
 export interface TestDepGraphMeta {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -52,7 +52,7 @@ export interface Options {
   docker?: boolean;
   iac?: boolean;
   code?: boolean;
-  source?: boolean; // C/C++ Ecosystem Support
+  unmanaged?: boolean; // C/C++ Unmanaged Ecosystem Support
   file?: string;
   policy?: string;
   json?: boolean;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,6 +69,7 @@ export interface Options {
   severityThreshold?: SEVERITY;
   dev?: boolean;
   'print-deps'?: boolean;
+  'print-dep-paths'?: boolean;
   'remote-repo-url'?: string;
   scanAllUnmanaged?: boolean;
   allProjects?: boolean;
@@ -79,6 +80,7 @@ export interface Options {
   experimental?: boolean;
   // Used with the Docker plugin only. Allows application scanning.
   'app-vulns'?: boolean;
+
   debug?: boolean;
   sarif?: boolean;
   'group-issues'?: boolean;

--- a/test/jest/unit/modes.spec.ts
+++ b/test/jest/unit/modes.spec.ts
@@ -138,13 +138,13 @@ describe('when have a valid mode and command', () => {
     expect(cliArgs['experimental']).toBeTruthy();
   });
 
-  it('"source test" should set source option and test command', () => {
+  it('"unmanaged test" should set unmanaged option and test command', () => {
     const expectedCommand = 'test';
     const expectedArgs = {
       _: [],
       source: true,
     };
-    const cliCommand = 'source';
+    const cliCommand = 'unmanaged';
     const cliArgs = {
       _: ['test'],
     };
@@ -152,16 +152,16 @@ describe('when have a valid mode and command', () => {
     const command = parseMode(cliCommand, cliArgs);
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
-    expect(cliArgs['source']).toBeTruthy();
+    expect(cliArgs['unmanaged']).toBeTruthy();
   });
 
-  it('"source monitor" should set source option and monitor command', () => {
+  it('"unmanaged monitor" should set source option and monitor command', () => {
     const expectedCommand = 'monitor';
     const expectedArgs = {
       _: [],
       source: true,
     };
-    const cliCommand = 'source';
+    const cliCommand = 'unmanaged';
     const cliArgs = {
       _: ['monitor'],
     };
@@ -169,7 +169,7 @@ describe('when have a valid mode and command', () => {
     const command = parseMode(cliCommand, cliArgs);
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
-    expect(cliArgs['source']).toBeTruthy();
+    expect(cliArgs['unmanaged']).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
- snyk c/c++ unmanaged async scanning
- scanResult now is able of contain analytics generated in
  snyk-*ecosystems*-plugings e.g. snyk-cpp-plugin
- receiving analytics from snyk-cpp-plugin and merging them with the
  rest of cli before of post them.


TODO:

decompose this branch in small and well tested pull requests