### PR TITLE
feat: add snyk apps command and create sub-command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,8 @@ help/  @snyk/hammer
 src/cli/commands/test/iac-local-execution/ @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-output.ts @snyk/group-infrastructure-as-code
 src/cli/commands/test/iac-test-shim.ts @snyk/group-infrastructure-as-code
+src/cli/commands/apps @snyk/moose
+src/lib/apps @snyk/moose
 src/lib/cloud-config-projects.ts @snyk/group-infrastructure-as-code
 src/lib/plugins/sast/ @snyk/sast-team
 test/fixtures/sast/ @snyk/sast-team
@@ -32,6 +34,7 @@ test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/iac-output.spec.ts @snyk/group-infrastructure-as-code
 test/jest/unit/iac-unit-tests/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
+test/jest/acceptance/snyk-apps @snyk-moose
 src/lib/errors/invalid-iac-file.ts @snyk/group-infrastructure-as-code
 src/lib/errors/unsupported-options-iac-error.ts @snyk/group-infrastructure-as-code
 src/lib/errors/no-supported-sast-files-found.ts @snyk/sast-team

--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,6 @@
 {
   "API": "https://snyk.io/api/v1",
+  "API_V3_URL": "https://api.snyk.io/v3",
   "devDeps": false,
   "PRUNE_DEPS_THRESHOLD": 40000,
   "MAX_PATH_COUNT": 1500000,

--- a/help/cli-commands/apps.md
+++ b/help/cli-commands/apps.md
@@ -1,0 +1,55 @@
+# snyk apps -- Create and manage your Snyk Apps
+
+# Usage
+
+`snyk apps <COMMAND> [<OPTIONS>]`
+
+## Description
+
+Snyk Apps are integrations that extend the functionality of the Snyk platform. They provide you with an opportunity to mould your Snyk experience to suit your specific needs.
+
+[For more information see our user docs](https://docs.snyk.io/features/integrations/snyk-apps)
+
+## Commands
+
+**_Note: All `apps` commands are only accessible behind the `--experimental` flag and the behaviour can change at any time, without prior notice. You are kindly advised to use all the commands with caution_**
+
+### `create`
+
+Create a new Snyk App.
+
+## Options
+
+### `--interactive`
+
+Use the command in interactive mode.
+
+### `--org=<ORG_ID>`
+
+(Required for the `create` command)
+Specify the `<ORG_ID>` to create the Snyk App under.
+
+### `--name=<SNYK_APP_NAME>`
+
+(Required for the `create` command)
+The name of Snyk App that will be displayed to the user during the authentication flow.
+
+### `--redirect-uris=<REDIRECT_URIS>`
+
+(Required for the `create` command)
+A comma separated list of redirect URIs. This will form a list of allowed redirect URIs to call back after authentication.
+
+### `--scopes=<SCOPES>`
+
+(Required for the `create` command)
+A comma separated list of scopes required by your Snyk App. This will for a list of scopes that your app is allowed to request during authorization.
+
+## Examples
+
+### `Create Snyk App`
+
+\$ snyk apps create --experimental --org=48ebb069-472f-40f4-b5bf-d2d103bc02d4 --name='My Awesome App' --redirect-uris=https://example1.com,https://example2.com --scopes=apps:beta
+
+### `Create Snyk App Interactive Mode`
+
+\$ snyk apps create --experimental --interactive

--- a/src/cli/commands/apps/create-app.ts
+++ b/src/cli/commands/apps/create-app.ts
@@ -1,0 +1,57 @@
+import * as Debug from 'debug';
+import {
+  EAppsURL,
+  getAppsURL,
+  handleCreateAppRes,
+  handleV3Error,
+  ICreateAppRequest,
+  ICreateAppResponse,
+  SNYK_APP_DEBUG,
+} from '../../../lib/apps';
+import { makeRequestV3 } from '../../../lib/request/promise';
+import { spinner } from '../../../lib/spinner';
+
+const debug = Debug(SNYK_APP_DEBUG);
+
+/**
+ * Function to process the app creation request and
+ * handle any errors that are request error and print
+ * in a formatted string. It throws is error is unknown
+ * or cannot be handled.
+ * @param {ICreateAppRequest} data to create the app
+ * @returns {String} response formatted string
+ */
+export async function createApp(
+  data: ICreateAppRequest,
+): Promise<string | void> {
+  debug('App data', data);
+  const {
+    orgId,
+    snykAppName: name,
+    snykAppRedirectUris: redirectUris,
+    snykAppScopes: scopes,
+  } = data;
+  const payload = {
+    method: 'POST',
+    url: getAppsURL(EAppsURL.CREATE_APP, { orgId }),
+    body: {
+      name,
+      redirectUris,
+      scopes,
+    },
+    qs: {
+      version: '2021-08-11~experimental',
+    },
+  };
+
+  try {
+    await spinner('Creating your Snyk App');
+    const response = await makeRequestV3<ICreateAppResponse>(payload);
+    debug(response);
+    spinner.clearAll();
+    return handleCreateAppRes(response);
+  } catch (error) {
+    spinner.clearAll();
+    handleV3Error(error);
+  }
+}

--- a/src/cli/commands/apps/index.ts
+++ b/src/cli/commands/apps/index.ts
@@ -1,0 +1,47 @@
+import * as Debug from 'debug';
+import { MethodArgs } from '../../args';
+import { processCommandArgs } from '../process-command-args';
+import {
+  EValidSubCommands,
+  validAppsSubCommands,
+  SNYK_APP_DEBUG,
+  ICreateAppOptions,
+  AppsErrorMessages,
+} from '../../../lib/apps';
+
+import { createApp } from './create-app';
+// import * as path from 'path';
+import {
+  createAppDataInteractive,
+  createAppDataScriptable,
+} from '../../../lib/apps/create-app';
+import help from '../help';
+
+const debug = Debug(SNYK_APP_DEBUG);
+
+export default async function apps(
+  ...args0: MethodArgs
+): Promise<string | undefined | any> {
+  debug('Snyk apps CLI called');
+
+  const { options, paths } = processCommandArgs<ICreateAppOptions>(...args0);
+  debug(options, paths);
+
+  const commandVerb1 = paths[0];
+  const validCommandVerb =
+    commandVerb1 && validAppsSubCommands.includes(commandVerb1);
+  if (!validCommandVerb) {
+    // Display help md for apps
+    debug(`Unknown subcommand: ${commandVerb1}`);
+    return help('apps');
+  }
+  // Check if experimental flag is being used
+  if (!options.experimental) throw new Error(AppsErrorMessages.useExperimental);
+
+  if (commandVerb1 === EValidSubCommands.CREATE) {
+    const createAppData = options.interactive
+      ? await createAppDataInteractive()
+      : createAppDataScriptable(options);
+    return await createApp(createAppData);
+  }
+}

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -20,6 +20,7 @@ const commands = {
   wizard: async (...args) => callModule(import('./protect/wizard'), args),
   woof: async (...args) => callModule(import('./woof'), args),
   log4shell: async (...args) => callModule(import('./log4shell'), args),
+  apps: async (...args) => callModule(import('./apps'), args),
 };
 
 commands.aliases = abbrev(Object.keys(commands));

--- a/src/lib/apps/constants.ts
+++ b/src/lib/apps/constants.ts
@@ -1,0 +1,57 @@
+import chalk from 'chalk';
+
+export const SNYK_APP_NAME = 'snykAppName';
+export const SNYK_APP_REDIRECT_URIS = 'snykAppRedirectUris';
+export const SNYK_APP_SCOPES = 'snykAppScopes';
+export const SNYK_APP_CLIENT_ID = 'snykAppClientId';
+export const SNYK_APP_ORG_ID = 'snykAppOrgId';
+export const SNYK_APP_DEBUG = 'snyk:apps';
+
+export enum EValidSubCommands {
+  CREATE = 'create',
+}
+
+export enum EAppsURL {
+  CREATE_APP,
+}
+
+export const validAppsSubCommands = Object.values<string>(EValidSubCommands);
+
+export const AppsErrorMessages = {
+  orgRequired: `Option '--org' is required! For interactive mode, please use '--interactive' or '-i' flag. For more information please run the help command 'snyk apps --help' or 'snyk apps -h'.`,
+  nameRequired: `Option '--name' is required! For interactive mode, please use '--interactive' or '-i' flag. For more information please run the help command 'snyk apps --help' or 'snyk apps -h'.`,
+  redirectUrisRequired: `Option '--redirect-uris' is required! For interactive mode, please use '--interactive' or '-i' flag. For more information please run the help command 'snyk apps --help' or 'snyk apps -h'.`,
+  scopesRequired: `Option '--scopes' is required! For interactive mode, please use '--interactive' or '-i' flag. For more information please run the help command 'snyk apps --help' or 'snyk apps -h'.`,
+  useExperimental: `\n${chalk.redBright(
+    "All 'apps' commands are only accessible behind the '--experimental' flag.",
+  )}\n 
+The behaviour can change at any time, without prior notice. 
+You are kindly advised to use all the commands with caution.
+  
+${chalk.bold('Usage')}
+  ${chalk.italic('snyk apps <COMMAND> --experimental')}\n`,
+};
+
+export const CreateAppPromptData = {
+  SNYK_APP_NAME: {
+    name: SNYK_APP_NAME,
+    message: `Name of the Snyk App (visible to users when they install the Snyk App)?`,
+  },
+  SNYK_APP_REDIRECT_URIS: {
+    name: SNYK_APP_REDIRECT_URIS,
+    message: `Your Snyk App's redirect URIs (comma seprated list. ${chalk.yellowBright(
+      ' Ex: https://example1.com,https://example2.com',
+    )})?: `,
+  },
+  SNYK_APP_SCOPES: {
+    name: SNYK_APP_SCOPES,
+    message: `Your Snyk App's permission scopes (comma separated list. ${chalk.yellowBright(
+      ' Ex: apps:beta',
+    )})?: `,
+  },
+  SNYK_APP_ORG_ID: {
+    name: SNYK_APP_ORG_ID,
+    message:
+      'Please provide the org id under which you want to create your Snyk App: ',
+  },
+};

--- a/src/lib/apps/create-app/index.ts
+++ b/src/lib/apps/create-app/index.ts
@@ -1,0 +1,73 @@
+import {
+  AppsErrorMessages,
+  createAppPrompts,
+  ICreateAppRequest,
+  ICreateAppOptions,
+  SNYK_APP_NAME,
+  SNYK_APP_REDIRECT_URIS,
+  SNYK_APP_SCOPES,
+  SNYK_APP_ORG_ID,
+  validateUUID,
+  validateAllURL,
+} from '..';
+import * as inquirer from '@snyk/inquirer';
+import { ValidationError } from '../../errors';
+
+/**
+ * Validates and parsed the data required to create app.
+ * Throws error if option is not provided or is invalid
+ * @param {ICreateAppOptions} options required to create an app
+ * @returns {ICreateAppRequest} data that is used to make the request
+ */
+export function createAppDataScriptable(
+  options: ICreateAppOptions,
+): ICreateAppRequest {
+  if (!options.org) {
+    throw new ValidationError(AppsErrorMessages.orgRequired);
+  } else if (typeof validateUUID(options.org) === 'string') {
+    // Combines to form "Invalid UUID provided for org id"
+    throw new ValidationError(`${validateUUID(options.org)} for org id`);
+  } else if (!options.name) {
+    throw new ValidationError(AppsErrorMessages.nameRequired);
+  } else if (!options['redirect-uris']) {
+    throw new ValidationError(AppsErrorMessages.redirectUrisRequired);
+  } else if (typeof validateAllURL(options['redirect-uris']) === 'string') {
+    throw new ValidationError(
+      validateAllURL(options['redirect-uris']) as string,
+    );
+  } else if (!options.scopes) {
+    throw new ValidationError(AppsErrorMessages.scopesRequired);
+  } else {
+    return {
+      orgId: options.org,
+      snykAppName: options.name,
+      snykAppRedirectUris: options['redirect-uris']
+        .replace(/\s+/g, '')
+        .split(','),
+      snykAppScopes: options.scopes.replace(/\s+/g, '').split(','),
+    };
+  }
+}
+
+// Interactive format
+export async function createAppDataInteractive(): Promise<ICreateAppRequest> {
+  // Proceed with interactive
+  const answers = await inquirer.prompt(createAppPrompts);
+  // Process answers
+  const snykAppName = answers[SNYK_APP_NAME].trim() as string;
+  const snykAppRedirectUris = answers[SNYK_APP_REDIRECT_URIS].replace(
+    /\s+/g,
+    '',
+  ).split(',') as string[];
+  const snykAppScopes = answers[SNYK_APP_SCOPES].replace(/\s+/g, '').split(
+    ',',
+  ) as string[];
+  const orgId = answers[SNYK_APP_ORG_ID].trim() as string;
+  // POST: to create an app
+  return {
+    orgId,
+    snykAppName,
+    snykAppRedirectUris,
+    snykAppScopes,
+  };
+}

--- a/src/lib/apps/index.ts
+++ b/src/lib/apps/index.ts
@@ -1,0 +1,6 @@
+export * from './constants';
+export * from './prompts';
+export * from './types';
+export * from './v3-utils';
+export * from './utils';
+export * from './input-validator';

--- a/src/lib/apps/input-validator.ts
+++ b/src/lib/apps/input-validator.ts
@@ -1,0 +1,60 @@
+import * as uuid from 'uuid';
+
+/**
+ *
+ * @param {String} input of space separated URL/URI passed by
+ * user for redirect URIs
+ * @returns { String | Boolean } complying with inquirer return values, the function
+ * separates the string on space and validates each to see
+ * if a valid URL/URI. Return a string if invalid and
+ * boolean true if valid
+ */
+export function validateAllURL(input: string): string | boolean {
+  const trimmedInput = input.trim();
+  let errMessage = '';
+  for (const i of trimmedInput.split(',')) {
+    if (typeof validURL(i) == 'string')
+      errMessage = errMessage + `\n${validURL(i)}`;
+  }
+
+  if (errMessage) return errMessage;
+  return true;
+}
+
+/**
+ * Custom validation logic which takes in consideration
+ * creation of Snyk Apps and thus allows localhost.com
+ * as a valid URL.
+ * @param {String} input of URI/URL value to validate using
+ * regex
+ * @returns {String | Boolean } string message is not valid
+ * and boolean true if valid
+ */
+export function validURL(input: string): boolean | string {
+  try {
+    new URL(input);
+    return true;
+  } catch (error) {
+    return `${input} is not a valid URL`;
+  }
+}
+
+/**
+ * Function validates if a valid UUID (version of UUID not tacken into account)
+ * @param {String} input UUID to be validated
+ * @returns {String | Boolean } string message is not valid
+ * and boolean true if valid
+ */
+export function validateUUID(input: string): boolean | string {
+  return uuid.validate(input) ? true : 'Invalid UUID provided';
+}
+
+/**
+ * @param {String} input
+ * @returns {String | Boolean } string message is not valid
+ * and boolean true if valid
+ */
+export function validInput(input: string): string | boolean {
+  if (!input) return 'Please enter something';
+  return true;
+}

--- a/src/lib/apps/prompts.ts
+++ b/src/lib/apps/prompts.ts
@@ -1,0 +1,28 @@
+import { CreateAppPromptData } from './constants';
+import { validInput, validateAllURL, validateUUID } from './input-validator';
+
+/**
+ * Prompts for $snyk apps create command
+ */
+export const createAppPrompts = [
+  {
+    name: CreateAppPromptData.SNYK_APP_NAME.name,
+    message: CreateAppPromptData.SNYK_APP_NAME.message,
+    validate: validInput,
+  },
+  {
+    name: CreateAppPromptData.SNYK_APP_REDIRECT_URIS.name,
+    message: CreateAppPromptData.SNYK_APP_REDIRECT_URIS.message,
+    validate: validateAllURL,
+  },
+  {
+    name: CreateAppPromptData.SNYK_APP_SCOPES.name,
+    message: CreateAppPromptData.SNYK_APP_SCOPES.message,
+    validate: validInput,
+  },
+  {
+    name: CreateAppPromptData.SNYK_APP_ORG_ID.name,
+    message: CreateAppPromptData.SNYK_APP_ORG_ID.message,
+    validate: validateUUID,
+  },
+];

--- a/src/lib/apps/types.ts
+++ b/src/lib/apps/types.ts
@@ -1,0 +1,57 @@
+export interface IGetAppsURLOpts {
+  orgId?: string;
+  clientId?: string;
+}
+
+interface IJSONApi {
+  version: string;
+}
+
+export interface ICreateAppResponse {
+  jsonapi: IJSONApi;
+  data: {
+    type: string;
+    id: string;
+    attributes: {
+      name: string;
+      clientId: string;
+      redirectUris: string[];
+      scopes: string[];
+      isPublic: boolean;
+      clientSecret: string;
+    };
+    links: {
+      self: string;
+    };
+  };
+}
+
+export interface IV3ErrorResponse {
+  jsonapi: IJSONApi;
+  errors: [
+    {
+      status: string;
+      detail: string;
+      source?: any;
+      meta?: any;
+    },
+  ];
+}
+
+export interface IGenerateAppsOptions {
+  interactive?: boolean;
+}
+
+export interface ICreateAppOptions extends IGenerateAppsOptions {
+  org?: string;
+  name?: string;
+  redirectUris?: string;
+  scopes?: string;
+}
+
+export interface ICreateAppRequest {
+  orgId: string;
+  snykAppName: string;
+  snykAppRedirectUris: string[];
+  snykAppScopes: string[];
+}

--- a/src/lib/apps/utils.ts
+++ b/src/lib/apps/utils.ts
@@ -1,0 +1,7 @@
+import * as fs from 'fs';
+import { renderMarkdown } from '../../cli/commands/help/markdown-renderer';
+
+export function readAppsHelpMarkdown(filename: string): string {
+  const file = fs.readFileSync(filename, 'utf8');
+  return renderMarkdown(file);
+}

--- a/src/lib/apps/v3-utils.ts
+++ b/src/lib/apps/v3-utils.ts
@@ -1,0 +1,121 @@
+/**
+ * Collection of utility function for the
+ * $snyk apps commands
+ */
+import {
+  EAppsURL,
+  ICreateAppResponse,
+  IGetAppsURLOpts,
+  IV3ErrorResponse,
+  SNYK_APP_DEBUG,
+} from '.';
+import chalk from 'chalk';
+import { AuthFailedError, InternalServerError } from '../errors';
+import * as Debug from 'debug';
+import config from '../config';
+
+const debug = Debug(SNYK_APP_DEBUG);
+
+export function getAppsURL(
+  selection: EAppsURL,
+  opts: IGetAppsURLOpts = {},
+): string {
+  // Get the V3 URL from user config
+  // Environment variable takes precendence over config
+  const baseURL = config.API_V3_URL;
+  debug(`API v3 base URL => ${baseURL}`);
+
+  switch (selection) {
+    case EAppsURL.CREATE_APP:
+      return `${baseURL}/orgs/${opts.orgId}/apps`;
+    default:
+      throw new Error('Invalid selection for URL');
+  }
+}
+
+export function handleV3Error(error: any): void {
+  if (error.code) {
+    if (error.code === 400) {
+      // Bad request
+      const responseJSON: IV3ErrorResponse = error.body;
+      const errString = errorsToDisplayString(responseJSON);
+      throw new Error(errString);
+    } else if (error.code === 401) {
+      // Unauthorized
+      throw AuthFailedError();
+    } else if (error.code === 403) {
+      throw new Error(
+        'Forbidden! the authentication token does not have access to the resource.',
+      );
+    } else if (error.code === 404) {
+      const responseJSON: IV3ErrorResponse = error.body;
+      const errString = errorsToDisplayString(responseJSON);
+      throw new Error(errString);
+    } else if (error.code === 500) {
+      throw new InternalServerError('Internal server error');
+    } else {
+      throw new Error(error.message);
+    }
+  } else {
+    throw error;
+  }
+}
+
+/**
+ * @param errRes V3Error response
+ * @returns {String} Iterates over error and
+ * converts them into a readible string
+ */
+function errorsToDisplayString(errRes: IV3ErrorResponse): string {
+  const resString = `Uh oh! an error occurred while trying to create the Snyk App.
+Please run the command with '--debug' or '-d' to get more information`;
+  if (!errRes.errors) return resString;
+  errRes.errors.forEach((e) => {
+    let metaString = '',
+      sourceString = '';
+    if (e.meta) {
+      for (const [key, value] of Object.entries(e.meta)) {
+        metaString += `${key}: ${value}\n`;
+      }
+    }
+    if (e.source) {
+      for (const [key, value] of Object.entries(e.source)) {
+        sourceString += `${key}: ${value}\n`;
+      }
+    }
+
+    const meta = metaString || '-';
+    const source = sourceString || '-';
+
+    return `Uh oh! an error occured while trying to create the Snyk App.
+  
+Error Description:\t${e.detail}
+Request Status:\t${e.status}
+Source:\t${source}
+Meta:\t${meta}`;
+  });
+  return resString;
+}
+
+export function handleCreateAppRes(res: ICreateAppResponse): string {
+  const {
+    name,
+    clientId,
+    redirectUris,
+    scopes,
+    isPublic,
+    clientSecret,
+  } = res.data.attributes;
+
+  return `Snyk App created successfully!
+Please ensure you save the following details:
+
+App Name:\t${name}
+Client ID:\t${clientId}
+Redirect URIs:\t${redirectUris}
+Scopes:\t${scopes}
+Is App Public:\t${isPublic}
+Client Secret (${chalk.redBright(
+    'keep it safe and protected',
+  )}):\t${clientSecret}`;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -9,6 +9,7 @@ interface Config {
   MAX_PATH_COUNT: number;
   API: string;
   api: string;
+  API_V3_URL: string;
   disableSuggestions: string;
   org: string;
   ROOT: string;

--- a/src/lib/request/promise.ts
+++ b/src/lib/request/promise.ts
@@ -1,3 +1,4 @@
+import { getAuthHeader } from '../api-token';
 import * as request from './index';
 
 export async function makeRequest<T>(payload: any): Promise<T> {
@@ -13,6 +14,34 @@ export async function makeRequest<T>(payload: any): Promise<T> {
         });
       }
       resolve(body);
+    });
+  });
+}
+
+/**
+ * All v3 request will essentially be the same and are JSON by default
+ * Thus if no headers provided default headers are used
+ * @param {any} payload for the request
+ * @returns
+ */
+export async function makeRequestV3<T>(payload: any): Promise<T> {
+  return new Promise((resolve, reject) => {
+    payload.headers = payload.headers ?? {
+      'Content-Type': 'application/vnd.api+json',
+      authorization: getAuthHeader(),
+    };
+    payload.json = true;
+    request.makeRequest(payload, (error, res, body) => {
+      if (error) {
+        return reject(error);
+      }
+      if (res.statusCode >= 400) {
+        return reject({
+          code: res.statusCode,
+          body: JSON.parse(body as any),
+        });
+      }
+      resolve(JSON.parse(body as any) as T);
     });
   });
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -252,6 +252,7 @@ export enum SupportedCliCommands {
   wizard = 'wizard',
   woof = 'woof',
   log4shell = 'log4shell',
+  apps = 'apps',
 }
 
 export interface IacFileInDirectory {

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -84,6 +84,8 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
 
   const app = express();
   app.use(bodyParser.json({ limit: '50mb' }));
+  // Content-Type for v3 API endpoints is 'application/vnd.api+json'
+  app.use(express.json({ type: 'application/vnd.api+json', strict: false }));
   app.use((req, res, next) => {
     requests.push(req);
     next();
@@ -442,6 +444,36 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       uri: `${req.params.registry}/some/project-id`,
       isMonitored: true,
     });
+  });
+
+  // Apps endpoint
+  app.post(`${basePath}/orgs/:orgId/apps`, (req, res) => {
+    const { orgId } = req.params;
+    const name = req.body.name;
+    const redirectUris = req.body.redirectUris;
+    const scopes = req.body.scopes;
+    res.send(
+      JSON.stringify({
+        jsonapi: {
+          version: '1.0',
+        },
+        data: {
+          type: 'app',
+          id: '84144c1d-a491-4fe5-94d1-ba143ba71b6d',
+          attributes: {
+            name,
+            clientId: '9f26c6c6-e04b-4310-8ce4-c3a6289d0633',
+            redirectUris,
+            scopes,
+            isPublic: false,
+            clientSecret: 'super-secret-client-secret',
+          },
+          links: {
+            self: `/orgs/${orgId}/apps?version=2021-08-11~experimental`,
+          },
+        },
+      }),
+    );
   });
 
   app.post(basePath + '/track-iac-usage/cli', (req, res) => {

--- a/test/jest/acceptance/snyk-apps/create-app.spec.ts
+++ b/test/jest/acceptance/snyk-apps/create-app.spec.ts
@@ -1,0 +1,266 @@
+import { runSnykCLI, runSnykCLIWithUserInputs } from '../../util/runSnykCLI';
+import { fakeServer } from '../../../acceptance/fake-server';
+
+// const DOWN = '\x1B\x5B\x42';
+// const UP = '\x1B\x5B\x41';
+const ENTER = '\x0D';
+// const SPACE = '\x20';
+
+describe('snyk-apps: create app', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+    const baseApi = '/v3';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_API_V3_URL: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_DISABLE_ANALYTICS: '1',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    server.listen(port, () => {
+      done();
+    });
+  });
+
+  afterEach(async () => {
+    jest.resetAllMocks();
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  const orgId = '4e0828f9-d92a-4f54-b005-6b9d8150b75f';
+  const testData = {
+    appName: 'Test',
+    redirectURIs: 'https://example.com,https://example1.com',
+    scopes: 'org.read',
+    orgId,
+  };
+
+  /**
+   * Test experimental feature flag functionality
+   */
+  describe('experimental flag', () => {
+    it('should throw error without the experimental flag', async () => {
+      const { stdout } = await runSnykCLI('apps create');
+      expect(stdout).toContain(
+        `All 'apps' commands are only accessible behind the '--experimental' flag.`,
+      );
+    });
+  });
+
+  /**
+   * Help command validation when invalid apps subcommand called
+   * TODO: breakdown test blocks to different file when more
+   * are added
+   */
+  describe('help', () => {
+    it('should print the apps helps document when apps subcommand invalid', async () => {
+      const { stdout } = await runSnykCLI('apps invalid');
+      // Check for first line to confirm help docs were indeed printed
+      // Snapshot testing can lead to flaky test due to varying screen width
+      expect(stdout).toContain(
+        'Snyk Apps are integrations that extend the functionality of the Snyk platform',
+      );
+    });
+  });
+  /**
+   * Tests for the interactive mode of the command to create apps.
+   * Using Jest snapshot testing led to very flaky behaviour.
+   * Suspected due to changing screen width
+   */
+  describe('interactive mode', () => {
+    it('should prompt for app name and print error if not provided', async () => {
+      const { stdout } = await runSnykCLIWithUserInputs(
+        'apps create --interactive --experimental',
+        [ENTER],
+        {
+          env,
+        },
+      );
+      // Assert for first question that is the name and error when no name provided
+      expect(stdout).toContain(
+        'Name of the Snyk App (visible to users when they install the Snyk App)?',
+      );
+      expect(stdout).toContain('Please enter something');
+    });
+
+    it('should prompt for redirect uris and print error if not provided', async () => {
+      const { stdout } = await runSnykCLIWithUserInputs(
+        'apps create --interactive --experimental',
+        [testData.appName, ENTER, 'something#invalid', ENTER],
+        {
+          env,
+        },
+      );
+      // Assert if URI validator is working or not
+      expect(stdout).toContain(
+        "Your Snyk App's redirect URIs (comma seprated list.",
+      );
+      expect(stdout).toContain('something#invalid is not a valid URL');
+    });
+
+    it('should prompt for scopes and print error if not provided', async () => {
+      const {
+        stdout,
+      } = await runSnykCLIWithUserInputs(
+        'apps create --interactive --experimental',
+        [testData.appName, ENTER, testData.redirectURIs, ENTER, ENTER],
+        { env },
+      );
+      // Assert
+      expect(stdout).toContain("Your Snyk App's permission scopes");
+      expect(stdout).toContain('Please enter something');
+    });
+
+    it('should prompt for org id and use default if not provided', async () => {
+      const {
+        stdout,
+      } = await runSnykCLIWithUserInputs(
+        'apps create --interactive --experimental',
+        [
+          testData.appName,
+          ENTER,
+          testData.redirectURIs,
+          ENTER,
+          testData.scopes,
+          ENTER,
+          ENTER,
+        ],
+        { env },
+      );
+      // Assert
+      expect(stdout).toContain('Please provide the org id under which');
+    });
+
+    it('should create app with user provided data (interactive mode)', async () => {
+      const {
+        stdout,
+        code,
+      } = await runSnykCLIWithUserInputs(
+        'apps create --interactive --experimental',
+        [
+          testData.appName,
+          ENTER,
+          testData.redirectURIs,
+          ENTER,
+          testData.scopes,
+          ENTER,
+          testData.orgId,
+          ENTER,
+        ],
+        { env },
+      );
+      // Assert
+      expect(code).toBe(0);
+      expect(stdout).toContain('Snyk App created successfully!');
+      expect(stdout).toContain(`${testData.appName}`);
+      expect(stdout).toContain(`${testData.redirectURIs}`);
+      expect(stdout).toContain(`${testData.scopes}`);
+    });
+
+    // Interactive mode with flag shortcut (-i)
+    it('should prompt users for input with flag shortcut (-i)', async () => {
+      const { stdout } = await runSnykCLIWithUserInputs(
+        'apps create -i --experimental',
+        [ENTER],
+        {
+          env,
+        },
+      );
+      // Assert for first question that is the name if presented all is working as expected
+      expect(stdout).toContain(
+        'Name of the Snyk App (visible to users when they install the Snyk App)?',
+      );
+    });
+  });
+
+  /**
+   * Scriptable mode testing
+   */
+  describe('scriptable mode', () => {
+    it('should throw error when org id not provided', async () => {
+      const {
+        code,
+        stdout,
+      } = await runSnykCLI(
+        `apps create --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+        { env },
+      );
+      // Assert
+      expect(code).toBe(2);
+      expect(stdout).toContain(
+        "Option '--org' is required! For interactive mode, please use '--interactive' or '-i' flag",
+      );
+    });
+
+    it('should throw error when app name not provided', async () => {
+      const {
+        code,
+        stdout,
+      } = await runSnykCLI(
+        `apps create --org=${testData.orgId} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+        { env },
+      );
+      // Assert
+      expect(code).toBe(2);
+      expect(stdout).toContain(
+        "Option '--name' is required! For interactive mode, please use '--interactive' or '-i' flag",
+      );
+    });
+
+    it('should throw error when redirect uris not provided', async () => {
+      const {
+        code,
+        stdout,
+      } = await runSnykCLI(
+        `apps create --org=${testData.orgId} --name=${testData.appName} --scopes=${testData.scopes} --experimental`,
+        { env },
+      );
+      // Assert
+      expect(code).toBe(2);
+      expect(stdout).toContain(
+        "Option '--redirect-uris' is required! For interactive mode, please use '--interactive' or '-i' flag",
+      );
+    });
+
+    it('shoud throw error when scopes not provided', async () => {
+      const {
+        code,
+        stdout,
+      } = await runSnykCLI(
+        `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --experimental`,
+        { env },
+      );
+      expect(code).toBe(2);
+      expect(stdout).toContain(
+        "Option '--scopes' is required! For interactive mode, please use '--interactive' or '-i' flag",
+      );
+    });
+
+    it('should create app with user provided data', async () => {
+      const {
+        code,
+        stdout,
+      } = await runSnykCLI(
+        `apps create --org=${testData.orgId} --name=${testData.appName} --redirect-uris=${testData.redirectURIs} --scopes=${testData.scopes} --experimental`,
+        { env },
+      );
+      // Assert
+      expect(code).toBe(0);
+      expect(stdout).toContain('Snyk App created successfully!');
+      expect(stdout).toContain(`${testData.appName}`);
+      expect(stdout).toContain(`${testData.redirectURIs}`);
+      expect(stdout).toContain(`${testData.scopes}`);
+    });
+  });
+});

--- a/test/jest/unit/lib/apps/input-validator.spec.ts
+++ b/test/jest/unit/lib/apps/input-validator.spec.ts
@@ -1,0 +1,60 @@
+import {
+  validateAllURL,
+  validInput,
+  validURL,
+} from '../../../../../src/lib/apps/input-validator';
+
+describe('input validation for snyk apps', () => {
+  // No unit test for validation uuid as we use built function
+  describe('validate url', () => {
+    const urlTable = [
+      ['https://example.com', true],
+      ['https://example.com/callback', true],
+      // Demo apps and for testing apps running locally
+      ['localhost:3000/callback', true],
+      ['localhost:3000/callback,something', true],
+      ['localhost:3000', true],
+      // inquirer validation return string message when false
+      ['#somethig-wrong.com', '#somethig-wrong.com is not a valid URL'],
+      ['#somethig-wrong', '#somethig-wrong is not a valid URL'],
+      ['somethig wrong', 'somethig wrong is not a valid URL'],
+      ['somethig&wrong.com', 'somethig&wrong.com is not a valid URL'],
+    ];
+
+    it.each(urlTable)("validate individual url '%s'", (url, valid) => {
+      expect(validURL(url as string)).toBe(valid);
+    });
+  });
+
+  describe('validate input', () => {
+    it('should return error message for empty input', () => {
+      const res = validInput('');
+      expect(res).toBe('Please enter something');
+    });
+
+    it('should return boolean true for valid input', () => {
+      const res = validInput('My Awesome App');
+      expect(res).toBe(true);
+    });
+  });
+
+  describe('validate all url string', () => {
+    // Expected that input is a comma separated list of url
+    it('should return error message if one or more url invalid', () => {
+      const res = validateAllURL(
+        'something wrong,#something-wrong,localhost:3000,https://example.com',
+      );
+      // Contain the invalid url
+      expect(res).toContain('something wrong is not a valid URL');
+      expect(res).toContain('#something-wrong is not a valid URL');
+      // Not to contain valid url
+      expect(res).not.toContain('localhost:3000');
+      expect(res).not.toContain('https://example.com');
+    });
+
+    it('should return true if all url valid', () => {
+      const res = validateAllURL('localhost:3000/callback,https://example.com');
+      expect(res).toBe(true);
+    });
+  });
+});

--- a/test/jest/util/runCommand.ts
+++ b/test/jest/util/runCommand.ts
@@ -41,4 +41,62 @@ const runCommand = (
   });
 };
 
