### PR TITLE
fix: unify the retry & contact support errors across commands

### DIFF
--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -1,3 +1,8 @@
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export const reTryMessage =
+  'Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>';
+export const contactSupportMessage =
+  'If the issue persists contact support@snyk.io';

--- a/src/lib/errors/error-with-retry.ts
+++ b/src/lib/errors/error-with-retry.ts
@@ -1,0 +1,5 @@
+import { contactSupportMessage, reTryMessage } from '../common';
+
+export function errorMessageWithRetry(message: string): string {
+  return `${message}\n${reTryMessage}\n${contactSupportMessage}`;
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -31,3 +31,4 @@ export {
   NotSupportedIacAllProjects,
 } from './invalid-iac-file';
 export { NotFoundError } from './not-found-error';
+export { errorMessageWithRetry } from './error-with-retry';

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -1,7 +1,7 @@
 const { default: config } = require('../config');
 const chalk = require('chalk');
 const { SEVERITIES } = require('../snyk-test/common');
-const { contactSupportMessage, reTryMessage } = require('../common');
+const { errorMessageWithRetry } = require('./error-with-retry');
 const analytics = require('../analytics');
 
 const errors = {
@@ -29,7 +29,9 @@ const errors = {
   noApiToken:
     '%s requires an authenticated account. Please run `snyk auth` ' +
     'and try again.',
-  timeout: `The request has timed out on the server side.\n${reTryMessage}\n${contactSupportMessage}`,
+  timeout: errorMessageWithRetry(
+    'The request has timed out on the server side.',
+  ),
   policyFile:
     'Bad policy file, please use --path=PATH to specify a ' +
     'directory with a .snyk file',

--- a/src/lib/errors/legacy-errors.js
+++ b/src/lib/errors/legacy-errors.js
@@ -1,6 +1,7 @@
 const { default: config } = require('../config');
 const chalk = require('chalk');
 const { SEVERITIES } = require('../snyk-test/common');
+const { contactSupportMessage, reTryMessage } = require('../common');
 const analytics = require('../analytics');
 
 const errors = {
@@ -28,9 +29,7 @@ const errors = {
   noApiToken:
     '%s requires an authenticated account. Please run `snyk auth` ' +
     'and try again.',
-  timeout:
-    'The request has timed out on the server side.\nPlease re-run ' +
-    'this command with the `-d` flag and send the output to support@snyk.io.',
+  timeout: `The request has timed out on the server side.\n${reTryMessage}\n${contactSupportMessage}`,
   policyFile:
     'Bad policy file, please use --path=PATH to specify a ' +
     'directory with a .snyk file',

--- a/src/lib/formatters/format-error-result-summary.ts
+++ b/src/lib/formatters/format-error-result-summary.ts
@@ -1,9 +1,11 @@
-import { contactSupportMessage, reTryMessage } from '../common';
+import { errorMessageWithRetry } from '../errors';
 
 export function summariseErrorResults(errorResultsLength: number): string {
   const projects = errorResultsLength > 1 ? 'projects' : 'project';
   if (errorResultsLength > 0) {
-    return ` Failed to test ${errorResultsLength} ${projects}.\n${reTryMessage}\n${contactSupportMessage}`;
+    return errorMessageWithRetry(
+      ` Failed to test ${errorResultsLength} ${projects}.`,
+    );
   }
 
   return '';

--- a/src/lib/formatters/format-error-result-summary.ts
+++ b/src/lib/formatters/format-error-result-summary.ts
@@ -1,10 +1,9 @@
+import { contactSupportMessage, reTryMessage } from '../common';
+
 export function summariseErrorResults(errorResultsLength: number): string {
   const projects = errorResultsLength > 1 ? 'projects' : 'project';
   if (errorResultsLength > 0) {
-    return (
-      ` Failed to test ${errorResultsLength} ${projects}.\n` +
-      'Run with `-d` for debug output and contact support@snyk.io'
-    );
+    return ` Failed to test ${errorResultsLength} ${projects}.\n${reTryMessage}\n${contactSupportMessage}`;
   }
 
   return '';

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -50,6 +50,7 @@ import {
 import { countPathsToGraphRoot } from '../utils';
 import * as alerts from '../alerts';
 import { abridgeErrorMessage } from '../error-format';
+import { contactSupportMessage, reTryMessage } from '../common';
 
 const debug = Debug('snyk');
 
@@ -164,7 +165,7 @@ async function monitorDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      'Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}',
     );
   }
 
@@ -249,7 +250,7 @@ async function monitorDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
     );
   }
 
@@ -338,7 +339,7 @@ export async function monitorDepGraph(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      'Your monitor request could not be completed. ',
     );
   }
 
@@ -407,7 +408,7 @@ export async function monitorDepGraph(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
     );
   }
 
@@ -487,7 +488,7 @@ async function monitorDepGraphFromDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
     );
   }
 
