### PR TITLE
fix: add sast-scan metadata before running (possibly throwing) test

### DIFF
--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -25,8 +25,8 @@ export const codePlugin: EcosystemPlugin = {
   },
   async test(paths, options) {
     try {
-      await validateCodeTest(options);
       analytics.add('sast-scan', true);
+      await validateCodeTest(options);
       // Currently code supports only one path
       const path = paths[0];
       const sarifTypedResult = await getCodeAnalysisAndParseResults(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds metadata before running the test. If the test fails (and throws) metadata will be sent in analytics

