### PR TITLE
feat: don't hash emails in monitor command

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -1,12 +1,20 @@
 import * as fs from 'fs';
 import * as tar from 'tar';
 import * as path from 'path';
+import * as crypto from 'crypto';
 import {
   FailedToInitLocalCacheError,
   LOCAL_POLICY_ENGINE_DIR,
 } from './local-cache';
 import { CUSTOM_RULES_TARBALL } from './oci-pull';
-import { hashData } from '../../../../lib/monitor/dev-count-analysis';
+
+function hashData(s: string): string {
+  const hashedData = crypto
+    .createHash('sha1')
+    .update(s)
+    .digest('hex');
+  return hashedData;
+}
 
 export function createIacDir(): void {
   // this path will be able to be customised by the user in the future

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -36,7 +36,7 @@ export interface ProtectOptions {
 }
 
 export interface Contributor {
-  userId: string;
+  email: string;
   lastCommitDate: string;
 }
 

--- a/test/dev-count-analysis.spec.ts
+++ b/test/dev-count-analysis.spec.ts
@@ -5,7 +5,6 @@ import {
   SERIOUS_DELIMITER,
   MAX_COMMITS_IN_GIT_LOG,
   separateLines,
-  hashData,
 } from '../src/lib/monitor/dev-count-analysis';
 
 const testTimeout = 60000;
@@ -13,10 +12,10 @@ const testTimeout = 60000;
 const TIMESTAMP_TO_TEST = 1590174610000;
 
 describe('cli dev count via git log analysis', () => {
-  let expectedContributorUserIds: string[] = [];
-  let expectedMergeOnlyUserIds: string[] = [];
+  let expectedContributoremails: string[] = [];
+  let expectedMergeOnlyemails: string[] = [];
 
-  // this computes the expectedContributorUserIds and expectedMergeOnlyUserIds
+  // this computes the expectedContributoremails and expectedMergeOnlyemails
   beforeAll(async () => {
     const timestampEpochSecondsEndOfPeriod = Math.floor(
       TIMESTAMP_TO_TEST / 1000,
@@ -53,12 +52,8 @@ describe('cli dev count via git log analysis', () => {
       }
     }
 
-    expectedContributorUserIds = uniqueEmailsContainingAtLeastOneNonMergeCommit.map(
-      hashData,
-    );
-    expectedMergeOnlyUserIds = uniqueEmailsContainingOnlyMergeCommits.map(
-      hashData,
-    );
+    expectedContributoremails = uniqueEmailsContainingAtLeastOneNonMergeCommit;
+    expectedMergeOnlyemails = uniqueEmailsContainingOnlyMergeCommits;
   }, testTimeout);
 
   it(
@@ -69,9 +64,9 @@ describe('cli dev count via git log analysis', () => {
         periodDays: 10,
         repoPath: process.cwd(),
       });
-      const contributorUserIds = contributors.map((c) => c.userId);
-      expect(contributorUserIds.sort()).toEqual(
-        expectedContributorUserIds.sort(),
+      const contributoremails = contributors.map((c) => c.email);
+      expect(contributoremails.sort()).toEqual(
+        expectedContributoremails.sort(),
       );
     },
     testTimeout,
@@ -85,13 +80,13 @@ describe('cli dev count via git log analysis', () => {
         periodDays: 10,
         repoPath: process.cwd(),
       });
-      const contributorUserIds = contributors.map((c) => c.userId);
+      const contributoremails = contributors.map((c) => c.email);
 
-      // make sure none of uniqueEmailsContainingOnlyMergeCommits are in contributorUserIds
-      const legitUserIdsWhichAreAlsoInMergeOnlyUserIds = expectedMergeOnlyUserIds.filter(
-        (user) => contributorUserIds.includes(user),
+      // make sure none of uniqueEmailsContainingOnlyMergeCommits are in contributoremails
+      const legitemailsWhichAreAlsoInMergeOnlyemails = expectedMergeOnlyemails.filter(
+        (user) => contributoremails.includes(user),
       );
-      expect(legitUserIdsWhichAreAlsoInMergeOnlyUserIds).toHaveLength(0);
+      expect(legitemailsWhichAreAlsoInMergeOnlyemails).toHaveLength(0);
     },
     testTimeout,
   );


### PR DESCRIPTION
Snyk CLI/API is now collecting emails of developers that contributed to the monitored project in last 90 days.