@@ -538,7 +539,7 @@ async function monitorDepGraphFromDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed. Please email support@snyk.io',
+      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
     );
   }
   const { res, body } = await makeRequest({

--- a/src/lib/monitor/index.ts
+++ b/src/lib/monitor/index.ts
@@ -25,6 +25,7 @@ import {
   MonitorError,
   ConnectionTimeoutError,
   FailedToRunTestError,
+  errorMessageWithRetry,
 } from '../errors';
 import { pruneGraph } from '../prune';
 import { GRAPH_SUPPORTED_PACKAGE_MANAGERS } from '../package-managers';
@@ -50,7 +51,6 @@ import {
 import { countPathsToGraphRoot } from '../utils';
 import * as alerts from '../alerts';
 import { abridgeErrorMessage } from '../error-format';
-import { contactSupportMessage, reTryMessage } from '../common';
 
 const debug = Debug('snyk');
 
@@ -165,7 +165,7 @@ async function monitorDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      'Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}',
+      errorMessageWithRetry('Your monitor request could not be completed.'),
     );
   }
 
@@ -250,7 +250,7 @@ async function monitorDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
+      errorMessageWithRetry('Your monitor request could not be completed.'),
     );
   }
 
@@ -408,7 +408,7 @@ export async function monitorDepGraph(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
+      errorMessageWithRetry('Your monitor request could not be completed.'),
     );
   }
 
@@ -488,7 +488,7 @@ async function monitorDepGraphFromDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
+      errorMessageWithRetry('Your monitor request could not be completed'),
     );
   }
 
@@ -539,7 +539,7 @@ async function monitorDepGraphFromDepTree(
       'scannedProject is missing depGraph or depTree, cannot run test/monitor',
     );
     throw new FailedToRunTestError(
-      `Your monitor request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
+      errorMessageWithRetry('Your monitor request could not be completed.'),
     );
   }
   const { res, body } = await makeRequest({

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -13,8 +13,7 @@ import { convertSingleResultToMultiCustom } from './convert-single-splugin-res-t
 import { convertMultiResultToMultiCustom } from './convert-multi-plugin-res-to-multi-custom';
 import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import { CallGraph } from '@snyk/cli-interface/legacy/common';
-import { FailedToRunTestError } from '../errors';
-import { reTryMessage, contactSupportMessage } from '../common';
+import { errorMessageWithRetry, FailedToRunTestError } from '../errors';
 
 const debug = debugModule('snyk-test');
 export interface ScannedProjectCustom
@@ -96,7 +95,9 @@ export async function getMultiPluginResult(
 
   if (!allResults.length) {
     throw new FailedToRunTestError(
-      `Failed to get dependencies for all ${targetFiles.length} potential projects.\n${reTryMessage}. ${contactSupportMessage}`,
+      errorMessageWithRetry(
+        `Failed to get dependencies for all ${targetFiles.length} potential projects.`,
+      ),
     );
   }
 

--- a/src/lib/plugins/get-multi-plugin-result.ts
+++ b/src/lib/plugins/get-multi-plugin-result.ts
@@ -14,6 +14,7 @@ import { convertMultiResultToMultiCustom } from './convert-multi-plugin-res-to-m
 import { PluginMetadata } from '@snyk/cli-interface/legacy/plugin';
 import { CallGraph } from '@snyk/cli-interface/legacy/common';
 import { FailedToRunTestError } from '../errors';
+import { reTryMessage, contactSupportMessage } from '../common';
 
 const debug = debugModule('snyk-test');
 export interface ScannedProjectCustom
@@ -95,7 +96,7 @@ export async function getMultiPluginResult(
 
   if (!allResults.length) {
     throw new FailedToRunTestError(
-      `Failed to get dependencies for all ${targetFiles.length} potential projects. Run with \`-d\` for debug output and contact support@snyk.io`,
+      `Failed to get dependencies for all ${targetFiles.length} potential projects.\n${reTryMessage}. ${contactSupportMessage}`,
     );
   }
 