-export { runCommand, RunCommandResult, RunCommandOptions };
+function runCommandsWithUserInputs(
+  command: string,
+  args: string[] = [],
+  inputs: string[] = [],
+  options?: RunCommandOptions,
+): Promise<any> {
+  const timeout = 100;
+  const childProcess = spawn(command, args, options);
+
+  // Creates a loop to feed user inputs to the child process
+  // in order to get results from the tool
+  // This code is heavily inspired (if not blantantly copied)
+  // from inquirer-test package
+  const loop = (inputs) => {
+    if (!inputs.length) {
+      childProcess.stdin.end();
+      return;
+    }
+
+    setTimeout(() => {
+      childProcess.stdin.write(inputs[0]);
+      loop(inputs.slice(1));
+    }, timeout);
+  };
+
+  return new Promise((resolve, reject) => {
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+
+    childProcess.on('error', (error) => {
+      reject(error);
+    });
+
+    childProcess.stdout.on('data', (chunk) => {
+      stdout.push(Buffer.from(chunk));
+    });
+
+    childProcess.stderr.on('data', (chunk) => {
+      stderr.push(Buffer.from(chunk));
+    });
+
+    childProcess.on('close', (code) => {
+      resolve({
+        code: code || 0,
+        stdout: Buffer.concat(stdout).toString('utf-8'),
+        stderr: Buffer.concat(stderr).toString('utf-8'),
+      });
+    });
+
+    loop(inputs);
+  });
+}
+
+export {
+  runCommand,
+  runCommandsWithUserInputs,
+  RunCommandResult,
+  RunCommandOptions,
+};

