### PR TITLE
refactor: extract re-usable code from poetry fix

### DIFF
--- a/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
+++ b/packages/snyk-fix/src/lib/errors/no-fixes-applied.ts
@@ -1,7 +1,13 @@
 import { CustomError, ERROR_CODES } from './custom-error';
 
 export class NoFixesCouldBeAppliedError extends CustomError {
-  public constructor() {
-    super('No fixes could be applied', ERROR_CODES.NoFixesCouldBeApplied);
+  public tip?: string;
+
+  public constructor(message?: string, tip?: string) {
+    super(
+      message || 'No fixes could be applied',
+      ERROR_CODES.NoFixesCouldBeApplied,
+    );
+    this.tip = tip;
   }
 }

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/attempted-changes-summary.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/attempted-changes-summary.ts
@@ -1,0 +1,74 @@
+import {
+  DependencyPins,
+  FixChangesError,
+  FixChangesSuccess,
+  FixChangesSummary,
+} from '../../../../../types';
+
+export function generateFailedChanges(
+  attemptedUpdates: string[],
+  pins: DependencyPins,
+  error: Error,
+  command?: string,
+): FixChangesError[] {
+  const changes: FixChangesError[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    if (
+      !attemptedUpdates
+        .map((update) => update.replace('==', '@'))
+        .includes(pin.upgradeTo)
+    ) {
+      continue;
+    }
+    const updatedMessage = pin.isTransitive ? 'pin' : 'upgrade';
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName, version] = pkgAtVersion.split('@');
+
+    changes.push({
+      success: false,
+      reason: error.message,
+      userMessage: `Failed to ${updatedMessage} ${pkgName} from ${version} to ${newVersion}`,
+      tip: command ? `Try running \`${command}\`` : undefined,
+      issueIds: pin.vulns,
+      from: pkgAtVersion,
+      to: `${pkgName}@${newVersion}`,
+    });
+  }
+  return changes;
+}
+
+export function generateSuccessfulChanges(
+  appliedUpgrades: string[],
+  pins: DependencyPins,
+): FixChangesSuccess[] {
+  const changes: FixChangesSuccess[] = [];
+  for (const pkgAtVersion of Object.keys(pins)) {
+    const pin = pins[pkgAtVersion];
+    if (
+      !appliedUpgrades
+        .map((upgrade) => upgrade.replace('==', '@'))
+        .includes(pin.upgradeTo)
+    ) {
+      continue;
+    }
+    const updatedMessage = pin.isTransitive ? 'Pinned' : 'Upgraded';
+    const newVersion = pin.upgradeTo.split('@')[1];
+    const [pkgName, version] = pkgAtVersion.split('@');
+
+    changes.push({
+      success: true,
+      userMessage: `${updatedMessage} ${pkgName} from ${version} to ${newVersion}`,
+      issueIds: pin.vulns,
+      from: pkgAtVersion,
+      to: `${pkgName}@${newVersion}`,
+    });
+  }
+  return changes;
+}
+
+export function isSuccessfulChange(
+  change: FixChangesSummary,
+): change is FixChangesError {
+  return change.success === true;
+}

--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -214,7 +214,7 @@ export interface WithUserMessage<Original> {
 
 export type FixChangesSummary = FixChangesSuccess | FixChangesError;
 
-interface FixChangesSuccess {
+export interface FixChangesSuccess {
   success: true;
   userMessage: string;
   issueIds: string[];
@@ -222,7 +222,7 @@ interface FixChangesSuccess {
   to?: string;
 }
 
-interface FixChangesError {
+export interface FixChangesError {
   success: false;
   userMessage: string;
   reason: string;

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/poetry/update-dependencies.spec.ts
@@ -164,7 +164,9 @@ describe('fix Poetry Python projects', () => {
           failed: [
             {
               original: entityToFix,
-              error: expect.objectContaining({ name: 'CommandFailedError' }),
+              error: expect.objectContaining({
+                name: 'NoFixesCouldBeAppliedError',
+              }),
               tip: 'Try running `poetry install six==2.0.1 transitive==1.1.1`',
             },
           ],
@@ -319,6 +321,7 @@ describe('fix Poetry Python projects', () => {
       quiet: true,
       stripAnsi: true,
     });
+
     // Assert
     expect(result).toMatchObject({
       exceptions: {},
@@ -331,14 +334,23 @@ describe('fix Poetry Python projects', () => {
               original: entityToFix,
               changes: [
                 {
+                  from: 'six@1.1.6',
+                  to: 'six@2.0.1',
+                  issueIds: ['VULN-six'],
                   success: true,
                   userMessage: 'Upgraded six from 1.1.6 to 2.0.1',
                 },
                 {
+                  from: 'transitive@1.0.0',
+                  to: 'transitive@1.1.1',
+                  issueIds: ['vuln-transitive'],
                   success: true,
                   userMessage: 'Pinned transitive from 1.0.0 to 1.1.1',
                 },
                 {
+                  from: 'json-api@0.1.21',
+                  to: 'json-api@0.1.22',
+                  issueIds: ['SNYK-1'],
                   success: true,
                   userMessage: 'Upgraded json-api from 0.1.21 to 0.1.22',
                 },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
In preparation for introducing a different sequential fix strategy
refactor the existing code into re-usable blocks needed to add sequential
fix. 
Added some extra optional fields that can be sent in changes so we have all the data we need in case we want to output is as --json or consume it another way

#### Where should the reviewer start?
packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts