### PR TITLE
docs: add help for --target-reference

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -67,6 +67,10 @@ For advanced usage, we offer language and context specific flags, listed further
 - `--project-name`=<PROJECT_NAME>:
   Specify a custom Snyk project name.
 
+- `--target-reference`=<TARGET_REFERENCE>:
+  (only in `monitor` command)
+  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-man/snyk-auth.1
+++ b/help/commands-man/snyk-auth.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-AUTH" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-AUTH" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-auth\fR \- Authenticate Snyk CLI with a Snyk account
 .SH "SYNOPSIS"
@@ -59,7 +59,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -78,7 +78,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-code.1
+++ b/help/commands-man/snyk-code.1
@@ -70,7 +70,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -89,7 +89,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-config.1
+++ b/help/commands-man/snyk-config.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-CONFIG" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-CONFIG" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-config\fR \- Manage Snyk CLI configuration
 .SH "SYNOPSIS"
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Manage your local Snyk CLI config file\. This config file is a JSON located at \fB$XDG_CONFIG_HOME\fR or \fB~/\.config\fR followed by \fBconfigstore/snyk\.json\fR\. For example \fB~/\.config/configstore/snyk\.json\fR\.
 .P
-This command does not manage the \fB\.snyk\fR file that\'s part of your project\. See \fBsnyk policy\fR, \fBsnyk ignore\fR or \fBsnyk wizard\fR\.
+This command does not manage the \fB\.snyk\fR file that's part of your project\. See \fBsnyk policy\fR, \fBsnyk ignore\fR or \fBsnyk wizard\fR\.
 .SH "COMMANDS"
 .TP
 \fBget\fR \fIKEY\fR
@@ -73,7 +73,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -92,7 +92,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-container.1
+++ b/help/commands-man/snyk-container.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-CONTAINER" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-CONTAINER" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-container\fR \- Test container images for vulnerabilities
 .SH "SYNOPSIS"
@@ -20,7 +20,7 @@ Record the state of dependencies and any vulnerabilities on snyk\.io\.
 Exclude from display base image vulnerabilities\.
 .TP
 \fB\-\-file\fR=\fIFILE_PATH\fR
