### PR TITLE
docs: target ref only works with snyk open source

### DIFF
--- a/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
+++ b/help/commands-docs/_SNYK_COMMAND_OPTIONS.md
@@ -68,7 +68,7 @@ For advanced usage, we offer language and context specific flags, listed further
   Specify a custom Snyk project name.
 
 - `--target-reference`=<TARGET_REFERENCE>:
-  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 - `--project-environment`=<ENVIRONMENT>[,<ENVIRONMENT>]...>:
   (only in `monitor` command)

--- a/help/commands-man/snyk-auth.1
+++ b/help/commands-man/snyk-auth.1
@@ -59,7 +59,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -78,7 +78,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-code.1
+++ b/help/commands-man/snyk-code.1
@@ -70,7 +70,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -89,7 +89,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-config.1
+++ b/help/commands-man/snyk-config.1
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Manage your local Snyk CLI config file\. This config file is a JSON located at \fB$XDG_CONFIG_HOME\fR or \fB~/\.config\fR followed by \fBconfigstore/snyk\.json\fR\. For example \fB~/\.config/configstore/snyk\.json\fR\.
 .P
-This command does not manage the \fB\.snyk\fR file that\'s part of your project\. See \fBsnyk policy\fR, \fBsnyk ignore\fR or \fBsnyk wizard\fR\.
+This command does not manage the \fB\.snyk\fR file that's part of your project\. See \fBsnyk policy\fR, \fBsnyk ignore\fR or \fBsnyk wizard\fR\.
 .SH "COMMANDS"
 .TP
 \fBget\fR \fIKEY\fR
@@ -82,7 +82,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -101,7 +101,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-container.1
+++ b/help/commands-man/snyk-container.1
@@ -20,7 +20,7 @@ Record the state of dependencies and any vulnerabilities on snyk\.io\.
 Exclude from display base image vulnerabilities\.
 .TP
 \fB\-\-file\fR=\fIFILE_PATH\fR
-Include the path to the image\'s Dockerfile for more detailed advice\.
+Include the path to the image's Dockerfile for more detailed advice\.
 .TP
 \fB\-\-platform\fR=\fIPLATFORM\fR
 For multi\-architecture images, specify the platform to test\. [linux/amd64, linux/arm64, linux/riscv64, linux/ppc64le, linux/s390x, linux/386, linux/arm/v7 or linux/arm/v6]
@@ -94,7 +94,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -113,7 +113,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-help.1
+++ b/help/commands-man/snyk-help.1
@@ -48,7 +48,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -67,7 +67,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-iac.1
+++ b/help/commands-man/snyk-iac.1
@@ -132,7 +132,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -151,7 +151,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-ignore.1
+++ b/help/commands-man/snyk-ignore.1
@@ -8,7 +8,7 @@
 .SH "DESCRIPTION"
 Ignore a certain issue, according to its snyk ID for all occurrences\. This will update your local \fB\.snyk\fR to contain a similar block:
 .P
-\fByaml ignore: \'<ISSUE_ID>\': \- \'*\': reason: <REASON> expires: <EXPIRY>\fR
+\fByaml ignore: '<ISSUE_ID>': \- '*': reason: <REASON> expires: <EXPIRY>\fR
 .SH "OPTIONS"
 .TP
 \fB\-\-id\fR=\fIISSUE_ID\fR
@@ -38,7 +38,7 @@ Prints a help text\. You may specify a \fICOMMAND\fR to get more details\.
 .SH "EXAMPLES"
 .TP
 \fBIgnore a specific vulnerability\fR
-$ snyk ignore \-\-id=\'npm:qs:20170213\' \-\-expiry=\'2021\-01\-10\' \-\-reason=\'Module not affected by this vuln\'
+$ snyk ignore \-\-id='npm:qs:20170213' \-\-expiry='2021\-01\-10' \-\-reason='Module not affected by this vuln'
 .SH "EXIT CODES"
 Possible exit codes and their meaning:
 .P
@@ -63,7 +63,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -82,7 +82,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-monitor.1
+++ b/help/commands-man/snyk-monitor.1
@@ -55,10 +55,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -66,7 +66,7 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 Specify a custom Snyk project name\.
 .TP
 \fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
