### PR TITLE
fix: tf plan parser test index cases

### DIFF
--- a/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/terraform-plan-parser.ts
@@ -25,14 +25,17 @@ function terraformPlanReducer(
     mode === 'data' ? 'data' : 'resource';
   if (scanInput[inputKey][type]) {
     // add new resources of the same type with different names
-    scanInput[inputKey][type][index !== undefined ? `${name}_${index}` : name] =
-      values || {};
+    scanInput[inputKey][type][getResourceName(index, name)] = values || {};
   } else {
     // add a new resource type
-    scanInput[inputKey][type] = { [name]: values };
+    scanInput[inputKey][type] = { [getResourceName(index, name)]: values };
   }
 
   return scanInput;
+}
+
+function getResourceName(index: string | number, name: string): string {
+  return index !== undefined ? `${name}["${index}"]` : name;
 }
 
 function resourceChangeReducer(

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -173,7 +173,7 @@ export interface TerraformPlanResource {
   type: string; // "aws_cloudwatch_log_group",
   name: string; // "terra_ci",
   values: Record<string, unknown>; // the values in the resource
-  index: number;
+  index: number | string; // can be either a number or a string (1, "rtb-asdasd", "10.10.10.10")
 }
 
 export interface TerraformPlanResourceChange

--- a/test/fixtures/iac/terraform-plan/expected-parser-results/delta-scan/tf-plan-create.resources.json
+++ b/test/fixtures/iac/terraform-plan/expected-parser-results/delta-scan/tf-plan-create.resources.json
@@ -149,6 +149,38 @@
           "tags": null,
           "type": "STANDARD"
         }
+      },
+      "aws_route": {
+        "private[\"1\"]": {
+          "carrier_gateway_id": null,
+          "destination_cidr_block": "172.25.16.0/20",
+          "destination_ipv6_cidr_block": null,
+          "destination_prefix_list_id": null,
+          "egress_only_gateway_id": null,
+          "gateway_id": null,
+          "local_gateway_id": null,
+          "nat_gateway_id": null,
+          "route_table_id": "rtb-00cf8381520103cfb",
+          "timeouts": null,
+          "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+          "vpc_endpoint_id": null,
+          "vpc_peering_connection_id": null
+        },
+        "private[\"rtb-00cf8381520103cfb\"]": {
+          "carrier_gateway_id": null,
+          "destination_cidr_block": "172.25.16.0/20",
+          "destination_ipv6_cidr_block": null,
+          "destination_prefix_list_id": null,
+          "egress_only_gateway_id": null,
+          "gateway_id": null,
+          "local_gateway_id": null,
+          "nat_gateway_id": null,
+          "route_table_id": "rtb-00cf8381520103cfb",
+          "timeouts": null,
+          "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+          "vpc_endpoint_id": null,
+          "vpc_peering_connection_id": null
+        }
       }
     },
     "data": {}

--- a/test/fixtures/iac/terraform-plan/expected-parser-results/full-scan/tf-plan-create.resources.json
+++ b/test/fixtures/iac/terraform-plan/expected-parser-results/full-scan/tf-plan-create.resources.json
@@ -149,6 +149,38 @@
           "tags": null,
           "type": "STANDARD"
         }
+      },
+      "aws_route": {
+        "private[\"1\"]": {
+          "carrier_gateway_id": null,
+          "destination_cidr_block": "172.25.16.0/20",
+          "destination_ipv6_cidr_block": null,
+          "destination_prefix_list_id": null,
+          "egress_only_gateway_id": null,
+          "gateway_id": null,
+          "local_gateway_id": null,
+          "nat_gateway_id": null,
+          "route_table_id": "rtb-00cf8381520103cfb",
+          "timeouts": null,
+          "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+          "vpc_endpoint_id": null,
+          "vpc_peering_connection_id": null
+        },
+        "private[\"rtb-00cf8381520103cfb\"]": {
+          "carrier_gateway_id": null,
+          "destination_cidr_block": "172.25.16.0/20",
+          "destination_ipv6_cidr_block": null,
+          "destination_prefix_list_id": null,
+          "egress_only_gateway_id": null,
+          "gateway_id": null,
+          "local_gateway_id": null,
+          "nat_gateway_id": null,
+          "route_table_id": "rtb-00cf8381520103cfb",
+          "timeouts": null,
+          "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+          "vpc_endpoint_id": null,
+          "vpc_peering_connection_id": null
+        }
       }
     },
     "data": {}

--- a/test/fixtures/iac/terraform-plan/tf-plan-create.json
+++ b/test/fixtures/iac/terraform-plan/tf-plan-create.json
@@ -641,6 +641,84 @@
             "logging_configuration": []
           }
         }
+      },
+      {
+        "address": "aws_route.private[\"1\"]",
+        "mode": "managed",
+        "type": "aws_route",
+        "name": "private",
+        "index": 1,
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "carrier_gateway_id": null,
+            "destination_cidr_block": "172.25.16.0/20",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "route_table_id": "rtb-00cf8381520103cfb",
+            "timeouts": null,
+            "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          },
+          "after_unknown": {
+            "id": true,
+            "instance_id": true,
+            "instance_owner_id": true,
+            "network_interface_id": true,
+            "origin": true,
+            "state": true
+          },
+          "before_sensitive": false,
+          "after_sensitive": {}
+        }
+      },
+      {
+        "address": "aws_route.private[\"rtb-00cf8381520103cfb\"]",
+        "mode": "managed",
+        "type": "aws_route",
+        "name": "private",
+        "index": "rtb-00cf8381520103cfb",
+        "provider_name": "registry.terraform.io/hashicorp/aws",
+        "change": {
+          "actions": [
+            "create"
+          ],
+          "before": null,
+          "after": {
+            "carrier_gateway_id": null,
+            "destination_cidr_block": "172.25.16.0/20",
+            "destination_ipv6_cidr_block": null,
+            "destination_prefix_list_id": null,
+            "egress_only_gateway_id": null,
+            "gateway_id": null,
+            "local_gateway_id": null,
+            "nat_gateway_id": null,
+            "route_table_id": "rtb-00cf8381520103cfb",
+            "timeouts": null,
+            "transit_gateway_id": "tgw-0f68a4f2c58772c51",
+            "vpc_endpoint_id": null,
+            "vpc_peering_connection_id": null
+          },
+          "after_unknown": {
+            "id": true,
+            "instance_id": true,
+            "instance_owner_id": true,
+            "network_interface_id": true,
+            "origin": true,
+            "state": true
+          },
+          "before_sensitive": false,
+          "after_sensitive": {}
+        }
       }
     ],
     "prior_state": {


### PR DESCRIPTION
#### What does this PR do?

Aligns the Terraform Plan parser with a small change in the way we use the `index` field for naming + added tests for a bug we found in the Go parser.