--- a/test/jest/util/runSnykCLI.ts
+++ b/test/jest/util/runSnykCLI.ts
@@ -1,5 +1,10 @@
 import * as path from 'path';
-import { runCommand, RunCommandResult, RunCommandOptions } from './runCommand';
+import {
+  runCommand,
+  runCommandsWithUserInputs,
+  RunCommandResult,
+  RunCommandOptions,
+} from './runCommand';
 
 const cwd = process.cwd();
 
@@ -12,4 +17,19 @@ const runSnykCLI = async (
   return await runCommand('node', [cliPath, ...args], options);
 };
 
-export { runSnykCLI };
+const runSnykCLIWithUserInputs = async (
+  argsString: string,
+  inputs: string[],
+  options?: RunCommandOptions,
+): Promise<any> => {
+  const cliPath = path.resolve(cwd, './bin/snyk');
+  const args = argsString.split(' ').filter((v) => !!v);
+  return await runCommandsWithUserInputs(
+    'node',
+    [cliPath, ...args],
+    inputs,
+    options,
+  );
+};
+
+export { runSnykCLI, runSnykCLIWithUserInputs };


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds `$snyk apps` command to the Snyk CLI. This command is available only under the `--experimental` flag. Example: `$snyk apps create --experimental`

The current PR only focuses on the `create` sub-command. There are two modes of the command 
1. `interactive` mode available with the `--interactive` or the `-i` flag. Example: `$ snyk apps create -i --experimental`
2. `scriptable` mode which is the default but has required options. Example: `$ snyk apps create --experimental --org=<your-org-id> --name=<your-snyk-app-name> --redirect-uris=https://example1.com,HTTP://example2.com` --scopes=apps:beta` 

Changes that this PR makes:
- `create` command to create a Snyk App
- `config` value `V3endpoint` to configure the Snyk V3 API endpoint base URL
- Initial acceptance to test the `create` command

#### Where should the reviewer start?

- `src/cli/commands/apps`

#### How should this be manually tested?



#### Any background context you want to provide?

We at `#team-moose` are starting our investigation to see how to provide users with a CLI to manage Snyk Apps. We have had a discussion with `#team-hammer` in the past and this is our first effort at doing so.
