### PR TITLE
chore: Temporarily skip GCR custom rules  acceptance test

### DIFF
--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -139,12 +139,12 @@ describe('custom rules pull from a remote OCI registry', () => {
       process.env.OCI_GITHUB_REGISTRY_USERNAME,
       process.env.OCI_GITHUB_REGISTRY_PASSWORD,
     ],
-    [
-      'GCR',
-      process.env.OCI_GCR_REGISTRY_URL,
-      process.env.OCI_GCR_REGISTRY_USERNAME,
-      process.env.OCI_GCR_REGISTRY_PASSWORD,
-    ],
+    // [
+    //   'GCR',
+    //   process.env.OCI_GCR_REGISTRY_URL,
+    //   process.env.OCI_GCR_REGISTRY_USERNAME,
+    //   process.env.OCI_GCR_REGISTRY_PASSWORD,
+    // ],
   ];
   test.each(cases)(
     'given %p as a registry and correct credentials, it returns a success exit code',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Temporarily skips the acceptance test for pulling custom rules bundles from GCR.

#### Where should the reviewer start?
- `test/jest/acceptance/iac/custom-rules.spec.ts`

#### How should this be manually tested?
- Run the following acceptance test: `test/jest/acceptance/iac/custom-rules.spec.ts`.
- Verify that all tests are passing.

#### Any background context you want to provide?
- Some of the IaC tests related credentials were revoked. As a result, the corresponding tests are failing. As a temporary fix, we would like to skip these tests until the credentials are updated.

### Additional info
- [Slack thread](https://snyk.slack.com/archives/C022H54L8PJ/p1637778795222300)