### PR TITLE
Feat: show confidence score

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.4",
+        "snyk-cpp-plugin": "2.13.0",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22809,9 +22809,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
-      "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
+      "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -45379,7 +45379,7 @@
         "@snyk/cli-alert": "file:packages/cli-alert",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.12.0",
-        "@snyk/code-client": "4.4.1",
+        "@snyk/code-client": "^4.4.1",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.4.0",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -45462,7 +45462,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.12.4",
+        "snyk-cpp-plugin": "2.13.0",
         "snyk-docker-plugin": "4.26.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -63588,9 +63588,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.12.4",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
-          "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
+          "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -67042,9 +67042,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.12.4",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.12.4.tgz",
-      "integrity": "sha512-bZZiGSh+2Wt1tn3R2zCwlV/BEKvSuZOpLL2ppAJ2uLkoF9U7Wu8SKQV1ezsF7LrDCyS+Z4wSR5sDWytSe2w65A==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.13.0.tgz",
+      "integrity": "sha512-yCTFg5YVpm67HDAYSpSv1RynQXeZd4EQoK8DSBKG00abj+eIow++zca7c6j56e4sH2GBTpMCOt9VNAjJ7gydHg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.12.4",
+    "snyk-cpp-plugin": "2.13.0",
     "snyk-docker-plugin": "4.26.1",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",

--- a/src/lib/ecosystems/resolve-test-facts.ts
+++ b/src/lib/ecosystems/resolve-test-facts.ts
@@ -40,6 +40,7 @@ export async function resolveAndTestFacts(
           issuesData: response?.issuesData,
           depGraphData: response?.depGraphData,
           depsFilePaths: response?.depsFilePaths,
+          fileSignaturesDetails: response?.fileSignaturesDetails,
         });
       } catch (error) {
         const hasStatusCodeError = error.code >= 400 && error.code <= 500;

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -79,11 +79,19 @@ export interface DepsFilePaths {
   [pkgKey: string]: string[];
 }
 
+export interface FileSignaturesDetails {
+  [pkgKey: string]: {
+    confidence: number;
+    filePaths: string[];
+  };
+}
+
 export interface TestResult {
   issues: Issue[];
   issuesData: IssuesData;
   depGraphData: DepGraphData;
   depsFilePaths?: DepsFilePaths;
+  fileSignaturesDetails?: FileSignaturesDetails;
   remediation?: RemediationChanges;
 }
 

--- a/src/lib/polling/polling-test.ts
+++ b/src/lib/polling/polling-test.ts
@@ -55,8 +55,20 @@ export async function pollingTestWithTokenUntilDone(
   const response = await makeRequest<ResolveAndTestFactsResponse>(payload);
 
   if (response.result) {
-    const { issues, issuesData, depGraphData, depsFilePaths } = response.result;
-    return { issues, issuesData, depGraphData, depsFilePaths };
+    const {
+      issues,
+      issuesData,
+      depGraphData,
+      depsFilePaths,
+      fileSignaturesDetails,
+    } = response.result;
+    return {
+      issues,
+      issuesData,
+      depGraphData,
+      depsFilePaths,
+      fileSignaturesDetails,
+    };
   }
 
   await delayNextStep(attemptsCount, maxAttempts, pollInterval);

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -1,6 +1,10 @@
 const values = require('lodash.values');
 import * as depGraphLib from '@snyk/dep-graph';
-import { DepsFilePaths, ScanResult } from '../ecosystems/types';
+import {
+  DepsFilePaths,
+  ScanResult,
+  FileSignaturesDetails,
+} from '../ecosystems/types';
 import { SupportedPackageManagers } from '../package-managers';
 import { Options, SupportedProjectTypes, TestOptions } from '../types';
 import { SEVERITIES } from './common';
@@ -251,6 +255,7 @@ export interface TestDependenciesResult {
   remediation?: RemediationChanges;
   depsFilePaths?: DepsFilePaths;
   depGraphData: depGraphLib.DepGraphData;
+  fileSignaturesDetails: FileSignaturesDetails;
 }
 
 export interface TestDepGraphMeta {

--- a/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
+++ b/test/jest/unit/lib/ecosystems/resolve-test-facts.spec.ts
@@ -70,6 +70,7 @@ describe('resolve and test facts', () => {
       issuesData: {},
       issues: [],
       depGraphData,
+      fileSignaturesDetails: {},
     });
 
     const extractAndApplyPluginAnalyticsSpy = jest.spyOn(
@@ -99,6 +100,7 @@ describe('resolve and test facts', () => {
         issuesData: {},
         issues: [],
         depGraphData,
+        fileSignaturesDetails: {},
       },
     ]);
     expect(errors).toEqual([]);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

The purpose of those changes are related to the addition of a new field (called confidence) in the CLI output for the unmanaged flows.

When using either `--print-deps` or `--print-dep-paths` args along with the `unmanaged scan` command on the CLI you should be able to see the confidence score of the found dependencies.

#### How should this be manually tested?
Yes

#### What are the relevant tickets?
TUN-58

#### Screenshot
`--print-deps`
<img width="1199" alt="Screenshot 2021-11-12 at 18 28 31" src="https://user-images.githubusercontent.com/6909300/141500796-1ea3668c-2f17-403b-bcd0-283c9fc9c561.png">

or 

`--print-dep-paths`
<img width="1239" alt="Screenshot 2021-11-12 at 18 29 35" src="https://user-images.githubusercontent.com/6909300/141500935-a6790d38-4dbd-4332-8d66-ef9b605cbfc3.png">


