### PR TITLE
docs: document new flag --tags which aliases to --project-tags

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -86,6 +86,9 @@ For advanced usage, we offer language and context specific flags, listed further
   (only in `monitor` command)
   Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
+- `--tags`=<TAG>[,<TAG>]...>:
+  This is an alias for --project-tags.
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -80,6 +80,9 @@ A reference to separate this project from other scans of the same project\. For 
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
+\fB\-\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
+This is an alias for \-\-project\-tags\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -80,6 +80,9 @@ A reference to separate this project from other scans of the same project\. For 
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
+\fB\-\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
+This is an alias for \-\-project\-tags\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -125,6 +125,9 @@ A reference to separate this project from other scans of the same project\. For 
 \fB\-\-project\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project tags to one or more values (comma\-separated key value pairs with an "=" separator)\. e\.g\. \-\-project\-tags=department=finance,team=alpha
 .TP
+\fB\-\-tags\fR=\fITAG\fR[,\fITAG\fR]\|\.\|\.\|\.>
+This is an alias for \-\-project\-tags\.
+.TP
 \fB\-\-policy\-path\fR=\fIPATH_TO_POLICY_FILE\fR`
 Manually pass a path to a snyk policy file\.
 .TP

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -97,6 +97,9 @@ For advanced usage, we offer language and context specific flags, listed further
   (only in `monitor` command)
   Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
+- `--tags`=<TAG>[,<TAG>]...>:
+  This is an alias for --project-tags.
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -97,6 +97,9 @@ For advanced usage, we offer language and context specific flags, listed further
   (only in `monitor` command)
   Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
+- `--tags`=<TAG>[,<TAG>]...>:
+  This is an alias for --project-tags.
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-md/snyk.md
+++ b/help/commands-md/snyk.md
@@ -142,6 +142,9 @@ For advanced usage, we offer language and context specific flags, listed further
   (only in `monitor` command)
   Set the project tags to one or more values (comma-separated key value pairs with an "=" separator). e.g. --project-tags=department=finance,team=alpha
 
+- `--tags`=<TAG>[,<TAG>]...>:
+  This is an alias for --project-tags.
+
 - `--policy-path`=<PATH_TO_POLICY_FILE>`:
   Manually pass a path to a snyk policy file.
 

