### PR TITLE
chore: Improve error messages for the pull flow [CFG-1197]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -51,6 +51,7 @@ import {
 } from './oci-pull';
 import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 import { isValidUrl } from './url-utils';
+import chalk from 'chalk';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -73,6 +74,14 @@ export async function test(
     const isOCIRegistryURLProvided = checkOCIRegistryURLProvided(
       iacOrgSettings,
     );
+
+    if (isOCIRegistryURLProvided || customRulesPath) {
+      console.log(
+        chalk.hex('#ff9b00')(
+          'Using custom rules to generate misconfigurations.',
+        ),
+      );
+    }
 
     if (isOCIRegistryURLProvided && customRulesPath) {
       throw new FailedToExecuteCustomRulesError();
@@ -251,7 +260,7 @@ export async function pullIaCCustomRules(
       );
     } else if (err.statusCode === 404) {
       throw new FailedToPullCustomBundleError(
-        'The remote repository could not be found. Please check the provided URL.',
+        'The remote repository could not be found. Please check the provided registry URL.',
       );
     } else if (err instanceof InvalidManifestSchemaVersionError) {
       throw new FailedToPullCustomBundleError(err.message);
@@ -331,8 +340,10 @@ export class FailedToPullCustomBundleError extends CustomError {
     super(message || 'Could not pull custom bundle');
     this.code = IaCErrorCodes.FailedToPullCustomBundleError;
     this.strCode = getErrorStringCode(this.code);
-    this.userMessage = `${message ? message + ' ' : ''}
-    We were unable to download the custom bundle to the disk. Please ensure access to the remote Registry and validate you have provided all the right parameters.`;
+    this.userMessage =
+      `${message ? message + ' ' : ''}` +
+      '\nWe were unable to download the custom bundle to the disk. Please ensure access to the remote Registry and validate you have provided all the right parameters.' +
+      '\nSee documentation on troubleshooting: https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/use-IaC-custom-rules-with-CLI/using-a-remote-custom-rules-bundle#troubleshooting';
   }
 }
 

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -23,6 +23,9 @@ describe('iac test --rules', () => {
     );
     expect(exitCode).toBe(1);
 
+    expect(stdout).toContain(
+      'Using custom rules to generate misconfigurations.',
+    );
     expect(stdout).toContain('Testing ./iac/terraform/sg_open_ssh.tf');
     expect(stdout).toContain('Infrastructure as code issues:');
     expect(stdout).toContain('Missing tags');
@@ -167,6 +170,9 @@ describe('custom rules pull from a remote OCI registry', () => {
       expect(SNYK_CFG_OCI_REGISTRY_PASSWORD).toBeDefined();
       expect(exitCode).toBe(1);
 
+      expect(stdout).toContain(
+        'Using custom rules to generate misconfigurations.',
+      );
       expect(stdout).toContain('Testing ./iac/terraform/sg_open_ssh.tf');
       expect(stdout).toContain('Infrastructure as code issues:');
       expect(stdout).toContain('Missing tags');


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
- Adds a user message when using custom rules to generate misconfigurations.
- Attaches a link to the troubleshooting page in error messages related to pulling custom rules bundles.
- Clarifies existing error messages.

#### Where should the reviewer start?
- `src/cli/commands/test/iac-local-execution/index.ts`

#### How should this be manually tested?
1. Make sure your org has the `iacCustomRulesEntitlement` entitlement.
3. Prepare a custom-rules bundle generated by the [Snyk custom-rules bundles SDK](https://github.com/snyk/snyk-iac-rules). 
6. Push the generated bundle to an OCI registry. You can refer to [our docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/pushing-a-bundle) to learn how.
7. Configure your remote bundle settings. You can refer to [our docs](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/use-IaC-custom-rules-with-CLI/using-a-remote-custom-rules-bundle) to learn how.
8. In the Snyk CLI, run:
```
snyk iac test <file>
```
9. Verify that:
    - No errors were thrown.
    - The new user message: `Using custom rules to generate misconfigurations.` was displayed.
    - The defined custom rules generated the expected issues successfully.
10. Configure an incorrect OCI registry URL.
11. In the Snyk CLI, run again:
```
snyk iac test <file>
```
12. Verify that the link to the troubleshooting page was added to the error message.

#### Any background context you want to provide?
As it is easy to misconfigure the custom rules settings with the Snyk CLI, we would like to ease the troubleshooting process by making the user messages more descriptive.

#### What are the relevant tickets?
- [CFG-1197](https://snyksec.atlassian.net/browse/CFG-1197)

#### Screenshots
![image](https://user-images.githubusercontent.com/46415136/143900153-26e5c52f-3777-47ed-b0fd-596543f88219.png)
![image](https://user-images.githubusercontent.com/46415136/143899938-cc6ff62d-fa65-4a79-a4fc-cd283fc1e366.png)
