### PR TITLE
fix: enable checksum metric for local scans

### DIFF
--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -6,7 +6,6 @@ import { computeCustomRulesBundleChecksum } from './file-utils';
 export function addIacAnalytics(
   formattedResults: FormattedResult[],
   ignoredIssuesCount: number,
-  isLocalCustomRules: boolean,
 ): void {
   let totalIssuesCount = 0;
   const customRulesIdsFoundInIssues: { [customRuleId: string]: true } = {};
@@ -49,12 +48,10 @@ export function addIacAnalytics(
     'iac-custom-rules-issues-percentage',
     calculatePercentage(issuesFromCustomRulesCount, totalIssuesCount),
   );
-  if (!isLocalCustomRules) {
-    analytics.add(
-      'iac-custom-rules-checksum',
-      computeCustomRulesBundleChecksum(),
-    );
-  }
+  analytics.add(
+    'iac-custom-rules-checksum',
+    computeCustomRulesBundleChecksum(),
+  );
   analytics.add('iac-custom-rules-coverage-count', uniqueCustomRulesCount);
 }
 

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -127,7 +127,7 @@ export async function test(
       // run their tests by squashing the error.
     }
 
-    addIacAnalytics(filteredIssues, ignoreCount, !!customRulesPath);
+    addIacAnalytics(filteredIssues, ignoreCount);
 
     // TODO: add support for proper typing of old TestResult interface.
     return {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Lets us send the checksum of local scans for analytics.
