### PR TITLE
Add ARM64 support

### DIFF
--- a/docker/Dockerfile.docker
+++ b/docker/Dockerfile.docker
@@ -6,7 +6,7 @@ MAINTAINER Snyk Ltd
 RUN apt-get update && \
     apt-get install -y apt-transport-https ca-certificates curl gnupg2 software-properties-common git && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
+    if [ "$(uname -m)" = "aarch64" ]; then add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"; else add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"; fi && \
     apt-get update && apt-get install -y docker-ce && \
     npm install --global snyk snyk-to-html && \
     apt-get autoremove -y && \


### PR DESCRIPTION
#### What does this PR do? 

Added ARM64 support in Dockerfile.docker to make it compatible for arm64 and amd64 platforms. 

#### What are the relevant tickets? 

https://github.com/snyk/snyk/issues/1498 