### PR TITLE
fix: IaC multi-doc yaml indexing

### DIFF
--- a/src/cli/commands/test/iac-local-execution/extract-line-number.ts
+++ b/src/cli/commands/test/iac-local-execution/extract-line-number.ts
@@ -1,4 +1,4 @@
-import { IaCErrorCodes, IacFileScanResult, PolicyMetadata } from './types';
+import { IaCErrorCodes } from './types';
 import { CustomError } from '../../../../lib/errors';
 import {
   CloudConfigFileTypes,
@@ -25,14 +25,15 @@ function getFileTypeForLineNumber(fileType: string): CloudConfigFileTypes {
 }
 
 export function extractLineNumber(
-  scanResult: IacFileScanResult,
-  policy: PolicyMetadata,
+  fileContent: string,
+  fileType: string,
+  cloudConfigPath: string[],
 ): number {
   try {
     return issuesToLineNumbers(
-      scanResult.fileContent,
-      getFileTypeForLineNumber(scanResult.fileType),
-      policy.msg.split('.'), // parser defaults to docId:0 and checks for the rest of the path
+      fileContent,
+      getFileTypeForLineNumber(fileType),
+      cloudConfigPath,
     );
   } catch {
     const err = new FailedToExtractLineNumberError();

--- a/test/fixtures/iac/kubernetes/pod-privileged-multi.yaml
+++ b/test/fixtures/iac/kubernetes/pod-privileged-multi.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example1
+spec:
+  containers:
+    - name: example
+      image: example:latest
+      securityContext:
+        privileged: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: example2
+spec:
+  containers:
+    - name: example
+      image: example:latest
+      securityContext:
+        privileged: true

--- a/test/jest/acceptance/iac/multidoc-yaml.spec.ts
+++ b/test/jest/acceptance/iac/multidoc-yaml.spec.ts
@@ -1,0 +1,34 @@
+import { startMockServer } from './helpers';
+import { MappedIacTestResponse } from '../../../../src/lib/snyk-test/iac-test-result';
+jest.setTimeout(50000);
+
+describe('iac test --json file.yaml', () => {
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    ({ run, teardown } = await startMockServer());
+  });
+
+  afterAll(async () => teardown());
+
+  it('supports the correct line numbers for multi-doc YAML files', async () => {
+    // Test a multidoc YAML file with one "high" issue in each subdoc.
+    const { stdout } = await run(
+      `snyk iac test --json --severity-threshold=high ./iac/kubernetes/pod-privileged-multi.yaml`,
+    );
+
+    const result: MappedIacTestResponse = JSON.parse(stdout);
+    const issues = result.infrastructureAsCodeIssues;
+
+    expect(issues.length).toBe(2);
+
+    expect(issues[0].lineNumber).toBe(11);
+    expect(issues[1].lineNumber).toBe(22);
+
+    expect(issues[0].path[0]).toBe('[DocId: 0]');
+    expect(issues[1].path[0]).toBe('[DocId: 1]');
+  });
+});

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -28,7 +28,6 @@ export const policyStub: PolicyMetadata = {
   subType: 'Deployment',
   title: 'Container is running in privileged mode',
   type: 'k8s',
-  documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-2',
 };
 
 const anotherPolicyStub: PolicyMetadata = {
@@ -36,6 +35,12 @@ const anotherPolicyStub: PolicyMetadata = {
   severity: 'high' as SEVERITY,
   id: '2',
   publicId: 'SNYK-CC-K8S-2',
+};
+
+const yetAnotherPolicyStub: PolicyMetadata = {
+  ...anotherPolicyStub,
+  id: '3',
+  publicId: 'SNYK-CC-K8S-3',
 };
 
 const relativeFilePath = 'dont-care.yaml';
@@ -63,6 +68,16 @@ export function generateScanResults(): Array<IacFileScanResult> {
       filePath: relativeFilePath,
       fileType: 'yaml',
     },
+    {
+      violatedPolicies: [{ ...yetAnotherPolicyStub }],
+      jsonContent: { dontCare: null },
+      docId: 1,
+      projectType: IacProjectType.K8S,
+      engineType: EngineType.Kubernetes,
+      fileContent: 'dont-care',
+      filePath: relativeFilePath,
+      fileType: 'yaml',
+    },
   ];
 }
 
@@ -80,7 +95,7 @@ export function generateCloudConfigResults(
       ...anotherPolicyStub,
       id: anotherPolicyStub.publicId,
       name: anotherPolicyStub.title,
-      cloudConfigPath: ['[DocId:0]'].concat(anotherPolicyStub.msg.split('.')),
+      cloudConfigPath: ['[DocId: 0]'].concat(anotherPolicyStub.msg.split('.')),
       isIgnored: false,
       iacDescription: {
         issue: anotherPolicyStub.issue,
@@ -89,7 +104,24 @@ export function generateCloudConfigResults(
       },
       severity: anotherPolicyStub.severity,
       lineNumber: withLineNumber ? 3 : -1,
-      documentation: anotherPolicyStub.documentation,
+      documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-2',
+    },
+    {
+      ...yetAnotherPolicyStub,
+      id: yetAnotherPolicyStub.publicId,
+      name: yetAnotherPolicyStub.title,
+      cloudConfigPath: ['[DocId: 1]'].concat(
+        yetAnotherPolicyStub.msg.split('.'),
+      ),
+      isIgnored: false,
+      iacDescription: {
+        issue: yetAnotherPolicyStub.issue,
+        impact: yetAnotherPolicyStub.impact,
+        resolve: yetAnotherPolicyStub.resolve,
+      },
+      severity: yetAnotherPolicyStub.severity,
+      lineNumber: withLineNumber ? 3 : -1,
+      documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-3',
     },
   ];
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

In the IaC local execution data flow, the stage in results-formatter.ts
takes a list of IacFileScanResult as input, and returns a list of
FormattedResult. One key difference between these two objects is that
the former list contains a distinct object per document in a multi-doc
yaml file, but for the latter we are grouping these so that there is a
distinct object per file.

FormattedResults each contain a list of vulnerabilities, so we end up
with vulnerabilities from different YAML documents (in the same file)
sharing a list. Vulnerabilities with the same "resource path"
(Kubernetes example: `spec.containers[web].securityContext.privileged`),
but in distinct YAML documents in the same file, should be
differentiated by the "cloudConfigPath" (analogous to the "path" of
libraries used to address dependecies in the open-source flows), and
also by the line number. Both of these distinguishing fields were
actually being clobbered by their values from the first document in a
file: doc ID was always 0, and the line numbers referred to identical
resources in the first doc rather than subsequent docs.

This needs to be resolved in order to deliver IaC CLI issue-ignore
support in a sane way, and so is tangentially related to
https://snyksec.atlassian.net/browse/CC-990.

This will also help any tooling that infers information from line
numbers, which could help us build things like editor plugins and
language servers in the future.


#### Where should the reviewer start?


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CC-990


#### Screenshots


#### Additional questions
