### PR TITLE
chore: Deprecate custom rules FF [CFG-1230]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/oci-pull.ts
+++ b/src/cli/commands/test/iac-local-execution/oci-pull.ts
@@ -132,15 +132,6 @@ export class InvalidRemoteRegistryURLError extends CustomError {
   }
 }
 
-export class UnsupportedFeatureFlagPullError extends CustomError {
-  constructor(featureFlag: string) {
-    super('OCI Pull not supported - Missing the ${featureFlag} feature flag');
-    this.code = IaCErrorCodes.UnsupportedFeatureFlagPullError;
-    this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `The custom rules feature is not supported for this org - The feature flag '${featureFlag}' is not currently enabled. It can be enabled via Snyk Preview, if you are on the Enterprise Plan.`;
-  }
-}
-
 export class UnsupportedEntitlementPullError extends CustomError {
   constructor(entitlement: string) {
     super(`OCI Pull not supported - Missing the ${entitlement} entitlement`);

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -43,17 +43,6 @@ describe('iac test --rules', () => {
     );
   });
 
-  it('presents an error message when the user is not part of the experiment', async () => {
-    const { stdout, exitCode } = await run(
-      `snyk iac test --org=no-flag --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
-    );
-
-    expect(exitCode).toBe(2);
-    expect(stdout).toContain(
-      `Flag "--rules" is only supported if feature flag 'iacCustomRules' is enabled.`,
-    );
-  });
-
   it('presents an error message when the user is not entitled to custom-rules', async () => {
     const { stdout, exitCode } = await run(
       `snyk iac test --org=no-entitlements --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
@@ -204,24 +193,6 @@ describe('custom rules pull from a remote OCI registry', () => {
     expect(exitCode).toBe(2);
     expect(stdout).toContain(
       'Remote and local custom rules bundle can not be used at the same time.',
-    );
-  });
-
-  it('presents an error message when the user is not part of the experiment', async () => {
-    const { stdout, exitCode } = await run(
-      `snyk iac test --org=no-flag ./iac/terraform/sg_open_ssh.tf`,
-      {
-        SNYK_CFG_OCI_REGISTRY_URL: process.env.OCI_DOCKER_REGISTRY_URL!,
-        SNYK_CFG_OCI_REGISTRY_USERNAME: process.env
-          .OCI_DOCKER_REGISTRY_USERNAME!,
-        SNYK_CFG_OCI_REGISTRY_PASSWORD: process.env
-          .OCI_DOCKER_REGISTRY_PASSWORD!,
-      },
-    );
-
-    expect(exitCode).toBe(2);
-    expect(stdout).toContain(
-      `The custom rules feature is not supported for this org - The feature flag 'iacCustomRules' is not currently enabled. It can be enabled via Snyk Preview, if you are on the Enterprise Plan.`,
     );
   });
 

--- a/test/jest/unit/iac-unit-tests/index.spec.ts
+++ b/test/jest/unit/iac-unit-tests/index.spec.ts
@@ -99,7 +99,7 @@ describe('test()', () => {
       pullSpy.mockReset();
     });
 
-    it('attemps to pull the custom-rules bundle using the provided configurations', async () => {
+    it('attempts to pull the custom-rules bundle using the provided configurations', async () => {
       const opts: IaCTestFlags = {};
 
       await test('./iac/terraform/sg_open_ssh.tf', opts);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Removes the `iacCustomRules` feature flag validation in custom rules related operations and flags in the CLI.

#### Where should the reviewer start?
- `src/cli/commands/test/iac-local-execution/index.ts`

#### How should this be manually tested?
1. Make sure your org has the `iacCustomRulesEntitlement` entitlement.
2. Make sure your org **does not** have the `iacCustomRules` feature flag.
3. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles SDK](https://github.com/snyk/snyk-iac-rules). 
4. In the Snyk CLI, run:
```
snyk iac test <file> --rules=<path-to-rules-bundle>
```
5. Verify that:
    - No errors were thrown.
    - The defined custom rules generated the expected issues successfully.
6. Push the generated bundle to an OCI registry. You can refer to [our docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/pushing-a-bundle) to learn how.
7. Configure your remote bundle settings. You can refer to [our docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/use-IaC-custom-rules-with-CLI/using-a-remote-custom-rules-bundle) to learn how.
8. In the Snyk CLI, run:
```
snyk iac test <file>
```
9. Verify that:
    - No errors were thrown.
    - The defined custom rules generated the expected issues successfully.

#### Any background context you want to provide?
Custom rules related operations, features and flags are currently wrapped with both the deprecated `iacCustomRules` feature flag, and the `iacCustomRulesEntitlement` entitlement.

We'd like to remove the usage of the deprecated `iacCustomRules` feature flag and use the `iacCustomRulesEntitlement` entitlement exclusively.

#### What are the relevant tickets?

- [CFG-1066](https://snyksec.atlassian.net/browse/CFG-1066)