### PR TITLE
fix: standardize poetry package names before comparing

### DIFF
--- a/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
+++ b/packages/snyk-fix/src/plugins/python/handlers/poetry/update-dependencies/index.ts
@@ -58,10 +58,10 @@ export async function generateUpgrades(
 
   const prodTopLevelDeps = Object.keys(
     pyProjectToml.tool.poetry.dependencies ?? {},
-  );
+  ).map((dep) => standardizePackageName(dep));
   const devTopLevelDeps = Object.keys(
     pyProjectToml.tool.poetry['dev-dependencies'] ?? {},
-  );
+  ).map((dep) => standardizePackageName(dep));
 
   const upgrades: string[] = [];
   const devUpgrades: string[] = [];

--- a/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
+++ b/packages/snyk-fix/test/unit/plugins/python/handlers/poetry/generate-upgrades.spec.ts
@@ -105,7 +105,7 @@ describe('generateUpgrades', () => {
 
     [tool.poetry.dependencies]
     python = "*"
-    django = "1.1.1"
+    Django = "1.1.1"
 
     [tool.poetry.dev-dependencies]
     json-api = "0.1.21"


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
When generating upgrades make sure to standardize both package
names and the remediation package names before comparing
and choosing to do the upgrade for prod / dev dep.
