### PR TITLE
chore: Update codeowners for the open source group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*  @snyk/hammer @snyk/loki @snyk/tardis @snyk/tundra
+*  @snyk/hammer @snyk/snyk-open-source
 
 # monorepo packages
 packages/snyk-fix/ @snyk/tech-services


### PR DESCRIPTION
Mirroring an internal change, this PR assigns reivews at a group level rather than to multiple teams. This should make communication clearer and make it easier for us to understand where we have poor ownership concerns
