### PR TITLE
spike: support node@16 lts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ defaults: &defaults
   parameters:
     node_version:
       type: string
-      default: '14.17.5'
+      default: '16.13.0'
     root_tap_tests:
       type: boolean
       default: false
@@ -34,7 +34,7 @@ commands:
         type: string
       npm_version:
         type: string
-        default: '7.21.1'
+        default: '8.1.0'
       npm_cache_directory:
         type: string
         default: /mnt/ramdisk/.npm
@@ -439,7 +439,7 @@ workflows:
                 - master
 
       - test-windows:
-          name: Windows, Node v14.17.5 - Packages, Jest, System Tests
+          name: Windows, Node v16.13.0 - Packages, Jest, System Tests
           context: nodejs-install
           requires:
             - Build
@@ -451,7 +451,7 @@ workflows:
           system_tests: true
           package_tests: true
       - test-windows:
-          name: Windows, Node v14.17.5 - Acceptance Tests
+          name: Windows, Node v16.13.0 - Acceptance Tests
           context: nodejs-install
           requires:
             - Build
@@ -461,7 +461,7 @@ workflows:
                 - master
           acceptance_tests: true
       - test-windows:
-          name: Windows, Node v14.17.5 - Root Tap Tests
+          name: Windows, Node v16.13.0 - Root Tap Tests
           context: nodejs-install
           requires:
             - Build
@@ -482,7 +482,7 @@ workflows:
                 - master
           matrix:
             parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5']
+              node_version: ['12.22.7', '14.18.1', '16.13.0']
           jest_tests: true
           system_tests: true
           package_tests: true
@@ -497,7 +497,7 @@ workflows:
                 - master
           matrix:
             parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5']
+              node_version: ['12.22.7', '14.18.1', '16.13.0']
           acceptance_tests: true
       - test-linux:
           name: Linux, Node v<< matrix.node_version >> - Root Tap Tests
@@ -510,7 +510,7 @@ workflows:
                 - master
           matrix:
             parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5']
+              node_version: ['12.22.7', '14.18.1', '16.13.0']
           root_tap_tests: true
 
       - dev-release:

--- a/.github/workflows/check-dependencies.yml
+++ b/.github/workflows/check-dependencies.yml
@@ -9,19 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-      - run: npm install -g npm@7
-
-      - name: npm config get cache
-        id: npm-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npx npm@7 config get cache)"
-      - uses: actions/cache@v2
-        id: npm-cache
+      - uses: actions/setup-node@v2
         with:
-          path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-npm-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-npm-
-      - run: npm install
+          node-version: '16'
+          cache: 'npm'
+      - run: npm ci
       - run: npx ts-node ./scripts/check-dependencies.ts

--- a/.github/workflows/cli-alert.yml
+++ b/.github/workflows/cli-alert.yml
@@ -12,10 +12,10 @@ jobs:
         working-directory: ./packages/cli-alert
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14
-      - run: npm install -g npm@7
+          node-version: '16'
+          cache: 'npm'
       - run: npm install
       - run: npm start
         env:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -22,11 +22,11 @@ jobs:
           # Skip yarn for Windows, as it's a bit crazy to get it working in CI environment. Unless we see evidence we need it, I'd avoid it
           - snyk_install_method: yarn
             os: windows
-          # For binary, use only the Node 14
+          # Binaries are compiled with Node 16 so don't need to test other versions.
           - snyk_install_method: binary
             node_version: 12
           - snyk_install_method: binary
-            node_version: 16
+            node_version: 14
         include:
           - snyk_install_method: binary
             os: ubuntu

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -17,20 +17,16 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         snyk_install_method: [binary, npm, yarn]
-        node_version: [10, 12, 14, 15]
+        node_version: [12, 14, 16]
         exclude:
           # Skip yarn for Windows, as it's a bit crazy to get it working in CI environment. Unless we see evidence we need it, I'd avoid it
           - snyk_install_method: yarn
             os: windows
           # For binary, use only the Node 14
           - snyk_install_method: binary
