### PR TITLE
fix: config set command when value contains =

### DIFF
--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -16,7 +16,7 @@ export default async function config(
     let res = '';
 
     args.forEach((item) => {
-      const [key, val] = item.split('=');
+      const [key, val] = item.split(/=(.+)/);
       snyk.config.set(key, val);
       res += key + ' updated\n';
 

--- a/test/user-config.test.ts
+++ b/test/user-config.test.ts
@@ -32,3 +32,35 @@ test('can unset config values', async (t) => {
       t.fail(e);
     });
 });
+
+test('can set config values with = inside', async (t) => {
+  let before: string | null = null;
+
+  config('get').catch(t.pass);
+  config('unset').catch(t.pass);
+  config('foo' as any).catch(t.pass);
+
+  await config()
+    .then(function(v) {
+      before = v;
+      return config('set', 'foo=10=');
+    })
+    .then(function(v) {
+      t.pass('value set', v);
+      return config('get', 'foo');
+    })
+    .then(function(value) {
+      t.equal(value, '10=', 'got value from config');
+      return config('unset', 'foo');
+    })
+    .then(function() {
+      return config();
+    })
+    .then(function(all) {
+      t.equal(before, all, 'final config matches');
+      config('unset', 'bar');
+    })
+    .catch(function(e) {
+      t.fail(e);
+    });
+});


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
If we run `snyk config set key=value=`, then the value we set is `value` instead of `value=`. This PR uses [capturing parantheses](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#Capturing_parentheses) so that the value we set becomes `value=`.

#### How should this be manually tested?
1. `npm run build`
2. `synk-dev config set key=value=`
3. `snyk-dev config get key`

#### Any background context you want to provide?
https://snyk.slack.com/archives/C0127HWU0E7/p1636722014155100

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/HMMR-470

#### Screenshots
![Screenshot 2021-11-14 at 17 04 46](https://user-images.githubusercontent.com/81559517/141690758-5b7a29ca-9af8-46ca-9da8-53ca4b205e6b.png)


