### PR TITLE
feat: Enable IaC analytics for ignores

### DIFF
--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -26,8 +26,7 @@ export function addIacAnalytics(
 
   analytics.add('packageManager', Array.from(new Set(packageManagers)));
   analytics.add('iac-issues-count', totalIssuesCount);
-  // TODO enable once we have support for it in registry
-  // analytics.add('iac-ignored-issues-count', ignoredIssuesCount);
+  analytics.add('iac-ignored-issues-count', ignoredIssuesCount);
   analytics.add('iac-type', issuesByType);
   analytics.add('iac-metrics', performanceAnalyticsObject);
   analytics.add('iac-test-count', formattedResults.length);


### PR DESCRIPTION
#### What does this PR do?

This PR adds the `iac-ignored-issues-count` field to the analytics metadata sent to Registry.
This will enable us track how many issues were ignored in a test  run.

#### How should this be manually tested?
- Add a snyk policy to ignore an issue, e.g.:
```
version: v1.19.0
ignore:
  SNYK-CC-K8S-1:
    - '*':
        reason: None Given
        expires: 2021-08-26T08:40:35.249Z
        created: 2021-07-27T08:40:35.251Z
```


- Run[ local branch of registry](https://github.com/snyk/registry/pull/22813) (if not merged): 
- Run 
```
npm run build 
node ./dist/cli iac test test/fixtures/iac/kubernetes/pod-privileged.yaml --policy-path=.snyk -d
```
 to see analytics under the debug flag.

#### What are the relevant tickets?
CC-995

#### Screenshots
Running a test with a Policy file - Ignoring 0 issues:

![image](https://user-images.githubusercontent.com/6989529/128729200-ab675a28-418c-4a6d-bdbf-46b7bfd16985.png)

Running a test with a Policy file - Ignoring 1 issue:
![image](https://user-images.githubusercontent.com/6989529/128729647-77ead6a0-3ca5-49c5-9cad-9bffbbd5c741.png)


