### PR TITLE
fix(protect): skip previously patched files

### DIFF
--- a/packages/snyk-protect/bin/snyk-protect
+++ b/packages/snyk-protect/bin/snyk-protect
@@ -1,2 +1,7 @@
 #!/usr/bin/env node
-require('../dist/index.js').protect();
+require('../dist/index.js')
+  .protect()
+  .catch((error) => {
+    // don't block pipelines on unexpected errors
+    console.error(error);
+  });

--- a/packages/snyk-protect/src/lib/index.ts
+++ b/packages/snyk-protect/src/lib/index.ts
@@ -26,7 +26,7 @@ async function protect(projectFolderPath: string) {
   const snykFilePath = path.resolve(projectFolderPath, '.snyk');
 
   if (!fs.existsSync(snykFilePath)) {
-    console.log('No .snyk file found');
+    console.log('No .snyk file found.');
     sendAnalytics({
       type: ProtectResultType.NO_SNYK_FILE,
     });
@@ -67,7 +67,7 @@ async function protect(projectFolderPath: string) {
   > = await getAllPatches(vulnIdAndPackageNames, packageNameToVersionsMap);
 
   if (packageAtVersionsToPatches.size === 0) {
-    console.log('Nothing to patch');
+    console.log('Nothing to patch.');
     sendAnalytics({
       type: ProtectResultType.NOTHING_TO_PATCH,
     });
@@ -83,7 +83,8 @@ async function protect(projectFolderPath: string) {
     vuldIdAndPatches?.forEach((vp) => {
       vp.patches.forEach((patchDiffs) => {
         patchDiffs.patchDiffs.forEach((diff) => {
-          applyPatchToFile(diff, fpp.path);
+          const patchedPath = applyPatchToFile(diff, fpp.path);
+          console.log(`Patched: ${patchedPath}`);
         });
       });
       patchedModules.push({
@@ -94,7 +95,7 @@ async function protect(projectFolderPath: string) {
     });
   });
 
-  console.log('Successfully applied Snyk patches');
+  console.log('Applied Snyk patches.');
 
   sendAnalytics({
     type: ProtectResultType.APPLIED_PATCHES,

--- a/packages/snyk-protect/src/lib/patch.ts
+++ b/packages/snyk-protect/src/lib/patch.ts
@@ -9,7 +9,7 @@ export function applyPatchToFile(patchContents: string, baseFolder: string) {
   const contentsToPatch = fs.readFileSync(targetFilePath, 'utf-8');
   const patchedContents = patchString(patchContents, contentsToPatch);
   fs.writeFileSync(targetFilePath, patchedContents);
-  console.log(`patched ${targetFilePath}`);
+  return targetFilePath;
 }
 
 export function extractTargetFilePathFromPatch(patchContents: string): string {
@@ -39,13 +39,11 @@ export function patchString(
   const contentsToPatchLines = contentsToPatch.split('\n');
 
   if (!patchContentLines[2]) {
-    // return;
-    throw new Error('Invalid patch');
+    throw new Error('Invalid patch.');
   }
   const unparsedLineToPatch = /^@@ -(\d*),.*@@/.exec(patchContentLines[2]);
   if (!unparsedLineToPatch || !unparsedLineToPatch[1]) {
-    // return;
-    throw new Error('Invalid patch');
+    throw new Error('Invalid patch.');
   }
   let lineToPatch = parseInt(unparsedLineToPatch[1], 10) - 2;
 
@@ -66,16 +64,13 @@ export function patchString(
       }
       case ' ': {
         if (currentLine !== nextLine) {
-          console.log(
-            'Expected\n  line from local file\n',
-            JSON.stringify(currentLine),
-            '\n  to match patch line\n',
-            JSON.stringify(nextLine),
-            '\n',
-          );
           throw new Error(
-            // `File ${filename} to be patched does not match, not patching`,
-            `File to be patched does not match, not patching`,
+            'File does not match patch contents.' +
+              '  Expected\n' +
+              '    line from local file\n' +
+              `      ${JSON.stringify(currentLine)}\n` +
+              '    to match patch line\n' +
+              `      ${JSON.stringify(nextLine)}\n`,
           );
         }
         break;

--- a/packages/snyk-protect/src/lib/patch.ts
+++ b/packages/snyk-protect/src/lib/patch.ts
@@ -6,9 +6,16 @@ export function applyPatchToFile(patchContents: string, baseFolder: string) {
     baseFolder,
     extractTargetFilePathFromPatch(patchContents),
   );
+
+  const flagPath = `${targetFilePath}.snyk-protect.flag`;
+  if (fs.existsSync(flagPath)) {
+    return targetFilePath;
+  }
+
   const contentsToPatch = fs.readFileSync(targetFilePath, 'utf-8');
   const patchedContents = patchString(patchContents, contentsToPatch);
   fs.writeFileSync(targetFilePath, patchedContents);
+  fs.writeFileSync(flagPath, '');
   return targetFilePath;
 }
 

--- a/packages/snyk-protect/src/lib/snyk-api.ts
+++ b/packages/snyk-protect/src/lib/snyk-api.ts
@@ -7,7 +7,7 @@ export function getApiBaseUrl(): string {
       // snyk CI environment - we use `.../api/v1` though the norm is just `.../api`
       apiBaseUrl = process.env.SNYK_API.replace('/v1', '');
     } else {
-      console.log(
+      console.warn(
         'Malformed SNYK_API value. Using default: https://snyk.io/api',
       );
     }

--- a/packages/snyk-protect/test/acceptance/fix-pr.smoke.spec.ts
+++ b/packages/snyk-protect/test/acceptance/fix-pr.smoke.spec.ts
@@ -16,7 +16,7 @@ describe('Fix PR', () => {
     ).toEqual(
       expect.objectContaining<RunCLIResult>({
         code: 0,
-        stdout: expect.stringContaining('Successfully applied Snyk patches'),
+        stdout: expect.stringContaining('Applied Snyk patches.'),
         stderr: expect.any(String),
       }),
     );

--- a/packages/snyk-protect/test/acceptance/fix-pr.smoke.spec.ts
+++ b/packages/snyk-protect/test/acceptance/fix-pr.smoke.spec.ts
@@ -16,8 +16,24 @@ describe('Fix PR', () => {
     ).toEqual(
       expect.objectContaining<RunCLIResult>({
         code: 0,
+        stdout: expect.stringContaining('Applied Snyk patches'),
+        stderr: expect.not.stringMatching(/snyk/gi),
+      }),
+    );
+
+    await expect(
+      project.read('node_modules/lodash/lodash.js'),
+    ).resolves.toEqual(patchedLodash);
+
+    expect(
+      await runCommand('npm', ['install'], {
+        cwd: project.path(),
+      }),
+    ).toEqual(
+      expect.objectContaining<RunCLIResult>({
+        code: 0,
         stdout: expect.stringContaining('Applied Snyk patches.'),
-        stderr: expect.any(String),
+        stderr: expect.not.stringMatching(/snyk/gi),
       }),
     );
 

--- a/packages/snyk-protect/test/acceptance/protect.spec.ts
+++ b/packages/snyk-protect/test/acceptance/protect.spec.ts
@@ -29,7 +29,7 @@ describe('@snyk/protect', () => {
         project.read('node_modules/nyc/node_modules/lodash/lodash.js'),
       ).resolves.toEqual(patchedLodash);
 
-      expect(log).toHaveBeenCalledWith('Successfully applied Snyk patches');
+      expect(log).toHaveBeenCalledWith('Applied Snyk patches.');
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({
         data: {
@@ -68,7 +68,7 @@ describe('@snyk/protect', () => {
         project.read('node_modules/lodash/lodash.js'),
       ).resolves.toEqual(patchedLodash);
 
-      expect(log).toHaveBeenCalledWith('Successfully applied Snyk patches');
+      expect(log).toHaveBeenCalledWith('Applied Snyk patches.');
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({
         data: {
@@ -107,7 +107,7 @@ describe('@snyk/protect', () => {
 
       await protect(project.path());
 
-      expect(log).toHaveBeenCalledWith('Nothing to patch');
+      expect(log).toHaveBeenCalledWith('Nothing to patch.');
 
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({
@@ -142,7 +142,7 @@ describe('@snyk/protect', () => {
 
       await protect(project.path());
 
-      expect(log).toHaveBeenCalledWith('No .snyk file found');
+      expect(log).toHaveBeenCalledWith('No .snyk file found.');
 
       expect(postJsonSpy).toHaveBeenCalledTimes(1);
       expect(postJsonSpy.mock.calls[0][1]).toEqual({


### PR DESCRIPTION
In the old `snyk protect` we used to add placeholder files to patched modules so indicate we've already patched them. The new snyk/protect doesn't do this so it attempts to patch modules that have already been patched, causing a failure.

This PR fixes that by creating the same placeholder file. The difference is that it's simpler and should work with any existing ignore rules a project might use to exclude them in their builds.

`snyk protect`:

`[filename].snyk-[vuln-id].flag` containing a timestamp.

Now:

`[filename].snyk-protect.flag` containing nothing.

So a project using `*.snyk-*.flag` will still match the same files. Like:

https://github.com/signalapp/Signal-Desktop/blob/f96246fecf4855db88d571e5825132ee4d5605c8/package.json#L435

<details>
<summary>See error logs</summary>
<pre>
node ➜ .../snyk-protect/test/fixtures/fix-pr (master ✗) $ npm install
> fix-pr@1.0.0 prepare
> npm run snyk-protect
> fix-pr@1.0.0 snyk-protect
> snyk-protect
patched /workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/lodash/lodash.js
Successfully applied Snyk patches
added 2 packages, and audited 3 packages in 9s
1 high severity vulnerability
To address all issues, run:
  npm audit fix --force
Run `npm audit` for details.
node ➜ .../snyk-protect/test/fixtures/fix-pr (master ✗) $ npm install
> fix-pr@1.0.0 prepare
> npm run snyk-protect
> fix-pr@1.0.0 snyk-protect
> snyk-protect
Expected
  line from local file
 "        if ((key === '__proto__' || key === 'constructor' || key === 'prototype')) {" 
  to match patch line
 "        if (index != lastIndex) {" 
(node:7862) UnhandledPromiseRejectionWarning: Error: File to be patched does not match, not patching
    at patchString (/workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/patch.js:59:27)
    at Object.applyPatchToFile (/workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/patch.js:9:29)
    at /workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/index.js:68:29
    at Array.forEach (<anonymous>)
    at /workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/index.js:67:39
    at Array.forEach (<anonymous>)
    at /workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/index.js:66:24
    at Array.forEach (<anonymous>)
    at /workspaces/snyk/packages/snyk-protect/test/fixtures/fix-pr/node_modules/@snyk/protect/dist/lib/index.js:65:94
    at Array.forEach (<anonymous>)
(node:7862) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:7862) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
up to date, audited 3 packages in 2s
1 high severity vulnerability
To address all issues, run:
  npm audit fix --force
Run `npm audit` for details.
</pre>
<details>