-Include the path to the image\'s Dockerfile for more detailed advice\.
+Include the path to the image's Dockerfile for more detailed advice\.
 .TP
 \fB\-\-platform\fR=\fIPLATFORM\fR
 For multi\-architecture images, specify the platform to test\. [linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
@@ -94,7 +94,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -113,7 +113,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-help.1
+++ b/help/commands-man/snyk-help.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-HELP" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-HELP" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-help\fR \- Prints help topics
 .SH "SYNOPSIS"
@@ -48,7 +48,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -67,7 +67,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-iac.1
+++ b/help/commands-man/snyk-iac.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-IAC" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-IAC" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-iac\fR \- Find security issues in your Infrastructure as Code files
 .SH "SYNOPSIS"
@@ -119,7 +119,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -138,7 +138,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-ignore.1
+++ b/help/commands-man/snyk-ignore.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-IGNORE" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-IGNORE" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-ignore\fR \- Modifies the \.snyk policy to ignore stated issues
 .SH "SYNOPSIS"
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Ignore a certain issue, according to its snyk ID for all occurrences\. This will update your local \fB\.snyk\fR to contain a similar block:
 .P
-\fByaml ignore: \'<ISSUE_ID>\': \- \'*\': reason: <REASON> expires: <EXPIRY>\fR
+\fByaml ignore: '<ISSUE_ID>': \- '*': reason: <REASON> expires: <EXPIRY>\fR
 .SH "OPTIONS"
 .TP
 \fB\-\-id\fR=\fIISSUE_ID\fR
@@ -38,7 +38,7 @@ Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
 .SH "EXAMPLES"
 .TP
 \fBIgnore a specific vulnerability\fR
-$ snyk ignore \-\-id=\'npm:qs:20170213\' \-\-expiry=\'2021\-01\-10\' \-\-reason=\'Module not affected by this vuln\'
+$ snyk ignore \-\-id='npm:qs:20170213' \-\-expiry='2021\-01\-10' \-\-reason='Module not affected by this vuln'
 .SH "EXIT CODES"
 Possible exit codes and their meaning:
 .P
@@ -63,7 +63,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -82,7 +82,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-MONITOR" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-MONITOR" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-monitor\fR \- Snapshot and continuously monitor your project
 .SH "SYNOPSIS"
@@ -55,10 +55,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -91,7 +91,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -162,7 +162,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -208,7 +208,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -227,7 +227,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -65,6 +65,9 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 \fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
 Specify a custom Snyk project name\.
 .TP
+\fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
+(only in \fBmonitor\fR command) A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-man/snyk-policy.1
+++ b/help/commands-man/snyk-policy.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-POLICY" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-POLICY" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-policy\fR \- Display the \.snyk policy for a package
 .SH "SYNOPSIS"
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-protect.1
+++ b/help/commands-man/snyk-protect.1
@@ -1,16 +1,16 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-PROTECT" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-PROTECT" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-protect\fR \- Applies the patches specified in your \.snyk file to the local file system
 .SH "SYNOPSIS"
 \fBsnyk\fR \fBprotect\fR [\fIOPTIONS\fR]
 .SH "DESCRIPTION"
-\fB$ snyk protect\fR is used to apply patches to your vulnerable dependencies\. It\'s useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI\. snyk protect reads a \.snyk policy file to determine what patches to apply\.
+\fB$ snyk protect\fR is used to apply patches to your vulnerable dependencies\. It's useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI\. snyk protect reads a \.snyk policy file to determine what patches to apply\.
 .SH "OPTIONS"
 .TP
 \fB\-\-dry\-run\fR
-Don\'t apply updates or patches when running\.
+Don't apply updates or patches when running\.
 .SS "Flags available accross all commands"
 .TP
 \fB\-\-insecure\fR
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-TEST" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-TEST" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-test\fR \- test local project for vulnerabilities
 .SH "SYNOPSIS"
@@ -55,10 +55,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -91,7 +91,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -162,7 +162,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -208,7 +208,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -227,7 +227,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -65,6 +65,9 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 \fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
 Specify a custom Snyk project name\.
 .TP
+\fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
+(only in \fBmonitor\fR command) A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-man/snyk-wizard.1
+++ b/help/commands-man/snyk-wizard.1
@@ -1,14 +1,14 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-WIZARD" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-WIZARD" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-wizard\fR \- Configure your policy file to update, auto patch and ignore vulnerabilities
 .SH "SYNOPSIS"
 \fBsnyk\fR \fBwizard\fR [\fIOPTIONS\fR]
 .SH "DESCRIPTION"
-Snyk\'s wizard will:
+Snyk's wizard will:
 .IP "\[ci]" 4
-Enumerate your local dependencies and query Snyk\'s servers for vulnerabilities
+Enumerate your local dependencies and query Snyk's servers for vulnerabilities
 .IP "\[ci]" 4
 Guide you through fixing found vulnerabilities
 .IP "\[ci]" 4
@@ -57,7 +57,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -76,7 +76,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-woof.1
+++ b/help/commands-man/snyk-woof.1
@@ -1,6 +1,6 @@
 .\" generated with Ronn-NG/v0.9.1
 .\" http://github.com/apjanke/ronn-ng/tree/0.9.1
-.TH "SNYK\-WOOF" "1" "August 2021" "Snyk.io"
+.TH "SNYK\-WOOF" "1" "September 2021" "Snyk.io"
 .SH "NAME"
 \fBsnyk\-woof\fR \- W00f
 .SH "SYNOPSIS"
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -110,6 +110,9 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 \fB\-\-project\-name\fR=\fIPROJECT_NAME\fR
 Specify a custom Snyk project name\.
 .TP
+\fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
+(only in \fBmonitor\fR command) A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -100,10 +100,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -136,7 +136,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -207,7 +207,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -297,7 +297,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -316,7 +316,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -78,6 +78,10 @@ For advanced usage, we offer language and context specific flags, listed further
 - `--project-name`=<PROJECT_NAME>:
   Specify a custom Snyk project name.
 
+- `--target-reference`=<TARGET_REFERENCE>:
+  (only in `monitor` command)
+  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -78,6 +78,10 @@ For advanced usage, we offer language and context specific flags, listed further
 - `--project-name`=<PROJECT_NAME>:
   Specify a custom Snyk project name.
 
+- `--target-reference`=<TARGET_REFERENCE>:
+  (only in `monitor` command)
+  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-md/snyk.md
+++ b/help/commands-md/snyk.md
@@ -123,6 +123,10 @@ For advanced usage, we offer language and context specific flags, listed further
 - `--project-name`=<PROJECT_NAME>:
   Specify a custom Snyk project name.
 
+- `--target-reference`=<TARGET_REFERENCE>:
+  (only in `monitor` command)
+  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-txt/snyk-monitor.txt
+++ b/help/commands-txt/snyk-monitor.txt
@@ -95,16 +95,22 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) A reference to separate  this  project
+              from other scans of the same project. For example, a branch name
+              or version. Projects using the same reference can  be  used  for
+              grouping. More information [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -112,9 +118,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -123,16 +129,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -144,17 +150,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects maven jars, aars, and wars in given directory. In-
+              Auto detects maven jars, aars, and wars in given directory.  In-
               dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -162,49 +168,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside a project along with any  de-
-              sired   separators,   e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -220,9 +226,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -233,10 +239,10 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your systems de-
-              fault python version. Run 'python -V' to find out  what  version
-              is  it.  If you are using multiple Python versions, use this pa-
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
               rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
@@ -257,7 +263,7 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
               tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
@@ -272,7 +278,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -280,47 +286,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-test.txt
+++ b/help/commands-txt/snyk-test.txt
@@ -95,16 +95,22 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) A reference to separate  this  project
+              from other scans of the same project. For example, a branch name
+              or version. Projects using the same reference can  be  used  for
+              grouping. More information [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -112,9 +118,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -123,16 +129,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -144,17 +150,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects maven jars, aars, and wars in given directory. In-
+              Auto detects maven jars, aars, and wars in given directory.  In-
               dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -162,49 +168,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside a project along with any  de-
-              sired   separators,   e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -220,9 +226,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -233,10 +239,10 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your systems de-
-              fault python version. Run 'python -V' to find out  what  version
-              is  it.  If you are using multiple Python versions, use this pa-
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
               rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
@@ -257,7 +263,7 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
               tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
@@ -272,7 +278,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -280,47 +286,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk.txt
+++ b/help/commands-txt/snyk.txt
@@ -140,16 +140,22 @@
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) A reference to separate  this  project
+              from other scans of the same project. For example, a branch name
+              or version. Projects using the same reference can  be  used  for
+              grouping. More information [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+
        [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -157,9 +163,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -168,16 +174,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -189,17 +195,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects maven jars, aars, and wars in given directory. In-
+              Auto detects maven jars, aars, and wars in given directory.  In-
               dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -207,49 +213,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside a project along with any  de-
-              sired   separators,   e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -265,9 +271,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -278,10 +284,10 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your systems de-
-              fault python version. Run 'python -V' to find out  what  version
-              is  it.  If you are using multiple Python versions, use this pa-
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
               rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
@@ -302,7 +308,7 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
               tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
@@ -364,7 +370,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -372,47 +378,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/generator/generator.ts
+++ b/help/generator/generator.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs';
-import { exec } from 'child_process';
+import { runCommand } from '../../test/jest/util/runCommand';
 
 const RONN_COMMAND = process.env.RONN_COMMAND || 'ronn';
 const COMMANDS: Record<string, { optionsFile?: string }> = {
@@ -23,35 +23,43 @@ const COMMANDS: Record<string, { optionsFile?: string }> = {
   woof: {},
 };
 
-const GENERATED_MARKDOWN_FOLDER = './help/commands-md';
-const GENERATED_MAN_FOLDER = './help/commands-man';
-const GENERATED_TXT_FOLDER = './help/commands-txt';
+const MARKDOWN_DIR = path.resolve(__dirname, '../commands-md');
+const MAN_DIR = path.resolve(__dirname, '../commands-man');
+const TXT_DIR = path.resolve(__dirname, '../commands-txt');
 
-function execShellCommand(cmd): Promise<string> {
-  return new Promise((resolve) => {
-    exec(cmd, (error, stdout, stderr) => {
-      if (error) {
-        console.warn(error);
-      }
-      return resolve(stdout ? stdout : stderr);
-    });
+async function execShellCommand(cmd: string, args: string[]): Promise<string> {
+  const { code, stdout, stderr } = await runCommand(cmd, args, {
+    env: {
+      ...process.env,
+      PAGER: 'more', // see https://github.com/apjanke/ronn-ng/issues/71
+    },
   });
+  if (stderr) {
+    console.error(stderr);
+  }
+  if (code !== 0) {
+    throw new Error('Command exiting with non-zero exit code.');
+  }
+  return stdout;
 }
 
 async function generateRoff(inputFile): Promise<string> {
-  return await execShellCommand(
-    `cat ${inputFile} | ${RONN_COMMAND} --roff --pipe --organization=Snyk.io`,
-  );
+  return await execShellCommand(RONN_COMMAND, [
+    '--roff',
+    '--pipe',
+    '--organization=Snyk.io',
+    inputFile,
+  ]);
 }
 
-async function printRoff2Txt(inputFile) {
-  return await execShellCommand(`cat ${inputFile} | ${RONN_COMMAND} -m`);
+async function printRoff2Txt(inputFile): Promise<string> {
+  return await execShellCommand(RONN_COMMAND, ['-m', inputFile]);
 }
 
 async function processMarkdown(markdownDoc, commandName) {
-  const markdownFilePath = `${GENERATED_MARKDOWN_FOLDER}/${commandName}.md`;
-  const roffFilePath = `${GENERATED_MAN_FOLDER}/${commandName}.1`;
-  const txtFilePath = `${GENERATED_TXT_FOLDER}/${commandName}.txt`;
+  const markdownFilePath = path.resolve(MARKDOWN_DIR, `${commandName}.md`);
+  const roffFilePath = path.resolve(MAN_DIR, `${commandName}.1`);
+  const txtFilePath = path.resolve(TXT_DIR, `${commandName}.txt`);
 
   console.info(`Generating markdown version ${commandName}.md`);
   fs.writeFileSync(markdownFilePath, markdownDoc);
@@ -74,18 +82,13 @@ async function processMarkdown(markdownDoc, commandName) {
     .split('\n')
     .slice(4, -4)
     .join('\n');
-  console.log(formattedTxtDoc);
 
   fs.writeFileSync(txtFilePath, formattedTxtDoc);
 }
 
 async function run() {
   // Ensure folders exists
-  [
-    GENERATED_MAN_FOLDER,
-    GENERATED_MARKDOWN_FOLDER,
-    GENERATED_TXT_FOLDER,
-  ].forEach((path) => {
+  [MAN_DIR, MARKDOWN_DIR, TXT_DIR].forEach((path) => {
     if (!fs.existsSync(path)) {
       fs.mkdirSync(path);
     }


### PR DESCRIPTION
A few things:

- `txt` docs weren't being generated due to an issue with ronn-ng.
  - https://github.com/apjanke/ronn-ng/issues/71
    - The issue is solve but hasn't been released yet.
    - I implemented a `PAGER` env workaround that was stated in the thread.
  - While I was there:
    - I updated the paths to use `path.resolve` so that they're not dependant on the current working directory.
    - Removed the `cat` piping as `ronn` can take a file path as input.
- I had to regenerate docs as it seems to have gotten misaligned for some reason. Cross-platform issues maybe. Main changes are:
  - Updated date.
  - Removed `'` escapes.
- I put the `--target-reference` change in a separate commit for readability.