### PR TITLE
fix: Exclude region field when missing line number

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ src/lib/cloud-config-projects.ts @snyk/group-infrastructure-as-code
 src/lib/plugins/sast/ @snyk/sast-team
 test/fixtures/sast/ @snyk/sast-team
 test/jest/unit/snyk-code/ @snyk/sast-team
+src/lib/formatters/iac-output.ts @snyk/group-infrastructure-as-code
 src/lib/iac/ @snyk/group-infrastructure-as-code
 src/lib/snyk-test/iac-test-result.ts @snyk/group-infrastructure-as-code
 src/lib/snyk-test/payload-schema.ts @snyk/group-infrastructure-as-code
@@ -25,6 +26,7 @@ test/fixtures/iac/ @snyk/group-infrastructure-as-code
 test/smoke/spec/iac/ @snyk/group-infrastructure-as-code
 test/smoke/spec/snyk_code_spec.sh @snyk/sast-team
 test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
+test/jest/unit/lib/formatters/iac-output.spec.ts @snyk/group-infrastructure-as-code
 test/jest/unit/iac-unit-tests/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 src/lib/errors/invalid-iac-file.ts @snyk/group-infrastructure-as-code

--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -226,23 +226,30 @@ export function extractReportingDescriptor(
 export function mapIacTestResponseToSarifResults(
   issues: ResponseIssues,
 ): sarif.Result[] {
-  return issues.map(({ targetPath, issue }) => ({
-    ruleId: issue.id,
-    message: {
-      text: `This line contains a potential ${issue.severity} severity misconfiguration affecting the ${issue.subType}`,
-    },
-    locations: [
-      {
-        physicalLocation: {
-          artifactLocation: {
-            uri: targetPath,
-            uriBaseId: PROJECT_ROOT_KEY,
-          },
-          region: {
-            startLine: issue.lineNumber,
+  return issues.map(({ targetPath, issue }) => {
+    const hasLineNumber = issue.lineNumber && issue.lineNumber >= 0;
+    return {
+      ruleId: issue.id,
+      message: {
+        text: `This line contains a potential ${issue.severity} severity misconfiguration affecting the ${issue.subType}`,
+      },
+      locations: [
+        {
+          physicalLocation: {
+            artifactLocation: {
+              uri: targetPath,
+              uriBaseId: PROJECT_ROOT_KEY,
+            },
+            // We exclude the `region` key when the line number is missing or -1.
+            // https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127873
+            ...(hasLineNumber && {
+              region: {
+                startLine: issue.lineNumber,
+              },
+            }),
           },
         },
-      },
-    ],
-  }));
+      ],
+    };
+  });
 }

--- a/test/jest/unit/lib/formatters/iac-output.spec.ts
+++ b/test/jest/unit/lib/formatters/iac-output.spec.ts
@@ -1,0 +1,89 @@
+import { createSarifOutputForIac } from '../../../../../src/lib/formatters/iac-output';
+import {
+  IacTestResponse,
+  AnnotatedIacIssue,
+} from '../../../../../src/lib/snyk-test/iac-test-result';
+import { SEVERITY } from '../../../../../src/lib/snyk-test/legacy';
+
+describe('createSarifOutputForIac', () => {
+  function createResponseIssue(
+    issueOverrides?: Partial<AnnotatedIacIssue>,
+  ): IacTestResponse {
+    const issue: AnnotatedIacIssue = {
+      id: 'ID',
+      title: 'TITLE',
+      severity: SEVERITY.HIGH,
+      isIgnored: false,
+      cloudConfigPath: ['resource', 'something'],
+      subType: 'SUBTYPE',
+      isGeneratedByCustomRule: false,
+      lineNumber: 1,
+      iacDescription: {
+        issue: 'Description of Issue',
+        impact: 'Description of Impact',
+        resolve: 'Description of Remediation',
+      },
+      ...issueOverrides,
+    };
+
+    return {
+      ok: true,
+      org: 'MY_ORG',
+      isPrivate: false,
+      summary: '',
+      path: 'target_file.tf',
+      targetFile: 'target_file.tf',
+      projectName: 'target_file.tf',
+      displayTargetFile: 'target_file.tf',
+      foundProjectCount: 0,
+      meta: {
+        isPublic: false,
+        isLicensesEnabled: false,
+        policy: '',
+        org: 'MY_ORG',
+      },
+      result: {
+        cloudConfigResults: [issue],
+        projectType: 'terraformconfig',
+      },
+    };
+  }
+
+  it('includes an artifactLocation and region', () => {
+    const issue = createResponseIssue();
+    const sarif = createSarifOutputForIac([issue]);
+
+    const location = sarif.runs?.[0]?.results?.[0]?.locations?.[0];
+    expect(location?.physicalLocation?.artifactLocation).toEqual({
+      uri: 'target_file.tf',
+      uriBaseId: 'PROJECTROOT',
+    });
+    expect(location?.physicalLocation?.region).toEqual({
+      startLine: 1,
+    });
+  });
+
+  it('excludes the region if no line number was found', () => {
+    const issue = createResponseIssue({ lineNumber: -1 });
+    const sarif = createSarifOutputForIac([issue]);
+
+    const location = sarif.runs?.[0]?.results?.[0]?.locations?.[0];
+    expect(location?.physicalLocation?.artifactLocation).toEqual({
+      uri: 'target_file.tf',
+      uriBaseId: 'PROJECTROOT',
+    });
+    expect(location?.physicalLocation?.region).not.toBeDefined();
+  });
+
+  it('excludes the region if no line number is present', () => {
+    const issue = createResponseIssue({ lineNumber: undefined });
+    const sarif = createSarifOutputForIac([issue]);
+
+    const location = sarif.runs?.[0]?.results?.[0]?.locations?.[0];
+    expect(location?.physicalLocation?.artifactLocation).toEqual({
+      uri: 'target_file.tf',
+      uriBaseId: 'PROJECTROOT',
+    });
+    expect(location?.physicalLocation?.region).not.toBeDefined();
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

For our `--sarif` output we want to exclude the `region` object and `startLine` field when a misconfiguration has no line number (either missing entirely or set to -1). 

Including a negative number for `startLine` is [invalid in the SARIF spec](https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/sarif-v2.0-csprd02.html#_Toc10127873) and causes issues with tools such as the GitHub security feature.

#### Where should the reviewer start?

Start at the test implementation in iac-output.spec.ts to see the inputs and then check the iac-output.ts file for the implementation.

#### How should this be manually tested?

Run the snyk tool against a CloudFormation file (we have the biggest parser issues here) and ensure that there are no `region` fields with a value of -1. For example check out [snyk-labs/infrastructure-as-code-goof](https://github.com/snyk-labs/infrastructure-as-code-goof) cd into the root directory and run:

    snyk iac test --sarif cloudformation/fargate-service.yml
    
With the current version you will see an entry:

```json
{
          "ruleId": "SNYK-CC-TF-98",
          "message": {
            "text": "This line contains a potential high severity misconfiguration affecting the undefined S3"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "cloudformation/fargate-service.yml",
                  "uriBaseId": "PROJECTROOT"
                },
                "region": {
                  "startLine": -1
                }
              }
            }
          ]
        }
```

With this commit the output will be:

```json
        {
          "ruleId": "SNYK-CC-TF-98",
          "message": {
            "text": "This line contains a potential high severity misconfiguration affecting the S3"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "cloudformation/fargate-service.yml",
                  "uriBaseId": "PROJECTROOT"
                }
              }
            }
          ]
        }
```

