### PR TITLE
fix: better error when org is not found for snyk code

### DIFF
--- a/src/lib/plugins/sast/checks.ts
+++ b/src/lib/plugins/sast/checks.ts
@@ -8,6 +8,7 @@ interface SastSettings {
   sastEnabled: boolean;
   code?: number;
   error?: string;
+  userMessage?: string;
 }
 
 interface TrackUsageResponse {

--- a/src/lib/plugins/sast/validate.ts
+++ b/src/lib/plugins/sast/validate.ts
@@ -17,8 +17,6 @@ export async function validateCodeTest(options: Options) {
     throw new FeatureNotSupportedForOrgError(org);
   }
 
-  // TODO: We would need to remove this once we fix circular import issue
-
   const sastSettingsResponse = await getSastSettingsForOrg(org);
 
   if (

--- a/src/lib/plugins/sast/validate.ts
+++ b/src/lib/plugins/sast/validate.ts
@@ -1,10 +1,12 @@
 import { Options } from '../../types';
 import config from '../../config';
+import { getSastSettingsForOrg, trackUsage } from './checks';
 
 import {
   AuthFailedError,
   FailedToRunTestError,
   FeatureNotSupportedForOrgError,
+  NotFoundError,
 } from '../../errors';
 
 export async function validateCodeTest(options: Options) {
@@ -16,7 +18,6 @@ export async function validateCodeTest(options: Options) {
   }
 
   // TODO: We would need to remove this once we fix circular import issue
-  const { getSastSettingsForOrg, trackUsage } = require('./checks');
 
   const sastSettingsResponse = await getSastSettingsForOrg(org);
 
@@ -28,6 +29,10 @@ export async function validateCodeTest(options: Options) {
       sastSettingsResponse.error,
       sastSettingsResponse.code,
     );
+  }
+
+  if (sastSettingsResponse?.code === 404) {
+    throw new NotFoundError(sastSettingsResponse?.userMessage);
   }
 
   if (!sastSettingsResponse.sastEnabled) {

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -17,7 +17,7 @@ import { jsonStringifyLargeObject } from '../../../../src/lib/json';
 import { ArgsOptions } from '../../../../src/cli/args';
 
 const { getCodeAnalysisAndParseResults } = analysis;
-const osName = require('os-name');
+import osName = require('os-name');
 
 describe('Test snyk code', () => {
   let apiUserConfig;
@@ -211,6 +211,17 @@ describe('Test snyk code', () => {
       'userMessage',
       'Snyk Code is not supported for org: enable in Settings > Snyk Code',
     );
+  });
+
+  it('should show org not found error according to response from api', async () => {
+    isSastEnabledForOrgSpy.mockResolvedValueOnce({
+      code: 404,
+      userMessage: 'error from api: org not found',
+    });
+
+    await expect(
+      snykTest('some/path', { code: true, _: [], _doubleDashArgs: [] }),
+    ).rejects.toHaveProperty('userMessage', 'error from api: org not found');
   });
 
   it('should show error if limit is reached', async () => {


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR shows better error when org is not found for user (instead of showing "Snyk code is not enabled for org")

#### Where should the reviewer start?


#### How should this be manually tested?
run `snyk code test --org=foo` with this PR

#### Any background context you want to provide?


#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/COD-556?atlOrigin=eyJpIjoiMTBlZjliODkxMjM4NGVkNjgzMGEyZmE5M2NkMDExMWMiLCJwIjoiaiJ9

#### Screenshots


#### Additional questions
