### PR TITLE
fix: support optional peerDeps for npm7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "snyk",
       "version": "1.0.0-monorepo",
       "license": "Apache-2.0",
       "workspaces": [
@@ -68,7 +69,7 @@
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
-        "snyk-nodejs-lockfile-parser": "1.37.1",
+        "snyk-nodejs-lockfile-parser": "1.37.2",
         "snyk-nuget-plugin": "1.23.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -23346,9 +23347,9 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.1.tgz",
-      "integrity": "sha512-GoC1Hqx4ZYr8Rma9aov5WQj5g+ByR1mCx5UARbbcE8Y7DPfAfzgicAJBbwiHWunYjADBGvnyTUPYfdcWODWlhw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+      "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -45408,7 +45409,7 @@
         "@snyk/cloud-config-parser": "^1.12.0",
         "@snyk/code-client": "^4.4.1",
         "@snyk/dep-graph": "^1.27.1",
-        "@snyk/docker-registry-v2-client": "2.5.1",
+        "@snyk/docker-registry-v2-client": "^2.5.1",
         "@snyk/fix": "file:packages/snyk-fix",
         "@snyk/gemfile": "1.2.0",
         "@snyk/graphlib": "^2.1.9-patch.3",
@@ -45422,7 +45423,7 @@
         "@types/fs-extra": "^9.0.11",
         "@types/jest": "^27.0.1",
         "@types/lodash": "^4.14.161",
-        "@types/marked": "*",
+        "@types/marked": "^4.0.0",
         "@types/needle": "^2.0.4",
         "@types/node": "^14.14.31",
         "@types/sarif": "^2.1.2",
@@ -45497,7 +45498,7 @@
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
-        "snyk-nodejs-lockfile-parser": "1.37.1",
+        "snyk-nodejs-lockfile-parser": "1.37.2",
         "snyk-nuget-plugin": "1.23.1",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -64038,9 +64039,9 @@
           }
         },
         "snyk-nodejs-lockfile-parser": {
-          "version": "1.37.1",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.1.tgz",
-          "integrity": "sha512-GoC1Hqx4ZYr8Rma9aov5WQj5g+ByR1mCx5UARbbcE8Y7DPfAfzgicAJBbwiHWunYjADBGvnyTUPYfdcWODWlhw==",
+          "version": "1.37.2",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+          "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/graphlib": "2.1.9-patch.3",
@@ -67492,9 +67493,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.37.1",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.1.tgz",
-      "integrity": "sha512-GoC1Hqx4ZYr8Rma9aov5WQj5g+ByR1mCx5UARbbcE8Y7DPfAfzgicAJBbwiHWunYjADBGvnyTUPYfdcWODWlhw==",
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+      "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
-    "snyk-nodejs-lockfile-parser": "1.37.1",
+    "snyk-nodejs-lockfile-parser": "1.37.2",
     "snyk-nuget-plugin": "1.23.1",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.1",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This adds support for optional peer dependencies in npm7 - stopping Snyk from throwing out of sync errors in cases where it cannot find the peerDep if it is optional.