-            node_version: 10
-          - snyk_install_method: binary
             node_version: 12
           - snyk_install_method: binary
-            node_version: 15
-          - snyk_install_method: yarn # yarn doesn't support Node v10 anymore
-            node_version: 10
+            node_version: 16
         include:
           - snyk_install_method: binary
             os: ubuntu
@@ -53,7 +49,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v1 # Needed for fixtures installation
+      - uses: actions/setup-node@v2 # Needed for fixtures installation
         with:
           node-version: ${{ matrix.node_version }}
 

--- a/.github/workflows/snyk-protect-production-smoke-tests.yml
+++ b/.github/workflows/snyk-protect-production-smoke-tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        node_version: [10, 12, 14, 16]
+        node_version: [12, 14, 16]
     runs-on: ${{ matrix.os }}-latest
     steps:
       # Avoid modifying line endings in fixtures.
@@ -24,21 +24,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node_version }}
+          cache: 'npm'
 
-      - name: npx npm@7 config get cache
-        id: npm7-cache-dir
-        run: |
-          echo "::set-output name=dir::$(npx npm@7 config get cache)"
-      - uses: actions/cache@v2
-        id: npm7-cache
-        with:
-          path: ${{ steps.npm7-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-node${{ matrix.node_version }}-npm7-${{ hashFiles('**/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node${{ matrix.node_version }}-npm7-
-
-      - run: npx npm@7 install
-      - run: npx npm@7 run test:smoke -w @snyk/protect
+      # Our dev environment needs npm@8 but we want to test bundled npm
+      # versions in our tests. So we're using npx here.
+      - run: npx npm@8 ci
+      - run: npx npm@8 run test:smoke -w @snyk/protect
         env:
           SNYK_TOKEN: ${{ secrets.SMOKE_TESTS_SNYK_TOKEN }}
           PRODUCTION_TEST: '1'

--- a/package-lock.json
+++ b/package-lock.json
@@ -20468,9 +20468,9 @@
       }
     },
     "node_modules/pkg": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.2.tgz",
-      "integrity": "sha512-78X8Tt71TI11XjkZm/r9shTdFRooFiiRcT8nfYeeOou5VKCkCysQauwAAkJKb5yjfrUhk3CBNL4zv22/iLpdnw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.4.1.tgz",
+      "integrity": "sha512-iJs3W6MCgeZ4MrH7iZtX6HTqsNzoh2U9rGILL3eOLbQFV43U8WPAzrqRK7cBQGuHx38UXxcGT6G/2yDl/GveRg==",
       "dev": true,
       "dependencies": {
         "@babel/parser": "7.13.13",
@@ -20482,7 +20482,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.3",
+        "pkg-fetch": "3.2.4",
         "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -20514,9 +20514,9 @@
       }
     },
     "node_modules/pkg-fetch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.3.tgz",
-      "integrity": "sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.4.tgz",
+      "integrity": "sha512-ewUD26GP86/8+Fu93zrb30CpJjKOtT4maSgm4SwTX9Ujy1pfdUdv+1PubsY9tTJES0iBYItAtqbfkf7Wu5LV9w==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.1.0",
@@ -43663,9 +43663,9 @@
       }
     },
     "pkg": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.2.tgz",
-      "integrity": "sha512-78X8Tt71TI11XjkZm/r9shTdFRooFiiRcT8nfYeeOou5VKCkCysQauwAAkJKb5yjfrUhk3CBNL4zv22/iLpdnw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.4.1.tgz",
+      "integrity": "sha512-iJs3W6MCgeZ4MrH7iZtX6HTqsNzoh2U9rGILL3eOLbQFV43U8WPAzrqRK7cBQGuHx38UXxcGT6G/2yDl/GveRg==",
       "dev": true,
       "requires": {
         "@babel/parser": "7.13.13",
@@ -43677,7 +43677,7 @@
         "into-stream": "^6.0.0",
         "minimist": "^1.2.5",
         "multistream": "^4.1.0",
-        "pkg-fetch": "3.2.3",
+        "pkg-fetch": "3.2.4",
         "prebuild-install": "6.0.1",
         "progress": "^2.0.3",
         "resolve": "^1.20.0",
@@ -43769,9 +43769,9 @@
       }
     },
     "pkg-fetch": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.3.tgz",
