### PR TITLE
fix: Remove http protocols validation in custom rules pull.

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -50,6 +50,7 @@ import {
   UnsupportedFeatureFlagPullError,
 } from './oci-pull';
 import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
+import { isValidUrl } from './url-utils';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -157,16 +158,6 @@ export function removeFileContent({
   };
 }
 
-export function isValidURL(str: string): boolean {
-  let url;
-  try {
-    url = new URL(str);
-  } catch (e) {
-    return false;
-  }
-  return url.protocol === 'http:' || url.protocol === 'https:';
-}
-
 /**
  * Checks if the OCI registry URL has been provided.
  */
@@ -197,10 +188,6 @@ function getOCIRegistryURLComponentsFromSettings(
 ) {
   const settingsOCIRegistryURL = iacOrgSettings.customRules!.ociRegistryURL!;
 
-  if (!isValidURL(settingsOCIRegistryURL)) {
-    throw new InvalidRemoteRegistryURLError();
-  }
-
   return {
     ...extractOCIRegistryURLComponents(settingsOCIRegistryURL),
     tag: iacOrgSettings.customRules!.ociRegistryTag || 'latest',
@@ -213,7 +200,7 @@ function getOCIRegistryURLComponentsFromSettings(
 function getOCIRegistryURLComponentsFromEnv() {
   const envOCIRegistryURL = userConfig.get('oci-registry-url')!;
 
-  if (!isValidURL(envOCIRegistryURL)) {
+  if (!isValidUrl(envOCIRegistryURL)) {
     throw new InvalidRemoteRegistryURLError();
   }
 

--- a/src/cli/commands/test/iac-local-execution/url-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/url-utils.ts
@@ -1,0 +1,8 @@
+const URL_REGEX = /^((?:https?:\/\/)?[^./]+(?:\.[^./]+)+(?:\/.*)?)$/;
+
+/**
+ * Checks if the provided URL string is valid.
+ */
+export function isValidUrl(urlStr: string): boolean {
+  return URL_REGEX.test(urlStr);
+}

--- a/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
+++ b/test/jest/unit/iac-unit-tests/oci-pull.spec.ts
@@ -22,6 +22,18 @@ describe('extractOCIRegistryURLComponents', () => {
       tag: 'latest',
     });
   });
+
+  it('extracts components from URL without protocol', async () => {
+    const expected = extractOCIRegistryURLComponents(
+      'gcr.io/user/repo-test:0.5.2',
+    );
+    expect(expected).toEqual({
+      registryBase: 'gcr.io',
+      repo: 'user/repo-test',
+      tag: '0.5.2',
+    });
+  });
+
   it('extracts components and a versioned tag', async () => {
     const expected = extractOCIRegistryURLComponents(
       'https://gcr.io/user/repo-test:0.5.2',
@@ -55,9 +67,27 @@ describe('extractOCIRegistryURLComponents', () => {
     });
   });
 
-  it('throws an error if URL is invalid', () => {
+  it('throws an error if a URL with an empty registry host is provided', function() {
     expect(() => {
-      extractOCIRegistryURLComponents('url/not/valid');
+      extractOCIRegistryURLComponents('https:///repository:0.2.0');
+    }).toThrow(InvalidRemoteRegistryURLError);
+  });
+
+  it('throws an error if a URL without a path is provided', function() {
+    expect(() => {
+      extractOCIRegistryURLComponents('https://registry');
+    }).toThrow(InvalidRemoteRegistryURLError);
+  });
+
+  it('throws an error if a URL with an empty path is provided', function() {
+    expect(() => {
+      extractOCIRegistryURLComponents('https://registry/');
+    }).toThrow(InvalidRemoteRegistryURLError);
+  });
+
+  it('throws an error if a URL with an empty repository name is provided', function() {
+    expect(() => {
+      extractOCIRegistryURLComponents('https://registry/:');
     }).toThrow(InvalidRemoteRegistryURLError);
   });
 });

--- a/test/jest/unit/iac-unit-tests/url-utils.spec.ts
+++ b/test/jest/unit/iac-unit-tests/url-utils.spec.ts
@@ -1,0 +1,61 @@
+import { isValidUrl } from '../../../../src/cli/commands/test/iac-local-execution/url-utils';
+
+describe('url-utils.ts', function() {
+  describe('isValidUrl', function() {
+    describe('Given a valid URL', function() {
+      describe('With a protocol - it returns true', function() {
+        it.each([
+          'https://valid.io/url',
+          'https://valid.io/url:latest',
+          'https://valid.io/url:0.1.0',
+        ])('%s', function(urlStr) {
+          // Act
+          const result = isValidUrl(urlStr);
+
+          // Assert
+          expect(result).toBe(true);
+        });
+      });
+
+      describe('Without a protocol - it returns true', function() {
+        it.each(['valid.io/url', 'valid.io/url:latest', 'valid.io/url:0.1.0'])(
+          '%s',
+          function(urlStr) {
+            // Act
+            const result = isValidUrl(urlStr);
+
+            // Assert
+            expect(result).toBe(true);
+          },
+        );
+      });
+    });
+
+    describe('When given an invalid URL', function() {
+      describe('With a protocol - it returns false', function() {
+        it.each([
+          'http://an/invalid/url',
+          'https://an-invalid-url',
+          'http://:an_invalid/url',
+        ])('%s', function(urlStr: string) {
+          const result = isValidUrl(urlStr);
+
+          // Assert
+          expect(result).toBe(false);
+        });
+      });
+
+      describe('Without a protocol - it returns false', function() {
+        it.each(['an/invalid/url', 'an-invalid-url', ':an_invalid/url'])(
+          '%s',
+          function(urlStr: string) {
+            const result = isValidUrl(urlStr);
+
+            // Assert
+            expect(result).toBe(false);
+          },
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- Changes the existence of protocols in OCI registry URLs to be optional

#### Where should the reviewer start?

- `src/cli/commands/test/iac-local-execution/index.ts`

#### How should this be manually tested?

1. Make sure your org has the `iacCustomRules` and the `infrastructureAsCode` feature flags.
2. Make sure your org has the `iacCustomRulesEntitlement` entitlement.
3. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles generator](https://github.com/snyk/snyk-iac-rules). 
4. Push the generated bundle to an OCI registry. You can refer to [our docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/pushing-a-bundle) to learn how.
. In the Snyk CLI, run `snyk-dev iac test <file> --path=<path-to-remote-bundle>`, where the path does not contain a protocol.
5. Verify that:
    - No errors were thrown.
    - The defined custom rules generated the expected issues successfully.

#### Any background context you want to provide?

At the moment we impose that customers provide an OCI registry URL with the http:// or https:// protocol in front. When we push, on the SDK side, we don’t have that. Customers may copy the URL from the push into the UI/CLI, which won’t work. We don’t need the protocol actually so this task is to remove the need for it. We should still allow customers to provide.

#### What are the relevant tickets?

- [CFG-1183](https://snyksec.atlassian.net/browse/CFG-1183)

#### Additional notes for reviewer

- During the task it's been discovered that our current URL validation method - using the [WHATWG URL API](https://nodejs.org/api/url.html#the-whatwg-url-api) is very basic, and validates most URLs passed to it. Some examples are:
    - `http://    $  `
    - `z://6`
    - `a://`

    Meanwhile, valid URIs like www.google.com will not pass due to the missing protocol.
