### PR TITLE
fix: skip files greater than or equal to 2GB

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.3",
+        "snyk-cpp-plugin": "2.12.4",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22905,9 +22905,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
-      "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
+      "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -45645,7 +45645,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.3",
+        "snyk-cpp-plugin": "2.12.4",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -63859,9 +63859,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.12.3",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
-          "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
+          "version": "2.12.4",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
+          "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -67313,9 +67313,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.12.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.3.tgz",
-      "integrity": "sha512-LjtYEJmc0RcqQAv4qmwvE+iUASi0gaIkec78C1GlIy1kUxUF+YlBLIFrnik6Yf/FHlJCekvr3SvxAS2qNdEBLg==",
+      "version": "2.12.4",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
+      "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.12.3",
+    "snyk-cpp-plugin": "2.12.4",
     "snyk-docker-plugin": "4.26.1",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
fix: skip files greater than or equal to 2GB

Due to limitations with nodes Buffer, we agreed
to skip files greater than or equal to 2GB.

This is implemented by following changes:

- Add file size validation to find.ts

To test this fix, run the CLI test with an unmanaged
project containing a file of at least 2GB. Consider
it a success if it's not crashing, and we generate
signatures for all other files.