### PR TITLE
fix: bubble up SolverProblemError for Poetry

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/index.ts
@@ -75,8 +75,8 @@ function throwPipenvError(stderr: string, command?: string) {
     }
   }
 
-  const solverProblemErrorRegex = /.*version solving failed/g;
-  const solverProblemError = solverProblemErrorRegex.exec(stderr);
+  const SOLVER_PROBLEM = /SolverProblemError(.* version solving failed)/gms;
+  const solverProblemError = SOLVER_PROBLEM.exec(stderr);
   if (solverProblemError) {
     throw new CommandFailedError(solverProblemError[0].trim(), command);
   }

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -111,14 +111,20 @@ function throwPoetryError(stderr: string, command?: string) {
     /Python requirement (.*) is not compatible/g,
     'gm',
   );
-  const match = INCOMPATIBLE_PYTHON.exec(stderr);
-  if (match) {
+  const SOLVER_PROBLEM = /SolverProblemError(.* version solving failed)/gms;
+
+  const incompatiblePythonError = INCOMPATIBLE_PYTHON.exec(stderr);
+  if (incompatiblePythonError) {
     throw new CommandFailedError(
-      `The current project's Python requirement ${match[1]} is not compatible with some of the required packages`,
+      `The current project's Python requirement ${incompatiblePythonError[1]} is not compatible with some of the required packages`,
       command,
     );
   }
-  // TODO: test this
+  const solverProblemError = SOLVER_PROBLEM.exec(stderr);
+  if (solverProblemError) {
+    throw new CommandFailedError(solverProblemError[0].trim(), command);
+  }
+
   if (stderr.includes(ALREADY_UP_TO_DATE)) {
     throw new CommandFailedError(
       'No dependencies could be updated as they seem to be at the correct versions. Make sure installed dependencies in the environment match those in the lockfile by running `poetry update`',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bubble up poetry errors that look like this as well:

```Resolving dependencies... (1.7s)

SolverProblemError

Because package-A (2.6) depends on package-B (>=1.19)
and package-C (2.2.1) depends on package-B (>=1.16.0,<1.19.0), package-D (2.6) is incompatible with package-C (2.2.1).
So, because package-Z depends on both  package-C (2.2.1) and package-D (2.6), version solving failed.
```
