### PR TITLE
chore: remove dud webpack loader exclude rule

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -60,7 +60,6 @@ module.exports = {
       {
         test: /\.ts$/i,
         loader: 'ts-loader',
-        exclude: ['/node_modules'],
       },
       {
         test: /\.node$/,


### PR DESCRIPTION
When providing strings, Webpack matches absolute paths so the current `'/node_modules'` rule excludes nothing.

>A string: To match the input must start with the provided string. I. e. an absolute directory path, or absolute path to the file.

https://webpack.js.org/configuration/module/#condition

Fixing this by using a regex `/node_modules/` does not improve build performance at all since imports via node_modules will likely never match the `test` rule (.ts files) so this exclude is not useful.