### PR TITLE
refactor: extract re-usable code from pipenv fix

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/attempted-changes-summary.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/attempted-changes-summary.ts
@@ -3,7 +3,7 @@ import {
   FixChangesError,
   FixChangesSuccess,
   FixChangesSummary,
-} from '../../../../../types';
+} from '../../../types';
 
 export function generateFailedChanges(
   attemptedUpdates: string[],

--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -19,7 +19,7 @@ import {
   generateFailedChanges,
   generateSuccessfulChanges,
   isSuccessfulChange,
-} from './attempted-changes-summary';
+} from '../../attempted-changes-summary';
 
 const debug = debugLib('snyk-fix:python:Poetry');
 

--- a/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
+++ b/packages/snyk-fix/test/acceptance/plugins/python/handlers/pipenv-pipfile/update-dependencies.spec.ts
@@ -158,7 +158,9 @@ describe('fix Pipfile Python projects', () => {
           failed: [
             {
               original: entityToFix,
-              error: expect.objectContaining({ name: 'CommandFailedError' }),
+              error: expect.objectContaining({
+                name: 'NoFixesCouldBeAppliedError',
+              }),
               tip:
                 'Try running `pipenv install django==2.0.1 transitive==1.1.1`',
             },
@@ -239,7 +241,9 @@ describe('fix Pipfile Python projects', () => {
           failed: [
             {
               original: entityToFix,
-              error: expect.objectContaining({ name: 'CommandFailedError' }),
+              error: expect.objectContaining({
+                name: 'NoFixesCouldBeAppliedError',
+              }),
               tip:
                 'Try running `pipenv install django==2.0.1 transitive==1.1.1`',
             },


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

In preparation for introducing a different sequential fix strategy
refactor the existing code into re-usable blocks needed to add sequential
fix

see https://github.com/snyk/snyk/pull/2240