### PR TITLE
feat(@snyk/fix): catch version resolving failed pip error.

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -99,14 +99,24 @@ function throwPipenvError(stderr: string, command?: string) {
     'There are incompatible versions in the resolved dependencies';
   const lockingFailed = 'Locking failed';
   const versionNotFound = 'Could not find a version that matches';
-  if (stderr.includes(incompatibleDeps.toLocaleLowerCase())) {
-    throw new CommandFailedError(incompatibleDeps, command);
+
+  const errorsToBubbleUp = [
+    lockingFailed,
+    versionNotFound,
+    incompatibleDeps,
+  ].map((e) => e.toLocaleLowerCase());
+
+  for (const error of errorsToBubbleUp) {
+    if (errorStr.includes(error)) {
+      throw new CommandFailedError(stderr, command);
+    }
   }
-  if (errorStr.includes(lockingFailed.toLocaleLowerCase())) {
-    throw new CommandFailedError(lockingFailed, command);
+
+  const solverProblemErrorRegex = /.*version solving failed/g;
+  const solverProblemError = solverProblemErrorRegex.exec(stderr);
+  if (solverProblemError) {
+    throw new CommandFailedError(solverProblemError[0].trim(), command);
   }
-  if (stderr.includes(versionNotFound.toLocaleLowerCase())) {
-    throw new CommandFailedError(versionNotFound, command);
-  }
+
   throw new NoFixesCouldBeAppliedError();
 }


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Bubble up pipenv errors that look like this:
```Updating dependencies
Resolving dependencies... (1.7s)

SolverProblemError

Because package-A (2.6) depends on package-B (>=1.19)
and package-C (2.2.1) depends on package-B (>=1.16.0,<1.19.0), package-D (2.6) is incompatible with package-C (2.2.1).
So, because package-Z depends on both  package-C (2.2.1) and package-D (2.6), version solving failed.```

```
#### Where should the reviewer start?
packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
