### PR TITLE
fix: custom rules json output

### DIFF
--- a/src/cli/commands/test/iac-local-execution/results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/results-formatter.ts
@@ -92,7 +92,9 @@ function formatScanResult(
       },
       severity: policy.severity,
       lineNumber,
-      documentation: `https://snyk.io/security-rules/${policy.publicId}`,
+      documentation: !isGeneratedByCustomRule
+        ? `https://snyk.io/security-rules/${policy.publicId}`
+        : undefined,
       isGeneratedByCustomRule,
     };
   });

--- a/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac-unit-tests/results-formatter.fixtures.ts
@@ -107,7 +107,9 @@ export function generateCloudConfigResults({
       },
       severity: anotherPolicyStub.severity,
       lineNumber: withLineNumber ? 3 : -1,
-      documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-2',
+      documentation: !isGeneratedByCustomRule
+        ? 'https://snyk.io/security-rules/SNYK-CC-K8S-2'
+        : undefined,
       isGeneratedByCustomRule,
     },
     {
@@ -125,7 +127,9 @@ export function generateCloudConfigResults({
       },
       severity: yetAnotherPolicyStub.severity,
       lineNumber: withLineNumber ? 3 : -1,
-      documentation: 'https://snyk.io/security-rules/SNYK-CC-K8S-3',
+      documentation: !isGeneratedByCustomRule
+        ? 'https://snyk.io/security-rules/SNYK-CC-K8S-3'
+        : undefined,
       isGeneratedByCustomRule,
     },
   ];


### PR DESCRIPTION
#### What does this PR do?
This PR makes sure that if a misconfiguration comes from a custom rule, then we don't provide link to the documentation. 

#### How should this be manually tested?
1. `npm run build`
2. Build a custom rules bundle using `snyk-iac-rules` 
3. `snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --json --rules=bundle.tar.gz`

#### Any background context you want to provide?
- [Slack thread](https://snyk.slack.com/archives/C022H54L8PJ/p1637933370240100)

#### Screenshots
![Screenshot 2021-11-26 at 16 56 29](https://user-images.githubusercontent.com/81559517/143612454-5d002bb0-7270-45cb-80f6-207d00336f19.png)

