### PR TITLE
refactor: remove isRequired check

### DIFF
--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -1,5 +1,4 @@
 const abbrev = require('abbrev');
-require('../../lib/spinner').isRequired = false;
 
 // Wrapper for Commonjs compatibility
 async function callModule(mod, args) {

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -26,7 +26,6 @@ Object.defineProperty(snyk, 'api', {
 
 snyk.test = require('./snyk-test');
 snyk.policy = require('snyk-policy');
-snyk.isRequired = true; // changed to false when loaded via cli
 
 // this is the user config, and not the internal config
 snyk.config = require('./user-config').config;

--- a/src/lib/spinner.ts
+++ b/src/lib/spinner.ts
@@ -1,7 +1,6 @@
 import { SpinnerOptions } from './types';
 
 export = createSpinner;
-createSpinner.isRequired = true;
 
 import debugModule = require('debug');
 const debug = debugModule('snyk:spinner');
@@ -65,7 +64,7 @@ createSpinner.clearAll = () => {
 
 // taken from http://git.io/vWdUm and modified
 function spinner(opt: SpinnerOptions) {
-  if (module.exports.isRequired || isCI()) {
+  if (isCI()) {
     return false;
   }
   debug('creating spinner');


### PR DESCRIPTION
Seems this was used at some point when Snyk CLI was used via imports.

We now only support Snyk CLI as an executable via bin/snyk so this shouldn't be needed.