--- a/src/lib/protect/patch.js
+++ b/src/lib/protect/patch.js
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const flatten = require('lodash.flatten');
 const cloneDeep = require('lodash.clonedeep');
+const { contactSupportMessage } = require('../common');
 const applyPatch = require('./apply-patch');
 const stripVersions = require('./strip-versions');
 const getVulnSource = require('./get-vuln-source');
@@ -214,9 +215,7 @@ function patch(vulns, live) {
             console.log(chalk.red(errors.message(error)));
             debug(error.stack);
           });
-          throw new Error(
-            'Please email support@snyk.io if this problem persists.',
-          );
+          throw new Error(contactSupportMessage);
         }
 
         return res;

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -75,6 +75,7 @@ import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
 import { makeRequest } from '../request';
 import { spinner } from '../spinner';
+import { contactSupportMessage, reTryMessage } from '../common';
 
 const debug = debugModule('snyk:run-test');
 
@@ -628,7 +629,7 @@ async function assembleLocalPayloads(
           'scannedProject is missing depGraph or depTree, cannot run test/monitor',
         );
         throw new FailedToRunTestError(
-          'Your test request could not be completed. Please email support@snyk.io',
+          `Your test request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
         );
       }
 

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -32,6 +32,7 @@ import {
   NoSupportedManifestsFoundError,
   UnsupportedFeatureFlagError,
   NotFoundError,
+  errorMessageWithRetry,
 } from '../errors';
 import * as snyk from '../';
 import { isCI } from '../is-ci';
@@ -75,7 +76,6 @@ import { Issue } from '../ecosystems/types';
 import { assembleEcosystemPayloads } from './assemble-payloads';
 import { makeRequest } from '../request';
 import { spinner } from '../spinner';
-import { contactSupportMessage, reTryMessage } from '../common';
 
 const debug = debugModule('snyk:run-test');
 
@@ -629,7 +629,7 @@ async function assembleLocalPayloads(
           'scannedProject is missing depGraph or depTree, cannot run test/monitor',
         );
         throw new FailedToRunTestError(
-          `Your test request could not be completed.\n${reTryMessage}\n${contactSupportMessage}`,
+          errorMessageWithRetry('Your test request could not be completed.'),
         );
       }
 

--- a/test/jest/acceptance/snyk-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-test/all-projects.spec.ts
@@ -47,7 +47,7 @@ describe('snyk test --all-projects (mocked server only)', () => {
     expect(code).toEqual(2);
 
     expect(stdout).toMatch(
-      'Failed to get dependencies for all 3 potential projects.\nTip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io',
+      'Failed to get dependencies for all 3 potential projects.\nTip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>\nIf the issue persists contact support@snyk.io',
     );
     expect(stderr).toEqual('');
   });

--- a/test/jest/acceptance/snyk-test/all-projects.spec.ts
+++ b/test/jest/acceptance/snyk-test/all-projects.spec.ts
@@ -47,7 +47,7 @@ describe('snyk test --all-projects (mocked server only)', () => {
     expect(code).toEqual(2);
 
     expect(stdout).toMatch(
-      'Failed to get dependencies for all 3 potential projects. Run with `-d` for debug output and contact support@snyk.io',
+      'Failed to get dependencies for all 3 potential projects.\nTip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>. If the issue persists contact support@snyk.io',
     );
     expect(stderr).toEqual('');
   });

--- a/test/jest/unit/lib/formatters/__snapshots__/format-error-result-summary.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/__snapshots__/format-error-result-summary.spec.ts.snap
@@ -2,10 +2,12 @@
 
 exports[`summariseErrorResults Multiple test results 1`] = `
 " Failed to test 4 projects.
-Run with \`-d\` for debug output and contact support@snyk.io"
+Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>
+If the issue persists contact support@snyk.io"
 `;
 
 exports[`summariseErrorResults Single test result 1`] = `
 " Failed to test 1 project.
-Run with \`-d\` for debug output and contact support@snyk.io"
+Tip: Re-run in debug mode to see more information: DEBUG=*snyk* <COMMAND>
+If the issue persists contact support@snyk.io"
 `;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Use consistent message for retry & contact where we ask the user to try again but with debug enabled.

#### Where should the reviewer start?
src/lib/common.ts