--- a/help/commands-txt/snyk-auth.txt
+++ b/help/commands-txt/snyk-auth.txt
@@ -1,101 +1,101 @@
-[1mNAME[0m
-       [1msnyk-auth [22m- Authenticate Snyk CLI with a Snyk account
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1ma[0m[1mu[0m[1mt[0m[1mh[0m - Authenticate Snyk CLI with a Snyk account
 
-[1mSYNOPSIS[0m
-       [1msnyk auth [22m[[4mAPI_TOKEN[24m] [[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       Authenticate  Snyk CLI with a Snyk account. Running [1m$ snyk auth [22mwithout
-       an [4mAPI_TOKEN[24m will open a browser window and asks you to login with Snyk
-       account  and  authorize.  When inputting an [4mAPI_TOKEN[24m, it will be vali-
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Authenticate  Snyk CLI with a Snyk account. Running [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m without
+       an [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m will open a browser window and asks you to login with Snyk
+       account  and  authorize.  When inputting an [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m, it will be vali-
        dated with Snyk API.
 
-       When running in a CI environment [4mAPI_TOKEN[24m is required.
+       When running in a CI environment [4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m is required.
 
-[1mOPTIONS[0m
-       [[4mAPI_TOKEN[24m]
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m]
               Your Snyk token. May be an user token or a service account.
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints a help text. You may specify a [4mCOMMAND[24m to  get  more  de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk  authorization token. Setting this envvar will override the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows you to override any key that's  also  available  as  [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--username [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m--password [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets API host to use for Snyk requests.  Useful  for  on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will upgrade the  requests  to  [1mhttps[22m.  Unless  [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If  set  to the value of [1m0[22m, API requests aimed at [1mhttp [22mURLs will
-              not be upgraded to [1mhttps[22m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mhttp [22mto [1mhttps[22m. Useful e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows you to specify a proxy to use for [1mhttps [22mand  [1mhttp  [22mcalls.
-              The  [1mhttps  [22min  the  [1mHTTPS_PROXY [22mmeans that [4mrequests[24m [4musing[24m [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol will use this proxy. The proxy itself doesn't  need  to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
        age  or   otherwise,   is   subject   to   the   terms   &   conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-code.txt
+++ b/help/commands-txt/snyk-code.txt
@@ -1,120 +1,120 @@
-[1mNAME[0m
-       [1msnyk-code [22m- Find security issues using Static code analysis
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mc[0m[1mo[0m[1md[0m[1me[0m - Find security issues using Static code analysis
 
-[1mSYNOPSIS[0m
-       [1msnyk code [22m[[4mCOMMAND[24m] [[4mOPTIONS[24m] [4mPATH[0m
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1md[0m[1me[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [4mP[0m[4mA[0m[4mT[0m[4mH[0m
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Find security issues using Static code analysis
 
        For   more   information   see   the   CLI  for  Snyk  Code  help  page
-       [4mhttps://docs.snyk.io/snyk-code/cli-for-snyk-code[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4md[0m[4mo[0m[4mc[0m[4ms[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m-[0m[4mc[0m[4mo[0m[4md[0m[4me[0m[4m/[0m[4mc[0m[4ml[0m[4mi[0m[4m-[0m[4mf[0m[4mo[0m[4mr[0m[4m-[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m-[0m[4mc[0m[4mo[0m[4md[0m[4me[0m
 
-[1mCOMMANDS[0m
-       [1mtest   [22mTest for any known issue.
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test for any known issue.
 
-[1mOPTIONS[0m
-       [1m--severity-threshold[22m=low|medium|high|critical
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only report configuration  issues  with  the  provided  severity
               level  or  higher.  Please note that the Snyk Code configuration
-              issues do not currently use the [1mcritical [22mseverity level.
+              issues do not currently use the [1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m severity level.
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--org[22m=[4mORG_NAME[0m
-              Specify the [4mORG_NAME[24m to run Snyk commands tied to a specific or-
-              ganization.  This  will  influence  private tests limits. If you
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
+              organization.  This  will influence private tests limits. If you
               have multiple organizations, you can set a default from the  CLI
               using:
 
-              [1m$ snyk config set org[22m=[4mORG_NAME[0m
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
               Setting  a default will ensure all newly tested projects will be
               tested under your default organization. If you need to  override
-              the  default,  you can use the [1m--org[22m=[4mORG_NAME[24m argument. Default:
-              uses [4mORG_NAME[24m that sets as  default  in  your  Account  settings
-              [4mhttps://app.snyk.io/account[0m
+              the  default,  you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument. Default:
+              uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as  default  in  your  Account  settings
+              [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-config.txt
+++ b/help/commands-txt/snyk-config.txt
@@ -1,128 +1,128 @@
-[1mNAME[0m
-       [1msnyk-config [22m- Manage Snyk CLI configuration
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m - Manage Snyk CLI configuration
 
-[1mSYNOPSIS[0m
-       [1msnyk config get|set|clear [22m[[4mKEY[24m[=[4mVALUE[24m]] [[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1mg[0m[1me[0m[1mt[0m[1m|[0m[1ms[0m[1me[0m[1mt[0m[1m|[0m[1mc[0m[1ml[0m[1me[0m[1ma[0m[1mr[0m [[4mK[0m[4mE[0m[4mY[0m[=[4mV[0m[4mA[0m[4mL[0m[4mU[0m[4mE[0m]] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       Manage  your local Snyk CLI config file. This config file is a JSON lo-
-       cated  at   [1m$XDG_CONFIG_HOME   [22mor   [1m~/.config   [22mfollowed   by   [1mconfig-[0m
-       [1mstore/snyk.json[22m. For example [1m~/.config/configstore/snyk.json[22m.
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Manage  your  local  Snyk  CLI  config file. This config file is a JSON
+       located  at  [1m$[0m[1mX[0m[1mD[0m[1mG[0m[1m_[0m[1mC[0m[1mO[0m[1mN[0m[1mF[0m[1mI[0m[1mG[0m[1m_[0m[1mH[0m[1mO[0m[1mM[0m[1mE[0m  or   [1m~[0m[1m/[0m[1m.[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m   followed   by   [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1m-[0m
+       [1ms[0m[1mt[0m[1mo[0m[1mr[0m[1me[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m. For example [1m~[0m[1m/[0m[1m.[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1m/[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1ms[0m[1mt[0m[1mo[0m[1mr[0m[1me[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m.
 
-       This  command  does  not  manage  the  [1m.snyk  [22mfile  that's part of your
-       project. See [1msnyk policy[22m, [1msnyk ignore [22mor [1msnyk wizard[22m.
+       This  command  does  not  manage  the  [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m  file  that's part of your
+       project. See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m, [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m or [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m.
 
-[1mCOMMANDS[0m
-       [1mget [4m[22mKEY[0m
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mg[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m
               Print a config value.
 
-       [1mset [4m[22mKEY[24m=[4mVALUE[0m
+       [1ms[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m=[4mV[0m[4mA[0m[4mL[0m[4mU[0m[4mE[0m
               Create a new config value.
 
-       [1munset [4m[22mKEY[0m
+       [1mu[0m[1mn[0m[1ms[0m[1me[0m[1mt[0m [4mK[0m[4mE[0m[4mY[0m
               Remove a config value.
 
-       [1mclear  [22mRemove all config values.
+       [1mc[0m[1ml[0m[1me[0m[1ma[0m[1mr[0m  Remove all config values.
 
-[1mOPTIONS[0m
-   [1mSupported <var>KEY</var> values[0m
-       [1mapi    [22mAPI token to use when calling Snyk API.
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mS[0m[1mu[0m[1mp[0m[1mp[0m[1mo[0m[1mr[0m[1mt[0m[1me[0m[1md[0m [1m<[0m[1mv[0m[1ma[0m[1mr[0m[1m>[0m[1mK[0m[1mE[0m[1mY[0m[1m<[0m[1m/[0m[1mv[0m[1ma[0m[1mr[0m[1m>[0m [1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m
+       [1ma[0m[1mp[0m[1mi[0m    API token to use when calling Snyk API.
 
-       [1mendpoint[0m
+       [1me[0m[1mn[0m[1md[0m[1mp[0m[1mo[0m[1mi[0m[1mn[0m[1mt[0m
               Defines the API endpoint to use.
 
-       [1mdisable-analytics[0m
+       [1md[0m[1mi[0m[1ms[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1ma[0m[1mn[0m[1ma[0m[1ml[0m[1my[0m[1mt[0m[1mi[0m[1mc[0m[1ms[0m
               Turns off analytics reporting.
 
-       [1moci-registry-url[0m
+       [1mo[0m[1mc[0m[1mi[0m[1m-[0m[1mr[0m[1me[0m[1mg[0m[1mi[0m[1ms[0m[1mt[0m[1mr[0m[1my[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m
               Configures the OCI registry used in IaC  scannings  with  custom
               rules.
 
-       [1moci-registry-username[0m
+       [1mo[0m[1mc[0m[1mi[0m[1m-[0m[1mr[0m[1me[0m[1mg[0m[1mi[0m[1ms[0m[1mt[0m[1mr[0m[1my[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
               Configures  the  username  for an OCI registry used in IaC scan-
               nings with custom rules.
 
-       [1moci-registry-password[0m
+       [1mo[0m[1mc[0m[1mi[0m[1m-[0m[1mr[0m[1me[0m[1mg[0m[1mi[0m[1ms[0m[1mt[0m[1mr[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m
               Configures the password for an OCI registry used  in  IaC  scan-
               nings with custom rules.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-container.txt
+++ b/help/commands-txt/snyk-container.txt
@@ -1,150 +1,150 @@
-[1mNAME[0m
-       [1msnyk-container [22m- Test container images for vulnerabilities
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m - Test container images for vulnerabilities
 
-[1mSYNOPSIS[0m
-       [1msnyk container [22m[[4mCOMMAND[24m] [[4mOPTIONS[24m] [[4mIMAGE[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [[4mI[0m[4mM[0m[4mA[0m[4mG[0m[4mE[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Find vulnerabilities in your container images.
 
-[1mCOMMANDS[0m
-       [1mtest   [22mTest for any known vulnerabilities.
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test for any known vulnerabilities.
 
-       [1mmonitor[0m
+       [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
               Record  the  state  of  dependencies  and any vulnerabilities on
               snyk.io.
 
-[1mOPTIONS[0m
-       [1m--exclude-base-image-vulns[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m[1m-[0m[1mb[0m[1ma[0m[1ms[0m[1me[0m[1m-[0m[1mi[0m[1mm[0m[1ma[0m[1mg[0m[1me[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1ms[0m
               Exclude from display base image vulnerabilities.
 
-       [1m--file[22m=[4mFILE_PATH[0m
-              Include the path to the image's Dockerfile for more detailed ad-
-              vice.
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              Include the path to the image's  Dockerfile  for  more  detailed
+              advice.
 
-       [1m--platform[22m=[4mPLATFORM[0m
+       [1m-[0m[1m-[0m[1mp[0m[1ml[0m[1ma[0m[1mt[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m=[4mP[0m[4mL[0m[4mA[0m[4mT[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m
               For  multi-architecture  images,  specify  the platform to test.
               [linux/amd64,   linux/arm64,    linux/riscv64,    linux/ppc64le,
               linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--json-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only  in [1mtest [22mcommand) Save test output in JSON format directly
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
               to the specified file, regardless of whether or not you use  the
-              [1m--json  [22moption. This is especially useful if you want to display
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
               the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-       [1m--sarif-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only in [1mtest [22mcommand) Save test output in SARIF format directly
-              to the [4mOUTPUT_FILE_PATH[24m file, regardless of whether or  not  you
-              use the [1m--sarif [22moption. This is especially useful if you want to
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
               display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
-       [1m--print-deps[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
               Print the dependency tree before sending it for analysis.
 
-       [1m--project-name[22m=[4mPROJECT_NAME[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
-       [1m--policy-path[22m=[4mPATH_TO_POLICY_FILE[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Manually pass a path to a snyk policy file.
 
-       [1m--severity-threshold[22m=low|medium|high|critical
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only report vulnerabilities of provided level or higher.
 
-       [1m--username[22m=[4mCONTAINER_REGISTRY_USERNAME[0m
+       [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mC[0m[4mO[0m[4mN[0m[4mT[0m[4mA[0m[4mI[0m[4mN[0m[4mE[0m[4mR[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mI[0m[4mS[0m[4mT[0m[4mR[0m[4mY[0m[1m_[0m[4mU[0m[4mS[0m[4mE[0m[4mR[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify  a  username  to use when connecting to a container reg-
               istry. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-       [1m--password[22m=[4mCONTAINER_REGISTRY_PASSWORD[0m
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m=[4mC[0m[4mO[0m[4mN[0m[4mT[0m[4mA[0m[4mI[0m[4mN[0m[4mE[0m[4mR[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mI[0m[4mS[0m[4mT[0m[4mR[0m[4mY[0m[1m_[0m[4mP[0m[4mA[0m[4mS[0m[4mS[0m[4mW[0m[4mO[0m[4mR[0m[4mD[0m
               Specify  a  password  to use when connecting to a container reg-
               istry. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-help.txt
+++ b/help/commands-txt/snyk-help.txt
@@ -1,90 +1,90 @@
-[1mNAME[0m
-       [1msnyk-help [22m- Prints help topics
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m - Prints help topics
 
-[1mSYNOPSIS[0m
-       [1msnyk help [22m[[4mTOPIC[24m] [[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mT[0m[4mO[0m[4mP[0m[4mI[0m[4mC[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       Prints help information. Pass in name of a command as [4mTOPIC[24m.
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Prints help information. Pass in name of a command as [4mT[0m[4mO[0m[4mP[0m[4mI[0m[4mC[0m.
 
-[1mOPTIONS[0m
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-iac.txt
+++ b/help/commands-txt/snyk-iac.txt
@@ -1,196 +1,196 @@
-[1mNAME[0m
-       [1msnyk-iac [22m- Find security issues in your Infrastructure as Code files
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1ma[0m[1mc[0m - Find security issues in your Infrastructure as Code files
 
-[1mSYNOPSIS[0m
-       [1msnyk iac [22m[[4mCOMMAND[24m] [[4mOPTIONS[24m] [4mPATH[0m
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [4mP[0m[4mA[0m[4mT[0m[4mH[0m
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Find security issues in your Infrastructure as Code files.
 
-       For more information see IaC help page [4mhttps://snyk.co/ucT6Q[0m
+       For more information see IaC help page [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mQ[0m
 
-[1mCOMMANDS[0m
-       [1mtest   [22mTest for any known issue.
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test for any known issue.
 
-[1mOPTIONS[0m
-       [1m--detection-depth[22m=[4mDEPTH[0m
-              (only in [1mtest [22mcommand)
-              Indicate  the  maximum depth of sub-directories to search. [4mDEPTH[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command)
+              Indicate  the  maximum depth of sub-directories to search. [4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
               must be a number.
 
               Default: No Limit
-              Example: [1m--detection-depth=3[0m
+              Example: [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m[1m=[0m[1m3[0m
               Will limit search to provided directory (or current directory if
-              no [4mPATH[24m provided) plus two levels of subdirectories.
+              no [4mP[0m[4mA[0m[4mT[0m[4mH[0m provided) plus two levels of subdirectories.
 
-       [1m--severity-threshold[22m=low|medium|high|critical
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only  report  configuration  issues  with  the provided severity
               level or higher. Please note that  the  Snyk  Infrastructure  as
-              Code  configuration  issues  do  not  currently use the [1mcritical[0m
+              Code  configuration  issues  do  not  currently use the [1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m
               severity level.
 
-       [1m--ignore-policy[0m
-              Ignores all set policies. The current policy in [1m.snyk [22mfile,  Org
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
               level ignores and the project policy on snyk.io.
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--json-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only  in [1mtest [22mcommand) Save test output in JSON format directly
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
               to the specified file, regardless of whether or not you use  the
-              [1m--json  [22moption. This is especially useful if you want to display
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
               the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
-       [1m--org[22m=[4mORG_NAME[0m
-              Specify the [4mORG_NAME[24m to run Snyk commands tied to a specific or-
-              ganization. This will influence private  tests  limits.  If  you
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify  the  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  to  run Snyk commands tied to a specific
+              organization. This will influence private tests limits.  If  you
               have  multiple organizations, you can set a default from the CLI
               using:
 
-              [1m$ snyk config set org[22m=[4mORG_NAME[0m
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
               Setting a default will ensure all newly tested projects will  be
               tested  under your default organization. If you need to override
-              the default, you can use the [1m--org[22m=[4mORG_NAME[24m  argument.  Default:
-              uses  [4mORG_NAME[24m  that  sets  as  default in your Account settings
-              [4mhttps://app.snyk.io/account[0m
+              the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  argument.  Default:
+              uses  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  that  sets  as  default in your Account settings
+              [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
-       [1m--policy-path[22m=[4mPATH_TO_POLICY_FILE[24m`
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-       [1m--sarif-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only in [1mtest [22mcommand) Save test output in SARIF format directly
-              to  the  [4mOUTPUT_FILE_PATH[24m file, regardless of whether or not you
-              use the [1m--sarif [22moption. This is especially useful if you want to
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
               display  the  human-readable  test  output via stdout and at the
               same time save the SARIF format output to a file.
 
-       [1m--scan=[4m[22mTERRAFORM_PLAN_SCAN_MODE[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[4mT[0m[4mE[0m[4mR[0m[4mR[0m[4mA[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m[1m_[0m[4mP[0m[4mL[0m[4mA[0m[4mN[0m[1m_[0m[4mS[0m[4mC[0m[4mA[0m[4mN[0m[1m_[0m[4mM[0m[4mO[0m[4mD[0m[4mE[0m
               Dedicated flag for Terraform plan scanning modes.
               It enables to control whether the scan should analyse  the  full
-              final  state (e.g. [1mplanned-values[22m), or the proposed changes only
-              (e.g. [1mresource-changes[22m).
-              Default: If the [1m--scan [22mflag is not provided it  would  scan  the
+              final  state (e.g. [1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m), or the proposed changes only
+              (e.g. [1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m).
+              Default: If the [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m flag is not provided it  would  scan  the
               proposed changes only by default.
-              Example  #1: [1m--scan=planned-values [22m(full state scan) Example #2:
-              [1m--scan=resource-changes [22m(proposed changes scan)
+              Example  #1: [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mp[0m[1ml[0m[1ma[0m[1mn[0m[1mn[0m[1me[0m[1md[0m[1m-[0m[1mv[0m[1ma[0m[1ml[0m[1mu[0m[1me[0m[1ms[0m (full state scan) Example #2:
+              [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m=[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1mu[0m[1mr[0m[1mc[0m[1me[0m[1m-[0m[1mc[0m[1mh[0m[1ma[0m[1mn[0m[1mg[0m[1me[0m[1ms[0m (proposed changes scan)
 
-       [1m--rules=[4m[22mPATH_TO_CUSTOM_RULES_BUNDLE[0m
+       [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m[1m=[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mC[0m[4mU[0m[4mS[0m[4mT[0m[4mO[0m[4mM[0m[1m_[0m[4mR[0m[4mU[0m[4mL[0m[4mE[0m[4mS[0m[1m_[0m[4mB[0m[4mU[0m[4mN[0m[4mD[0m[4mL[0m[4mE[0m
               Dedicated flag for Custom Rules scanning.
               It enables the IaC scans to use a custom rules bundle  generated
-              via  the [1msnyk-iac-rules [22mSDK. To download it and learn how to use
+              via  the [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1ma[0m[1mc[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m SDK. To download it and learn how to use
               it, go to https://github.com/snyk/snyk-iac-rules. This flag can-
               not be used if the custom rules settings were configured via the
-              Snyk UI. Default: If the [1m--rules [22mflag is not provided  it  would
+              Snyk UI. Default: If the [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m flag is not provided  it  would
               scan the configuration files using the internal Snyk rules only.
-              Example:  [1m--rules=bundle.tar.gz  [22m(scans  the configuration files
+              Example: [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m[1m=[0m[1mb[0m[1mu[0m[1mn[0m[1md[0m[1ml[0m[1me[0m[1m.[0m[1mt[0m[1ma[0m[1mr[0m[1m.[0m[1mg[0m[1mz[0m (scans  the  configuration  files
               using custom rules and internal Snyk rules)
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints a help text. You may specify a [4mCOMMAND[24m to  get  more  de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXAMPLES[0m
-       For more information see IaC help page [4mhttps://snyk.co/ucT6Q[0m
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       For more information see IaC help page [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mQ[0m
 
-       [1mTest CloudFormation file[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mC[0m[1ml[0m[1mo[0m[1mu[0m[1md[0m[1mF[0m[1mo[0m[1mr[0m[1mm[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/cloudformation_file.yaml
 
-       [1mTest kubernetes file[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mk[0m[1mu[0m[1mb[0m[1me[0m[1mr[0m[1mn[0m[1me[0m[1mt[0m[1me[0m[1ms[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/kubernetes_file.yaml
 
-       [1mTest terraform file[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mt[0m[1me[0m[1mr[0m[1mr[0m[1ma[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/terraform_file.tf
 
-       [1mTest terraform plan file[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mt[0m[1me[0m[1mr[0m[1mr[0m[1ma[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m [1mp[0m[1ml[0m[1ma[0m[1mn[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/tf-plan.json
 
-       [1mTest ARM file[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mA[0m[1mR[0m[1mM[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/arm_file.json
 
-       [1mTest matching files in a directory[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m[1ms[0m [1mi[0m[1mn[0m [1ma[0m [1md[0m[1mi[0m[1mr[0m[1me[0m[1mc[0m[1mt[0m[1mo[0m[1mr[0m[1my[0m
               $ snyk iac test /path/to/directory
 
-       [1mTest matching files in a directory using a local custom rules bundle[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m [1mf[0m[1mi[0m[1ml[0m[1me[0m[1ms[0m [1mi[0m[1mn[0m [1ma[0m [1md[0m[1mi[0m[1mr[0m[1me[0m[1mc[0m[1mt[0m[1mo[0m[1mr[0m[1my[0m [1mu[0m[1ms[0m[1mi[0m[1mn[0m[1mg[0m [1ma[0m [1ml[0m[1mo[0m[1mc[0m[1ma[0m[1ml[0m [1mc[0m[1mu[0m[1ms[0m[1mt[0m[1mo[0m[1mm[0m [1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m [1mb[0m[1mu[0m[1mn[0m[1md[0m[1ml[0m[1me[0m
               $ snyk iac test /path/to/directory --rules=bundle.tar.gz
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
-              Snyk  authorization token. Setting this envvar will override the
-              token that may be available in your [1msnyk config [22msettings.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows you to override any key that's  also  available  as  [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--username [22mflag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
-              credentials when Docker is present.
-
-       [1mSNYK_REGISTRY_PASSWORD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m--password [22mflag  will  override  this
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
 
-       [1mSNYK_API[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will upgrade the  requests  to  [1mhttps[22m.  Unless  [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If  set  to the value of [1m0[22m, API requests aimed at [1mhttp [22mURLs will
-              not be upgraded to [1mhttps[22m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mhttp [22mto [1mhttps[22m. Useful e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows you to specify a proxy to use for [1mhttps [22mand  [1mhttp  [22mcalls.
-              The  [1mhttps  [22min  the  [1mHTTPS_PROXY [22mmeans that [4mrequests[24m [4musing[24m [1mhttps[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
-              use [1mhttps[22m.
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
-       [4mhttps://snyk.co/ucT6N[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-ignore.txt
+++ b/help/commands-txt/snyk-ignore.txt
@@ -1,108 +1,108 @@
-[1mNAME[0m
-       [1msnyk-ignore [22m- Modifies the .snyk policy to ignore stated issues
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m - Modifies the .snyk policy to ignore stated issues
 
-[1mSYNOPSIS[0m
-       [1msnyk ignore --id[22m=[4mISSUE_ID[24m [[1m--expiry[22m=[4mEXPIRY[24m] [[1m--reason[22m=[4mREASON[24m] [[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1m-[0m[1m-[0m[1mi[0m[1md[0m=[4mI[0m[4mS[0m[4mS[0m[4mU[0m[4mE[0m[1m_[0m[4mI[0m[4mD[0m [[1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m] [[1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       Ignore  a  certain issue, according to its snyk ID for all occurrences.
-       This will update your local [1m.snyk [22mto contain a similar block:
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Ignore a certain issue, according to its snyk ID for  all  occurrences.
+       This will update your local [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m to contain a similar block:
 
-       [1myaml ignore: '<ISSUE_ID>': - '*': reason: <REASON> expires: <EXPIRY>[0m
+       [1my[0m[1ma[0m[1mm[0m[1ml[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m:[0m [1m'[0m[1m<[0m[1mI[0m[1mS[0m[1mS[0m[1mU[0m[1mE[0m[1m_[0m[1mI[0m[1mD[0m[1m>[0m[1m'[0m[1m:[0m [1m-[0m [1m'[0m[1m*[0m[1m'[0m[1m:[0m [1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m[1m:[0m [1m<[0m[1mR[0m[1mE[0m[1mA[0m[1mS[0m[1mO[0m[1mN[0m[1m>[0m [1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1me[0m[1ms[0m[1m:[0m [1m<[0m[1mE[0m[1mX[0m[1mP[0m[1mI[0m[1mR[0m[1mY[0m[1m>[0m
 
-[1mOPTIONS[0m
-       [1m--id[22m=[4mISSUE_ID[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1mi[0m[1md[0m=[4mI[0m[4mS[0m[4mS[0m[4mU[0m[4mE[0m[1m_[0m[4mI[0m[4mD[0m
               Snyk ID for the issue to ignore. Required.
 
-       [1m--expiry[22m=[4mEXPIRY[0m
-              Expiry        date,         according         to         RFC2822
-              [4mhttps://tools.ietf.org/html/rfc2822[0m
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m
+              Expiry         date,         according         to        RFC2822
+              [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4mt[0m[4mo[0m[4mo[0m[4ml[0m[4ms[0m[4m.[0m[4mi[0m[4me[0m[4mt[0m[4mf[0m[4m.[0m[4mo[0m[4mr[0m[4mg[0m[4m/[0m[4mh[0m[4mt[0m[4mm[0m[4ml[0m[4m/[0m[4mr[0m[4mf[0m[4mc[0m[4m2[0m[4m8[0m[4m2[0m[4m2[0m
 
-       [1m--reason[22m=[4mREASON[0m
-              Human-readable [4mREASON[24m to ignore this issue.
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m
+              Human-readable [4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m to ignore this issue.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXAMPLES[0m
-       [1mIgnore a specific vulnerability[0m
-              $  snyk  ignore   --id='npm:qs:20170213'   --expiry='2021-01-10'
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       [1mI[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1ma[0m [1ms[0m[1mp[0m[1me[0m[1mc[0m[1mi[0m[1mf[0m[1mi[0m[1mc[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m
+              $   snyk   ignore  --id='npm:qs:20170213'  --expiry='2021-01-10'
               --reason='Module not affected by this vuln'
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
-              Snyk  authorization token. Setting this envvar will override the
-              token that may be available in your [1msnyk config [22msettings.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows you to override any key that's  also  available  as  [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--username [22mflag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
-              credentials when Docker is present.
-
-       [1mSNYK_REGISTRY_PASSWORD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m--password [22mflag  will  override  this
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
 
-       [1mSNYK_API[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will upgrade the  requests  to  [1mhttps[22m.  Unless  [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If  set  to the value of [1m0[22m, API requests aimed at [1mhttp [22mURLs will
-              not be upgraded to [1mhttps[22m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mhttp [22mto [1mhttps[22m. Useful e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows you to specify a proxy to use for [1mhttps [22mand  [1mhttp  [22mcalls.
-              The  [1mhttps  [22min  the  [1mHTTPS_PROXY [22mmeans that [4mrequests[24m [4musing[24m [1mhttps[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
-              use [1mhttps[22m.
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
-       [4mhttps://snyk.co/ucT6N[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-monitor.txt
+++ b/help/commands-txt/snyk-monitor.txt
@@ -1,354 +1,357 @@
-[1mNAME[0m
-       [1msnyk-monitor [22m- Snapshot and continuously monitor your project
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m - Snapshot and continuously monitor your project
 
-[1mSYNOPSIS[0m
-       [1msnyk monitor [22m[[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Create  a  project  on the Snyk website that will be continuously moni-
        tored for new vulnerabilities. After running this command you will  see
        it by logging in to the website and viewing Your projects.
 
-[1mOPTIONS[0m
-       To  see  command-specific  flags and usage, see [1mhelp [22mcommand, e.g. [1msnyk[0m
-       [1mcontainer --help[22m. For advanced usage, we  offer  language  and  context
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. For advanced usage, we  offer  language  and  context
        specific flags, listed further down this document.
 
-       [1m--all-projects[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Auto-detect all projects in
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects in
               working directory
 
-       [1m--detection-depth[22m=[4mDEPTH[0m
-              (only in [1mtest [22mand [1mmonitor [22mcommands) Use with  --all-projects  or
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with  --all-projects  or
               --yarn-workspaces   to  indicate  how  many  sub-directories  to
-              search. [1mDEPTH [22mmust be a number.
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
 
               Default: 4 (the current working directory and 3 sub-directories)
 
-       [1m--exclude[22m=[4mDIRECTORY[24m[,[4mDIRECTORY[24m]...>
-              (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Can   be   used   with
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If using with [1m--detection-depth [22mexclude ignores  directories  at
+              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
               any level deep.
 
-       [1m--prune-repeated-subdependencies[22m, [1m-p[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Prune dependency trees, re-
-              moving duplicate sub-dependencies. Will still find all  vulnera-
-              bilities, but potentially not all of the vulnerable paths.
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
+              removing duplicate sub-dependencies. Will still find all vulner-
+              abilities, but potentially not all of the vulnerable paths.
 
-       [1m--print-deps[0m
-              (only  in  [1mtest  [22mand [1mmonitor [22mcommands) Print the dependency tree
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
               before sending it for analysis.
 
-       [1m--remote-repo-url[22m=[4mURL[0m
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m--dev  [22mInclude  development-only dependencies. Applicable only for some
-              package managers. E.g. [4mdevDependencies[24m in  npm  or  [4m:development[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
+              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
-       [1m--org[22m=[4mORG_NAME[0m
-              Specify the [4mORG_NAME[24m to run Snyk commands tied to a specific or-
-              ganization. This will influence where will new projects be  cre-
-              ated  after  running [1mmonitor [22mcommand, some features availability
-              and private tests limits. If you  have  multiple  organizations,
-              you can set a default from the CLI using:
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
+              organization.  This  will  influence  where will new projects be
+              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
+              ity  and  private  tests  limits. If you have multiple organiza-
+              tions, you can set a default from the CLI using:
 
-              [1m$ snyk config set org[22m=[4mORG_NAME[0m
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting  a default will ensure all newly monitored projects will
+              Setting a default will ensure all newly monitored projects  will
               be created under your default organization. If you need to over-
-              ride the default, you can use the [1m--org[22m=[4mORG_NAME[24m argument.
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
-              Default: uses [4mORG_NAME[24m that sets as default in your Account set-
-              tings [4mhttps://app.snyk.io/account[0m
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
-       [1m--file[22m=[4mFILE[0m
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When testing locally or monitoring a project,  you  can  specify
-              the  file that Snyk should inspect for package information. When
-              ommitted Snyk will try to detect the appropriate file  for  your
+              When  testing  locally  or monitoring a project, you can specify
+              the file that Snyk should inspect for package information.  When
+              ommitted  Snyk  will try to detect the appropriate file for your
               project.
 
-       [1m--ignore-policy[0m
-              Ignores  all set policies. The current policy in [1m.snyk [22mfile, Org
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
               level ignores and the project policy on snyk.io.
 
-       [1m--trust-policies[0m
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a suggestion.
+              cies, otherwise ignore policies are only shown as a  suggestion.
 
-       [1m--show-vulnerable-paths[22m=none|some|all
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable packages. Doesn't affect output when  us-
-              ing JSON [1m--json [22moutput.
+              down to the vulnerable  packages.  Doesn't  affect  output  when
+              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
-              Default:  [4msome[24m (a few example paths shown) [4mfalse[24m is an alias for
-              [4mnone[24m.
+              Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
 
-       [1m--project-name[22m=[4mPROJECT_NAME[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
-       [1m--target-reference[22m=[4mTARGET_REFERENCE[0m
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
               A reference to separate this project from  other  scans  of  the
               same  project.  For  example, a branch name or version. Projects
               using the same reference can be used for grouping. More informa-
-              tion [4mhttps://snyk.info/3B0vTPs[24m.
+              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
-       [1m--project-environment[22m=[4mENVIRONMENT[24m[,[4mENVIRONMENT[24m]...>
-              (only  in [1mmonitor [22mcommand) Set the project environment to one or
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
+              (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
               more values (comma-separated). Allowed values:  frontend,  back-
               end,  internal, external, mobile, saas, onprem, hosted, distrib-
               uted
 
-       [1m--project-lifecycle[22m=[4mLIFECYCLE[24m[,[4mLIFECYCLE[24m]...>
-              (only in [1mmonitor [22mcommand) Set the project lifecycle  to  one  or
-              more  values  (comma-separated). Allowed values: production, de-
-              velopment, sandbox
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
+              more   values  (comma-separated).  Allowed  values:  production,
+              development, sandbox
 
-       [1m--project-business-criticality[22m=[4mBUSINESS_CRITICALITY[24m[,[4mBUSINESS_CRITICAL-[0m
-       [4mITY[24m]...>
-              (only  in  [1mmonitor [22mcommand) Set the project business criticality
-              to one or more values (comma-separated). Allowed values:  criti-
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
+       [4mI[0m[4mT[0m[4mY[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
+              to  one or more values (comma-separated). Allowed values: criti-
               cal, high, medium, low
 
-       [1m--project-tags[22m=[4mTAG[24m[,[4mTAG[24m]...>
-              (only  in  [1mmonitor  [22mcommand) Set the project tags to one or more
-              values (comma-separated key value pairs with an "="  separator).
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
+              values  (comma-separated key value pairs with an "=" separator).
               e.g. --project-tags=department=finance,team=alpha
 
-       [1m--policy-path[22m=[4mPATH_TO_POLICY_FILE[24m`
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              This is an alias for --project-tags.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--json-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only  in [1mtest [22mcommand) Save test output in JSON format directly
-              to the specified file, regardless of whether or not you use  the
-              [1m--json  [22moption. This is especially useful if you want to display
-              the human-readable test output via stdout and at the  same  time
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
               save the JSON format output to a file.
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-       [1m--sarif-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only in [1mtest [22mcommand) Save test output in SARIF format directly
-              to the [4mOUTPUT_FILE_PATH[24m file, regardless of whether or  not  you
-              use the [1m--sarif [22moption. This is especially useful if you want to
-              display the human-readable test output via  stdout  and  at  the
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
               same time save the SARIF format output to a file.
 
-       [1m--severity-threshold[22m=low|medium|high|critical
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only report vulnerabilities of provided level or higher.
 
-       [1m--fail-on[22m=all|upgradable|patchable
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4mall[24m  fails  when there is at least one vulnerability that can be
-              either upgraded or patched. [4mupgradable[24m fails when  there  is  at
-              least  one  vulnerability  that can be upgraded. [4mpatchable[24m fails
+              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
+              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
+              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
               when there is at least one vulnerability that can be patched.
 
-              If vulnerabilities do not have a fix and this  option  is  being
+              If  vulnerabilities  do  not have a fix and this option is being
               used, tests will pass.
 
-       [1m--dry-run[0m
-              (only  in [1mprotect [22mcommand) Don't apply updates or patches during
-              [1mprotect [22mcommand run.
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
-       [1m-- [22m[[4mCOMPILER_OPTIONS[24m]
-              Pass extra arguments directly to Gradle or Maven. E.g. [1msnyk test[0m
-              [1m-- --build-cache[0m
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
 
        Below  are  flags  that  are  influencing  CLI  behavior  for  specific
        projects, languages and contexts:
 
-   [1mMaven options[0m
-       [1m--scan-all-unmanaged[0m
-              Auto detects maven jars, aars, and wars in given directory.  In-
-              dividual testing can be done with [1m--file[22m=[4mJAR_FILE_NAME[0m
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto  detects  maven  jars,  aars,  and wars in given directory.
+              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-       [1m--reachable[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Analyze your source code to
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
               find which vulnerable functions and packages are called.
 
-       [1m--reachable-timeout[22m=[4mTIMEOUT[0m
-              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
-              reachability  data.  If  it takes longer than [4mTIMEOUT[24m, Reachable
-              Vulnerabilities are not reported. This does not  affect  regular
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
+              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
+              Vulnerabilities  are  not reported. This does not affect regular
               test or monitor output.
 
               Default: 300 (5 minutes).
 
-   [1mGradle options[0m
-       More information about Gradle CLI options [4mhttps://snyk.co/ucT6P[0m
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m--sub-project[22m=[4mNAME[24m,  [1m--gradle-sub-project[22m=[4mNAME[24m:  For  Gradle "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m--all-sub-projects[22m: For "multi project"  configurations,  test  all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
            sub-projects.
 
-       O   [1m--configuration-matching[22m=[4mCONFIGURATION_REGEX[24m:  Resolve dependencies
-           using only configuration(s) that match the  provided  Java  regular
-           expression, e.g. [1m^releaseRuntimeClasspath$[22m.
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
+           using  only  configuration(s)  that match the provided Java regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
-       O   [1m--configuration-attributes[22m=[4mATTRIBUTE[24m[,[4mATTRIBUTE[24m]...: Select certain
-           values of configuration attributes  to  resolve  the  dependencies.
-           E.g. [1mbuildtype:release,usage:java-runtime[0m
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values  of  configuration  attributes  to resolve the dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m--reachable[22m:  (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands) Analyze your
-           source code to find which vulnerable  functions  and  packages  are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
+           source  code  to  find  which vulnerable functions and packages are
            called.
 
-       O   [1m--reachable-timeout[22m=[4mTIMEOUT[24m:  The  amount  of  time (in seconds) to
-           wait for Snyk to gather reachability data. If it takes longer  than
-           [4mTIMEOUT[24m,  Reachable Vulnerabilities are not reported. This does not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
+           wait  for Snyk to gather reachability data. If it takes longer than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m--init-script[22m=[4mFILE[24m For projects that contain a  gradle  initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
            tion script.
 
 
 
-   [1m.Net & NuGet options[0m
-       [1m--assets-project-name[0m
-              When  monitoring a .NET project using NuGet [1mPackageReference [22muse
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
               the project name in project.assets.json, if found.
 
-       [1m--packages-folder[0m
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
-       [1m--project-name-prefix[22m=[4mPREFIX_STRING[0m
-              When monitoring a .NET project, use this flag to  add  a  custom
-              prefix  to the name of files inside a project along with any de-
-              sired  separators,  e.g.  [1msnyk   monitor   --file=my-project.sln[0m
-              [1m--project-name-prefix=my-group/[22m.  This  is  useful when you have
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When  monitoring  a  .NET project, use this flag to add a custom
+              prefix to the name of files inside  a  project  along  with  any
+              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
               multiple projects with the same name in other sln files.
 
-   [1mnpm options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-   [1mYarn options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-       [1m--yarn-workspaces[0m
-              (only in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Detect  and  scan  yarn
-              workspaces.  You  can specify how many sub-directories to search
-              using [1m--detection-depth [22mand exclude directories and files  using
-              [1m--exclude[22m.
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
+              workspaces. You can specify how many sub-directories  to  search
+              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
-   [1mCocoaPods options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: false
 
-   [1mPython options[0m
-       [1m--command[22m=[4mCOMMAND[0m
-              Indicate  which  specific Python commands to use based on Python
-              version. The default is [1mpython [22mwhich executes your  systems  de-
-              fault  python  version. Run 'python -V' to find out what version
-              is it. If you are using multiple Python versions, use  this  pa-
-              rameter to specify the correct Python command for execution.
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate which specific Python commands to use based  on  Python
+              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
+              default python version. Run 'python -V' to find out what version
+              is  it.  If  you  are  using  multiple Python versions, use this
+              parameter to specify the correct Python command for execution.
 
-              Default: [1mpython [22mExample: [1m--command=python3[0m
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
-       [1m--skip-unresolved[22m=true|false
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
               Allow skipping packages that are not found in the environment.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
-              Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
-              credentials when Docker is present.
-
-       [1mSNYK_REGISTRY_PASSWORD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
 
-       [1mSNYK_API[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-policy.txt
+++ b/help/commands-txt/snyk-policy.txt
@@ -1,93 +1,93 @@
-[1mNAME[0m
-       [1msnyk-policy [22m- Display the .snyk policy for a package
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m - Display the .snyk policy for a package
 
-[1mSYNOPSIS[0m
-       [1msnyk policy [22m[[4mPATH_TO_POLICY_FILE[24m] [[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m [[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       Displays a [1m.snyk [22mpolicy file.
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       Displays a [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m policy file.
 
-[1mOPTIONS[0m
-       [4mPATH_TO_POLICY_FILE[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Manually pass a path to a snyk policy file.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-protect.txt
+++ b/help/commands-txt/snyk-protect.txt
@@ -1,97 +1,97 @@
-[1mNAME[0m
-       [1msnyk-protect  [22m- Applies the patches specified in your .snyk file to the
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m  - Applies the patches specified in your .snyk file to the
        local file system
 
-[1mSYNOPSIS[0m
-       [1msnyk protect [22m[[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
-       [1m$ snyk protect [22mis used to apply patches to  your  vulnerable  dependen-
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
+       [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m is used to apply patches to  your  vulnerable  dependen-
        cies.  It's  useful  after  opening a fix pull request from our website
        (GitHub only) or after running snyk wizard on  the  CLI.  snyk  protect
        reads a .snyk policy file to determine what patches to apply.
 
-[1mOPTIONS[0m
-       [1m--dry-run[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
               Don't apply updates or patches when running.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-test.txt
+++ b/help/commands-txt/snyk-test.txt
@@ -1,354 +1,357 @@
-[1mNAME[0m
-       [1msnyk-test [22m- test local project for vulnerabilities
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mt[0m[1me[0m[1ms[0m[1mt[0m - test local project for vulnerabilities
 
-[1mSYNOPSIS[0m
-       [1msnyk test [22m[[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Test  command checks locally installed projects for vulnerabilities. It
        tries to autodetect supported manifest files with dependencies and test
        those.
 
-[1mOPTIONS[0m
-       To  see  command-specific  flags and usage, see [1mhelp [22mcommand, e.g. [1msnyk[0m
-       [1mcontainer --help[22m. For advanced usage, we  offer  language  and  context
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. For advanced usage, we  offer  language  and  context
        specific flags, listed further down this document.
 
-       [1m--all-projects[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Auto-detect all projects in
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects in
               working directory
 
-       [1m--detection-depth[22m=[4mDEPTH[0m
-              (only in [1mtest [22mand [1mmonitor [22mcommands) Use with  --all-projects  or
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with  --all-projects  or
               --yarn-workspaces   to  indicate  how  many  sub-directories  to
-              search. [1mDEPTH [22mmust be a number.
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
 
               Default: 4 (the current working directory and 3 sub-directories)
 
-       [1m--exclude[22m=[4mDIRECTORY[24m[,[4mDIRECTORY[24m]...>
-              (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Can   be   used   with
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If using with [1m--detection-depth [22mexclude ignores  directories  at
+              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
               any level deep.
 
-       [1m--prune-repeated-subdependencies[22m, [1m-p[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Prune dependency trees, re-
-              moving duplicate sub-dependencies. Will still find all  vulnera-
-              bilities, but potentially not all of the vulnerable paths.
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
+              removing duplicate sub-dependencies. Will still find all vulner-
+              abilities, but potentially not all of the vulnerable paths.
 
-       [1m--print-deps[0m
-              (only  in  [1mtest  [22mand [1mmonitor [22mcommands) Print the dependency tree
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
               before sending it for analysis.
 
-       [1m--remote-repo-url[22m=[4mURL[0m
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m--dev  [22mInclude  development-only dependencies. Applicable only for some
-              package managers. E.g. [4mdevDependencies[24m in  npm  or  [4m:development[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
+              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
-       [1m--org[22m=[4mORG_NAME[0m
-              Specify the [4mORG_NAME[24m to run Snyk commands tied to a specific or-
-              ganization. This will influence where will new projects be  cre-
-              ated  after  running [1mmonitor [22mcommand, some features availability
-              and private tests limits. If you  have  multiple  organizations,
-              you can set a default from the CLI using:
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
+              organization.  This  will  influence  where will new projects be
+              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
+              ity  and  private  tests  limits. If you have multiple organiza-
+              tions, you can set a default from the CLI using:
 
-              [1m$ snyk config set org[22m=[4mORG_NAME[0m
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting  a default will ensure all newly monitored projects will
+              Setting a default will ensure all newly monitored projects  will
               be created under your default organization. If you need to over-
-              ride the default, you can use the [1m--org[22m=[4mORG_NAME[24m argument.
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
-              Default: uses [4mORG_NAME[24m that sets as default in your Account set-
-              tings [4mhttps://app.snyk.io/account[0m
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
-       [1m--file[22m=[4mFILE[0m
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When testing locally or monitoring a project,  you  can  specify
-              the  file that Snyk should inspect for package information. When
-              ommitted Snyk will try to detect the appropriate file  for  your
+              When  testing  locally  or monitoring a project, you can specify
+              the file that Snyk should inspect for package information.  When
+              ommitted  Snyk  will try to detect the appropriate file for your
               project.
 
-       [1m--ignore-policy[0m
-              Ignores  all set policies. The current policy in [1m.snyk [22mfile, Org
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
               level ignores and the project policy on snyk.io.
 
-       [1m--trust-policies[0m
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a suggestion.
+              cies, otherwise ignore policies are only shown as a  suggestion.
 
-       [1m--show-vulnerable-paths[22m=none|some|all
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable packages. Doesn't affect output when  us-
-              ing JSON [1m--json [22moutput.
+              down to the vulnerable  packages.  Doesn't  affect  output  when
+              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
-              Default:  [4msome[24m (a few example paths shown) [4mfalse[24m is an alias for
-              [4mnone[24m.
+              Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
 
-       [1m--project-name[22m=[4mPROJECT_NAME[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
-       [1m--target-reference[22m=[4mTARGET_REFERENCE[0m
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
               A reference to separate this project from  other  scans  of  the
               same  project.  For  example, a branch name or version. Projects
               using the same reference can be used for grouping. More informa-
-              tion [4mhttps://snyk.info/3B0vTPs[24m.
+              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
-       [1m--project-environment[22m=[4mENVIRONMENT[24m[,[4mENVIRONMENT[24m]...>
-              (only  in [1mmonitor [22mcommand) Set the project environment to one or
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
+              (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
               more values (comma-separated). Allowed values:  frontend,  back-
               end,  internal, external, mobile, saas, onprem, hosted, distrib-
               uted
 
-       [1m--project-lifecycle[22m=[4mLIFECYCLE[24m[,[4mLIFECYCLE[24m]...>
-              (only in [1mmonitor [22mcommand) Set the project lifecycle  to  one  or
-              more  values  (comma-separated). Allowed values: production, de-
-              velopment, sandbox
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
+              more   values  (comma-separated).  Allowed  values:  production,
+              development, sandbox
 
-       [1m--project-business-criticality[22m=[4mBUSINESS_CRITICALITY[24m[,[4mBUSINESS_CRITICAL-[0m
-       [4mITY[24m]...>
-              (only  in  [1mmonitor [22mcommand) Set the project business criticality
-              to one or more values (comma-separated). Allowed values:  criti-
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
+       [4mI[0m[4mT[0m[4mY[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
+              to  one or more values (comma-separated). Allowed values: criti-
               cal, high, medium, low
 
-       [1m--project-tags[22m=[4mTAG[24m[,[4mTAG[24m]...>
-              (only  in  [1mmonitor  [22mcommand) Set the project tags to one or more
-              values (comma-separated key value pairs with an "="  separator).
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
+              values  (comma-separated key value pairs with an "=" separator).
               e.g. --project-tags=department=finance,team=alpha
 
-       [1m--policy-path[22m=[4mPATH_TO_POLICY_FILE[24m`
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              This is an alias for --project-tags.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--json-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only  in [1mtest [22mcommand) Save test output in JSON format directly
-              to the specified file, regardless of whether or not you use  the
-              [1m--json  [22moption. This is especially useful if you want to display
-              the human-readable test output via stdout and at the  same  time
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
               save the JSON format output to a file.
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-       [1m--sarif-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only in [1mtest [22mcommand) Save test output in SARIF format directly
-              to the [4mOUTPUT_FILE_PATH[24m file, regardless of whether or  not  you
-              use the [1m--sarif [22moption. This is especially useful if you want to
-              display the human-readable test output via  stdout  and  at  the
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
               same time save the SARIF format output to a file.
 
-       [1m--severity-threshold[22m=low|medium|high|critical
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only report vulnerabilities of provided level or higher.
 
-       [1m--fail-on[22m=all|upgradable|patchable
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4mall[24m  fails  when there is at least one vulnerability that can be
-              either upgraded or patched. [4mupgradable[24m fails when  there  is  at
-              least  one  vulnerability  that can be upgraded. [4mpatchable[24m fails
+              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
+              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
+              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
               when there is at least one vulnerability that can be patched.
 
-              If vulnerabilities do not have a fix and this  option  is  being
+              If  vulnerabilities  do  not have a fix and this option is being
               used, tests will pass.
 
-       [1m--dry-run[0m
-              (only  in [1mprotect [22mcommand) Don't apply updates or patches during
-              [1mprotect [22mcommand run.
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
-       [1m-- [22m[[4mCOMPILER_OPTIONS[24m]
-              Pass extra arguments directly to Gradle or Maven. E.g. [1msnyk test[0m
-              [1m-- --build-cache[0m
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
 
        Below  are  flags  that  are  influencing  CLI  behavior  for  specific
        projects, languages and contexts:
 
-   [1mMaven options[0m
-       [1m--scan-all-unmanaged[0m
-              Auto detects maven jars, aars, and wars in given directory.  In-
-              dividual testing can be done with [1m--file[22m=[4mJAR_FILE_NAME[0m
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto  detects  maven  jars,  aars,  and wars in given directory.
+              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-       [1m--reachable[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Analyze your source code to
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
               find which vulnerable functions and packages are called.
 
-       [1m--reachable-timeout[22m=[4mTIMEOUT[0m
-              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
-              reachability  data.  If  it takes longer than [4mTIMEOUT[24m, Reachable
-              Vulnerabilities are not reported. This does not  affect  regular
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
+              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
+              Vulnerabilities  are  not reported. This does not affect regular
               test or monitor output.
 
               Default: 300 (5 minutes).
 
-   [1mGradle options[0m
-       More information about Gradle CLI options [4mhttps://snyk.co/ucT6P[0m
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m--sub-project[22m=[4mNAME[24m,  [1m--gradle-sub-project[22m=[4mNAME[24m:  For  Gradle "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m--all-sub-projects[22m: For "multi project"  configurations,  test  all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
            sub-projects.
 
-       O   [1m--configuration-matching[22m=[4mCONFIGURATION_REGEX[24m:  Resolve dependencies
-           using only configuration(s) that match the  provided  Java  regular
-           expression, e.g. [1m^releaseRuntimeClasspath$[22m.
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
+           using  only  configuration(s)  that match the provided Java regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
-       O   [1m--configuration-attributes[22m=[4mATTRIBUTE[24m[,[4mATTRIBUTE[24m]...: Select certain
-           values of configuration attributes  to  resolve  the  dependencies.
-           E.g. [1mbuildtype:release,usage:java-runtime[0m
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values  of  configuration  attributes  to resolve the dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m--reachable[22m:  (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands) Analyze your
-           source code to find which vulnerable  functions  and  packages  are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
+           source  code  to  find  which vulnerable functions and packages are
            called.
 
-       O   [1m--reachable-timeout[22m=[4mTIMEOUT[24m:  The  amount  of  time (in seconds) to
-           wait for Snyk to gather reachability data. If it takes longer  than
-           [4mTIMEOUT[24m,  Reachable Vulnerabilities are not reported. This does not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
+           wait  for Snyk to gather reachability data. If it takes longer than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m--init-script[22m=[4mFILE[24m For projects that contain a  gradle  initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
            tion script.
 
 
 
-   [1m.Net & NuGet options[0m
-       [1m--assets-project-name[0m
-              When  monitoring a .NET project using NuGet [1mPackageReference [22muse
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
               the project name in project.assets.json, if found.
 
-       [1m--packages-folder[0m
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
-       [1m--project-name-prefix[22m=[4mPREFIX_STRING[0m
-              When monitoring a .NET project, use this flag to  add  a  custom
-              prefix  to the name of files inside a project along with any de-
-              sired  separators,  e.g.  [1msnyk   monitor   --file=my-project.sln[0m
-              [1m--project-name-prefix=my-group/[22m.  This  is  useful when you have
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When  monitoring  a  .NET project, use this flag to add a custom
+              prefix to the name of files inside  a  project  along  with  any
+              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
               multiple projects with the same name in other sln files.
 
-   [1mnpm options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-   [1mYarn options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-       [1m--yarn-workspaces[0m
-              (only in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Detect  and  scan  yarn
-              workspaces.  You  can specify how many sub-directories to search
-              using [1m--detection-depth [22mand exclude directories and files  using
-              [1m--exclude[22m.
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
+              workspaces. You can specify how many sub-directories  to  search
+              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
-   [1mCocoaPods options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: false
 
-   [1mPython options[0m
-       [1m--command[22m=[4mCOMMAND[0m
-              Indicate  which  specific Python commands to use based on Python
-              version. The default is [1mpython [22mwhich executes your  systems  de-
-              fault  python  version. Run 'python -V' to find out what version
-              is it. If you are using multiple Python versions, use  this  pa-
-              rameter to specify the correct Python command for execution.
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate which specific Python commands to use based  on  Python
+              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
+              default python version. Run 'python -V' to find out what version
+              is  it.  If  you  are  using  multiple Python versions, use this
+              parameter to specify the correct Python command for execution.
 
-              Default: [1mpython [22mExample: [1m--command=python3[0m
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
-       [1m--skip-unresolved[22m=true|false
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
               Allow skipping packages that are not found in the environment.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
-              Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk  authorization token. Setting this envvar will override the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
-              credentials when Docker is present.
-
-       [1mSNYK_REGISTRY_PASSWORD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
+              credentials when Docker is present.
 
-       [1mSNYK_API[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-wizard.txt
+++ b/help/commands-txt/snyk-wizard.txt
@@ -1,11 +1,11 @@
-[1mNAME[0m
-       [1msnyk-wizard  [22m- Configure your policy file to update, auto patch and ig-
-       nore vulnerabilities
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m  -  Configure  your  policy  file to update, auto patch and
+       ignore vulnerabilities
 
-[1mSYNOPSIS[0m
-       [1msnyk wizard [22m[[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Snyk's wizard will:
 
        O   Enumerate your local dependencies and query Snyk's servers for vul-
@@ -13,92 +13,92 @@
 
        O   Guide you through fixing found vulnerabilities
 
-       O   Create  a .snyk policy file to guide snyk commands such as [1mtest [22mand
-           [1mprotect[0m
+       O   Create  a .snyk policy file to guide snyk commands such as [1mt[0m[1me[0m[1ms[0m[1mt[0m and
+           [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m
 
        O   Remember your dependencies to alert you  when  new  vulnerabilities
            are disclosed
 
 
 
-[1mOPTIONS[0m
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk authorization token. Setting this envvar will override  the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows  you  to  override  any key that's also available as [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m--username [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--password [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets  API  host  to use for Snyk requests. Useful for on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will  upgrade  the  requests  to  [1mhttps[22m. Unless [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If set to the value of [1m0[22m, API requests aimed at [1mhttp  [22mURLs  will
-              not  be upgraded to [1mhttps[22m. If not set, the default behavior will
-              be to upgrade these requests from [1mhttp [22mto  [1mhttps[22m.  Useful  e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows  you  to specify a proxy to use for [1mhttps [22mand [1mhttp [22mcalls.
-              The [1mhttps [22min the [1mHTTPS_PROXY [22mmeans  that  [4mrequests[24m  [4musing[24m  [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol  will  use this proxy. The proxy itself doesn't need to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
        age   or   otherwise,   is   subject   to   the   terms   &  conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-woof.txt
+++ b/help/commands-txt/snyk-woof.txt
@@ -1,94 +1,94 @@
-[1mNAME[0m
-       [1msnyk-woof [22m- W00f
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mo[0m[1mo[0m[1mf[0m - W00f
 
-[1mSYNOPSIS[0m
-       [1msnyk woof [22m[[4mOPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mo[0m[1mo[0m[1mf[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Easter egg that prints a Patch ascii art.
 
-[1mOPTIONS[0m
-       [1m--language[22m=[4mLANGUAGE[0m
-              Woof  in  a  specific  language.  [4mLANGUAGE[24m should be a ISO 639-1
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       [1m-[0m[1m-[0m[1ml[0m[1ma[0m[1mn[0m[1mg[0m[1mu[0m[1ma[0m[1mg[0m[1me[0m=[4mL[0m[4mA[0m[4mN[0m[4mG[0m[4mU[0m[4mA[0m[4mG[0m[4mE[0m
+              Woof  in  a  specific  language.  [4mL[0m[4mA[0m[4mN[0m[4mG[0m[4mU[0m[4mA[0m[4mG[0m[4mE[0m should be a ISO 639-1
               code.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints a help text. You may specify a [4mCOMMAND[24m to  get  more  de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
               Snyk  authorization token. Setting this envvar will override the
-              token that may be available in your [1msnyk config [22msettings.
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows you to override any key that's  also  available  as  [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
               Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--username [22mflag will override this
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
               value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
-       [1mSNYK_REGISTRY_PASSWORD[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
               Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m--password [22mflag  will  override  this
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_API[0m
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
               Sets API host to use for Snyk requests.  Useful  for  on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will upgrade the  requests  to  [1mhttps[22m.  Unless  [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If  set  to the value of [1m0[22m, API requests aimed at [1mhttp [22mURLs will
-              not be upgraded to [1mhttps[22m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mhttp [22mto [1mhttps[22m. Useful e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows you to specify a proxy to use for [1mhttps [22mand  [1mhttp  [22mcalls.
-              The  [1mhttps  [22min  the  [1mHTTPS_PROXY [22mmeans that [4mrequests[24m [4musing[24m [1mhttps[0m
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
               protocol will use this proxy. The proxy itself doesn't  need  to
-              use [1mhttps[22m.
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
        The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
        age  or   otherwise,   is   subject   to   the   terms   &   conditions
-       [4mhttps://snyk.co/ucT6N[0m
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk.txt
+++ b/help/commands-txt/snyk.txt
@@ -1,346 +1,349 @@
-[1mNAME[0m
-       [1msnyk  [22m-  CLI and build-time tool to find & fix known vulnerabilities in
+[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m  -  CLI and build-time tool to find & fix known vulnerabilities in
        open-source dependencies
 
-[1mSYNOPSIS[0m
-       [1msnyk [22m[[4mCOMMAND[24m] [[4mSUBCOMMAND[24m] [[4mOPTIONS[24m] [[4mPACKAGE[24m] [-- [4mCOMPILER_OPTIONS[24m]
+[1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mS[0m[4mU[0m[4mB[0m[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m] [[4mP[0m[4mA[0m[4mC[0m[4mK[0m[4mA[0m[4mG[0m[4mE[0m] [-- [4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
-[1mDESCRIPTION[0m
+[1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
        Snyk helps you find, fix and  monitor  known  vulnerabilities  in  open
        source dependencies.
        For more information see https://snyk.io
 
-   [1mNot sure where to start?[0m
-       1.  authenticate with [1m$ snyk auth[0m
+   [1mN[0m[1mo[0m[1mt[0m [1ms[0m[1mu[0m[1mr[0m[1me[0m [1mw[0m[1mh[0m[1me[0m[1mr[0m[1me[0m [1mt[0m[1mo[0m [1ms[0m[1mt[0m[1ma[0m[1mr[0m[1mt[0m[1m?[0m
+       1.  authenticate with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1ma[0m[1mu[0m[1mt[0m[1mh[0m
 
-       2.  test your local project with [1m$ snyk test[0m
+       2.  test your local project with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
 
-       3.  get alerted for new vulnerabilities with [1m$ snyk monitor[0m
+       3.  get alerted for new vulnerabilities with [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
 
 
 
-[1mCOMMANDS[0m
-       To  see  command-specific  flags and usage, see [1mhelp [22mcommand, e.g. [1msnyk[0m
-       [1mcontainer --help[22m. Available top-level CLI commands:
+[1mC[0m[1mO[0m[1mM[0m[1mM[0m[1mA[0m[1mN[0m[1mD[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. Available top-level CLI commands:
 
-       [1mauth [22m[[4mAPI_TOKEN[24m]
+       [1ma[0m[1mu[0m[1mt[0m[1mh[0m [[4mA[0m[4mP[0m[4mI[0m[1m_[0m[4mT[0m[4mO[0m[4mK[0m[4mE[0m[4mN[0m]
               Authenticate Snyk CLI with a Snyk account.
 
-       [1mtest   [22mTest local project for vulnerabilities.
+       [1mt[0m[1me[0m[1ms[0m[1mt[0m   Test local project for vulnerabilities.
 
-       [1mmonitor[0m
+       [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m
               Snapshot and continuously monitor your project.
 
-       [1mcontainer[0m
-              Test container images for vulnerabilities.  See  [1msnyk  container[0m
-              [1m--help [22mfor full instructions.
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m
+              Test container images for vulnerabilities.  See  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m
+              [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for full instructions.
 
-       [1miac    [22mFind  security  issues in your Infrastructure as Code files. See
-              [1msnyk iac --help [22mfor full instructions.
+       [1mi[0m[1ma[0m[1mc[0m    Find  security  issues in your Infrastructure as Code files. See
+              [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for full instructions.
 
-       [1mcode   [22mFind security issues using static code analysis. See  [1msnyk  code[0m
-              [1m--help [22mfor full instructions.
+       [1mc[0m[1mo[0m[1md[0m[1me[0m   Find security issues using static code analysis. See  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mc[0m[1mo[0m[1md[0m[1me[0m
+              [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for full instructions.
 
-       [1mconfig [22mManage Snyk CLI configuration.
+       [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m Manage Snyk CLI configuration.
 
-       [1mprotect[0m
+       [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m
               Applies  the  patches  specified in your .snyk file to the local
               file system.
 
-       [1mpolicy [22mDisplay the .snyk policy for a package.
+       [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m Display the .snyk policy for a package.
 
-       [1mignore [22mModifies the .snyk policy to ignore stated issues.
+       [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m Modifies the .snyk policy to ignore stated issues.
 
-       [1mwizard [22mConfigure your policy file to update, auto patch and ignore vul-
+       [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m Configure your policy file to update, auto patch and ignore vul-
               nerabilities. Snyk wizard updates your .snyk file.
 
-[1mOPTIONS[0m
-       To  see  command-specific  flags and usage, see [1mhelp [22mcommand, e.g. [1msnyk[0m
-       [1mcontainer --help[22m. For advanced usage, we  offer  language  and  context
+[1mO[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m[1mS[0m
+       To  see  command-specific  flags and usage, see [1mh[0m[1me[0m[1ml[0m[1mp[0m command, e.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m
+       [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m. For advanced usage, we  offer  language  and  context
        specific flags, listed further down this document.
 
-       [1m--all-projects[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Auto-detect all projects in
+       [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Auto-detect all projects in
               working directory
 
-       [1m--detection-depth[22m=[4mDEPTH[0m
-              (only in [1mtest [22mand [1mmonitor [22mcommands) Use with  --all-projects  or
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m=[4mD[0m[4mE[0m[4mP[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Use with  --all-projects  or
               --yarn-workspaces   to  indicate  how  many  sub-directories  to
-              search. [1mDEPTH [22mmust be a number.
+              search. [1mD[0m[1mE[0m[1mP[0m[1mT[0m[1mH[0m must be a number.
 
               Default: 4 (the current working directory and 3 sub-directories)
 
-       [1m--exclude[22m=[4mDIRECTORY[24m[,[4mDIRECTORY[24m]...>
-              (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Can   be   used   with
+       [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
+              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If using with [1m--detection-depth [22mexclude ignores  directories  at
+              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
               any level deep.
 
-       [1m--prune-repeated-subdependencies[22m, [1m-p[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Prune dependency trees, re-
-              moving duplicate sub-dependencies. Will still find all  vulnera-
-              bilities, but potentially not all of the vulnerable paths.
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
+              removing duplicate sub-dependencies. Will still find all vulner-
+              abilities, but potentially not all of the vulnerable paths.
 
-       [1m--print-deps[0m
-              (only  in  [1mtest  [22mand [1mmonitor [22mcommands) Print the dependency tree
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
               before sending it for analysis.
 
-       [1m--remote-repo-url[22m=[4mURL[0m
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m--dev  [22mInclude  development-only dependencies. Applicable only for some
-              package managers. E.g. [4mdevDependencies[24m in  npm  or  [4m:development[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
+              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
-       [1m--org[22m=[4mORG_NAME[0m
-              Specify the [4mORG_NAME[24m to run Snyk commands tied to a specific or-
-              ganization. This will influence where will new projects be  cre-
-              ated  after  running [1mmonitor [22mcommand, some features availability
-              and private tests limits. If you  have  multiple  organizations,
-              you can set a default from the CLI using:
+       [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
+              organization.  This  will  influence  where will new projects be
+              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
+              ity  and  private  tests  limits. If you have multiple organiza-
+              tions, you can set a default from the CLI using:
 
-              [1m$ snyk config set org[22m=[4mORG_NAME[0m
+              [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting  a default will ensure all newly monitored projects will
+              Setting a default will ensure all newly monitored projects  will
               be created under your default organization. If you need to over-
-              ride the default, you can use the [1m--org[22m=[4mORG_NAME[24m argument.
+              ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
-              Default: uses [4mORG_NAME[24m that sets as default in your Account set-
-              tings [4mhttps://app.snyk.io/account[0m
+              Default: uses [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m that sets as default in your Account set-
+              tings [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ma[0m[4mp[0m[4mp[0m[4m.[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mo[0m[4m/[0m[4ma[0m[4mc[0m[4mc[0m[4mo[0m[4mu[0m[4mn[0m[4mt[0m
 
-       [1m--file[22m=[4mFILE[0m
+       [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When testing locally or monitoring a project,  you  can  specify
-              the  file that Snyk should inspect for package information. When
-              ommitted Snyk will try to detect the appropriate file  for  your
+              When  testing  locally  or monitoring a project, you can specify
+              the file that Snyk should inspect for package information.  When
+              ommitted  Snyk  will try to detect the appropriate file for your
               project.
 
-       [1m--ignore-policy[0m
-              Ignores  all set policies. The current policy in [1m.snyk [22mfile, Org
+       [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
               level ignores and the project policy on snyk.io.
 
-       [1m--trust-policies[0m
+       [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a suggestion.
+              cies, otherwise ignore policies are only shown as a  suggestion.
 
-       [1m--show-vulnerable-paths[22m=none|some|all
+       [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable packages. Doesn't affect output when  us-
-              ing JSON [1m--json [22moutput.
+              down to the vulnerable  packages.  Doesn't  affect  output  when
+              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
-              Default:  [4msome[24m (a few example paths shown) [4mfalse[24m is an alias for
-              [4mnone[24m.
+              Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
+              [4mn[0m[4mo[0m[4mn[0m[4me[0m.
 
-       [1m--project-name[22m=[4mPROJECT_NAME[0m
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m=[4mP[0m[4mR[0m[4mO[0m[4mJ[0m[4mE[0m[4mC[0m[4mT[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
               Specify a custom Snyk project name.
 
-       [1m--target-reference[22m=[4mTARGET_REFERENCE[0m
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
               A reference to separate this project from  other  scans  of  the
               same  project.  For  example, a branch name or version. Projects
               using the same reference can be used for grouping. More informa-
-              tion [4mhttps://snyk.info/3B0vTPs[24m.
+              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
-       [1m--project-environment[22m=[4mENVIRONMENT[24m[,[4mENVIRONMENT[24m]...>
-              (only  in [1mmonitor [22mcommand) Set the project environment to one or
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
+              (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
               more values (comma-separated). Allowed values:  frontend,  back-
               end,  internal, external, mobile, saas, onprem, hosted, distrib-
               uted
 
-       [1m--project-lifecycle[22m=[4mLIFECYCLE[24m[,[4mLIFECYCLE[24m]...>
-              (only in [1mmonitor [22mcommand) Set the project lifecycle  to  one  or
-              more  values  (comma-separated). Allowed values: production, de-
-              velopment, sandbox
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
+              more   values  (comma-separated).  Allowed  values:  production,
+              development, sandbox
 
-       [1m--project-business-criticality[22m=[4mBUSINESS_CRITICALITY[24m[,[4mBUSINESS_CRITICAL-[0m
-       [4mITY[24m]...>
-              (only  in  [1mmonitor [22mcommand) Set the project business criticality
-              to one or more values (comma-separated). Allowed values:  criti-
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
+       [4mI[0m[4mT[0m[4mY[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
+              to  one or more values (comma-separated). Allowed values: criti-
               cal, high, medium, low
 
-       [1m--project-tags[22m=[4mTAG[24m[,[4mTAG[24m]...>
-              (only  in  [1mmonitor  [22mcommand) Set the project tags to one or more
-              values (comma-separated key value pairs with an "="  separator).
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
+              values  (comma-separated key value pairs with an "=" separator).
               e.g. --project-tags=department=finance,team=alpha
 
-       [1m--policy-path[22m=[4mPATH_TO_POLICY_FILE[24m`
+       [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
+              This is an alias for --project-tags.
+
+       [1m-[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m=[4mP[0m[4mA[0m[4mT[0m[4mH[0m[1m_[0m[4mT[0m[4mO[0m[1m_[0m[4mP[0m[4mO[0m[4mL[0m[4mI[0m[4mC[0m[4mY[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m`
               Manually pass a path to a snyk policy file.
 
-       [1m--json [22mPrints results in JSON format.
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
-       [1m--json-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only  in [1mtest [22mcommand) Save test output in JSON format directly
-              to the specified file, regardless of whether or not you use  the
-              [1m--json  [22moption. This is especially useful if you want to display
-              the human-readable test output via stdout and at the  same  time
+       [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
+              to  the specified file, regardless of whether or not you use the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
+              the  human-readable  test output via stdout and at the same time
               save the JSON format output to a file.
 
-       [1m--sarif[0m
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
               Return results in SARIF format.
 
-       [1m--sarif-file-output[22m=[4mOUTPUT_FILE_PATH[0m
-              (only in [1mtest [22mcommand) Save test output in SARIF format directly
-              to the [4mOUTPUT_FILE_PATH[24m file, regardless of whether or  not  you
-              use the [1m--sarif [22moption. This is especially useful if you want to
-              display the human-readable test output via  stdout  and  at  the
+       [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
+              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
+              display  the  human-readable  test  output via stdout and at the
               same time save the SARIF format output to a file.
 
-       [1m--severity-threshold[22m=low|medium|high|critical
+       [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
               Only report vulnerabilities of provided level or higher.
 
-       [1m--fail-on[22m=all|upgradable|patchable
+       [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4mall[24m  fails  when there is at least one vulnerability that can be
-              either upgraded or patched. [4mupgradable[24m fails when  there  is  at
-              least  one  vulnerability  that can be upgraded. [4mpatchable[24m fails
+              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
+              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
+              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
               when there is at least one vulnerability that can be patched.
 
-              If vulnerabilities do not have a fix and this  option  is  being
+              If  vulnerabilities  do  not have a fix and this option is being
               used, tests will pass.
 
-       [1m--dry-run[0m
-              (only  in [1mprotect [22mcommand) Don't apply updates or patches during
-              [1mprotect [22mcommand run.
+       [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
+              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
-       [1m-- [22m[[4mCOMPILER_OPTIONS[24m]
-              Pass extra arguments directly to Gradle or Maven. E.g. [1msnyk test[0m
-              [1m-- --build-cache[0m
+       [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
+              Pass extra arguments directly to Gradle or Maven. E.g. [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mt[0m[1me[0m[1ms[0m[1mt[0m
+              [1m-[0m[1m-[0m [1m-[0m[1m-[0m[1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1m-[0m[1mc[0m[1ma[0m[1mc[0m[1mh[0m[1me[0m
 
        Below  are  flags  that  are  influencing  CLI  behavior  for  specific
        projects, languages and contexts:
 
-   [1mMaven options[0m
-       [1m--scan-all-unmanaged[0m
-              Auto detects maven jars, aars, and wars in given directory.  In-
-              dividual testing can be done with [1m--file[22m=[4mJAR_FILE_NAME[0m
+   [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
+              Auto  detects  maven  jars,  aars,  and wars in given directory.
+              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-       [1m--reachable[0m
-              (only  in [1mtest [22mand [1mmonitor [22mcommands) Analyze your source code to
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
+              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
               find which vulnerable functions and packages are called.
 
-       [1m--reachable-timeout[22m=[4mTIMEOUT[0m
-              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
-              reachability  data.  If  it takes longer than [4mTIMEOUT[24m, Reachable
-              Vulnerabilities are not reported. This does not  affect  regular
+       [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
+              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
+              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
+              Vulnerabilities  are  not reported. This does not affect regular
               test or monitor output.
 
               Default: 300 (5 minutes).
 
-   [1mGradle options[0m
-       More information about Gradle CLI options [4mhttps://snyk.co/ucT6P[0m
+   [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m--sub-project[22m=[4mNAME[24m,  [1m--gradle-sub-project[22m=[4mNAME[24m:  For  Gradle "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m--all-sub-projects[22m: For "multi project"  configurations,  test  all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
            sub-projects.
 
-       O   [1m--configuration-matching[22m=[4mCONFIGURATION_REGEX[24m:  Resolve dependencies
-           using only configuration(s) that match the  provided  Java  regular
-           expression, e.g. [1m^releaseRuntimeClasspath$[22m.
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
+           using  only  configuration(s)  that match the provided Java regular
+           expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
-       O   [1m--configuration-attributes[22m=[4mATTRIBUTE[24m[,[4mATTRIBUTE[24m]...: Select certain
-           values of configuration attributes  to  resolve  the  dependencies.
-           E.g. [1mbuildtype:release,usage:java-runtime[0m
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
+           values  of  configuration  attributes  to resolve the dependencies.
+           E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m--reachable[22m:  (only  in  [1mtest  [22mand  [1mmonitor  [22mcommands) Analyze your
-           source code to find which vulnerable  functions  and  packages  are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
+           source  code  to  find  which vulnerable functions and packages are
            called.
 
-       O   [1m--reachable-timeout[22m=[4mTIMEOUT[24m:  The  amount  of  time (in seconds) to
-           wait for Snyk to gather reachability data. If it takes longer  than
-           [4mTIMEOUT[24m,  Reachable Vulnerabilities are not reported. This does not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
+           wait  for Snyk to gather reachability data. If it takes longer than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m--init-script[22m=[4mFILE[24m For projects that contain a  gradle  initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
            tion script.
 
 
 
-   [1m.Net & NuGet options[0m
-       [1m--assets-project-name[0m
-              When  monitoring a .NET project using NuGet [1mPackageReference [22muse
+   [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
+              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
               the project name in project.assets.json, if found.
 
-       [1m--packages-folder[0m
+       [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
-       [1m--project-name-prefix[22m=[4mPREFIX_STRING[0m
-              When monitoring a .NET project, use this flag to  add  a  custom
-              prefix  to the name of files inside a project along with any de-
-              sired  separators,  e.g.  [1msnyk   monitor   --file=my-project.sln[0m
-              [1m--project-name-prefix=my-group/[22m.  This  is  useful when you have
+       [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
+              When  monitoring  a  .NET project, use this flag to add a custom
+              prefix to the name of files inside  a  project  along  with  any
+              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
               multiple projects with the same name in other sln files.
 
-   [1mnpm options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-   [1mYarn options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mY[0m[1ma[0m[1mr[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: true
 
-       [1m--yarn-workspaces[0m
-              (only in  [1mtest  [22mand  [1mmonitor  [22mcommands)  Detect  and  scan  yarn
-              workspaces.  You  can specify how many sub-directories to search
-              using [1m--detection-depth [22mand exclude directories and files  using
-              [1m--exclude[22m.
+       [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
+              workspaces. You can specify how many sub-directories  to  search
+              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
-   [1mCocoaPods options[0m
-       [1m--strict-out-of-sync[22m=true|false
+   [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1ms[0m[1mt[0m[1mr[0m[1mi[0m[1mc[0m[1mt[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1m-[0m[1mo[0m[1mf[0m[1m-[0m[1ms[0m[1my[0m[1mn[0m[1mc[0m=true|false
               Control testing out of sync lockfiles.
 
               Default: false
 
-   [1mPython options[0m
-       [1m--command[22m=[4mCOMMAND[0m
-              Indicate  which  specific Python commands to use based on Python
-              version. The default is [1mpython [22mwhich executes your  systems  de-
-              fault  python  version. Run 'python -V' to find out what version
-              is it. If you are using multiple Python versions, use  this  pa-
-              rameter to specify the correct Python command for execution.
+   [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
+              Indicate which specific Python commands to use based  on  Python
+              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
+              default python version. Run 'python -V' to find out what version
+              is  it.  If  you  are  using  multiple Python versions, use this
+              parameter to specify the correct Python command for execution.
 
-              Default: [1mpython [22mExample: [1m--command=python3[0m
+              Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
-       [1m--skip-unresolved[22m=true|false
+       [1m-[0m[1m-[0m[1ms[0m[1mk[0m[1mi[0m[1mp[0m[1m-[0m[1mu[0m[1mn[0m[1mr[0m[1me[0m[1ms[0m[1mo[0m[1ml[0m[1mv[0m[1me[0m[1md[0m=true|false
               Allow skipping packages that are not found in the environment.
 
-   [1mFlags available accross all commands[0m
-       [1m--insecure[0m
+   [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
+       [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1ms[0m[1me[0m[1mc[0m[1mu[0m[1mr[0m[1me[0m
               Ignore unknown certificate authorities.
 
-       [1m-d     [22mOutput debug logs.
+       [1m-[0m[1md[0m     Output debug logs.
 
-       [1m--quiet[22m, [1m-q[0m
+       [1m-[0m[1m-[0m[1mq[0m[1mu[0m[1mi[0m[1me[0m[1mt[0m, [1m-[0m[1mq[0m
               Silence all output.
 
-       [1m--version[22m, [1m-v[0m
+       [1m-[0m[1m-[0m[1mv[0m[1me[0m[1mr[0m[1ms[0m[1mi[0m[1mo[0m[1mn[0m, [1m-[0m[1mv[0m
               Prints versions.
 
-       [[4mCOMMAND[24m] [1m--help[22m, [1m--help [22m[[4mCOMMAND[24m], [1m-h[0m
-              Prints  a  help  text. You may specify a [4mCOMMAND[24m to get more de-
-              tails.
+       [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
+              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
+              details.
 
-[1mEXAMPLES[0m
-       [1mAuthenticate in your CI without user interaction[0m
+[1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
+       [1mA[0m[1mu[0m[1mt[0m[1mh[0m[1me[0m[1mn[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1mt[0m[1me[0m [1mi[0m[1mn[0m [1my[0m[1mo[0m[1mu[0m[1mr[0m [1mC[0m[1mI[0m [1mw[0m[1mi[0m[1mt[0m[1mh[0m[1mo[0m[1mu[0m[1mt[0m [1mu[0m[1ms[0m[1me[0m[1mr[0m [1mi[0m[1mn[0m[1mt[0m[1me[0m[1mr[0m[1ma[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m
               $ snyk auth MY_API_TOKEN
 
-       [1mTest a project in current folder for known vulnerabilities[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1ma[0m [1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m [1mi[0m[1mn[0m [1mc[0m[1mu[0m[1mr[0m[1mr[0m[1me[0m[1mn[0m[1mt[0m [1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m [1mf[0m[1mo[0m[1mr[0m [1mk[0m[1mn[0m[1mo[0m[1mw[0m[1mn[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1mi[0m[1me[0m[1ms[0m
               $ snyk test
 
-       [1mTest a specific dependency for vulnerabilities[0m
+       [1mT[0m[1me[0m[1ms[0m[1mt[0m [1ma[0m [1ms[0m[1mp[0m[1me[0m[1mc[0m[1mi[0m[1mf[0m[1mi[0m[1mc[0m [1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1my[0m [1mf[0m[1mo[0m[1mr[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1mi[0m[1me[0m[1ms[0m
               $ snyk test ionic@1.6.5
 
        More examples:
@@ -352,8 +355,8 @@
 
 
 
-   [1mContainer scanning[0m
-       See [1msnyk container --help [22mfor more details and examples:
+   [1mC[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1ms[0m[1mc[0m[1ma[0m[1mn[0m[1mn[0m[1mi[0m[1mn[0m[1mg[0m
+       See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mt[0m[1ma[0m[1mi[0m[1mn[0m[1me[0m[1mr[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for more details and examples:
 
 
            $ snyk container test ubuntu:18.04 --org=my-team
@@ -361,8 +364,8 @@
 
 
 
-   [1mInfrastructure as Code (IAC) scanning[0m
-       See [1msnyk iac --help [22mfor more details and examples:
+   [1mI[0m[1mn[0m[1mf[0m[1mr[0m[1ma[0m[1ms[0m[1mt[0m[1mr[0m[1mu[0m[1mc[0m[1mt[0m[1mu[0m[1mr[0m[1me[0m [1ma[0m[1ms[0m [1mC[0m[1mo[0m[1md[0m[1me[0m [1m([0m[1mI[0m[1mA[0m[1mC[0m[1m)[0m [1ms[0m[1mc[0m[1ma[0m[1mn[0m[1mn[0m[1mi[0m[1mn[0m[1mg[0m
+       See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1ma[0m[1mc[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for more details and examples:
 
 
            $ snyk iac test /path/to/cloudformation_file.yaml
@@ -373,10 +376,10 @@
 
 
 
-       To use your own custom rules to scan IaC configuration files,  download
-       the  [1msnyk-iac-rules  [22mSDK  from  https://github.com/snyk/snyk-iac-rules.
-       Follow the instructions there to write, build, and push a custom  rules
-       bundle  and  then either use the Snyk UI to configure your custom rules
+       To  use your own custom rules to scan IaC configuration files, download
+       the  [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1ma[0m[1mc[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m  SDK  from  https://github.com/snyk/snyk-iac-rules.
+       Follow  the instructions there to write, build, and push a custom rules
+       bundle and then either use the Snyk UI to configure your  custom  rules
        settings or configure a remote OCI registry locally by running the fol-
        lowing commands:
 
@@ -387,75 +390,75 @@
 
 
 
-   [1mStatic code analysis (SAST) scanning[0m
-       See [1msnyk code --help [22mfor more details and examples:
+   [1mS[0m[1mt[0m[1ma[0m[1mt[0m[1mi[0m[1mc[0m [1mc[0m[1mo[0m[1md[0m[1me[0m [1ma[0m[1mn[0m[1ma[0m[1ml[0m[1my[0m[1ms[0m[1mi[0m[1ms[0m [1m([0m[1mS[0m[1mA[0m[1mS[0m[1mT[0m[1m)[0m [1ms[0m[1mc[0m[1ma[0m[1mn[0m[1mn[0m[1mi[0m[1mn[0m[1mg[0m
+       See [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1md[0m[1me[0m [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m for more details and examples:
 
 
            $ snyk code test /path/to/project
 
 
 
-[1mEXIT CODES[0m
+[1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
 
-       [1m0[22m: success, no vulns found
-       [1m1[22m: action_needed, vulns found
-       [1m2[22m: failure, try to re-run command
-       [1m3[22m: failure, no supported projects detected
+       [1m0[0m: success, no vulns found
+       [1m1[0m: action_needed, vulns found
+       [1m2[0m: failure, try to re-run command
+       [1m3[0m: failure, no supported projects detected
 
-[1mENVIRONMENT[0m
+[1mE[0m[1mN[0m[1mV[0m[1mI[0m[1mR[0m[1mO[0m[1mN[0m[1mM[0m[1mE[0m[1mN[0m[1mT[0m
        You can set these environment variables to change CLI run settings.
 
-       [1mSNYK_TOKEN[0m
-              Snyk  authorization token. Setting this envvar will override the
-              token that may be available in your [1msnyk config [22msettings.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
+              Snyk authorization token. Setting this envvar will override  the
+              token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
-              How to get your account token [4mhttps://snyk.co/ucT6J[0m
-              How to use Service Accounts [4mhttps://snyk.co/ucT6L[0m
+              How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
+              How to use Service Accounts [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mL[0m
 
 
-       [1mSNYK_CFG_KEY[0m
-              Allows you to override any key that's  also  available  as  [1msnyk[0m
-              [1mconfig [22moption.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
-              E.g. [1mSNYK_CFG_ORG[22m=myorg will override default org option in [1mcon-[0m
-              [1mfig [22mwith "myorg".
+              E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
+              [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
-       [1mSNYK_REGISTRY_USERNAME[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m--username [22mflag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
-              credentials when Docker is present.
-
-       [1mSNYK_REGISTRY_PASSWORD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m--password [22mflag  will  override  this
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
               value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
-[1mConnecting to Snyk API[0m
-       By default Snyk CLI will connect to [1mhttps://snyk.io/api/v1[22m.
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
+              credentials when Docker is present.
 
-       [1mSNYK_API[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
-              instances and configuring proxies. If set with [1mhttp [22mprotocol CLI
-              will upgrade the  requests  to  [1mhttps[22m.  Unless  [1mSNYK_HTTP_PROTO-[0m
-              [1mCOL_UPGRADE [22mis set to [1m0[22m.
+[1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
+       By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
-       [1mSNYK_HTTP_PROTOCOL_UPGRADE[22m=0
-              If  set  to the value of [1m0[22m, API requests aimed at [1mhttp [22mURLs will
-              not be upgraded to [1mhttps[22m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mhttp [22mto [1mhttps[22m. Useful e.g.,
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
+
+       [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
-       [1mHTTPS_PROXY [22mand [1mHTTP_PROXY[0m
-              Allows you to specify a proxy to use for [1mhttps [22mand  [1mhttp  [22mcalls.
-              The  [1mhttps  [22min  the  [1mHTTPS_PROXY [22mmeans that [4mrequests[24m [4musing[24m [1mhttps[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
-              use [1mhttps[22m.
+       [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
+              use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
-[1mNOTICES[0m
-   [1mSnyk API usage policy[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
-       [4mhttps://snyk.co/ucT6N[0m
+[1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
+   [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m


### PR DESCRIPTION
To make the CLI easier to use, we are aliasing `--project-tags` to simply `--tags`.

We shipped the actual change in https://github.com/snyk/snyk/pull/2330