### PR TITLE
test: add acceptance test for github cr [CFG-1105]

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -133,6 +133,12 @@ describe('custom rules pull from a remote OCI registry', () => {
       'AWS',
       getOciElasticRegistryPassword(),
     ],
+    [
+      'GitHub',
+      process.env.OCI_GITHUB_REGISTRY_URL,
+      process.env.OCI_GITHUB_REGISTRY_USERNAME,
+      process.env.OCI_GITHUB_REGISTRY_PASSWORD,
+    ],
   ];
   test.each(cases)(
     'given %p as a registry and correct credentials, it returns a success exit code',


### PR DESCRIPTION
#### What does this PR do?
This PR adds an acceptance test for GitHub CR.

#### Any background context you want to provide?
This test is one of the acceptance criteria to be able to claim we support GitHub CR for storing custom rules.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1105
