### PR TITLE
chore: don't warn about changes to test fixtures in dangerjs

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -58,7 +58,8 @@ if (danger.github && danger.github.pr) {
     const inTestFolder = f.startsWith('test/');
     const isATestFile = f.includes('.test.ts') || f.includes('.spec.ts');
     const inJestFolder = f.startsWith('test/jest/');
-    return inTestFolder && isATestFile && !inJestFolder;
+    const inFixturesFolder = f.startsWith('test/fixtures/');
+    return inTestFolder && isATestFile && !inJestFolder && !inFixturesFolder;
   });
 
   if (newTestFiles.length) {


### PR DESCRIPTION
`dangerfile.js` contained some logic regarding adding new Tap tests instead of Jest test. This logic resulted in a redundant warning when adding new test fixtures. This should stop these warnings.