-      "integrity": "sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.4.tgz",
+      "integrity": "sha512-ewUD26GP86/8+Fu93zrb30CpJjKOtT4maSgm4SwTX9Ujy1pfdUdv+1PubsY9tTJES0iBYItAtqbfkf7Wu5LV9w==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
@@ -61954,9 +61954,9 @@
           }
         },
         "pkg": {
-          "version": "5.3.2",
-          "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.3.2.tgz",
-          "integrity": "sha512-78X8Tt71TI11XjkZm/r9shTdFRooFiiRcT8nfYeeOou5VKCkCysQauwAAkJKb5yjfrUhk3CBNL4zv22/iLpdnw==",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/pkg/-/pkg-5.4.1.tgz",
+          "integrity": "sha512-iJs3W6MCgeZ4MrH7iZtX6HTqsNzoh2U9rGILL3eOLbQFV43U8WPAzrqRK7cBQGuHx38UXxcGT6G/2yDl/GveRg==",
           "dev": true,
           "requires": {
             "@babel/parser": "7.13.13",
@@ -61968,7 +61968,7 @@
             "into-stream": "^6.0.0",
             "minimist": "^1.2.5",
             "multistream": "^4.1.0",
-            "pkg-fetch": "3.2.3",
+            "pkg-fetch": "3.2.4",
             "prebuild-install": "6.0.1",
             "progress": "^2.0.3",
             "resolve": "^1.20.0",
@@ -62060,9 +62060,9 @@
           }
         },
         "pkg-fetch": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.3.tgz",