-A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+A reference which differentiates this project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. Only supported for Snyk Open Source\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
 .TP
 \fB\-\-project\-environment\fR=\fIENVIRONMENT\fR[,\fIENVIRONMENT\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project environment to one or more values (comma\-separated)\. Allowed values: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed
@@ -109,7 +109,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -180,7 +180,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -226,7 +226,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -245,7 +245,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-policy.1
+++ b/help/commands-man/snyk-policy.1
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-protect.1
+++ b/help/commands-man/snyk-protect.1
@@ -6,11 +6,11 @@
 .SH "SYNOPSIS"
 \fBsnyk\fR \fBprotect\fR [\fIOPTIONS\fR]
 .SH "DESCRIPTION"
-\fB$ snyk protect\fR is used to apply patches to your vulnerable dependencies\. It\'s useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI\. snyk protect reads a \.snyk policy file to determine what patches to apply\.
+\fB$ snyk protect\fR is used to apply patches to your vulnerable dependencies\. It's useful after opening a fix pull request from our website (GitHub only) or after running snyk wizard on the CLI\. snyk protect reads a \.snyk policy file to determine what patches to apply\.
 .SH "OPTIONS"
 .TP
 \fB\-\-dry\-run\fR
-Don\'t apply updates or patches when running\.
+Don't apply updates or patches when running\.
 .SS "Flags available accross all commands"
 .TP
 \fB\-\-insecure\fR
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-test.1
+++ b/help/commands-man/snyk-test.1
@@ -55,10 +55,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -66,7 +66,7 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 Specify a custom Snyk project name\.
 .TP
 \fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
-A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+A reference which differentiates this project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. Only supported for Snyk Open Source\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
 .TP
 \fB\-\-project\-environment\fR=\fIENVIRONMENT\fR[,\fIENVIRONMENT\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project environment to one or more values (comma\-separated)\. Allowed values: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed
@@ -109,7 +109,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -180,7 +180,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -226,7 +226,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -245,7 +245,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-wizard.1
+++ b/help/commands-man/snyk-wizard.1
@@ -6,9 +6,9 @@
 .SH "SYNOPSIS"
 \fBsnyk\fR \fBwizard\fR [\fIOPTIONS\fR]
 .SH "DESCRIPTION"
-Snyk\'s wizard will:
+Snyk's wizard will:
 .IP "\[ci]" 4
-Enumerate your local dependencies and query Snyk\'s servers for vulnerabilities
+Enumerate your local dependencies and query Snyk's servers for vulnerabilities
 .IP "\[ci]" 4
 Guide you through fixing found vulnerabilities
 .IP "\[ci]" 4
@@ -57,7 +57,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -76,7 +76,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk-woof.1
+++ b/help/commands-man/snyk-woof.1
@@ -51,7 +51,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -70,7 +70,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-man/snyk.1
+++ b/help/commands-man/snyk.1
@@ -100,10 +100,10 @@ When testing locally or monitoring a project, you can specify the file that Snyk
 Ignores all set policies\. The current policy in \fB\.snyk\fR file, Org level ignores and the project policy on snyk\.io\.
 .TP
 \fB\-\-trust\-policies\fR
-Applies and uses ignore rules from your dependencies\' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
+Applies and uses ignore rules from your dependencies' Snyk policies, otherwise ignore policies are only shown as a suggestion\.
 .TP
 \fB\-\-show\-vulnerable\-paths\fR=none|some|all
-Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn\'t affect output when using JSON \fB\-\-json\fR output\.
+Display the dependency paths from the top level dependencies, down to the vulnerable packages\. Doesn't affect output when using JSON \fB\-\-json\fR output\.
 .IP
 Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fInone\fR\.
 .TP
@@ -111,7 +111,7 @@ Default: \fIsome\fR (a few example paths shown) \fIfalse\fR is an alias for \fIn
 Specify a custom Snyk project name\.
 .TP
 \fB\-\-target\-reference\fR=\fITARGET_REFERENCE\fR
-A reference to separate this project from other scans of the same project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
+A reference which differentiates this project\. For example, a branch name or version\. Projects using the same reference can be used for grouping\. Only supported for Snyk Open Source\. More information \fIhttps://snyk\.info/3B0vTPs\fR\.
 .TP
 \fB\-\-project\-environment\fR=\fIENVIRONMENT\fR[,\fIENVIRONMENT\fR]\|\.\|\.\|\.>
 (only in \fBmonitor\fR command) Set the project environment to one or more values (comma\-separated)\. Allowed values: frontend, backend, internal, external, mobile, saas, onprem, hosted, distributed
@@ -154,7 +154,7 @@ Only fail when there are vulnerabilities that can be fixed\.
 If vulnerabilities do not have a fix and this option is being used, tests will pass\.
 .TP
 \fB\-\-dry\-run\fR
-(only in \fBprotect\fR command) Don\'t apply updates or patches during \fBprotect\fR command run\.
+(only in \fBprotect\fR command) Don't apply updates or patches during \fBprotect\fR command run\.
 .TP
 \fB\-\-\fR [\fICOMPILER_OPTIONS\fR]
 Pass extra arguments directly to Gradle or Maven\. E\.g\. \fBsnyk test \-\- \-\-build\-cache\fR
@@ -225,7 +225,7 @@ Default: false
 .SS "Python options"
 .TP
 \fB\-\-command\fR=\fICOMMAND\fR
-Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run \'python \-V\' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
+Indicate which specific Python commands to use based on Python version\. The default is \fBpython\fR which executes your systems default python version\. Run 'python \-V' to find out what version is it\. If you are using multiple Python versions, use this parameter to specify the correct Python command for execution\.
 .IP
 Default: \fBpython\fR Example: \fB\-\-command=python3\fR
 .TP
@@ -325,7 +325,7 @@ How to use Service Accounts \fIhttps://snyk\.co/ucT6L\fR
 
 .TP
 \fBSNYK_CFG_KEY\fR
-Allows you to override any key that\'s also available as \fBsnyk config\fR option\.
+Allows you to override any key that's also available as \fBsnyk config\fR option\.
 .IP
 E\.g\. \fBSNYK_CFG_ORG\fR=myorg will override default org option in \fBconfig\fR with "myorg"\.
 .TP
@@ -344,7 +344,7 @@ Sets API host to use for Snyk requests\. Useful for on\-premise instances and co
 If set to the value of \fB0\fR, API requests aimed at \fBhttp\fR URLs will not be upgraded to \fBhttps\fR\. If not set, the default behavior will be to upgrade these requests from \fBhttp\fR to \fBhttps\fR\. Useful e\.g\., for reverse proxies\.
 .TP
 \fBHTTPS_PROXY\fR and \fBHTTP_PROXY\fR
-Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn\'t need to use \fBhttps\fR\.
+Allows you to specify a proxy to use for \fBhttps\fR and \fBhttp\fR calls\. The \fBhttps\fR in the \fBHTTPS_PROXY\fR means that \fIrequests using \fBhttps\fR protocol\fR will use this proxy\. The proxy itself doesn't need to use \fBhttps\fR\.
 .SH "NOTICES"
 .SS "Snyk API usage policy"
-The use of Snyk\'s API, whether through the use of the \'snyk\' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR
+The use of Snyk's API, whether through the use of the 'snyk' npm package or otherwise, is subject to the terms & conditions \fIhttps://snyk\.co/ucT6N\fR

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -79,7 +79,7 @@ For advanced usage, we offer language and context specific flags, listed further
   Specify a custom Snyk project name.
 
 - `--target-reference`=<TARGET_REFERENCE>:
-  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 - `--project-environment`=<ENVIRONMENT>[,<ENVIRONMENT>]...>:
   (only in `monitor` command)

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -79,7 +79,7 @@ For advanced usage, we offer language and context specific flags, listed further
   Specify a custom Snyk project name.
 
 - `--target-reference`=<TARGET_REFERENCE>:
-  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 - `--project-environment`=<ENVIRONMENT>[,<ENVIRONMENT>]...>:
   (only in `monitor` command)

--- a/help/commands-md/snyk.md
+++ b/help/commands-md/snyk.md
@@ -124,7 +124,7 @@ For advanced usage, we offer language and context specific flags, listed further
   Specify a custom Snyk project name.
 
 - `--target-reference`=<TARGET_REFERENCE>:
-  A reference to separate this project from other scans of the same project. For example, a branch name or version. Projects using the same reference can be used for grouping. [More information](https://snyk.info/3B0vTPs).
+  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 - `--project-environment`=<ENVIRONMENT>[,<ENVIRONMENT>]...>:
   (only in `monitor` command)

--- a/help/commands-txt/snyk-auth.txt
+++ b/help/commands-txt/snyk-auth.txt
@@ -32,8 +32,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-code.txt
+++ b/help/commands-txt/snyk-code.txt
@@ -22,8 +22,8 @@
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
-              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
-              organization.  This  will influence private tests limits. If you
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization.  This  will  influence  private tests limits. If you
               have multiple organizations, you can set a default from the  CLI
               using:
 
@@ -51,8 +51,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-config.txt
+++ b/help/commands-txt/snyk-config.txt
@@ -5,8 +5,8 @@
        [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1mg[0m[1me[0m[1mt[0m[1m|[0m[1ms[0m[1me[0m[1mt[0m[1m|[0m[1mc[0m[1ml[0m[1me[0m[1ma[0m[1mr[0m [[4mK[0m[4mE[0m[4mY[0m[=[4mV[0m[4mA[0m[4mL[0m[4mU[0m[4mE[0m]] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
 [1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
-       Manage  your  local  Snyk  CLI  config file. This config file is a JSON
-       located  at  [1m$[0m[1mX[0m[1mD[0m[1mG[0m[1m_[0m[1mC[0m[1mO[0m[1mN[0m[1mF[0m[1mI[0m[1mG[0m[1m_[0m[1mH[0m[1mO[0m[1mM[0m[1mE[0m  or   [1m~[0m[1m/[0m[1m.[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m   followed   by   [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1m-[0m
+       Manage  your local Snyk CLI config file. This config file is a JSON lo-
+       cated  at   [1m$[0m[1mX[0m[1mD[0m[1mG[0m[1m_[0m[1mC[0m[1mO[0m[1mN[0m[1mF[0m[1mI[0m[1mG[0m[1m_[0m[1mH[0m[1mO[0m[1mM[0m[1mE[0m   or   [1m~[0m[1m/[0m[1m.[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m   followed   by   [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1m-[0m
        [1ms[0m[1mt[0m[1mo[0m[1mr[0m[1me[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m. For example [1m~[0m[1m/[0m[1m.[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1m/[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1ms[0m[1mt[0m[1mo[0m[1mr[0m[1me[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m.
 
        This  command  does  not  manage  the  [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m  file  that's part of your
@@ -59,8 +59,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-container.txt
+++ b/help/commands-txt/snyk-container.txt
@@ -19,8 +19,8 @@
               Exclude from display base image vulnerabilities.
 
        [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              Include the path to the image's  Dockerfile  for  more  detailed
-              advice.
+              Include the path to the image's Dockerfile for more detailed ad-
+              vice.
 
        [1m-[0m[1m-[0m[1mp[0m[1ml[0m[1ma[0m[1mt[0m[1mf[0m[1mo[0m[1mr[0m[1mm[0m=[4mP[0m[4mL[0m[4mA[0m[4mT[0m[4mF[0m[4mO[0m[4mR[0m[4mM[0m
               For  multi-architecture  images,  specify  the platform to test.
@@ -81,8 +81,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-help.txt
+++ b/help/commands-txt/snyk-help.txt
@@ -21,8 +21,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-iac.txt
+++ b/help/commands-txt/snyk-iac.txt
@@ -43,8 +43,8 @@
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
-              Specify  the  [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m  to  run Snyk commands tied to a specific
-              organization. This will influence private tests limits.  If  you
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence private  tests  limits.  If  you
               have  multiple organizations, you can set a default from the CLI
               using:
 
@@ -87,7 +87,7 @@
               not be used if the custom rules settings were configured via the
               Snyk UI. Default: If the [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m flag is not provided  it  would
               scan the configuration files using the internal Snyk rules only.
-              Example: [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m[1m=[0m[1mb[0m[1mu[0m[1mn[0m[1md[0m[1ml[0m[1me[0m[1m.[0m[1mt[0m[1ma[0m[1mr[0m[1m.[0m[1mg[0m[1mz[0m (scans  the  configuration  files
+              Example:  [1m-[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m[1m=[0m[1mb[0m[1mu[0m[1mn[0m[1md[0m[1ml[0m[1me[0m[1m.[0m[1mt[0m[1ma[0m[1mr[0m[1m.[0m[1mg[0m[1mz[0m  (scans  the configuration files
               using custom rules and internal Snyk rules)
 
    [1mF[0m[1ml[0m[1ma[0m[1mg[0m[1ms[0m [1ma[0m[1mv[0m[1ma[0m[1mi[0m[1ml[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m [1ma[0m[1mc[0m[1mc[0m[1mr[0m[1mo[0m[1ms[0m[1ms[0m [1ma[0m[1ml[0m[1ml[0m [1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1ms[0m
@@ -103,8 +103,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
        For more information see IaC help page [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mQ[0m
@@ -142,7 +142,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk authorization token. Setting this envvar will override  the
+              Snyk  authorization token. Setting this envvar will override the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -150,47 +150,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
-              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
-              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
-              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-ignore.txt
+++ b/help/commands-txt/snyk-ignore.txt
@@ -5,7 +5,7 @@
        [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1m-[0m[1m-[0m[1mi[0m[1md[0m=[4mI[0m[4mS[0m[4mS[0m[4mU[0m[4mE[0m[1m_[0m[4mI[0m[4mD[0m [[1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m] [[1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m] [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
 
 [1mD[0m[1mE[0m[1mS[0m[1mC[0m[1mR[0m[1mI[0m[1mP[0m[1mT[0m[1mI[0m[1mO[0m[1mN[0m
-       Ignore a certain issue, according to its snyk ID for  all  occurrences.
+       Ignore  a  certain issue, according to its snyk ID for all occurrences.
        This will update your local [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m to contain a similar block:
 
        [1my[0m[1ma[0m[1mm[0m[1ml[0m [1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m:[0m [1m'[0m[1m<[0m[1mI[0m[1mS[0m[1mS[0m[1mU[0m[1mE[0m[1m_[0m[1mI[0m[1mD[0m[1m>[0m[1m'[0m[1m:[0m [1m-[0m [1m'[0m[1m*[0m[1m'[0m[1m:[0m [1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m[1m:[0m [1m<[0m[1mR[0m[1mE[0m[1mA[0m[1mS[0m[1mO[0m[1mN[0m[1m>[0m [1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1me[0m[1ms[0m[1m:[0m [1m<[0m[1mE[0m[1mX[0m[1mP[0m[1mI[0m[1mR[0m[1mY[0m[1m>[0m
@@ -15,7 +15,7 @@
               Snyk ID for the issue to ignore. Required.
 
        [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mp[0m[1mi[0m[1mr[0m[1my[0m=[4mE[0m[4mX[0m[4mP[0m[4mI[0m[4mR[0m[4mY[0m
-              Expiry         date,         according         to        RFC2822
+              Expiry        date,         according         to         RFC2822
               [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4mt[0m[4mo[0m[4mo[0m[4ml[0m[4ms[0m[4m.[0m[4mi[0m[4me[0m[4mt[0m[4mf[0m[4m.[0m[4mo[0m[4mr[0m[4mg[0m[4m/[0m[4mh[0m[4mt[0m[4mm[0m[4ml[0m[4m/[0m[4mr[0m[4mf[0m[4mc[0m[4m2[0m[4m8[0m[4m2[0m[4m2[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1ms[0m[1mo[0m[1mn[0m=[4mR[0m[4mE[0m[4mA[0m[4mS[0m[4mO[0m[4mN[0m
@@ -34,12 +34,12 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
        [1mI[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m [1ma[0m [1ms[0m[1mp[0m[1me[0m[1mc[0m[1mi[0m[1mf[0m[1mi[0m[1mc[0m [1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1mi[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m
-              $   snyk   ignore  --id='npm:qs:20170213'  --expiry='2021-01-10'
+              $  snyk  ignore   --id='npm:qs:20170213'   --expiry='2021-01-10'
               --reason='Module not affected by this vuln'
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
@@ -54,7 +54,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk authorization token. Setting this envvar will override  the
+              Snyk  authorization token. Setting this envvar will override the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -62,47 +62,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
-              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
-              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
-              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-monitor.txt
+++ b/help/commands-txt/snyk-monitor.txt
@@ -26,42 +26,42 @@
               Default: 4 (the current working directory and 3 sub-directories)
 
        [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
-              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can   be   used   with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
+              If using with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores  directories  at
               any level deep.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
-              removing duplicate sub-dependencies. Will still find all vulner-
-              abilities, but potentially not all of the vulnerable paths.
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees, re-
+              moving duplicate sub-dependencies. Will still find all  vulnera-
+              bilities, but potentially not all of the vulnerable paths.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print the dependency tree
               before sending it for analysis.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
-              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include  development-only dependencies. Applicable only for some
+              package managers. E.g. [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in  npm  or  [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
-              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
-              organization.  This  will  influence  where will new projects be
-              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
-              ity  and  private  tests  limits. If you have multiple organiza-
-              tions, you can set a default from the CLI using:
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence where will new projects be  cre-
+              ated  after  running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features availability
+              and private tests limits. If you  have  multiple  organizations,
+              you can set a default from the CLI using:
 
               [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting a default will ensure all newly monitored projects  will
+              Setting  a default will ensure all newly monitored projects will
               be created under your default organization. If you need to over-
               ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
@@ -71,23 +71,23 @@
        [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When  testing  locally  or monitoring a project, you can specify
-              the file that Snyk should inspect for package information.  When
-              ommitted  Snyk  will try to detect the appropriate file for your
+              When testing locally or monitoring a project,  you  can  specify
+              the  file that Snyk should inspect for package information. When
+              ommitted Snyk will try to detect the appropriate file  for  your
               project.
 
        [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
               level ignores and the project policy on snyk.io.
 
        [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a  suggestion.
+              cies, otherwise ignore policies are only shown as a suggestion.
 
        [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable  packages.  Doesn't  affect  output  when
-              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+              down to the vulnerable packages. Doesn't affect output when  us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
               Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
               [4mn[0m[4mo[0m[4mn[0m[4me[0m.
@@ -96,10 +96,10 @@
               Specify a custom Snyk project name.
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
-              A reference to separate this project from  other  scans  of  the
-              same  project.  For  example, a branch name or version. Projects
-              using the same reference can be used for grouping. More informa-
-              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+              A reference which differentiates this project.  For  example,  a
+              branch name or version. Projects using the same reference can be
+              used for grouping. Only supported for Snyk Open Source. More in-
+              formation [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
               (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
@@ -109,18 +109,18 @@
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
-              more   values  (comma-separated).  Allowed  values:  production,
-              development, sandbox
+              more  values  (comma-separated). Allowed values: production, de-
+              velopment, sandbox
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
        [4mI[0m[4mT[0m[4mY[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
-              to  one or more values (comma-separated). Allowed values: criti-
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project business criticality
+              to one or more values (comma-separated). Allowed values:  criti-
               cal, high, medium, low
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
-              values  (comma-separated key value pairs with an "=" separator).
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  command) Set the project tags to one or more
+              values (comma-separated key value pairs with an "="  separator).
               e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
@@ -132,10 +132,10 @@
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -143,9 +143,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -154,16 +154,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -175,17 +175,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects  maven  jars,  aars,  and wars in given directory.
-              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Auto detects maven jars, aars, and wars in given directory.  In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -193,49 +193,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside  a  project  along  with  any
-              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -251,9 +251,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -264,11 +264,11 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
-              default python version. Run 'python -V' to find out what version
-              is  it.  If  you  are  using  multiple Python versions, use this
-              parameter to specify the correct Python command for execution.
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
+              rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
@@ -288,8 +288,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
@@ -303,7 +303,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -311,47 +311,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-policy.txt
+++ b/help/commands-txt/snyk-policy.txt
@@ -24,8 +24,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-protect.txt
+++ b/help/commands-txt/snyk-protect.txt
@@ -28,8 +28,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-test.txt
+++ b/help/commands-txt/snyk-test.txt
@@ -26,42 +26,42 @@
               Default: 4 (the current working directory and 3 sub-directories)
 
        [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
-              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can   be   used   with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
+              If using with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores  directories  at
               any level deep.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
-              removing duplicate sub-dependencies. Will still find all vulner-
-              abilities, but potentially not all of the vulnerable paths.
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees, re-
+              moving duplicate sub-dependencies. Will still find all  vulnera-
+              bilities, but potentially not all of the vulnerable paths.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print the dependency tree
               before sending it for analysis.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
-              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include  development-only dependencies. Applicable only for some
+              package managers. E.g. [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in  npm  or  [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
-              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
-              organization.  This  will  influence  where will new projects be
-              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
-              ity  and  private  tests  limits. If you have multiple organiza-
-              tions, you can set a default from the CLI using:
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence where will new projects be  cre-
+              ated  after  running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features availability
+              and private tests limits. If you  have  multiple  organizations,
+              you can set a default from the CLI using:
 
               [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting a default will ensure all newly monitored projects  will
+              Setting  a default will ensure all newly monitored projects will
               be created under your default organization. If you need to over-
               ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
@@ -71,23 +71,23 @@
        [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When  testing  locally  or monitoring a project, you can specify
-              the file that Snyk should inspect for package information.  When
-              ommitted  Snyk  will try to detect the appropriate file for your
+              When testing locally or monitoring a project,  you  can  specify
+              the  file that Snyk should inspect for package information. When
+              ommitted Snyk will try to detect the appropriate file  for  your
               project.
 
        [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
               level ignores and the project policy on snyk.io.
 
        [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a  suggestion.
+              cies, otherwise ignore policies are only shown as a suggestion.
 
        [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable  packages.  Doesn't  affect  output  when
-              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+              down to the vulnerable packages. Doesn't affect output when  us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
               Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
               [4mn[0m[4mo[0m[4mn[0m[4me[0m.
@@ -96,10 +96,10 @@
               Specify a custom Snyk project name.
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
-              A reference to separate this project from  other  scans  of  the
-              same  project.  For  example, a branch name or version. Projects
-              using the same reference can be used for grouping. More informa-
-              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+              A reference which differentiates this project.  For  example,  a
+              branch name or version. Projects using the same reference can be
+              used for grouping. Only supported for Snyk Open Source. More in-
+              formation [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
               (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
@@ -109,18 +109,18 @@
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
-              more   values  (comma-separated).  Allowed  values:  production,
-              development, sandbox
+              more  values  (comma-separated). Allowed values: production, de-
+              velopment, sandbox
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
        [4mI[0m[4mT[0m[4mY[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
-              to  one or more values (comma-separated). Allowed values: criti-
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project business criticality
+              to one or more values (comma-separated). Allowed values:  criti-
               cal, high, medium, low
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
-              values  (comma-separated key value pairs with an "=" separator).
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  command) Set the project tags to one or more
+              values (comma-separated key value pairs with an "="  separator).
               e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
@@ -132,10 +132,10 @@
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -143,9 +143,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -154,16 +154,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -175,17 +175,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects  maven  jars,  aars,  and wars in given directory.
-              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Auto detects maven jars, aars, and wars in given directory.  In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -193,49 +193,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside  a  project  along  with  any
-              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -251,9 +251,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -264,11 +264,11 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
-              default python version. Run 'python -V' to find out what version
-              is  it.  If  you  are  using  multiple Python versions, use this
-              parameter to specify the correct Python command for execution.
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
+              rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
@@ -288,8 +288,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:
@@ -303,7 +303,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk  authorization token. Setting this envvar will override the
+              Snyk authorization token. Setting this envvar will override  the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -311,47 +311,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify a username to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  username  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify  a  password  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a password to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets API host to use for Snyk requests.  Useful  for  on-premise
+              Sets  API  host  to use for Snyk requests. Useful for on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
-              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
-              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
+              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
+              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
+              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
-              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol will use this proxy. The proxy itself doesn't  need  to
+              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
+              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol  will  use this proxy. The proxy itself doesn't need to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
-       age  or   otherwise,   is   subject   to   the   terms   &   conditions
+       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
+       age   or   otherwise,   is   subject   to   the   terms   &  conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m

--- a/help/commands-txt/snyk-wizard.txt
+++ b/help/commands-txt/snyk-wizard.txt
@@ -1,6 +1,6 @@
 [1mN[0m[1mA[0m[1mM[0m[1mE[0m
-       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m  -  Configure  your  policy  file to update, auto patch and
-       ignore vulnerabilities
+       [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m  - Configure your policy file to update, auto patch and ig-
+       nore vulnerabilities
 
 [1mS[0m[1mY[0m[1mN[0m[1mO[0m[1mP[0m[1mS[0m[1mI[0m[1mS[0m
        [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mw[0m[1mi[0m[1mz[0m[1ma[0m[1mr[0m[1md[0m [[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -35,8 +35,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints  a  help  text.  You  may  specify  a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk-woof.txt
+++ b/help/commands-txt/snyk-woof.txt
@@ -25,8 +25,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints a help text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to  get  more  de-
+              tails.
 
 [1mE[0m[1mX[0m[1mI[0m[1mT[0m [1mC[0m[1mO[0m[1mD[0m[1mE[0m[1mS[0m
        Possible exit codes and their meaning:

--- a/help/commands-txt/snyk.txt
+++ b/help/commands-txt/snyk.txt
@@ -71,42 +71,42 @@
               Default: 4 (the current working directory and 3 sub-directories)
 
        [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m=[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m[,[4mD[0m[4mI[0m[4mR[0m[4mE[0m[4mC[0m[4mT[0m[4mO[0m[4mR[0m[4mY[0m]...>
-              (only   in   [1mt[0m[1me[0m[1ms[0m[1mt[0m   and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can  be  used  with
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Can   be   used   with
               --all-projects and --yarn-workspaces to indicate sub-directories
               and files to exclude. Must be comma separated.
 
-              If  using  with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores directories at
+              If using with [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m exclude ignores  directories  at
               any level deep.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mu[0m[1mn[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1me[0m[1ma[0m[1mt[0m[1me[0m[1md[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1md[0m[1me[0m[1mp[0m[1me[0m[1mn[0m[1md[0m[1me[0m[1mn[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m, [1m-[0m[1mp[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Prune  dependency  trees,
-              removing duplicate sub-dependencies. Will still find all vulner-
-              abilities, but potentially not all of the vulnerable paths.
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Prune dependency trees, re-
+              moving duplicate sub-dependencies. Will still find all  vulnera-
+              bilities, but potentially not all of the vulnerable paths.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mi[0m[1mn[0m[1mt[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1ms[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print  the  dependency  tree
+              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Print the dependency tree
               before sending it for analysis.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1mm[0m[1mo[0m[1mt[0m[1me[0m[1m-[0m[1mr[0m[1me[0m[1mp[0m[1mo[0m[1m-[0m[1mu[0m[1mr[0m[1ml[0m=[4mU[0m[4mR[0m[4mL[0m
               Set or override the remote URL for the repository that you would
               like to monitor.
 
-       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include development-only dependencies. Applicable only for  some
-              package  managers.  E.g.  [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in npm or [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
+       [1m-[0m[1m-[0m[1md[0m[1me[0m[1mv[0m  Include  development-only dependencies. Applicable only for some
+              package managers. E.g. [4md[0m[4me[0m[4mv[0m[4mD[0m[4me[0m[4mp[0m[4me[0m[4mn[0m[4md[0m[4me[0m[4mn[0m[4mc[0m[4mi[0m[4me[0m[4ms[0m in  npm  or  [4m:[0m[4md[0m[4me[0m[4mv[0m[4me[0m[4ml[0m[4mo[0m[4mp[0m[4mm[0m[4me[0m[4mn[0m[4mt[0m
               dependencies in Gemfile.
 
               Default: scan only production dependencies
 
        [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
-              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands  tied  to  a  specific
-              organization.  This  will  influence  where will new projects be
-              created after running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features  availabil-
-              ity  and  private  tests  limits. If you have multiple organiza-
-              tions, you can set a default from the CLI using:
+              Specify the [4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m to run Snyk commands tied to a specific or-
+              ganization. This will influence where will new projects be  cre-
+              ated  after  running [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command, some features availability
+              and private tests limits. If you  have  multiple  organizations,
+              you can set a default from the CLI using:
 
               [1m$[0m [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m [1ms[0m[1me[0m[1mt[0m [1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
-              Setting a default will ensure all newly monitored projects  will
+              Setting  a default will ensure all newly monitored projects will
               be created under your default organization. If you need to over-
               ride the default, you can use the [1m-[0m[1m-[0m[1mo[0m[1mr[0m[1mg[0m=[4mO[0m[4mR[0m[4mG[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m argument.
 
@@ -116,23 +116,23 @@
        [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m
               Sets a package file.
 
-              When  testing  locally  or monitoring a project, you can specify
-              the file that Snyk should inspect for package information.  When
-              ommitted  Snyk  will try to detect the appropriate file for your
+              When testing locally or monitoring a project,  you  can  specify
+              the  file that Snyk should inspect for package information. When
+              ommitted Snyk will try to detect the appropriate file  for  your
               project.
 
        [1m-[0m[1m-[0m[1mi[0m[1mg[0m[1mn[0m[1mo[0m[1mr[0m[1me[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-              Ignores all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file,  Org
+              Ignores  all set policies. The current policy in [1m.[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m file, Org
               level ignores and the project policy on snyk.io.
 
        [1m-[0m[1m-[0m[1mt[0m[1mr[0m[1mu[0m[1ms[0m[1mt[0m[1m-[0m[1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1mi[0m[1me[0m[1ms[0m
               Applies and uses ignore rules from your dependencies' Snyk poli-
-              cies, otherwise ignore policies are only shown as a  suggestion.
+              cies, otherwise ignore policies are only shown as a suggestion.
 
        [1m-[0m[1m-[0m[1ms[0m[1mh[0m[1mo[0m[1mw[0m[1m-[0m[1mv[0m[1mu[0m[1ml[0m[1mn[0m[1me[0m[1mr[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1ms[0m=none|some|all
               Display  the  dependency  paths from the top level dependencies,
-              down to the vulnerable  packages.  Doesn't  affect  output  when
-              using JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
+              down to the vulnerable packages. Doesn't affect output when  us-
+              ing JSON [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m output.
 
               Default:  [4ms[0m[4mo[0m[4mm[0m[4me[0m (a few example paths shown) [4mf[0m[4ma[0m[4ml[0m[4ms[0m[4me[0m is an alias for
               [4mn[0m[4mo[0m[4mn[0m[4me[0m.
@@ -141,10 +141,10 @@
               Specify a custom Snyk project name.
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mr[0m[1mg[0m[1me[0m[1mt[0m[1m-[0m[1mr[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m=[4mT[0m[4mA[0m[4mR[0m[4mG[0m[4mE[0m[4mT[0m[1m_[0m[4mR[0m[4mE[0m[4mF[0m[4mE[0m[4mR[0m[4mE[0m[4mN[0m[4mC[0m[4mE[0m
-              A reference to separate this project from  other  scans  of  the
-              same  project.  For  example, a branch name or version. Projects
-              using the same reference can be used for grouping. More informa-
-              tion [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
+              A reference which differentiates this project.  For  example,  a
+              branch name or version. Projects using the same reference can be
+              used for grouping. Only supported for Snyk Open Source. More in-
+              formation [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mi[0m[4mn[0m[4mf[0m[4mo[0m[4m/[0m[4m3[0m[4mB[0m[4m0[0m[4mv[0m[4mT[0m[4mP[0m[4ms[0m.
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1me[0m[1mn[0m[1mv[0m[1mi[0m[1mr[0m[1mo[0m[1mn[0m[1mm[0m[1me[0m[1mn[0m[1mt[0m=[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m[,[4mE[0m[4mN[0m[4mV[0m[4mI[0m[4mR[0m[4mO[0m[4mN[0m[4mM[0m[4mE[0m[4mN[0m[4mT[0m]...>
               (only  in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project environment to one or
@@ -154,18 +154,18 @@
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1ml[0m[1mi[0m[1mf[0m[1me[0m[1mc[0m[1my[0m[1mc[0m[1ml[0m[1me[0m=[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m[,[4mL[0m[4mI[0m[4mF[0m[4mE[0m[4mC[0m[4mY[0m[4mC[0m[4mL[0m[4mE[0m]...>
               (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project lifecycle  to  one  or
-              more   values  (comma-separated).  Allowed  values:  production,
-              development, sandbox
+              more  values  (comma-separated). Allowed values: production, de-
+              velopment, sandbox
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mb[0m[1mu[0m[1ms[0m[1mi[0m[1mn[0m[1me[0m[1ms[0m[1ms[0m[1m-[0m[1mc[0m[1mr[0m[1mi[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1ml[0m[1mi[0m[1mt[0m[1my[0m=[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4mI[0m[4mT[0m[4mY[0m[,[4mB[0m[4mU[0m[4mS[0m[4mI[0m[4mN[0m[4mE[0m[4mS[0m[4mS[0m[1m_[0m[4mC[0m[4mR[0m[4mI[0m[4mT[0m[4mI[0m[4mC[0m[4mA[0m[4mL[0m[4m-[0m
        [4mI[0m[4mT[0m[4mY[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project  business  criticality
-              to  one or more values (comma-separated). Allowed values: criti-
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project business criticality
+              to one or more values (comma-separated). Allowed values:  criti-
               cal, high, medium, low
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
-              (only in [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m command) Set the project tags to  one  or  more
-              values  (comma-separated key value pairs with an "=" separator).
+              (only  in  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  command) Set the project tags to one or more
+              values (comma-separated key value pairs with an "="  separator).
               e.g. --project-tags=department=finance,team=alpha
 
        [1m-[0m[1m-[0m[1mt[0m[1ma[0m[1mg[0m[1ms[0m=[4mT[0m[4mA[0m[4mG[0m[,[4mT[0m[4mA[0m[4mG[0m]...>
@@ -177,10 +177,10 @@
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m Prints results in JSON format.
 
        [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format  directly
-              to  the specified file, regardless of whether or not you use the
-              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m option. This is especially useful if you want to  display
-              the  human-readable  test output via stdout and at the same time
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in JSON format directly
+              to the specified file, regardless of whether or not you use  the
+              [1m-[0m[1m-[0m[1mj[0m[1ms[0m[1mo[0m[1mn[0m  option. This is especially useful if you want to display
+              the human-readable test output via stdout and at the  same  time
               save the JSON format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m
@@ -188,9 +188,9 @@
 
        [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m-[0m[1mo[0m[1mu[0m[1mt[0m[1mp[0m[1mu[0m[1mt[0m=[4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m
               (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m command) Save test output in SARIF format directly
-              to  the  [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or not you
+              to the [4mO[0m[4mU[0m[4mT[0m[4mP[0m[4mU[0m[4mT[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mP[0m[4mA[0m[4mT[0m[4mH[0m file, regardless of whether or  not  you
               use the [1m-[0m[1m-[0m[1ms[0m[1ma[0m[1mr[0m[1mi[0m[1mf[0m option. This is especially useful if you want to
-              display  the  human-readable  test  output via stdout and at the
+              display the human-readable test output via  stdout  and  at  the
               same time save the SARIF format output to a file.
 
        [1m-[0m[1m-[0m[1ms[0m[1me[0m[1mv[0m[1me[0m[1mr[0m[1mi[0m[1mt[0m[1my[0m[1m-[0m[1mt[0m[1mh[0m[1mr[0m[1me[0m[1ms[0m[1mh[0m[1mo[0m[1ml[0m[1md[0m=low|medium|high|critical
@@ -199,16 +199,16 @@
        [1m-[0m[1m-[0m[1mf[0m[1ma[0m[1mi[0m[1ml[0m[1m-[0m[1mo[0m[1mn[0m=all|upgradable|patchable
               Only fail when there are vulnerabilities that can be fixed.
 
-              [4ma[0m[4ml[0m[4ml[0m fails when there is at least one vulnerability that  can  be
-              either  upgraded  or  patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when there is at
-              least one vulnerability that can be  upgraded.  [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m  fails
+              [4ma[0m[4ml[0m[4ml[0m  fails  when there is at least one vulnerability that can be
+              either upgraded or patched. [4mu[0m[4mp[0m[4mg[0m[4mr[0m[4ma[0m[4md[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails when  there  is  at
+              least  one  vulnerability  that can be upgraded. [4mp[0m[4ma[0m[4mt[0m[4mc[0m[4mh[0m[4ma[0m[4mb[0m[4ml[0m[4me[0m fails
               when there is at least one vulnerability that can be patched.
 
-              If  vulnerabilities  do  not have a fix and this option is being
+              If vulnerabilities do not have a fix and this  option  is  being
               used, tests will pass.
 
        [1m-[0m[1m-[0m[1md[0m[1mr[0m[1my[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m
-              (only in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches  during
+              (only  in [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command) Don't apply updates or patches during
               [1mp[0m[1mr[0m[1mo[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m command run.
 
        [1m-[0m[1m-[0m [[4mC[0m[4mO[0m[4mM[0m[4mP[0m[4mI[0m[4mL[0m[4mE[0m[4mR[0m[1m_[0m[4mO[0m[4mP[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[4mS[0m]
@@ -220,17 +220,17 @@
 
    [1mM[0m[1ma[0m[1mv[0m[1me[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ms[0m[1mc[0m[1ma[0m[1mn[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1mu[0m[1mn[0m[1mm[0m[1ma[0m[1mn[0m[1ma[0m[1mg[0m[1me[0m[1md[0m
-              Auto  detects  maven  jars,  aars,  and wars in given directory.
-              Individual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
+              Auto detects maven jars, aars, and wars in given directory.  In-
+              dividual testing can be done with [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m=[4mJ[0m[4mA[0m[4mR[0m[1m_[0m[4mF[0m[4mI[0m[4mL[0m[4mE[0m[1m_[0m[4mN[0m[4mA[0m[4mM[0m[4mE[0m
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m
-              (only in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code  to
+              (only  in [1mt[0m[1me[0m[1ms[0m[1mt[0m and [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m commands) Analyze your source code to
               find which vulnerable functions and packages are called.
 
        [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m
-              The  amount  of  time  (in  seconds)  to wait for Snyk to gather
-              reachability data. If it takes longer  than  [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable
-              Vulnerabilities  are  not reported. This does not affect regular
+              The amount of time (in seconds)  to  wait  for  Snyk  to  gather
+              reachability  data.  If  it takes longer than [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable
+              Vulnerabilities are not reported. This does not  affect  regular
               test or monitor output.
 
               Default: 300 (5 minutes).
@@ -238,49 +238,49 @@
    [1mG[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        More information about Gradle CLI options [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mP[0m
 
-       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m, [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle  "multi
+       O   [1m-[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m,  [1m-[0m[1m-[0m[1mg[0m[1mr[0m[1ma[0m[1md[0m[1ml[0m[1me[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m=[4mN[0m[4mA[0m[4mM[0m[4mE[0m:  For  Gradle "multi
            project" configurations, test a specific sub-project.
 
-       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m:  For  "multi  project" configurations, test all
+       O   [1m-[0m[1m-[0m[1ma[0m[1ml[0m[1ml[0m[1m-[0m[1ms[0m[1mu[0m[1mb[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1ms[0m: For "multi project"  configurations,  test  all
            sub-projects.
 
-       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m: Resolve  dependencies
-           using  only  configuration(s)  that match the provided Java regular
+       O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1mm[0m[1ma[0m[1mt[0m[1mc[0m[1mh[0m[1mi[0m[1mn[0m[1mg[0m=[4mC[0m[4mO[0m[4mN[0m[4mF[0m[4mI[0m[4mG[0m[4mU[0m[4mR[0m[4mA[0m[4mT[0m[4mI[0m[4mO[0m[4mN[0m[1m_[0m[4mR[0m[4mE[0m[4mG[0m[4mE[0m[4mX[0m:  Resolve dependencies
+           using only configuration(s) that match the  provided  Java  regular
            expression, e.g. [1m^[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1mR[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mC[0m[1ml[0m[1ma[0m[1ms[0m[1ms[0m[1mp[0m[1ma[0m[1mt[0m[1mh[0m[1m$[0m.
 
        O   [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m[1mu[0m[1mr[0m[1ma[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1ma[0m[1mt[0m[1mt[0m[1mr[0m[1mi[0m[1mb[0m[1mu[0m[1mt[0m[1me[0m[1ms[0m=[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m[,[4mA[0m[4mT[0m[4mT[0m[4mR[0m[4mI[0m[4mB[0m[4mU[0m[4mT[0m[4mE[0m]...: Select certain
-           values  of  configuration  attributes  to resolve the dependencies.
+           values of configuration attributes  to  resolve  the  dependencies.
            E.g. [1mb[0m[1mu[0m[1mi[0m[1ml[0m[1md[0m[1mt[0m[1my[0m[1mp[0m[1me[0m[1m:[0m[1mr[0m[1me[0m[1ml[0m[1me[0m[1ma[0m[1ms[0m[1me[0m[1m,[0m[1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m[1m:[0m[1mj[0m[1ma[0m[1mv[0m[1ma[0m[1m-[0m[1mr[0m[1mu[0m[1mn[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m: (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Analyze  your
-           source  code  to  find  which vulnerable functions and packages are
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m:  (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands) Analyze your
+           source code to find which vulnerable  functions  and  packages  are
            called.
 
-       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m: The amount of  time  (in  seconds)  to
-           wait  for Snyk to gather reachability data. If it takes longer than
-           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m, Reachable Vulnerabilities are not reported. This does  not
+       O   [1m-[0m[1m-[0m[1mr[0m[1me[0m[1ma[0m[1mc[0m[1mh[0m[1ma[0m[1mb[0m[1ml[0m[1me[0m[1m-[0m[1mt[0m[1mi[0m[1mm[0m[1me[0m[1mo[0m[1mu[0m[1mt[0m=[4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m:  The  amount  of  time (in seconds) to
+           wait for Snyk to gather reachability data. If it takes longer  than
+           [4mT[0m[4mI[0m[4mM[0m[4mE[0m[4mO[0m[4mU[0m[4mT[0m,  Reachable Vulnerabilities are not reported. This does not
            affect regular test or monitor output.
 
            Default: 300 (5 minutes).
 
-       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m  For  projects that contain a gradle initializa-
+       O   [1m-[0m[1m-[0m[1mi[0m[1mn[0m[1mi[0m[1mt[0m[1m-[0m[1ms[0m[1mc[0m[1mr[0m[1mi[0m[1mp[0m[1mt[0m=[4mF[0m[4mI[0m[4mL[0m[4mE[0m For projects that contain a  gradle  initializa-
            tion script.
 
 
 
    [1m.[0m[1mN[0m[1me[0m[1mt[0m [1m&[0m [1mN[0m[1mu[0m[1mG[0m[1me[0m[1mt[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1ma[0m[1ms[0m[1ms[0m[1me[0m[1mt[0m[1ms[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m
-              When monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m  use
+              When  monitoring a .NET project using NuGet [1mP[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1mR[0m[1me[0m[1mf[0m[1me[0m[1mr[0m[1me[0m[1mn[0m[1mc[0m[1me[0m use
               the project name in project.assets.json, if found.
 
        [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1mc[0m[1mk[0m[1ma[0m[1mg[0m[1me[0m[1ms[0m[1m-[0m[1mf[0m[1mo[0m[1ml[0m[1md[0m[1me[0m[1mr[0m
               Custom path to packages folder
 
        [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m=[4mP[0m[4mR[0m[4mE[0m[4mF[0m[4mI[0m[4mX[0m[1m_[0m[4mS[0m[4mT[0m[4mR[0m[4mI[0m[4mN[0m[4mG[0m
-              When  monitoring  a  .NET project, use this flag to add a custom
-              prefix to the name of files inside  a  project  along  with  any
-              desired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
-              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m. This is useful  when  you  have
+              When monitoring a .NET project, use this flag to  add  a  custom
+              prefix  to the name of files inside a project along with any de-
+              sired  separators,  e.g.  [1ms[0m[1mn[0m[1my[0m[1mk[0m   [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m   [1m-[0m[1m-[0m[1mf[0m[1mi[0m[1ml[0m[1me[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m.[0m[1ms[0m[1ml[0m[1mn[0m
+              [1m-[0m[1m-[0m[1mp[0m[1mr[0m[1mo[0m[1mj[0m[1me[0m[1mc[0m[1mt[0m[1m-[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m[1m-[0m[1mp[0m[1mr[0m[1me[0m[1mf[0m[1mi[0m[1mx[0m[1m=[0m[1mm[0m[1my[0m[1m-[0m[1mg[0m[1mr[0m[1mo[0m[1mu[0m[1mp[0m[1m/[0m.  This  is  useful when you have
               multiple projects with the same name in other sln files.
 
    [1mn[0m[1mp[0m[1mm[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -296,9 +296,9 @@
               Default: true
 
        [1m-[0m[1m-[0m[1my[0m[1ma[0m[1mr[0m[1mn[0m[1m-[0m[1mw[0m[1mo[0m[1mr[0m[1mk[0m[1ms[0m[1mp[0m[1ma[0m[1mc[0m[1me[0m[1ms[0m
-              (only  in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan yarn
-              workspaces. You can specify how many sub-directories  to  search
-              using  [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files using
+              (only in  [1mt[0m[1me[0m[1ms[0m[1mt[0m  and  [1mm[0m[1mo[0m[1mn[0m[1mi[0m[1mt[0m[1mo[0m[1mr[0m  commands)  Detect  and  scan  yarn
+              workspaces.  You  can specify how many sub-directories to search
+              using [1m-[0m[1m-[0m[1md[0m[1me[0m[1mt[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1m-[0m[1md[0m[1me[0m[1mp[0m[1mt[0m[1mh[0m and exclude directories and files  using
               [1m-[0m[1m-[0m[1me[0m[1mx[0m[1mc[0m[1ml[0m[1mu[0m[1md[0m[1me[0m.
 
    [1mC[0m[1mo[0m[1mc[0m[1mo[0m[1ma[0m[1mP[0m[1mo[0m[1md[0m[1ms[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
@@ -309,11 +309,11 @@
 
    [1mP[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m [1mo[0m[1mp[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m[1ms[0m
        [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m=[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m
-              Indicate which specific Python commands to use based  on  Python
-              version.  The  default  is  [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m  which  executes your systems
-              default python version. Run 'python -V' to find out what version
-              is  it.  If  you  are  using  multiple Python versions, use this
-              parameter to specify the correct Python command for execution.
+              Indicate  which  specific Python commands to use based on Python
+              version. The default is [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m which executes your  systems  de-
+              fault  python  version. Run 'python -V' to find out what version
+              is it. If you are using multiple Python versions, use  this  pa-
+              rameter to specify the correct Python command for execution.
 
               Default: [1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m Example: [1m-[0m[1m-[0m[1mc[0m[1mo[0m[1mm[0m[1mm[0m[1ma[0m[1mn[0m[1md[0m[1m=[0m[1mp[0m[1my[0m[1mt[0m[1mh[0m[1mo[0m[1mn[0m[1m3[0m
 
@@ -333,8 +333,8 @@
               Prints versions.
 
        [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m] [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m, [1m-[0m[1m-[0m[1mh[0m[1me[0m[1ml[0m[1mp[0m [[4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m], [1m-[0m[1mh[0m
-              Prints a help text. You  may  specify  a  [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m  to  get  more
-              details.
+              Prints  a  help  text. You may specify a [4mC[0m[4mO[0m[4mM[0m[4mM[0m[4mA[0m[4mN[0m[4mD[0m to get more de-
+              tails.
 
 [1mE[0m[1mX[0m[1mA[0m[1mM[0m[1mP[0m[1mL[0m[1mE[0m[1mS[0m
        [1mA[0m[1mu[0m[1mt[0m[1mh[0m[1me[0m[1mn[0m[1mt[0m[1mi[0m[1mc[0m[1ma[0m[1mt[0m[1me[0m [1mi[0m[1mn[0m [1my[0m[1mo[0m[1mu[0m[1mr[0m [1mC[0m[1mI[0m [1mw[0m[1mi[0m[1mt[0m[1mh[0m[1mo[0m[1mu[0m[1mt[0m [1mu[0m[1ms[0m[1me[0m[1mr[0m [1mi[0m[1mn[0m[1mt[0m[1me[0m[1mr[0m[1ma[0m[1mc[0m[1mt[0m[1mi[0m[1mo[0m[1mn[0m
@@ -376,10 +376,10 @@
 
 
 
-       To  use your own custom rules to scan IaC configuration files, download
+       To use your own custom rules to scan IaC configuration files,  download
        the  [1ms[0m[1mn[0m[1my[0m[1mk[0m[1m-[0m[1mi[0m[1ma[0m[1mc[0m[1m-[0m[1mr[0m[1mu[0m[1ml[0m[1me[0m[1ms[0m  SDK  from  https://github.com/snyk/snyk-iac-rules.
-       Follow  the instructions there to write, build, and push a custom rules
-       bundle and then either use the Snyk UI to configure your  custom  rules
+       Follow the instructions there to write, build, and push a custom  rules
+       bundle  and  then either use the Snyk UI to configure your custom rules
        settings or configure a remote OCI registry locally by running the fol-
        lowing commands:
 
@@ -410,7 +410,7 @@
        You can set these environment variables to change CLI run settings.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mT[0m[1mO[0m[1mK[0m[1mE[0m[1mN[0m
-              Snyk authorization token. Setting this envvar will override  the
+              Snyk  authorization token. Setting this envvar will override the
               token that may be available in your [1ms[0m[1mn[0m[1my[0m[1mk[0m [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m settings.
 
               How to get your account token [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mJ[0m
@@ -418,47 +418,47 @@
 
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mK[0m[1mE[0m[1mY[0m
-              Allows  you  to  override  any key that's also available as [1ms[0m[1mn[0m[1my[0m[1mk[0m
+              Allows you to override any key that's  also  available  as  [1ms[0m[1mn[0m[1my[0m[1mk[0m
               [1mc[0m[1mo[0m[1mn[0m[1mf[0m[1mi[0m[1mg[0m option.
 
               E.g. [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mC[0m[1mF[0m[1mG[0m[1m_[0m[1mO[0m[1mR[0m[1mG[0m=myorg will override default org option in [1mc[0m[1mo[0m[1mn[0m[1m-[0m
               [1mf[0m[1mi[0m[1mg[0m with "myorg".
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mU[0m[1mS[0m[1mE[0m[1mR[0m[1mN[0m[1mA[0m[1mM[0m[1mE[0m
-              Specify  a  username  to use when connecting to a container reg-
-              istry. Note that using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag  will  override  this
-              value.  This  will  be  ignored in favour of local Docker binary
+              Specify a username to use when connecting to  a  container  reg-
+              istry.  Note  that  using the [1m-[0m[1m-[0m[1mu[0m[1ms[0m[1me[0m[1mr[0m[1mn[0m[1ma[0m[1mm[0m[1me[0m flag will override this
+              value. This will be ignored in favour  of  local  Docker  binary
               credentials when Docker is present.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mR[0m[1mE[0m[1mG[0m[1mI[0m[1mS[0m[1mT[0m[1mR[0m[1mY[0m[1m_[0m[1mP[0m[1mA[0m[1mS[0m[1mS[0m[1mW[0m[1mO[0m[1mR[0m[1mD[0m
-              Specify a password to use when connecting to  a  container  reg-
-              istry.  Note  that  using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag will override this
-              value. This will be ignored in favour  of  local  Docker  binary
+              Specify  a  password  to use when connecting to a container reg-
+              istry. Note that using the [1m-[0m[1m-[0m[1mp[0m[1ma[0m[1ms[0m[1ms[0m[1mw[0m[1mo[0m[1mr[0m[1md[0m flag  will  override  this
+              value.  This  will  be  ignored in favour of local Docker binary
               credentials when Docker is present.
 
 [1mC[0m[1mo[0m[1mn[0m[1mn[0m[1me[0m[1mc[0m[1mt[0m[1mi[0m[1mn[0m[1mg[0m [1mt[0m[1mo[0m [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m
        By default Snyk CLI will connect to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m[1m:[0m[1m/[0m[1m/[0m[1ms[0m[1mn[0m[1my[0m[1mk[0m[1m.[0m[1mi[0m[1mo[0m[1m/[0m[1ma[0m[1mp[0m[1mi[0m[1m/[0m[1mv[0m[1m1[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mA[0m[1mP[0m[1mI[0m
-              Sets  API  host  to use for Snyk requests. Useful for on-premise
+              Sets API host to use for Snyk requests.  Useful  for  on-premise
               instances and configuring proxies. If set with [1mh[0m[1mt[0m[1mt[0m[1mp[0m protocol CLI
-              will  upgrade  the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Unless [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
+              will upgrade the  requests  to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Unless  [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1m-[0m
               [1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m is set to [1m0[0m.
 
        [1mS[0m[1mN[0m[1mY[0m[1mK[0m[1m_[0m[1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mT[0m[1mO[0m[1mC[0m[1mO[0m[1mL[0m[1m_[0m[1mU[0m[1mP[0m[1mG[0m[1mR[0m[1mA[0m[1mD[0m[1mE[0m=0
-              If set to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m  URLs  will
-              not  be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior will
-              be to upgrade these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.  Useful  e.g.,
+              If  set  to the value of [1m0[0m, API requests aimed at [1mh[0m[1mt[0m[1mt[0m[1mp[0m URLs will
+              not be upgraded to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. If not set, the default behavior  will
+              be  to  upgrade  these requests from [1mh[0m[1mt[0m[1mt[0m[1mp[0m to [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m. Useful e.g.,
               for reverse proxies.
 
        [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m and [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m
-              Allows  you  to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and [1mh[0m[1mt[0m[1mt[0m[1mp[0m calls.
-              The [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m in the [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means  that  [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m  [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
-              protocol  will  use this proxy. The proxy itself doesn't need to
+              Allows you to specify a proxy to use for [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m and  [1mh[0m[1mt[0m[1mt[0m[1mp[0m  calls.
+              The  [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m  in  the  [1mH[0m[1mT[0m[1mT[0m[1mP[0m[1mS[0m[1m_[0m[1mP[0m[1mR[0m[1mO[0m[1mX[0m[1mY[0m means that [4mr[0m[4me[0m[4mq[0m[4mu[0m[4me[0m[4ms[0m[4mt[0m[4ms[0m [4mu[0m[4ms[0m[4mi[0m[4mn[0m[4mg[0m [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m
+              protocol will use this proxy. The proxy itself doesn't  need  to
               use [1mh[0m[1mt[0m[1mt[0m[1mp[0m[1ms[0m.
 
 [1mN[0m[1mO[0m[1mT[0m[1mI[0m[1mC[0m[1mE[0m[1mS[0m
    [1mS[0m[1mn[0m[1my[0m[1mk[0m [1mA[0m[1mP[0m[1mI[0m [1mu[0m[1ms[0m[1ma[0m[1mg[0m[1me[0m [1mp[0m[1mo[0m[1ml[0m[1mi[0m[1mc[0m[1my[0m
-       The use of Snyk's API, whether through the use of the 'snyk' npm  pack-
-       age   or   otherwise,   is   subject   to   the   terms   &  conditions
+       The  use of Snyk's API, whether through the use of the 'snyk' npm pack-
+       age  or   otherwise,   is   subject   to   the   terms   &   conditions
        [4mh[0m[4mt[0m[4mt[0m[4mp[0m[4ms[0m[4m:[0m[4m/[0m[4m/[0m[4ms[0m[4mn[0m[4my[0m[4mk[0m[4m.[0m[4mc[0m[4mo[0m[4m/[0m[4mu[0m[4mc[0m[4mT[0m[4m6[0m[4mN[0m


### PR DESCRIPTION
Adding some clarification to the current state of `--target-reference`.

Generated files have excessive differences again. At this point, don't think it matters since #2361 is on the horizon.

`help/commands-docs/_SNYK_COMMAND_OPTIONS.md` is the source file.