### PR TITLE
feat: Return vulns from shaded jars

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.2.1",
-    "snyk-docker-plugin": "4.23.0",
+    "snyk-docker-plugin": "4.24.0",
     "snyk-go-plugin": "1.17.0",
     "snyk-gradle-plugin": "3.16.1",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Pumbing snyk-docker-plugin to get support for shaded jars scanning. 
If nested jars found, we are not returning the parent (fat / shaded) jar. We are hiding unpacking jar functionality behind CLI flag. The uberjar code wont run at all if app-vulns is not specified. In order to make this clear to the user, we're throwing an error in case
    the user specifies --shaded-jars, but does not specify --app-vulns