### PR TITLE
chore: add gcr acceptance test [CFG-1111]

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -139,6 +139,12 @@ describe('custom rules pull from a remote OCI registry', () => {
       process.env.OCI_GITHUB_REGISTRY_USERNAME,
       process.env.OCI_GITHUB_REGISTRY_PASSWORD,
     ],
+    [
+      'GCR',
+      process.env.OCI_GCR_REGISTRY_URL,
+      process.env.OCI_GCR_REGISTRY_USERNAME,
+      process.env.OCI_GCR_REGISTRY_PASSWORD,
+    ],
   ];
   test.each(cases)(
     'given %p as a registry and correct credentials, it returns a success exit code',


### PR DESCRIPTION
#### What does this PR do?
This PR adds acceptance tests for GCR, to prove that we support it and make sure we keep supporting it. The credentials are for a GCR service account set up for automated testing.
