### PR TITLE
refactor: remove main cli export

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -338,17 +338,6 @@ async function main() {
   return res;
 }
 
-const cli = main().catch((e) => {
-  console.error('Something unexpected went wrong: ', e.stack);
-  console.error('Exit code: ' + EXIT_CODES.ERROR);
-  process.exit(EXIT_CODES.ERROR);
-});
-
-if (module.parent) {
-  // eslint-disable-next-line id-blacklist
-  module.exports = cli;
-}
-
 function validateUnsupportedOptionCombinations(
   options: AllSupportedCliOptions,
 ): void {
@@ -492,3 +481,9 @@ function validateOutputFile(
     throw error;
   }
 }
+
+main().catch((e) => {
+  console.error('Something unexpected went wrong: ', e.stack);
+  console.error('Exit code: ' + EXIT_CODES.ERROR);
+  process.exit(EXIT_CODES.ERROR);
+});


### PR DESCRIPTION
We no longer export "main" in our package.json so we don't need this export.