### PR TITLE
feat: add custom tag to result from custom rules scan [CC-1139]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -80,6 +80,7 @@ function formatScanResult(
       name: policy.title,
       cloudConfigPath,
       isIgnored: false,
+      isCustomRule: scanResult.engineType === EngineType.Custom,
       iacDescription: {
         issue: policy.issue,
         impact: policy.impact,

--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -42,6 +42,7 @@ function formatIacIssue(
       )} Severity]`,
     ) +
     ` [${issue.id}]` +
+    (issue.isCustomRule ? ' [Custom]' : '') +
     name +
     introducedBy +
     '\n'

--- a/src/lib/snyk-test/iac-test-result.ts
+++ b/src/lib/snyk-test/iac-test-result.ts
@@ -6,6 +6,7 @@ export interface AnnotatedIacIssue {
   description: string;
   severity: SEVERITY | 'none';
   isIgnored: boolean;
+  isCustomRule: boolean;
   cloudConfigPath: string[];
   type: string;
   subType: string;


### PR DESCRIPTION
#### What does this PR do?
This PR adds a new tag to the `snyk iac test` results when the misconfiguration was flagged up from custom rules.

#### Where should the reviewer start?


#### How should this be manually tested?
1. `npm run build`
2. Download [bundle.tar.gz](https://github.com/snyk/snyk/files/7129088/bundle.tar.gz)
3. Author the following file - `test.tf`:
```
resource "aws_ami" "denied" {
  name                = "aws_ami_not_encrypted"
  virtualization_type = "hvm"
  root_device_name    = "/dev/xvda"

  ebs_block_device {
    device_name = "/dev/xvda"
    encrypted   = false
    volume_size = 8
  }
}
```
4. Run the command `snyk-dev iac test --rules=bundle.tar.gz test.tf`

#### What are the relevant tickets?
- https://snyksec.atlassian.net/browse/CC-1139

#### Screenshots