-          "integrity": "sha512-bv9vYANgAZ2Lvxn5Dsq7E0rLqzcqYkV4gnwe2f7oHV9N4SVMfDOIjjFCRuuTltop5EmsOcu7XkQpB5A/pIgC1g==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-3.2.4.tgz",
+          "integrity": "sha512-ewUD26GP86/8+Fu93zrb30CpJjKOtT4maSgm4SwTX9Ujy1pfdUdv+1PubsY9tTJES0iBYItAtqbfkf7Wu5LV9w==",
           "dev": true,
           "requires": {
             "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "snyk": "bin/snyk"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "workspaces": [
     ".",

--- a/packages/snyk-fix/package.json
+++ b/packages/snyk-fix/package.json
@@ -16,7 +16,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "tsc",

--- a/packages/snyk-protect/package.json
+++ b/packages/snyk-protect/package.json
@@ -20,7 +20,7 @@
     "snyk-protect": "bin/snyk-protect"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "scripts": {
     "build": "tsc",

--- a/release-scripts/docker-desktop-release.sh
+++ b/release-scripts/docker-desktop-release.sh
@@ -17,7 +17,7 @@ cp ./release-scripts/snyk-mac.sh ./dist-docker/docker/
 cd ./dist-docker/docker/
 
 # Download macOS NodeJS binary, using same as pkg
-curl "https://nodejs.org/dist/v12.18.3/node-v12.18.3-darwin-x64.tar.gz" | tar -xz
+curl "https://nodejs.org/dist/v12.22.7/node-v12.22.7-darwin-x64.tar.gz" | tar -xz
 
 cd ..
 

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -3,10 +3,10 @@ set -e
 
 mkdir binary-releases
 
-npx pkg . --compress Brotli -t node14-alpine-x64 -o binary-releases/snyk-alpine
-npx pkg . --compress Brotli -t node14-linux-x64  -o binary-releases/snyk-linux
-npx pkg . --compress Brotli -t node14-macos-x64  -o binary-releases/snyk-macos
-npx pkg . --compress Brotli -t node14-win-x64    -o binary-releases/snyk-win-unsigned.exe
+npx pkg . --compress Brotli -t node16-alpine-x64 -o binary-releases/snyk-alpine
+npx pkg . --compress Brotli -t node16-linux-x64  -o binary-releases/snyk-linux
+npx pkg . --compress Brotli -t node16-macos-x64  -o binary-releases/snyk-macos
+npx pkg . --compress Brotli -t node16-win-x64    -o binary-releases/snyk-win-unsigned.exe
 
 # build docker package
 ./release-scripts/docker-desktop-release.sh

--- a/release-scripts/snyk-mac.sh
+++ b/release-scripts/snyk-mac.sh
@@ -3,7 +3,7 @@ set -e
 
 DIRNAME=$(dirname "$0")
 
-NODE="$DIRNAME/node-v12.18.3-darwin-x64/bin/node"
+NODE="$DIRNAME/node-v12.22.7-darwin-x64/bin/node"
 SNYK_CLI="$DIRNAME/dist/cli/index.js"
 
 "$NODE" "$SNYK_CLI" "$@"

--- a/scripts/check-dev-environment.ts
+++ b/scripts/check-dev-environment.ts
@@ -4,19 +4,9 @@ type Issue = {
   enforce: boolean;
 };
 
-/**
- * We have a hack in .circleci/config.yml which uses npm@6 for regression
- * tests. Once that's removed we can remove this check.
- */
-const isCIHackInstall = (): boolean => {
-  return (
-    typeof process.env.CI === 'string' && process.env.NODE_ENV === 'production'
-  );
-};
-
 const checkDevEnvironment = async () => {
   const issues: Issue[] = [];
-  const expectedNpmVersion = '7';
+  const expectedNpmVersion = '8';
 
   try {
     // npm/7.14.0 node/v14.16.1 linux x64 workspaces/false
@@ -35,7 +25,7 @@ const checkDevEnvironment = async () => {
       issues.push({
         target: 'npm',
         reason: `Expected npm@${expectedNpmVersion} but found npm@${npmVersion}`,
-        enforce: !isCIHackInstall(),
+        enforce: true,
       });
     }
   } catch (error) {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -207,14 +207,13 @@ async function saveJsonResultsToFile(
   );
 }
 
-function checkRuntime() {
-  if (!runtime.isSupported(process.versions.node)) {
+function checkRuntime(): void | never {
+  if (runtime.isSupported(process.versions.node)) {
     console.error(
-      `Node.js version ${process.versions.node} is an unsupported Node.js ` +
-        `runtime! Supported runtime range is '${runtime.supportedRange}'`,
+      `Node.js v${process.versions.node} is no longer maintained. Please upgrade to Node.js ${runtime.supportedRange}.`,
     );
     console.error(
-      'Please upgrade your Node.js runtime. The last version of Snyk CLI that supports Node.js v8 is v1.454.0.',
+      'If you wish to use Snyk CLI despite this, downgrade to v1.756.0 or below',
     );
     process.exit(EXIT_CODES.ERROR);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -338,17 +338,6 @@ async function main() {
   return res;
 }
 
-const cli = main().catch((e) => {
-  console.error('Something unexpected went wrong: ', e.stack);
-  console.error('Exit code: ' + EXIT_CODES.ERROR);
-  process.exit(EXIT_CODES.ERROR);
-});
-
-if (module.parent) {
-  // eslint-disable-next-line id-blacklist
-  module.exports = cli;
-}
-
 function validateUnsupportedOptionCombinations(
   options: AllSupportedCliOptions,
 ): void {
@@ -491,4 +480,20 @@ function validateOutputFile(
   if (fileOutputValue === "''" || fileOutputValue === '""') {
     throw error;
   }
+}
+
+function handleUnexpectedError(reason: unknown): never {
+  console.error('Something unexpected went wrong: ', reason);
+  console.error('Exit code: ' + EXIT_CODES.ERROR);
+  process.exit(EXIT_CODES.ERROR);
+}
+
+process.on('unhandledRejection', handleUnexpectedError);
+process.on('uncaughtException', handleUnexpectedError);
+
+const cli = main().catch(handleUnexpectedError);
+
+if (module.parent) {
+  // eslint-disable-next-line id-blacklist
+  module.exports = cli;
 }

--- a/src/cli/runtime.ts
+++ b/src/cli/runtime.ts
@@ -1,6 +1,6 @@
 import { gte } from 'semver';
 
-const MIN_RUNTIME = '10.0.0';
+const MIN_RUNTIME = '12.0.0';
 
 export const supportedRange = `>= ${MIN_RUNTIME}`;
 

--- a/test/jest/acceptance/proxy-behavior.spec.ts
+++ b/test/jest/acceptance/proxy-behavior.spec.ts
@@ -5,7 +5,7 @@ const SNYK_API_HTTPS = 'https://snyk.io/api/v1';
 const SNYK_API_HTTP = 'http://snyk.io/api/v1';
 const FAKE_HTTP_PROXY = `http://localhost:${fakeServerPort}`;
 
-jest.setTimeout(1000 * 60 * 1);
+jest.setTimeout(1000 * 60);
 
 describe('Proxy configuration behavior', () => {
   describe('*_PROXY against HTTPS host', () => {
@@ -71,7 +71,7 @@ describe('Proxy configuration behavior', () => {
         },
       });
 
-      expect(code).toBe(1);
+      expect(code).toBe(2);
 
       // Incorrect behavior when Needle tries to upgrade connection after 301 http->https and the Agent option is set to a strict http/s protocol.
       // See lines with `keepAlive` in request.ts for more details

--- a/test/jest/unit/runtime.spec.ts
+++ b/test/jest/unit/runtime.spec.ts
@@ -1,37 +1,21 @@
-import * as runtime from '../../../src/cli/runtime';
+import { isSupported } from '../../../src/cli/runtime';
 
-describe('verify supported nodejs runtime versions', () => {
-  it('current runtime is supported', async () => {
-    expect(runtime.isSupported(process.versions.node)).toBeTruthy();
+describe('isSupported', () => {
+  it('supports this test runtime', async () => {
+    expect(isSupported(process.versions.node)).toBe(true);
   });
 
-  it('pre-release is supported', async () => {
-    expect(runtime.isSupported('11.0.0-pre')).toBeTruthy();
-  });
-});
-
-describe('verify unsupported nodejs runtime versions', () => {
-  it('v6.16.0 is not supported', async () => {
-    expect(runtime.isSupported('6.16.0')).toBeFalsy();
+  it('supports pre-release versions', async () => {
+    expect(isSupported('16.0.0-pre')).toBe(true);
   });
 
-  it('v0.10 is not supported', async () => {
-    expect(runtime.isSupported('0.10.48')).toBeFalsy();
+  it('supports minimum version', async () => {
+    expect(isSupported('12.0.0')).toBe(true);
   });
 
-  it('v0.12 is not supported', async () => {
-    expect(runtime.isSupported('0.12.18')).toBeFalsy();
-  });
-
-  it('v4.0.0 is not supported', async () => {
-    expect(runtime.isSupported('4.0.0')).toBeFalsy();
-  });
-
-  it('verifies v6.4.0 is not supported', async () => {
-    expect(runtime.isSupported('6.4.0')).toBeFalsy();
-  });
-
-  it('verifies v8.0.0 is not supported', async () => {
-    expect(runtime.isSupported('8.0.0')).toBeFalsy();
+  it('does not support versions below minimum version', async () => {
+    expect(isSupported('8.0.0')).toBe(false);
+    expect(isSupported('10.0.0')).toBe(false);
+    expect(isSupported('11.9.0')).toBe(false);
   });
 });

--- a/test/system/cli.test.ts
+++ b/test/system/cli.test.ts
@@ -79,8 +79,9 @@ test('test without authentication', async (t) => {
       '`snyk` requires an authenticated account. Please run `snyk auth` and try again.',
       'error message is shown as expected',
     );
+  } finally {
+    await cli.config('set', 'api=' + apiKey);
   }
-  await cli.config('set', 'api=' + apiKey);
 });
 
 test('auth via key', async (t) => {
@@ -132,13 +133,14 @@ test('auth with no args', async (t) => {
       'http://localhost:12345/login?token=',
       'opens login with token param',
     );
-    ciStub.restore();
-    dockerStub.restore();
   } catch (e) {
     t.threw(e);
+  } finally {
+    ciStub.restore();
+    dockerStub.restore();
+    // turn console.log back on
+    enableLog();
   }
-  // turn console.log back on
-  enableLog();
 });
 
 test('auth with UTMs in environment variables', async (t) => {
@@ -173,7 +175,9 @@ test('auth with UTMs in environment variables', async (t) => {
       '&utm_medium=ide&utm_source=eclipse&utm_campaign=plugin',
       'opens login with utm tokens provided',
     );
-
+  } catch (e) {
+    t.threw(e);
+  } finally {
     // clean up environment variables
     delete process.env.SNYK_UTM_MEDIUM;
     delete process.env.SNYK_UTM_SOURCE;
@@ -184,8 +188,6 @@ test('auth with UTMs in environment variables', async (t) => {
 
     // restore original console.log
     console.log = origConsoleLog;
-  } catch (e) {
-    t.threw(e);
   }
 });
 
@@ -216,15 +218,15 @@ test('auth with default UTMs', async (t) => {
       '&utm_medium=cli&utm_source=cli&utm_campaign=cli&os=darwin&docker=false',
       'defualt utms are exists',
     );
-
+  } catch (e) {
+    t.threw(e);
+  } finally {
     // clean up stubs
     ciStub.restore();
     osStub.restore();
     isDockerStub.restore();
     // restore original console.log
     console.log = origConsoleLog;
-  } catch (e) {
-    t.threw(e);
   }
 });
 test('cli tests error paths', async (t) => {
@@ -262,9 +264,10 @@ test('snyk ignore - all options', async (t) => {
     });
     const pol = await policy.load(dir);
     t.deepEquals(pol.ignore, fullPolicy, 'policy written correctly');
-    clock.restore();
   } catch (err) {
     t.throws(err, 'ignore should succeed');
+  } finally {
+    clock.restore();
   }
 });
 
@@ -315,9 +318,10 @@ test('snyk ignore - default options', async (t) => {
       new Date().getTime(),
       'created date is the current date',
     );
-    clock.restore();
   } catch (e) {
     t.fail(e, 'ignore should succeed');
+  } finally {
+    clock.restore();
   }
 });
 


### PR DESCRIPTION
Node 16 LTS was released at the end of October 2021. It will work with existing CLI releases, but we aren't explicity testing it. This PR adds Node 16 to our CI pipeline to ensure everything we test for continues working.

## To Do

- [x] Fix analytics error
  - #2346 
- [x] Handle unhandled rejection
  - #2368 
- [x] Update pipelines to run against Node 16
- [x] Fix failing tests
  - #2409 

## After Merge

1. Deprecate Node 10
2. Upgrade to npm 8
3. Upgrade binaries

## npm 8 and Node 10

Node 16 ships with npm 8. npm 8 dropped support for Node 10 and fails if it's detected. This means we cannot run builds and tests against a Node 10 environment. Node 10 is deprecated and is no longer maintained.

So to properly support Node 16 in the future, we'll need to drop Node 10. For now, we can downgrade to npm 7.