### PR TITLE
chore: use commonjs instead of umd

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -10,7 +10,7 @@ module.exports = {
     filename: 'index.js',
     library: {
       name: 'snyk',
-      type: 'umd',
+      type: 'commonjs2',
     },
   },
   node: false, // don't mock node modules


### PR DESCRIPTION
Since our outputs are used only by bin/snyk and bin/snyk uses `require`, there's no need to use UMD exports (which attempts to support a wide range of module formats), we can use regular CommonJS. Reduces our build complexity.

https://webpack.js.org/configuration/output/#outputlibrarytype
