### PR TITLE
fix: error to handle when no fixes applied

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/ensure-has-updates.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/ensure-has-updates.ts
@@ -1,0 +1,20 @@
+import * as debugLib from 'debug';
+
+import { NoFixesCouldBeAppliedError } from '../../../lib/errors/no-fixes-applied';
+import { FixChangesError, FixChangesSummary } from '../../../types';
+import { isSuccessfulChange } from './attempted-changes-summary';
+
+const debug = debugLib('snyk-fix:python:ensure-changes-applied');
+
+export function ensureHasUpdates(changes: FixChangesSummary[]) {
+  if (!changes.length) {
+    throw new NoFixesCouldBeAppliedError();
+  }
+  if (!changes.some((c) => isSuccessfulChange(c))) {
+    debug('Manifest has not changed as no changes got applied!');
+    // throw the first error tip since 100% failed, they all failed with the same
+    // error
+    const { reason, tip } = changes[0] as FixChangesError;
+    throw new NoFixesCouldBeAppliedError(reason, tip);
+  }
+}

--- a/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/pipenv-add.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/pipenv-pipfile/update-dependencies/pipenv-add.ts
@@ -1,0 +1,73 @@
+import * as pathLib from 'path';
+import * as pipenvPipfileFix from '@snyk/fix-pipenv-pipfile';
+
+import {
+  EntityToFix,
+  FixChangesSummary,
+  FixOptions,
+} from '../../../../../types';
+import { validateRequiredData } from '../../validate-required-data';
+
+import {
+  generateFailedChanges,
+  generateSuccessfulChanges,
+} from '../../attempted-changes-summary';
+import { CommandFailedError } from '../../../../../lib/errors/command-failed-to-run-error';
+import { NoFixesCouldBeAppliedError } from '../../../../../lib/errors/no-fixes-applied';
+
+export async function pipenvAdd(
+  entity: EntityToFix,
+  options: FixOptions,
+  upgrades: string[],
+): Promise<FixChangesSummary[]> {
+  const changes: FixChangesSummary[] = [];
+  let pipenvCommand;
+  const { remediation, targetFile } = validateRequiredData(entity);
+  try {
+    const targetFilePath = pathLib.resolve(entity.workspace.path, targetFile);
+    const { dir } = pathLib.parse(targetFilePath);
+    if (!options.dryRun && upgrades.length) {
+      const res = await pipenvPipfileFix.pipenvInstall(dir, upgrades, {
+        python: entity.options.command,
+      });
+      if (res.exitCode !== 0) {
+        pipenvCommand = res.command;
+        throwPipenvError(res.stderr ? res.stderr : res.stdout, res.command);
+      }
+    }
+    changes.push(...generateSuccessfulChanges(upgrades, remediation.pin));
+  } catch (error) {
+    changes.push(
+      ...generateFailedChanges(upgrades, remediation.pin, error, pipenvCommand),
+    );
+  }
+  return changes;
+}
+
+function throwPipenvError(stderr: string, command?: string) {
+  const errorStr = stderr.toLowerCase();
+  const incompatibleDeps =
+    'There are incompatible versions in the resolved dependencies';
+  const lockingFailed = 'Locking failed';
+  const versionNotFound = 'Could not find a version that matches';
+
+  const errorsToBubbleUp = [
+    lockingFailed,
+    versionNotFound,
+    incompatibleDeps,
+  ].map((e) => e.toLowerCase());
+
+  for (const error of errorsToBubbleUp) {
+    if (errorStr.includes(error)) {
+      throw new CommandFailedError(stderr, command);
+    }
+  }
+
+  const SOLVER_PROBLEM = /SolverProblemError(.* version solving failed)/gms;
+  const solverProblemError = SOLVER_PROBLEM.exec(stderr);
+  if (solverProblemError) {
+    throw new CommandFailedError(solverProblemError[0].trim(), command);
+  }
+
+  throw new NoFixesCouldBeAppliedError();
+}


### PR DESCRIPTION

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Ensure we separately throw when nothing was changed vs when
100% of fixes failed. And send appropriate message.

Revert a change that was outputting the whole pipenv stderr and only
show a short summary for those caught errors
