### PR TITLE
fix: exclude application vulns from filtering

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -253,7 +253,7 @@ export async function main(): Promise<void> {
       throw new UnsupportedOptionCombinationError([
         'Application vulnerabilities is currently not supported with JSON output. ' +
           'Please try using —app-vulns only to get application vulnerabilities, or ' +
-          '—json only to get your image vulnerabilties, excluding the application ones.',
+          '—json only to get your image vulnerabilities, excluding the application ones.',
       ]);
     }
     if (globalArgs.options['group-issues'] && globalArgs.options['iac']) {

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -435,7 +435,11 @@ function convertTestDepGraphResultToLegacy(
       ? undefined
       : options.severityThreshold;
 
-  if (options.docker && options.file && options['exclude-base-image-vulns']) {
+  if (
+    options.docker &&
+    dockerRes?.baseImage &&
+    options['exclude-base-image-vulns']
+  ) {
     vulns = vulns.filter((vuln) => (vuln as DockerIssue).dockerfileInstruction);
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,6 +89,7 @@ export interface Options {
   'fail-fast'?: boolean;
   tags?: string;
   'target-reference'?: string;
+  'exclude-base-image-vulns'?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/fixtures/container-projects/app-vuln-apk-fixture.json
+++ b/test/fixtures/container-projects/app-vuln-apk-fixture.json
@@ -1,0 +1,6188 @@
+{
+  "res": {
+    "meta": {
+      "isPrivate": true,
+      "isLicensesEnabled": false,
+      "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.22.1\nignore: {}\npatch: {}\n",
+      "ignoreSettings": null,
+      "org": "minsi.yang",
+      "licensesPolicy": {
+        "severities": {},
+        "orgLicenseRules": {
+          "AGPL-1.0": {
+            "licenseType": "AGPL-1.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "AGPL-3.0": {
+            "licenseType": "AGPL-3.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "Artistic-1.0": {
+            "licenseType": "Artistic-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "Artistic-2.0": {
+            "licenseType": "Artistic-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "CDDL-1.0": {
+            "licenseType": "CDDL-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "CPOL-1.02": {
+            "licenseType": "CPOL-1.02",
+            "severity": "high",
+            "instructions": ""
+          },
+          "EPL-1.0": {
+            "licenseType": "EPL-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "GPL-2.0": {
+            "licenseType": "GPL-2.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "GPL-3.0": {
+            "licenseType": "GPL-3.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "LGPL-2.0": {
+            "licenseType": "LGPL-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "LGPL-2.1": {
+            "licenseType": "LGPL-2.1",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "LGPL-3.0": {
+            "licenseType": "LGPL-3.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MPL-1.1": {
+            "licenseType": "MPL-1.1",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MPL-2.0": {
+            "licenseType": "MPL-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MS-RL": {
+            "licenseType": "MS-RL",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "SimPL-2.0": {
+            "licenseType": "SimPL-2.0",
+            "severity": "high",
+            "instructions": ""
+          }
+        }
+      }
+    },
+    "result": {
+      "issuesData": {
+        "SNYK-ALPINE312-APKTOOLS-1246338": {
+          "title": "Out-of-bounds Read",
+          "credit": [
+            ""
+          ],
+          "packageName": "apk-tools",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `apk-tools` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nIn Alpine Linux apk-tools before 2.12.5, the tarball parser allows a buffer overflow and crash.\n## Remediation\nUpgrade `Alpine:3.12` `apk-tools` to version 2.10.6-r0 or higher.\n## References\n- [MISC](https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741)\n- [MISC](https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-30139"
+            ],
+            "CWE": [
+              "CWE-125"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "cvssScore": 7.5,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "MISC",
+              "url": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10741"
+            },
+            {
+              "title": "MISC",
+              "url": "https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606"
+            }
+          ],
+          "creationTime": "2021-04-15T03:45:07.931682Z",
+          "modificationTime": "2021-10-03T21:27:25.932909Z",
+          "publicationTime": "2021-04-15T03:45:07.947271Z",
+          "disclosureTime": "2021-04-21T16:15:00Z",
+          "id": "SNYK-ALPINE312-APKTOOLS-1246338",
+          "malicious": false,
+          "nvdSeverity": "high",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<2.10.6-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-APKTOOLS-1533753": {
+          "title": "Out-of-bounds Read",
+          "credit": [
+            ""
+          ],
+          "packageName": "apk-tools",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `apk-tools` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nlibfetch before 2021-07-26, as used in apk-tools, xbps, and other products, mishandles numeric strings for the FTP and HTTP protocols. The FTP passive mode implementation allows an out-of-bounds read because strtol is used to parse the relevant numbers into address bytes. It does not check if the line ends prematurely. If it does, the for-loop condition checks for the &#39;\\0&#39; terminator one byte too late.\n## Remediation\nUpgrade `Alpine:3.12` `apk-tools` to version 2.10.7-r0 or higher.\n## References\n- [MISC](https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch)\n- [MISC](https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749)\n- [MLIST](https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cdev.kafka.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cusers.kafka.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cdev.kafka.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cusers.kafka.apache.org%3E)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-36159"
+            ],
+            "CWE": [
+              "CWE-125"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "cvssScore": 9.1,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "MISC",
+              "url": "https://github.com/freebsd/freebsd-src/commits/main/lib/libfetch"
+            },
+            {
+              "title": "MISC",
+              "url": "https://gitlab.alpinelinux.org/alpine/apk-tools/-/issues/10749"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cdev.kafka.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r61db8e7dcb56dc000a5387a88f7a473bacec5ee01b9ff3f55308aacc@%3Cusers.kafka.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cdev.kafka.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rbf4ce74b0d1fa9810dec50ba3ace0caeea677af7c27a97111c06ccb7@%3Cusers.kafka.apache.org%3E"
+            }
+          ],
+          "creationTime": "2021-07-27T14:06:41.093570Z",
+          "modificationTime": "2021-10-03T21:38:21.648947Z",
+          "publicationTime": "2021-07-27T14:06:38.323743Z",
+          "disclosureTime": "2021-08-03T14:15:00Z",
+          "id": "SNYK-ALPINE312-APKTOOLS-1533753",
+          "malicious": false,
+          "nvdSeverity": "critical",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<2.10.7-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1089799": {
+          "title": "Improper Handling of Exceptional Conditions",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\ndecompress_gunzip.c in BusyBox through 1.32.1 mishandles the error bit on the huft_build result pointer, with a resultant invalid free or segmentation fault, via malformed gzip data.\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.32.1-r4 or higher.\n## References\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/)\n- [GENTOO](https://security.gentoo.org/glsa/202105-09)\n- [MISC](https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-28831"
+            ],
+            "CWE": [
+              "CWE-755"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "cvssScore": 7.5,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/3UDQGJRECXFS5EZVDH2OI45FMO436AC4/"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/Z7ZIFKPRR32ZYA3WAA2NXFA3QHHOU6FJ/"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/ZASBW7QRRLY5V2R44MQ4QQM4CZIDHM2U/"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202105-09"
+            },
+            {
+              "title": "MISC",
+              "url": "https://git.busybox.net/busybox/commit/?id=f25d254dfd4243698c31a4f3153d4ac72aa9e9bd"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2021/04/msg00001.html"
+            }
+          ],
+          "creationTime": "2021-03-31T03:45:09.434484Z",
+          "modificationTime": "2021-11-12T15:57:59.935783Z",
+          "publicationTime": "2021-03-31T03:45:09.443687Z",
+          "disclosureTime": "2021-03-19T05:15:00Z",
+          "id": "SNYK-ALPINE312-BUSYBOX-1089799",
+          "malicious": false,
+          "nvdSeverity": "high",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.32.1-r4"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920710": {
+          "title": "CVE-2021-42381",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42381"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:52:58.916293Z",
+          "modificationTime": "2021-11-12T15:52:58.920653Z",
+          "publicationTime": "2021-11-12T15:52:58.898238Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920710",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920711": {
+          "title": "CVE-2021-42379",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42379"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:53:02.462024Z",
+          "modificationTime": "2021-11-12T15:53:02.468085Z",
+          "publicationTime": "2021-11-12T15:53:02.430956Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920711",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920712": {
+          "title": "CVE-2021-42380",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42380"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:53:05.477938Z",
+          "modificationTime": "2021-11-12T15:53:05.480987Z",
+          "publicationTime": "2021-11-12T15:53:05.463526Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920712",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920717": {
+          "title": "CVE-2021-42374",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42374"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:54:19.394197Z",
+          "modificationTime": "2021-11-12T15:54:19.398706Z",
+          "publicationTime": "2021-11-11T16:06:33.834204Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920717",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920729": {
+          "title": "CVE-2021-42384",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42384"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:55:58.164395Z",
+          "modificationTime": "2021-11-12T15:55:58.167206Z",
+          "publicationTime": "2021-11-12T15:54:37.525613Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920729",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920730": {
+          "title": "CVE-2021-42385",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42385"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:56:01.195427Z",
+          "modificationTime": "2021-11-12T15:56:01.198092Z",
+          "publicationTime": "2021-11-12T15:54:28.310365Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920730",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920731": {
+          "title": "CVE-2021-42378",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42378"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:56:01.340753Z",
+          "modificationTime": "2021-11-12T15:56:01.345958Z",
+          "publicationTime": "2021-11-12T15:56:01.325166Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920731",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920739": {
+          "title": "CVE-2021-42386",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42386"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:56:09.702875Z",
+          "modificationTime": "2021-11-12T15:56:09.706346Z",
+          "publicationTime": "2021-11-12T15:54:40.152384Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920739",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920754": {
+          "title": "CVE-2021-42382",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42382"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:57:51.860733Z",
+          "modificationTime": "2021-11-12T15:57:51.863340Z",
+          "publicationTime": "2021-11-12T15:53:10.195605Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920754",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-BUSYBOX-1920758": {
+          "title": "CVE-2021-42383",
+          "credit": [
+            ""
+          ],
+          "packageName": "busybox",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `busybox` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nNone\n## Remediation\nUpgrade `Alpine:3.12` `busybox` to version 1.31.1-r21 or higher.\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-42383"
+            ],
+            "CWE": []
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": null,
+          "CVSSv3": null,
+          "patches": [],
+          "references": [],
+          "creationTime": "2021-11-12T15:57:55.073311Z",
+          "modificationTime": "2021-11-12T15:57:55.075998Z",
+          "publicationTime": "2021-11-12T15:53:11.928545Z",
+          "disclosureTime": null,
+          "id": "SNYK-ALPINE312-BUSYBOX-1920758",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.31.1-r21"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-MUSL-1042762": {
+          "title": "Out-of-bounds Write",
+          "credit": [
+            ""
+          ],
+          "packageName": "musl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `musl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nIn musl libc through 1.2.1, wcsnrtombs mishandles particular combinations of destination buffer size and source character limit, as demonstrated by an invalid write access (buffer overflow).\n## Remediation\nUpgrade `Alpine:3.12` `musl` to version 1.1.24-r10 or higher.\n## References\n- [CONFIRM](http://www.openwall.com/lists/oss-security/2020/11/20/4)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/)\n- [MISC](https://musl.libc.org/releases.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2020-28928"
+            ],
+            "CWE": [
+              "CWE-787"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "cvssScore": 5.5,
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "http://www.openwall.com/lists/oss-security/2020/11/20/4"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/LKQ3RVSMVZNZNO4D65W2CZZ4DMYFZN2Q/"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/UW27QVY7ERPTSGKS4KAWE5TU7EJWHKVQ/"
+            },
+            {
+              "title": "MISC",
+              "url": "https://musl.libc.org/releases.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r2134abfe847bea7795f0e53756d10a47e6643f35ab8169df8b8a9eb1@%3Cnotifications.apisix.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r90b60cf49348e515257b4950900c1bd3ab95a960cf2469d919c7264e@%3Cnotifications.apisix.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/ra63e8dc5137d952afc55dbbfa63be83304ecf842d1eab1ff3ebb29e2@%3Cnotifications.apisix.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2020/11/msg00050.html"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2020-11-21T03:45:00.394040Z",
+          "modificationTime": "2021-10-03T22:07:44.223653Z",
+          "publicationTime": "2020-11-21T03:45:00.333919Z",
+          "disclosureTime": "2020-11-24T18:15:00Z",
+          "id": "SNYK-ALPINE312-MUSL-1042762",
+          "malicious": false,
+          "nvdSeverity": "medium",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.24-r10"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1050745": {
+          "title": "NULL Pointer Dereference",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nThe X.509 GeneralName type is a generic type for representing different types of names. One of those name types is known as EDIPartyName. OpenSSL provides a function GENERAL_NAME_cmp which compares different instances of a GENERAL_NAME to see if they are equal or not. This function behaves incorrectly when both GENERAL_NAMEs contain an EDIPARTYNAME. A NULL pointer dereference and a crash may occur leading to a possible denial of service attack. OpenSSL itself uses the GENERAL_NAME_cmp function for two purposes: 1) Comparing CRL distribution point names between an available CRL and a CRL distribution point embedded in an X509 certificate 2) When verifying that a timestamp response token signer matches the timestamp authority name (exposed via the API functions TS_RESP_verify_response and TS_RESP_verify_token) If an attacker can control both items being compared then that attacker could trigger a crash. For example if the attacker can trick a client or server into checking a malicious certificate against a malicious CRL then this may occur. Note that some applications automatically download CRLs based on a URL embedded in a certificate. This checking happens prior to the signatures on the certificate and CRL being verified. OpenSSL&#39;s s_server, s_client and verify tools have support for the &#34;-crl_download&#34; option which implements automatic CRL downloading and this attack has been demonstrated to work against those tools. Note that an unrelated bug means that affected versions of OpenSSL cannot parse or construct correct encodings of EDIPARTYNAME. However it is possible to construct a malformed EDIPARTYNAME that OpenSSL&#39;s parser will accept and hence trigger this attack. All OpenSSL 1.1.1 and 1.0.2 versions are affected by this issue. Other OpenSSL releases are out of support and have not been checked. Fixed in OpenSSL 1.1.1i (Affected 1.1.1-1.1.1h). Fixed in OpenSSL 1.0.2x (Affected 1.0.2-1.0.2w).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1i-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=f960d81215ebf3f65e03d4d5d857fb9b666d6920)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20201218-0005/)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210513-0002/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20201208.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2020-11)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-09)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-10)\n- [DEBIAN](https://www.debian.org/security/2020/dsa-4807)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/)\n- [FREEBSD](https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc)\n- [GENTOO](https://security.gentoo.org/glsa/202012-13)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpujan2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/09/14/2)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2020-1971"
+            ],
+            "CWE": [
+              "CWE-476"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "cvssScore": 5.9,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2154ab83e14ede338d2ede9bbe5cdfce5d5a6c9e"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=f960d81215ebf3f65e03d4d5d857fb9b666d6920"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44676"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20201218-0005/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210513-0002/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20201208.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2020-11"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-09"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-10"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2020/dsa-4807"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/DGSI34Y5LQ5RYXN4M2I5ZQT65LFVDOUU/"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/PWPSSZNZOBJU2YR6Z4TGHXKYW3YP5QG7/"
+            },
+            {
+              "title": "FREEBSD",
+              "url": "https://security.FreeBSD.org/advisories/FreeBSD-SA-20:33.openssl.asc"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202012-13"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpujan2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r63c6f2dd363d9b514d0a4bcf624580616a679898cc14c109a49b750c@%3Cdev.tomcat.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rbb769f771711fb274e0a4acb1b5911c8aab544a6ac5e8c12d40c5143@%3Ccommits.pulsar.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2020/12/msg00020.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2020/12/msg00021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/09/14/2"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2020-12-12T03:45:01.596080Z",
+          "modificationTime": "2021-10-03T22:02:03.149433Z",
+          "publicationTime": "2020-12-12T03:45:01.609611Z",
+          "disclosureTime": "2020-12-08T16:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1050745",
+          "malicious": false,
+          "nvdSeverity": "medium",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1i-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1075734": {
+          "title": "Integer Overflow or Wraparound",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nCalls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1j-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=122a19ab48091c657f7cb1fb3af9fc07bd557bbf)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210219-0009/)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210513-0002/)\n- [CONFIRM](https://support.apple.com/kb/HT212528)\n- [CONFIRM](https://support.apple.com/kb/HT212529)\n- [CONFIRM](https://support.apple.com/kb/HT212534)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210216.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-03)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-09)\n- [DEBIAN](https://www.debian.org/security/2021/dsa-4855)\n- [FULLDISC](http://seclists.org/fulldisclosure/2021/May/67)\n- [FULLDISC](http://seclists.org/fulldisclosure/2021/May/68)\n- [FULLDISC](http://seclists.org/fulldisclosure/2021/May/70)\n- [GENTOO](https://security.gentoo.org/glsa/202103-03)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-23841"
+            ],
+            "CWE": [
+              "CWE-190"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "cvssScore": 5.9,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=122a19ab48091c657f7cb1fb3af9fc07bd557bbf"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=8252ee4d90f3f2004d3d0aeeed003ad49c9a7807"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210219-0009/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210513-0002/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://support.apple.com/kb/HT212528"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://support.apple.com/kb/HT212529"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://support.apple.com/kb/HT212534"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210216.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-03"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-09"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2021/dsa-4855"
+            },
+            {
+              "title": "FULLDISC",
+              "url": "http://seclists.org/fulldisclosure/2021/May/67"
+            },
+            {
+              "title": "FULLDISC",
+              "url": "http://seclists.org/fulldisclosure/2021/May/68"
+            },
+            {
+              "title": "FULLDISC",
+              "url": "http://seclists.org/fulldisclosure/2021/May/70"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202103-03"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2021-02-17T15:45:08.506840Z",
+          "modificationTime": "2021-10-03T22:03:33.390817Z",
+          "publicationTime": "2021-02-17T15:45:08.370259Z",
+          "disclosureTime": "2021-02-16T17:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1075734",
+          "malicious": false,
+          "nvdSeverity": "medium",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1j-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1075735": {
+          "title": "Integer Overflow or Wraparound",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nCalls to EVP_CipherUpdate, EVP_EncryptUpdate and EVP_DecryptUpdate may overflow the output length argument in some cases where the input length is close to the maximum permissable length for an integer on the platform. In such cases the return value from the function call will be 1 (indicating success), but the output length value will be negative. This could cause applications to behave incorrectly or crash. OpenSSL versions 1.1.1i and below are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1j. OpenSSL versions 1.0.2x and below are affected by this issue. However OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1i). Fixed in OpenSSL 1.0.2y (Affected 1.0.2-1.0.2x).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1j-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210219-0009/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210216.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-03)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-09)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-10)\n- [DEBIAN](https://www.debian.org/security/2021/dsa-4855)\n- [GENTOO](https://security.gentoo.org/glsa/202103-03)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-23840"
+            ],
+            "CWE": [
+              "CWE-190"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "cvssScore": 7.5,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=6a51b9e1d0cf0bf8515f7201b68fb0a3482b3dc1"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=9b1129239f3ebb1d1c98ce9ed41d5c9476c47cb2"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210219-0009/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210216.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-03"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-09"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-10"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2021/dsa-4855"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202103-03"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r58af02e294bd07f487e2c64ffc0a29b837db5600e33b6e698b9d696b@%3Cissues.bookkeeper.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rf4c02775860db415b4955778a131c2795223f61cb8c6a450893651e4@%3Cissues.bookkeeper.apache.org%3E"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2021-02-17T15:45:08.551256Z",
+          "modificationTime": "2021-10-03T22:02:05.709457Z",
+          "publicationTime": "2021-02-17T15:45:08.420994Z",
+          "disclosureTime": "2021-02-16T17:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1075735",
+          "malicious": false,
+          "nvdSeverity": "high",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1j-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1075736": {
+          "title": "Inadequate Encryption Strength",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nOpenSSL 1.0.2 supports SSLv2. If a client attempts to negotiate SSLv2 with a server that is configured to support both SSLv2 and more recent SSL and TLS versions then a check is made for a version rollback attack when unpadding an RSA signature. Clients that support SSL or TLS versions greater than SSLv2 are supposed to use a special form of padding. A server that supports greater than SSLv2 is supposed to reject connection attempts from a client where this special form of padding is present, because this indicates that a version rollback has occurred (i.e. both client and server support greater than SSLv2, and yet this is the version that is being requested). The implementation of this padding check inverted the logic so that the connection attempt is accepted if the padding is present, and rejected if it is absent. This means that such as server will accept a connection if a version rollback attack has occurred. Further the server will erroneously reject a connection if a normal SSLv2 connection attempt is made. Only OpenSSL 1.0.2 servers from version 1.0.2s to 1.0.2x are affected by this issue. In order to be vulnerable a 1.0.2 server must: 1) have configured SSLv2 support at compile time (this is off by default), 2) have configured SSLv2 support at runtime (this is off by default), 3) have configured SSLv2 ciphersuites (these are not in the default ciphersuite list) OpenSSL 1.1.1 does not have SSLv2 support and therefore is not vulnerable to this issue. The underlying error is in the implementation of the RSA_padding_check_SSLv23() function. This also affects the RSA_SSLV23_PADDING padding mode used by various other functions. Although 1.1.1 does not support SSLv2 the RSA_padding_check_SSLv23() function still exists, as does the RSA_SSLV23_PADDING padding mode. Applications that directly call that function or use that padding mode will encounter this issue. However since there is no support for the SSLv2 protocol in 1.1.1 this is considered a bug and not a security issue in that version. OpenSSL 1.0.2 is out of support and no longer receiving public updates. Premium support customers of OpenSSL 1.0.2 should upgrade to 1.0.2y. Other users should upgrade to 1.1.1j. Fixed in OpenSSL 1.0.2y (Affected 1.0.2s-1.0.2x).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1j-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=30919ab80a478f2d81f2e9acdcca3fa4740cd547)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210219-0009/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210216.txt)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-23839"
+            ],
+            "CWE": [
+              "CWE-326"
+            ]
+          },
+          "severity": "low",
+          "severityWithCritical": "low",
+          "socialTrendAlert": false,
+          "cvssScore": 3.7,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=30919ab80a478f2d81f2e9acdcca3fa4740cd547"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44846"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210219-0009/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210216.txt"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2021-02-17T15:45:08.595024Z",
+          "modificationTime": "2021-10-03T22:02:09.000597Z",
+          "publicationTime": "2021-02-17T15:45:08.467564Z",
+          "disclosureTime": "2021-02-16T17:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1075736",
+          "malicious": false,
+          "nvdSeverity": "low",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1j-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1089237": {
+          "title": "NULL Pointer Dereference",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nAn OpenSSL TLS server may crash if sent a maliciously crafted renegotiation ClientHello message from a client. If a TLSv1.2 renegotiation ClientHello omits the signature_algorithms extension (where it was present in the initial ClientHello), but includes a signature_algorithms_cert extension then a NULL pointer dereference will result, leading to a crash and a denial of service attack. A server is only vulnerable if it has TLSv1.2 and renegotiation enabled (which is the default configuration). OpenSSL TLS clients are not impacted by this issue. All OpenSSL 1.1.1 versions are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1-1.1.1j).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1k-r0 or higher.\n## References\n- [CISCO](https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd)\n- [CONFIRM](https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=fb9fa6b51defd48157eeb207f52181f735d96148)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845)\n- [CONFIRM](https://kc.mcafee.com/corporate/index?page=content&id=SB10356)\n- [CONFIRM](https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210326-0006/)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210513-0002/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210325.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-05)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-06)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-09)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-10)\n- [DEBIAN](https://www.debian.org/security/2021/dsa-4875)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/)\n- [GENTOO](https://security.gentoo.org/glsa/202103-03)\n- [MISC](https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/27/1)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/27/2)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/28/3)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/28/4)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-3449"
+            ],
+            "CWE": [
+              "CWE-476"
+            ]
+          },
+          "severity": "medium",
+          "severityWithCritical": "medium",
+          "socialTrendAlert": false,
+          "cvssScore": 5.9,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CISCO",
+              "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://cert-portal.siemens.com/productcert/pdf/ssa-772220.pdf"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=fb9fa6b51defd48157eeb207f52181f735d96148"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210326-0006/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210513-0002/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210325.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-05"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-06"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-09"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-10"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2021/dsa-4875"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202103-03"
+            },
+            {
+              "title": "MISC",
+              "url": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2021/08/msg00029.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/27/1"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/27/2"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/28/3"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/28/4"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2021-03-26T03:45:13.264566Z",
+          "modificationTime": "2021-10-03T22:01:16.580714Z",
+          "publicationTime": "2021-03-26T03:45:12.930575Z",
+          "disclosureTime": "2021-03-25T15:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1089237",
+          "malicious": false,
+          "nvdSeverity": "medium",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1k-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1089238": {
+          "title": "Improper Certificate Validation",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nThe X509_V_FLAG_X509_STRICT flag enables additional security checks of the certificates present in a certificate chain. It is not set by default. Starting from OpenSSL version 1.1.1h a check to disallow certificates in the chain that have explicitly encoded elliptic curve parameters was added as an additional strict check. An error in the implementation of this check meant that the result of a previous check to confirm that certificates in the chain are valid CA certificates was overwritten. This effectively bypasses the check that non-CA certificates must not be able to issue other certificates. If a &#34;purpose&#34; has been configured then there is a subsequent opportunity for checks that the certificate is a valid CA. All of the named &#34;purpose&#34; values implemented in libcrypto perform this check. Therefore, where a purpose is set the certificate chain will still be rejected even when the strict flag has been used. A purpose is set by default in libssl client and server certificate verification routines, but it can be overridden or removed by an application. In order to be affected, an application must explicitly set the X509_V_FLAG_X509_STRICT verification flag and either not set a purpose for the certificate verification or, in the case of TLS client or server applications, override the default purpose. OpenSSL versions 1.1.1h and newer are affected by this issue. Users of these versions should upgrade to OpenSSL 1.1.1k. OpenSSL 1.0.2 is not impacted by this issue. Fixed in OpenSSL 1.1.1k (Affected 1.1.1h-1.1.1j).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1k-r0 or higher.\n## References\n- [CISCO](https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b)\n- [CONFIRM](https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845)\n- [CONFIRM](https://kc.mcafee.com/corporate/index?page=content&id=SB10356)\n- [CONFIRM](https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210326-0006/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210325.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-05)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-08)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-09)\n- [FEDORA](https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/)\n- [GENTOO](https://security.gentoo.org/glsa/202103-03)\n- [MISC](https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html)\n- [MISC](https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc)\n- [MISC](https://www.oracle.com/security-alerts/cpuApr2021.html)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/27/1)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/27/2)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/28/3)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/03/28/4)\n- [N/A](https://www.oracle.com//security-alerts/cpujul2021.html)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-3450"
+            ],
+            "CWE": [
+              "CWE-295"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "cvssScore": 7.4,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+          "patches": [],
+          "references": [
+            {
+              "title": "CISCO",
+              "url": "https://tools.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-openssl-2021-GHY28dJd"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=2a40b7bc7b94dd7de897a74571e7024f0cf0d63b"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kb.pulsesecure.net/articles/Pulse_Security_Advisories/SA44845"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://kc.mcafee.com/corporate/index?page=content&id=SB10356"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://psirt.global.sonicwall.com/vuln-detail/SNWLID-2021-0013"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210326-0006/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210325.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-05"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-08"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-09"
+            },
+            {
+              "title": "FEDORA",
+              "url": "https://lists.fedoraproject.org/archives/list/package-announce@lists.fedoraproject.org/message/CCBFLLVQVILIVGZMBJL3IXZGKWQISYNP/"
+            },
+            {
+              "title": "GENTOO",
+              "url": "https://security.gentoo.org/glsa/202103-03"
+            },
+            {
+              "title": "MISC",
+              "url": "https://mta.openssl.org/pipermail/openssl-announce/2021-March/000198.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://security.FreeBSD.org/advisories/FreeBSD-SA-21:07.openssl.asc"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuApr2021.html"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/27/1"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/27/2"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/28/3"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/03/28/4"
+            },
+            {
+              "title": "N/A",
+              "url": "https://www.oracle.com//security-alerts/cpujul2021.html"
+            }
+          ],
+          "creationTime": "2021-03-26T03:45:13.313842Z",
+          "modificationTime": "2021-10-03T22:01:22.381451Z",
+          "publicationTime": "2021-03-26T03:45:13.018982Z",
+          "disclosureTime": "2021-03-25T15:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1089238",
+          "malicious": false,
+          "nvdSeverity": "high",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1k-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1569450": {
+          "title": "Out-of-bounds Read",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nASN.1 strings are represented internally within OpenSSL as an ASN1_STRING structure which contains a buffer holding the string data and a field holding the buffer length. This contrasts with normal C strings which are repesented as a buffer for the string data which is terminated with a NUL (0) byte. Although not a strict requirement, ASN.1 strings that are parsed using OpenSSL&#39;s own &#34;d2i&#34; functions (and other similar parsing functions) as well as any string whose value has been set with the ASN1_STRING_set() function will additionally NUL terminate the byte array in the ASN1_STRING structure. However, it is possible for applications to directly construct valid ASN1_STRING structures which do not NUL terminate the byte array by directly setting the &#34;data&#34; and &#34;length&#34; fields in the ASN1_STRING array. This can also happen by using the ASN1_STRING_set0() function. Numerous OpenSSL functions that print ASN.1 data have been found to assume that the ASN1_STRING byte array will be NUL terminated, even though this is not guaranteed for strings that have been directly constructed. Where an application requests an ASN.1 structure to be printed, and where that ASN.1 structure contains ASN1_STRINGs that have been directly constructed by the application without NUL terminating the &#34;data&#34; field, then a read buffer overrun can occur. The same thing can also occur during name constraints processing of certificates (for example if a certificate has been directly constructed by the application instead of loading it via the OpenSSL parsing functions, and the certificate contains non NUL terminated ASN1_STRING structures). It can also occur in the X509_get1_email(), X509_REQ_get1_email() and X509_get1_ocsp() functions. If a malicious actor can cause an application to directly construct an ASN1_STRING and then process it through one of the affected OpenSSL functions then this issue could be hit. This might result in a crash (causing a Denial of Service attack). It could also result in the disclosure of private memory contents (such as private keys, or sensitive plaintext). Fixed in OpenSSL 1.1.1j (Affected 1.1.1-1.1.1k). Fixed in OpenSSL 1.0.2za (Affected 1.0.2-1.0.2y).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1l-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=94d23fcff9b2a7a8368dfe52214d5c2569882c11)\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=ccb0a11145ee72b042d10593a64eaf9e8a55ec12)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210827-0010/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210824.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-16)\n- [DEBIAN](https://www.debian.org/security/2021/dsa-4963)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html)\n- [MLIST](https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/08/26/2)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-3712"
+            ],
+            "CWE": [
+              "CWE-125"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "cvssScore": 7.4,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=94d23fcff9b2a7a8368dfe52214d5c2569882c11"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=ccb0a11145ee72b042d10593a64eaf9e8a55ec12"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210827-0010/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210824.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-16"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2021/dsa-4963"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2021/09/msg00014.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.debian.org/debian-lts-announce/2021/09/msg00021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/08/26/2"
+            }
+          ],
+          "creationTime": "2021-08-25T05:14:28.732044Z",
+          "modificationTime": "2021-10-03T22:01:40.199145Z",
+          "publicationTime": "2021-08-25T05:11:36.281456Z",
+          "disclosureTime": "2021-08-24T15:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1569450",
+          "malicious": false,
+          "nvdSeverity": "high",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1l-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        },
+        "SNYK-ALPINE312-OPENSSL-1569452": {
+          "title": "Buffer Overflow",
+          "credit": [
+            ""
+          ],
+          "packageName": "openssl",
+          "language": "linux",
+          "packageManager": "alpine:3.12",
+          "description": "## NVD Description\n<i> **Note:** </i>\n<i> Versions mentioned in the description apply to the upstream `openssl` package. </i>\n<i> See `How to fix?` for `Alpine:3.12` relevant versions. </i>\n\nIn order to decrypt SM2 encrypted data an application is expected to call the API function EVP_PKEY_decrypt(). Typically an application will call this function twice. The first time, on entry, the &#34;out&#34; parameter can be NULL and, on exit, the &#34;outlen&#34; parameter is populated with the buffer size required to hold the decrypted plaintext. The application can then allocate a sufficiently sized buffer and call EVP_PKEY_decrypt() again, but this time passing a non-NULL value for the &#34;out&#34; parameter. A bug in the implementation of the SM2 decryption code means that the calculation of the buffer size required to hold the plaintext returned by the first call to EVP_PKEY_decrypt() can be smaller than the actual size required by the second call. This can lead to a buffer overflow when EVP_PKEY_decrypt() is called by the application a second time with a buffer that is too small. A malicious attacker who is able present SM2 content for decryption to an application could cause attacker chosen data to overflow the buffer by up to a maximum of 62 bytes altering the contents of other data held after the buffer, possibly changing application behaviour or causing the application to crash. The location of the buffer is application dependent but is typically heap allocated. Fixed in OpenSSL 1.1.1l (Affected 1.1.1-1.1.1k).\n## Remediation\nUpgrade `Alpine:3.12` `openssl` to version 1.1.1l-r0 or higher.\n## References\n- [CONFIRM](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=59f5e75f3bced8fc0e130d72a3f582cf7b480b46)\n- [CONFIRM](https://security.netapp.com/advisory/ntap-20210827-0010/)\n- [CONFIRM](https://www.openssl.org/news/secadv/20210824.txt)\n- [CONFIRM](https://www.tenable.com/security/tns-2021-16)\n- [DEBIAN](https://www.debian.org/security/2021/dsa-4963)\n- [MISC](https://www.oracle.com/security-alerts/cpuoct2021.html)\n- [MLIST](https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E)\n- [MLIST](https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E)\n- [MLIST](http://www.openwall.com/lists/oss-security/2021/08/26/2)\n",
+          "identifiers": {
+            "ALTERNATIVE": [],
+            "CVE": [
+              "CVE-2021-3711"
+            ],
+            "CWE": [
+              "CWE-120"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "critical",
+          "socialTrendAlert": false,
+          "cvssScore": 9.8,
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "patches": [],
+          "references": [
+            {
+              "title": "CONFIRM",
+              "url": "https://git.openssl.org/gitweb/?p=openssl.git%3Ba=commitdiff%3Bh=59f5e75f3bced8fc0e130d72a3f582cf7b480b46"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://security.netapp.com/advisory/ntap-20210827-0010/"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.openssl.org/news/secadv/20210824.txt"
+            },
+            {
+              "title": "CONFIRM",
+              "url": "https://www.tenable.com/security/tns-2021-16"
+            },
+            {
+              "title": "DEBIAN",
+              "url": "https://www.debian.org/security/2021/dsa-4963"
+            },
+            {
+              "title": "MISC",
+              "url": "https://www.oracle.com/security-alerts/cpuoct2021.html"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/r18995de860f0e63635f3008fd2a6aca82394249476d21691e7c59c9e@%3Cdev.tomcat.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "https://lists.apache.org/thread.html/rad5d9f83f0d11fb3f8bb148d179b8a9ad7c6a17f18d70e5805a713d1@%3Cdev.tomcat.apache.org%3E"
+            },
+            {
+              "title": "MLIST",
+              "url": "http://www.openwall.com/lists/oss-security/2021/08/26/2"
+            }
+          ],
+          "creationTime": "2021-08-25T05:16:18.150026Z",
+          "modificationTime": "2021-10-03T22:03:37.805380Z",
+          "publicationTime": "2021-08-25T05:11:05.591709Z",
+          "disclosureTime": "2021-08-24T15:15:00Z",
+          "id": "SNYK-ALPINE312-OPENSSL-1569452",
+          "malicious": false,
+          "nvdSeverity": "critical",
+          "relativeImportance": null,
+          "semver": {
+            "vulnerable": [
+              "<1.1.1l-r0"
+            ]
+          },
+          "exploit": "Not Defined"
+        }
+      },
+      "issues": [
+        {
+          "pkgName": "apk-tools/apk-tools",
+          "pkgVersion": "2.10.5-r1",
+          "issueId": "SNYK-ALPINE312-APKTOOLS-1246338",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "apk-tools",
+                    "version": "2.10.5-r1",
+                    "newVersion": "2.10.6-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "2.10.6-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "apk-tools/apk-tools",
+          "pkgVersion": "2.10.5-r1",
+          "issueId": "SNYK-ALPINE312-APKTOOLS-1533753",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "apk-tools",
+                    "version": "2.10.5-r1",
+                    "newVersion": "2.10.7-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "2.10.7-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1089799",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.32.1-r4"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.32.1-r4"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.32.1-r4",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920710",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920711",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920712",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920717",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920729",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920730",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920731",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920739",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920754",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/busybox",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920758",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1089799",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.32.1-r4"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.32.1-r4",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920710",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920711",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920712",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920717",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920729",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920730",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920731",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920739",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920754",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "busybox/ssl_client",
+          "pkgVersion": "1.31.1-r16",
+          "issueId": "SNYK-ALPINE312-BUSYBOX-1920758",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "busybox",
+                    "version": "1.31.1-r16",
+                    "newVersion": "1.31.1-r21"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.31.1-r21",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "musl/musl",
+          "pkgVersion": "1.1.24-r8",
+          "issueId": "SNYK-ALPINE312-MUSL-1042762",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "busybox/busybox",
+                    "version": "1.31.1-r16"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "alpine-baselayout/alpine-baselayout",
+                    "version": "3.2.0-r6"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libcrypto1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "zlib/zlib",
+                    "version": "1.2.11-r3"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "busybox/ssl_client",
+                    "version": "1.31.1-r16"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "musl/musl-utils",
+                    "version": "1.1.24-r8"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "pax-utils/scanelf",
+                    "version": "1.2.6-r0"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.24-r10",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "musl/musl-utils",
+          "pkgVersion": "1.1.24-r8",
+          "issueId": "SNYK-ALPINE312-MUSL-1042762",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libc-dev/libc-utils",
+                    "version": "0.7.2-r3"
+                  },
+                  {
+                    "name": "musl",
+                    "version": "1.1.24-r8",
+                    "newVersion": "1.1.24-r10"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.24-r10",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1050745",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1i-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075734",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075735",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075736",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1089237",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1k-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1089238",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1k-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1569450",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1l-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libcrypto1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1569452",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "openssl/libssl1.1",
+                    "version": "1.1.1g-r0"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1l-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1050745",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1i-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1i-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075734",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075735",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1075736",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1j-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1j-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1089237",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1k-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1089238",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1k-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1k-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1569450",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1l-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "openssl/libssl1.1",
+          "pkgVersion": "1.1.1g-r0",
+          "issueId": "SNYK-ALPINE312-OPENSSL-1569452",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "docker-image|alpine",
+                    "version": "1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "apk-tools/apk-tools",
+                    "version": "2.10.5-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "libtls-standalone/libtls-standalone",
+                    "version": "2.9.1-r1"
+                  },
+                  {
+                    "name": "openssl",
+                    "version": "1.1.1g-r0",
+                    "newVersion": "1.1.1l-r0"
+                  }
+                ]
+              }
+            ],
+            "nearestFixedInVersion": "1.1.1l-r0",
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        }
+      ],
+      "docker": {
+        "baseImage": "alpine:3.12.0",
+        "baseImageRemediation": {
+          "code": "REMEDIATION_AVAILABLE",
+          "advice": [
+            {
+              "message": "Base Image     Vulnerabilities  Severity\nalpine:3.12.0  22               2 critical, 5 high, 4 medium, 11 low\n"
+            },
+            {
+              "message": "Recommendations for base image upgrade:\n",
+              "bold": true
+            },
+            {
+              "message": "Minor upgrades",
+              "bold": true
+            },
+            {
+              "message": "Base Image   Vulnerabilities  Severity\nalpine:3.14  0                0 critical, 0 high, 0 medium, 0 low\n"
+            }
+          ]
+        }
+      },
+      "depGraphData": {
+        "schemaVersion": "1.2.0",
+        "pkgManager": {
+          "name": "apk",
+          "repositories": [
+            {
+              "alias": "alpine:3.12.0"
+            }
+          ]
+        },
+        "pkgs": [
+          {
+            "id": "docker-image|alpine@1",
+            "info": {
+              "name": "docker-image|alpine",
+              "version": "1"
+            }
+          },
+          {
+            "id": "busybox/busybox@1.31.1-r16",
+            "info": {
+              "name": "busybox/busybox",
+              "version": "1.31.1-r16"
+            }
+          },
+          {
+            "id": "musl/musl@1.1.24-r8",
+            "info": {
+              "name": "musl/musl",
+              "version": "1.1.24-r8"
+            }
+          },
+          {
+            "id": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+            "info": {
+              "name": "alpine-baselayout/alpine-baselayout",
+              "version": "3.2.0-r6"
+            }
+          },
+          {
+            "id": "alpine-keys/alpine-keys@2.2-r0",
+            "info": {
+              "name": "alpine-keys/alpine-keys",
+              "version": "2.2-r0"
+            }
+          },
+          {
+            "id": "openssl/libcrypto1.1@1.1.1g-r0",
+            "info": {
+              "name": "openssl/libcrypto1.1",
+              "version": "1.1.1g-r0"
+            }
+          },
+          {
+            "id": "openssl/libssl1.1@1.1.1g-r0",
+            "info": {
+              "name": "openssl/libssl1.1",
+              "version": "1.1.1g-r0"
+            }
+          },
+          {
+            "id": "zlib/zlib@1.2.11-r3",
+            "info": {
+              "name": "zlib/zlib",
+              "version": "1.2.11-r3"
+            }
+          },
+          {
+            "id": "apk-tools/apk-tools@2.10.5-r1",
+            "info": {
+              "name": "apk-tools/apk-tools",
+              "version": "2.10.5-r1"
+            }
+          },
+          {
+            "id": "libtls-standalone/libtls-standalone@2.9.1-r1",
+            "info": {
+              "name": "libtls-standalone/libtls-standalone",
+              "version": "2.9.1-r1"
+            }
+          },
+          {
+            "id": "busybox/ssl_client@1.31.1-r16",
+            "info": {
+              "name": "busybox/ssl_client",
+              "version": "1.31.1-r16"
+            }
+          },
+          {
+            "id": "ca-certificates/ca-certificates-bundle@20191127-r2",
+            "info": {
+              "name": "ca-certificates/ca-certificates-bundle",
+              "version": "20191127-r2"
+            }
+          },
+          {
+            "id": "musl/musl-utils@1.1.24-r8",
+            "info": {
+              "name": "musl/musl-utils",
+              "version": "1.1.24-r8"
+            }
+          },
+          {
+            "id": "libc-dev/libc-utils@0.7.2-r3",
+            "info": {
+              "name": "libc-dev/libc-utils",
+              "version": "0.7.2-r3"
+            }
+          },
+          {
+            "id": "pax-utils/scanelf@1.2.6-r0",
+            "info": {
+              "name": "pax-utils/scanelf",
+              "version": "1.2.6-r0"
+            }
+          }
+        ],
+        "graph": {
+          "rootNodeId": "root-node",
+          "nodes": [
+            {
+              "nodeId": "root-node",
+              "pkgId": "docker-image|alpine@1",
+              "deps": [
+                {
+                  "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6"
+                },
+                {
+                  "nodeId": "alpine-keys/alpine-keys@2.2-r0"
+                },
+                {
+                  "nodeId": "apk-tools/apk-tools@2.10.5-r1"
+                },
+                {
+                  "nodeId": "busybox/busybox@1.31.1-r16|2"
+                },
+                {
+                  "nodeId": "busybox/ssl_client@1.31.1-r16"
+                },
+                {
+                  "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2"
+                },
+                {
+                  "nodeId": "libc-dev/libc-utils@0.7.2-r3"
+                },
+                {
+                  "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2"
+                },
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                },
+                {
+                  "nodeId": "musl/musl-utils@1.1.24-r8|2"
+                },
+                {
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2"
+                },
+                {
+                  "nodeId": "openssl/libssl1.1@1.1.1g-r0|2"
+                },
+                {
+                  "nodeId": "pax-utils/scanelf@1.2.6-r0|2"
+                },
+                {
+                  "nodeId": "zlib/zlib@1.2.11-r3|2"
+                }
+              ]
+            },
+            {
+              "nodeId": "busybox/busybox@1.31.1-r16|1",
+              "pkgId": "busybox/busybox@1.31.1-r16",
+              "deps": []
+            },
+            {
+              "nodeId": "busybox/busybox@1.31.1-r16|2",
+              "pkgId": "busybox/busybox@1.31.1-r16",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            },
+            {
+              "nodeId": "musl/musl@1.1.24-r8",
+              "pkgId": "musl/musl@1.1.24-r8",
+              "deps": []
+            },
+            {
+              "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+              "pkgId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+              "deps": [
+                {
+                  "nodeId": "busybox/busybox@1.31.1-r16|1"
+                },
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            },
+            {
+              "nodeId": "alpine-keys/alpine-keys@2.2-r0",
+              "pkgId": "alpine-keys/alpine-keys@2.2-r0",
+              "deps": []
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+              "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+              "deps": []
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+              "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            },
+            {
+              "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+              "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+              "deps": []
+            },
+            {
+              "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+              "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                },
+                {
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+                }
+              ]
+            },
+            {
+              "nodeId": "zlib/zlib@1.2.11-r3|1",
+              "pkgId": "zlib/zlib@1.2.11-r3",
+              "deps": []
+            },
+            {
+              "nodeId": "zlib/zlib@1.2.11-r3|2",
+              "pkgId": "zlib/zlib@1.2.11-r3",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            },
+            {
+              "nodeId": "apk-tools/apk-tools@2.10.5-r1",
+              "pkgId": "apk-tools/apk-tools@2.10.5-r1",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                },
+                {
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+                },
+                {
+                  "nodeId": "openssl/libssl1.1@1.1.1g-r0|1"
+                },
+                {
+                  "nodeId": "zlib/zlib@1.2.11-r3|1"
+                }
+              ]
+            },
+            {
+              "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1",
+              "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+              "deps": []
+            },
+            {
+              "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2",
+              "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+              "deps": [
+                {
+                  "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2"
+                },
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                },
+                {
+                  "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+                },
+                {
+                  "nodeId": "openssl/libssl1.1@1.1.1g-r0|1"
+                }
+              ]
+            },
+            {
+              "nodeId": "busybox/ssl_client@1.31.1-r16",
+              "pkgId": "busybox/ssl_client@1.31.1-r16",
+              "deps": [
+                {
+                  "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1"
+                },
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            },
+            {
+              "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+              "pkgId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+              "deps": []
+            },
+            {
+              "nodeId": "musl/musl-utils@1.1.24-r8|1",
+              "pkgId": "musl/musl-utils@1.1.24-r8",
+              "deps": []
+            },
+            {
+              "nodeId": "musl/musl-utils@1.1.24-r8|2",
+              "pkgId": "musl/musl-utils@1.1.24-r8",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                },
+                {
+                  "nodeId": "pax-utils/scanelf@1.2.6-r0|1"
+                }
+              ]
+            },
+            {
+              "nodeId": "libc-dev/libc-utils@0.7.2-r3",
+              "pkgId": "libc-dev/libc-utils@0.7.2-r3",
+              "deps": [
+                {
+                  "nodeId": "musl/musl-utils@1.1.24-r8|1"
+                }
+              ]
+            },
+            {
+              "nodeId": "pax-utils/scanelf@1.2.6-r0|1",
+              "pkgId": "pax-utils/scanelf@1.2.6-r0",
+              "deps": []
+            },
+            {
+              "nodeId": "pax-utils/scanelf@1.2.6-r0|2",
+              "pkgId": "pax-utils/scanelf@1.2.6-r0",
+              "deps": [
+                {
+                  "nodeId": "musl/musl@1.1.24-r8"
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "affectedPkgs": {
+        "apk-tools/apk-tools@2.10.5-r1": {
+          "pkg": {
+            "name": "apk-tools/apk-tools",
+            "version": "2.10.5-r1"
+          },
+          "issues": {
+            "SNYK-ALPINE312-APKTOOLS-1246338": {
+              "pkgName": "apk-tools/apk-tools",
+              "pkgVersion": "2.10.5-r1",
+              "issueId": "SNYK-ALPINE312-APKTOOLS-1246338",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "apk-tools",
+                        "version": "2.10.5-r1",
+                        "newVersion": "2.10.6-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "2.10.6-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-APKTOOLS-1533753": {
+              "pkgName": "apk-tools/apk-tools",
+              "pkgVersion": "2.10.5-r1",
+              "issueId": "SNYK-ALPINE312-APKTOOLS-1533753",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "apk-tools",
+                        "version": "2.10.5-r1",
+                        "newVersion": "2.10.7-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "2.10.7-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "busybox/busybox@1.31.1-r16": {
+          "pkg": {
+            "name": "busybox/busybox",
+            "version": "1.31.1-r16"
+          },
+          "issues": {
+            "SNYK-ALPINE312-BUSYBOX-1089799": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1089799",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.32.1-r4"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.32.1-r4"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.32.1-r4",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920710": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920710",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920711": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920711",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920712": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920712",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920717": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920717",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920729": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920729",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920730": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920730",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920731": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920731",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920739": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920739",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920754": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920754",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920758": {
+              "pkgName": "busybox/busybox",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920758",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "busybox/ssl_client@1.31.1-r16": {
+          "pkg": {
+            "name": "busybox/ssl_client",
+            "version": "1.31.1-r16"
+          },
+          "issues": {
+            "SNYK-ALPINE312-BUSYBOX-1089799": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1089799",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.32.1-r4"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.32.1-r4",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920710": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920710",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920711": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920711",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920712": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920712",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920717": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920717",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920729": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920729",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920730": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920730",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920731": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920731",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920739": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920739",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920754": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920754",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-BUSYBOX-1920758": {
+              "pkgName": "busybox/ssl_client",
+              "pkgVersion": "1.31.1-r16",
+              "issueId": "SNYK-ALPINE312-BUSYBOX-1920758",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "busybox",
+                        "version": "1.31.1-r16",
+                        "newVersion": "1.31.1-r21"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.31.1-r21",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "musl/musl@1.1.24-r8": {
+          "pkg": {
+            "name": "musl/musl",
+            "version": "1.1.24-r8"
+          },
+          "issues": {
+            "SNYK-ALPINE312-MUSL-1042762": {
+              "pkgName": "musl/musl",
+              "pkgVersion": "1.1.24-r8",
+              "issueId": "SNYK-ALPINE312-MUSL-1042762",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "busybox/busybox",
+                        "version": "1.31.1-r16"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "alpine-baselayout/alpine-baselayout",
+                        "version": "3.2.0-r6"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libcrypto1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "zlib/zlib",
+                        "version": "1.2.11-r3"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "busybox/ssl_client",
+                        "version": "1.31.1-r16"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "musl/musl-utils",
+                        "version": "1.1.24-r8"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "pax-utils/scanelf",
+                        "version": "1.2.6-r0"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.24-r10",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "musl/musl-utils@1.1.24-r8": {
+          "pkg": {
+            "name": "musl/musl-utils",
+            "version": "1.1.24-r8"
+          },
+          "issues": {
+            "SNYK-ALPINE312-MUSL-1042762": {
+              "pkgName": "musl/musl-utils",
+              "pkgVersion": "1.1.24-r8",
+              "issueId": "SNYK-ALPINE312-MUSL-1042762",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libc-dev/libc-utils",
+                        "version": "0.7.2-r3"
+                      },
+                      {
+                        "name": "musl",
+                        "version": "1.1.24-r8",
+                        "newVersion": "1.1.24-r10"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.24-r10",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "openssl/libcrypto1.1@1.1.1g-r0": {
+          "pkg": {
+            "name": "openssl/libcrypto1.1",
+            "version": "1.1.1g-r0"
+          },
+          "issues": {
+            "SNYK-ALPINE312-OPENSSL-1050745": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1050745",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1i-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075734": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075734",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075735": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075735",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075736": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075736",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1089237": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1089237",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1k-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1089238": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1089238",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1k-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1569450": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1569450",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1l-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1569452": {
+              "pkgName": "openssl/libcrypto1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1569452",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "openssl/libssl1.1",
+                        "version": "1.1.1g-r0"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1l-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "openssl/libssl1.1@1.1.1g-r0": {
+          "pkg": {
+            "name": "openssl/libssl1.1",
+            "version": "1.1.1g-r0"
+          },
+          "issues": {
+            "SNYK-ALPINE312-OPENSSL-1050745": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1050745",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1i-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1i-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075734": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075734",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075735": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075735",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1075736": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1075736",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1j-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1j-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1089237": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1089237",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1k-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1089238": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1089238",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1k-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1k-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1569450": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1569450",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1l-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            },
+            "SNYK-ALPINE312-OPENSSL-1569452": {
+              "pkgName": "openssl/libssl1.1",
+              "pkgVersion": "1.1.1g-r0",
+              "issueId": "SNYK-ALPINE312-OPENSSL-1569452",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "docker-image|alpine",
+                        "version": "1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "apk-tools/apk-tools",
+                        "version": "2.10.5-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "libtls-standalone/libtls-standalone",
+                        "version": "2.9.1-r1"
+                      },
+                      {
+                        "name": "openssl",
+                        "version": "1.1.1g-r0",
+                        "newVersion": "1.1.1l-r0"
+                      }
+                    ]
+                  }
+                ],
+                "nearestFixedInVersion": "1.1.1l-r0",
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "filesystemPolicy": false
+  },
+  "depGraph": {
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "apk",
+      "repositories": [
+        {
+          "alias": "alpine:3.12.0"
+        }
+      ]
+    },
+    "pkgs": [
+      {
+        "id": "docker-image|alpine@1",
+        "info": {
+          "name": "docker-image|alpine",
+          "version": "1"
+        }
+      },
+      {
+        "id": "busybox/busybox@1.31.1-r16",
+        "info": {
+          "name": "busybox/busybox",
+          "version": "1.31.1-r16"
+        }
+      },
+      {
+        "id": "musl/musl@1.1.24-r8",
+        "info": {
+          "name": "musl/musl",
+          "version": "1.1.24-r8"
+        }
+      },
+      {
+        "id": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+        "info": {
+          "name": "alpine-baselayout/alpine-baselayout",
+          "version": "3.2.0-r6"
+        }
+      },
+      {
+        "id": "alpine-keys/alpine-keys@2.2-r0",
+        "info": {
+          "name": "alpine-keys/alpine-keys",
+          "version": "2.2-r0"
+        }
+      },
+      {
+        "id": "openssl/libcrypto1.1@1.1.1g-r0",
+        "info": {
+          "name": "openssl/libcrypto1.1",
+          "version": "1.1.1g-r0"
+        }
+      },
+      {
+        "id": "openssl/libssl1.1@1.1.1g-r0",
+        "info": {
+          "name": "openssl/libssl1.1",
+          "version": "1.1.1g-r0"
+        }
+      },
+      {
+        "id": "zlib/zlib@1.2.11-r3",
+        "info": {
+          "name": "zlib/zlib",
+          "version": "1.2.11-r3"
+        }
+      },
+      {
+        "id": "apk-tools/apk-tools@2.10.5-r1",
+        "info": {
+          "name": "apk-tools/apk-tools",
+          "version": "2.10.5-r1"
+        }
+      },
+      {
+        "id": "libtls-standalone/libtls-standalone@2.9.1-r1",
+        "info": {
+          "name": "libtls-standalone/libtls-standalone",
+          "version": "2.9.1-r1"
+        }
+      },
+      {
+        "id": "busybox/ssl_client@1.31.1-r16",
+        "info": {
+          "name": "busybox/ssl_client",
+          "version": "1.31.1-r16"
+        }
+      },
+      {
+        "id": "ca-certificates/ca-certificates-bundle@20191127-r2",
+        "info": {
+          "name": "ca-certificates/ca-certificates-bundle",
+          "version": "20191127-r2"
+        }
+      },
+      {
+        "id": "musl/musl-utils@1.1.24-r8",
+        "info": {
+          "name": "musl/musl-utils",
+          "version": "1.1.24-r8"
+        }
+      },
+      {
+        "id": "libc-dev/libc-utils@0.7.2-r3",
+        "info": {
+          "name": "libc-dev/libc-utils",
+          "version": "0.7.2-r3"
+        }
+      },
+      {
+        "id": "pax-utils/scanelf@1.2.6-r0",
+        "info": {
+          "name": "pax-utils/scanelf",
+          "version": "1.2.6-r0"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "docker-image|alpine@1",
+          "deps": [
+            {
+              "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6"
+            },
+            {
+              "nodeId": "alpine-keys/alpine-keys@2.2-r0"
+            },
+            {
+              "nodeId": "apk-tools/apk-tools@2.10.5-r1"
+            },
+            {
+              "nodeId": "busybox/busybox@1.31.1-r16|2"
+            },
+            {
+              "nodeId": "busybox/ssl_client@1.31.1-r16"
+            },
+            {
+              "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2"
+            },
+            {
+              "nodeId": "libc-dev/libc-utils@0.7.2-r3"
+            },
+            {
+              "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2"
+            },
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            },
+            {
+              "nodeId": "musl/musl-utils@1.1.24-r8|2"
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2"
+            },
+            {
+              "nodeId": "openssl/libssl1.1@1.1.1g-r0|2"
+            },
+            {
+              "nodeId": "pax-utils/scanelf@1.2.6-r0|2"
+            },
+            {
+              "nodeId": "zlib/zlib@1.2.11-r3|2"
+            }
+          ]
+        },
+        {
+          "nodeId": "busybox/busybox@1.31.1-r16|1",
+          "pkgId": "busybox/busybox@1.31.1-r16",
+          "deps": []
+        },
+        {
+          "nodeId": "busybox/busybox@1.31.1-r16|2",
+          "pkgId": "busybox/busybox@1.31.1-r16",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        },
+        {
+          "nodeId": "musl/musl@1.1.24-r8",
+          "pkgId": "musl/musl@1.1.24-r8",
+          "deps": []
+        },
+        {
+          "nodeId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+          "pkgId": "alpine-baselayout/alpine-baselayout@3.2.0-r6",
+          "deps": [
+            {
+              "nodeId": "busybox/busybox@1.31.1-r16|1"
+            },
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        },
+        {
+          "nodeId": "alpine-keys/alpine-keys@2.2-r0",
+          "pkgId": "alpine-keys/alpine-keys@2.2-r0",
+          "deps": []
+        },
+        {
+          "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1",
+          "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+          "deps": []
+        },
+        {
+          "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|2",
+          "pkgId": "openssl/libcrypto1.1@1.1.1g-r0",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        },
+        {
+          "nodeId": "openssl/libssl1.1@1.1.1g-r0|1",
+          "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+          "deps": []
+        },
+        {
+          "nodeId": "openssl/libssl1.1@1.1.1g-r0|2",
+          "pkgId": "openssl/libssl1.1@1.1.1g-r0",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+            }
+          ]
+        },
+        {
+          "nodeId": "zlib/zlib@1.2.11-r3|1",
+          "pkgId": "zlib/zlib@1.2.11-r3",
+          "deps": []
+        },
+        {
+          "nodeId": "zlib/zlib@1.2.11-r3|2",
+          "pkgId": "zlib/zlib@1.2.11-r3",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        },
+        {
+          "nodeId": "apk-tools/apk-tools@2.10.5-r1",
+          "pkgId": "apk-tools/apk-tools@2.10.5-r1",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+            },
+            {
+              "nodeId": "openssl/libssl1.1@1.1.1g-r0|1"
+            },
+            {
+              "nodeId": "zlib/zlib@1.2.11-r3|1"
+            }
+          ]
+        },
+        {
+          "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1",
+          "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+          "deps": []
+        },
+        {
+          "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|2",
+          "pkgId": "libtls-standalone/libtls-standalone@2.9.1-r1",
+          "deps": [
+            {
+              "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2"
+            },
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            },
+            {
+              "nodeId": "openssl/libcrypto1.1@1.1.1g-r0|1"
+            },
+            {
+              "nodeId": "openssl/libssl1.1@1.1.1g-r0|1"
+            }
+          ]
+        },
+        {
+          "nodeId": "busybox/ssl_client@1.31.1-r16",
+          "pkgId": "busybox/ssl_client@1.31.1-r16",
+          "deps": [
+            {
+              "nodeId": "libtls-standalone/libtls-standalone@2.9.1-r1|1"
+            },
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        },
+        {
+          "nodeId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+          "pkgId": "ca-certificates/ca-certificates-bundle@20191127-r2",
+          "deps": []
+        },
+        {
+          "nodeId": "musl/musl-utils@1.1.24-r8|1",
+          "pkgId": "musl/musl-utils@1.1.24-r8",
+          "deps": []
+        },
+        {
+          "nodeId": "musl/musl-utils@1.1.24-r8|2",
+          "pkgId": "musl/musl-utils@1.1.24-r8",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            },
+            {
+              "nodeId": "pax-utils/scanelf@1.2.6-r0|1"
+            }
+          ]
+        },
+        {
+          "nodeId": "libc-dev/libc-utils@0.7.2-r3",
+          "pkgId": "libc-dev/libc-utils@0.7.2-r3",
+          "deps": [
+            {
+              "nodeId": "musl/musl-utils@1.1.24-r8|1"
+            }
+          ]
+        },
+        {
+          "nodeId": "pax-utils/scanelf@1.2.6-r0|1",
+          "pkgId": "pax-utils/scanelf@1.2.6-r0",
+          "deps": []
+        },
+        {
+          "nodeId": "pax-utils/scanelf@1.2.6-r0|2",
+          "pkgId": "pax-utils/scanelf@1.2.6-r0",
+          "deps": [
+            {
+              "nodeId": "musl/musl@1.1.24-r8"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "packageManager": "apk",
+  "options": {
+    "path": "alpine:1",
+    "showVulnPaths": "all",
+    "docker": true,
+    "file": "testDir/Dockerfile",
+    "app-vulns": true,
+    "exclude-base-image-vulns": true
+  }
+}

--- a/test/fixtures/container-projects/app-vuln-npm-fixture.json
+++ b/test/fixtures/container-projects/app-vuln-npm-fixture.json
@@ -1,0 +1,15355 @@
+{
+  "res": {
+    "meta": {
+      "isPrivate": true,
+      "isLicensesEnabled": false,
+      "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.22.1\nignore: {}\npatch: {}\n",
+      "ignoreSettings": null,
+      "org": "minsi.yang",
+      "licensesPolicy": {
+        "severities": {},
+        "orgLicenseRules": {
+          "AGPL-1.0": {
+            "licenseType": "AGPL-1.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "AGPL-3.0": {
+            "licenseType": "AGPL-3.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "Artistic-1.0": {
+            "licenseType": "Artistic-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "Artistic-2.0": {
+            "licenseType": "Artistic-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "CDDL-1.0": {
+            "licenseType": "CDDL-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "CPOL-1.02": {
+            "licenseType": "CPOL-1.02",
+            "severity": "high",
+            "instructions": ""
+          },
+          "EPL-1.0": {
+            "licenseType": "EPL-1.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "GPL-2.0": {
+            "licenseType": "GPL-2.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "GPL-3.0": {
+            "licenseType": "GPL-3.0",
+            "severity": "high",
+            "instructions": ""
+          },
+          "LGPL-2.0": {
+            "licenseType": "LGPL-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "LGPL-2.1": {
+            "licenseType": "LGPL-2.1",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "LGPL-3.0": {
+            "licenseType": "LGPL-3.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MPL-1.1": {
+            "licenseType": "MPL-1.1",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MPL-2.0": {
+            "licenseType": "MPL-2.0",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "MS-RL": {
+            "licenseType": "MS-RL",
+            "severity": "medium",
+            "instructions": ""
+          },
+          "SimPL-2.0": {
+            "licenseType": "SimPL-2.0",
+            "severity": "high",
+            "instructions": ""
+          }
+        }
+      }
+    },
+    "result": {
+      "issuesData": {
+        "SNYK-JS-ANSIREGEX-1583908": {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "alternativeIds": [],
+          "creationTime": "2021-09-09T14:28:31.617043Z",
+          "credit": [
+            "Yeting Li"
+          ],
+          "cvssScore": 7.5,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) due to the sub-patterns` [[\\\\]()#;?]*` and `(?:;[-a-zA-Z\\\\d\\\\/#&.:=?%@~_]*)*`.\r\n\r\n\r\n### PoC\r\n```\r\nimport ansiRegex from 'ansi-regex';\r\n\r\nfor(var i = 1; i <= 50000; i++) {\r\n    var time = Date.now();\r\n    var attack_str = \"\\u001B[\"+\";\".repeat(i*10000);\r\n    ansiRegex().test(attack_str)\r\n    var time_cost = Date.now() - time;\r\n    console.log(\"attack_str.length: \" + attack_str.length + \": \" + time_cost+\" ms\")\r\n}\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `ansi-regex` to version 6.0.1, 5.0.1 or higher.\n## References\n- [GitHub Commit](https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9)\n- [GitHub PR](https://github.com/chalk/ansi-regex/pull/37)\n",
+          "disclosureTime": "2021-09-09T14:27:43Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "6.0.1",
+            "5.0.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-ANSIREGEX-1583908",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-3807"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-09-23T15:49:52.792982Z",
+          "moduleName": "ansi-regex",
+          "packageManager": "npm",
+          "packageName": "ansi-regex",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2021-09-12T12:52:37Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/chalk/ansi-regex/commit/8d1d7cdb586269882c4bdc1b7325d0c58c8f76f9"
+            },
+            {
+              "title": "GitHub PR",
+              "url": "https://github.com/chalk/ansi-regex/pull/37"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              ">=6.0.0 <6.0.1",
+              ">2.1.1 <5.0.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Regular Expression Denial of Service (ReDoS)"
+        },
+        "SNYK-JS-NETMASK-1089716": {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:L/E:P",
+          "alternativeIds": [],
+          "creationTime": "2021-03-30T09:49:33.483598Z",
+          "credit": [
+            "Unknown"
+          ],
+          "cvssScore": 7.7,
+          "description": "## Overview\n[netmask](https://www.npmjs.org/package/netmask) is a library to parse IPv4 CIDR blocks.\n\nAffected versions of this package are vulnerable to Server-side Request Forgery (SSRF). It incorrectly evaluates individual IPv4 octets that contain octal strings as left-stripped integers, leading to an inordinate attack surface on hundreds of thousands of projects that rely on `netmask` to filter or evaluate IPv4 block ranges, both inbound and outbound.\r\n\r\nFor example, a remote unauthenticated attacker can request local resources using input data `0177.0.0.1` (`127.0.0.1`), which `netmask` evaluates as the public IP `177.0.0.1`.\r\nContrastingly, a remote authenticated or unauthenticated attacker can input the data `0127.0.0.01` (`87.0.0.1`) as localhost, yet the input data is a public IP and can potentially cause local and remote file inclusion (LFI/RFI).\r\nA remote authenticated or unauthenticated attacker can bypass packages that rely on `netmask` to filter IP address blocks to reach intranets, VPNs, containers, adjacent VPC instances, or LAN hosts, using input data such as `012.0.0.1` (`10.0.0.1`), which `netmask` evaluates as `12.0.0.1` (public).\n## Remediation\nUpgrade `netmask` to version 2.0.1 or higher.\n## References\n- [GitHub Commit](https://github.com/rs/node-netmask/commit/3f19a056c4eb808ea4a29f234274c67bc5a848f4)\n- [PoC](https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md)\n- [Researcher Report](https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/)\n",
+          "disclosureTime": "2021-03-29T21:32:05Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "2.0.1"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-NETMASK-1089716",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-28918",
+              "CVE-2021-29418"
+            ],
+            "CWE": [
+              "CWE-20",
+              "CWE-918"
+            ],
+            "GHSA": [
+              "GHSA-pch5-whg9-qr2r"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-03-30T21:51:32.450263Z",
+          "moduleName": "netmask",
+          "packageManager": "npm",
+          "packageName": "netmask",
+          "patches": [],
+          "proprietary": false,
+          "publicationTime": "2021-03-30T14:57:04Z",
+          "references": [
+            {
+              "title": "GitHub Commit",
+              "url": "https://github.com/rs/node-netmask/commit/3f19a056c4eb808ea4a29f234274c67bc5a848f4"
+            },
+            {
+              "title": "PoC",
+              "url": "https://github.com/sickcodes/security/blob/master/advisories/SICK-2021-011.md"
+            },
+            {
+              "title": "Researcher Report",
+              "url": "https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<2.0.1"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Server-side Request Forgery (SSRF)"
+        },
+        "SNYK-JS-PACRESOLVER-1564857": {
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P",
+          "alternativeIds": [],
+          "creationTime": "2021-08-15T12:18:11.115775Z",
+          "credit": [
+            "Tim Perry"
+          ],
+          "cvssScore": 8.1,
+          "description": "## Overview\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). This can occur when used with untrusted input, due to unsafe PAC file handling.\r\n\r\n**NOTE:** The fix for this vulnerability is applied in the `node-degenerator` library, a dependency written by the same maintainer. \r\n\r\n### PoC\r\n```\r\nconst pac = require('pac-resolver');\r\n\r\n// Should keep running forever (if not vulnerable):\r\nsetInterval(() => {\r\n    console.log(\"Still running\");\r\n}, 1000);\r\n\r\n// Parsing a malicious PAC file unexpectedly executes unsandboxed code:\r\npac(`\r\n    // Real PAC config:\r\n    function FindProxyForURL(url, host) {\r\n        return \"DIRECT\";\r\n    }\r\n\r\n    // But also run arbitrary code:\r\n    var f = this.constructor.constructor(\\`\r\n        // Running outside the sandbox:\r\n        console.log('Read env vars:', process.env);\r\n        console.log('!!! PAC file is running arbitrary code !!!');\r\n        console.log('Can read & could exfiltrate env vars ^');\r\n        console.log('Can kill parsing process, like so:');\r\n        process.exit(100); // Kill the vulnerable process\r\n        // etc etc\r\n    \\`);\r\n\r\n    f();\r\n`);\r\n```\n## Remediation\nUpgrade `pac-resolver` to version 5.0.0 or higher.\n## References\n- [GitHub Commit #1](https://github.com/TooTallNate/node-degenerator/commit/ccc3445354135398b6eb1a04c7d27c13b833f2d5)\n- [GitHub Commit #2](https://github.com/TooTallNate/node-degenerator/commit/9d25bb67d957bc2e5425fea7bf7a58b3fc64ff9e)\n- [Github Release](https://github.com/TooTallNate/node-pac-resolver/releases/tag/5.0.0)\n- [Researcher Blog](https://httptoolkit.tech/blog/npm-pac-proxy-agent-vulnerability/)\n",
+          "disclosureTime": "2021-05-30T13:37:37Z",
+          "exploit": "Proof of Concept",
+          "fixedIn": [
+            "5.0.0"
+          ],
+          "functions": [],
+          "functions_new": [],
+          "id": "SNYK-JS-PACRESOLVER-1564857",
+          "identifiers": {
+            "CVE": [
+              "CVE-2021-23406"
+            ],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "language": "js",
+          "malicious": false,
+          "modificationTime": "2021-08-22T13:26:30.852456Z",
+          "moduleName": "pac-resolver",
+          "packageManager": "npm",
+          "packageName": "pac-resolver",
+          "patches": [],
+          "proprietary": true,
+          "publicationTime": "2021-08-22T13:26:31Z",
+          "references": [
+            {
+              "title": "GitHub Commit #1",
+              "url": "https://github.com/TooTallNate/node-degenerator/commit/ccc3445354135398b6eb1a04c7d27c13b833f2d5"
+            },
+            {
+              "title": "GitHub Commit #2",
+              "url": "https://github.com/TooTallNate/node-degenerator/commit/9d25bb67d957bc2e5425fea7bf7a58b3fc64ff9e"
+            },
+            {
+              "title": "Github Release",
+              "url": "https://github.com/TooTallNate/node-pac-resolver/releases/tag/5.0.0"
+            },
+            {
+              "title": "Researcher Blog",
+              "url": "https://httptoolkit.tech/blog/npm-pac-proxy-agent-vulnerability/"
+            }
+          ],
+          "semver": {
+            "vulnerable": [
+              "<5.0.0"
+            ]
+          },
+          "severity": "high",
+          "severityWithCritical": "high",
+          "socialTrendAlert": false,
+          "title": "Remote Code Execution (RCE)"
+        }
+      },
+      "issues": [
+        {
+          "pkgName": "ansi-regex",
+          "pkgVersion": "3.0.0",
+          "issueId": "SNYK-JS-ANSIREGEX-1583908",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.316.0"
+                  },
+                  {
+                    "name": "inquirer",
+                    "version": "6.5.2",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "string-width",
+                    "version": "2.1.1",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "strip-ansi",
+                    "version": "4.0.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "ansi-regex",
+                    "version": "3.0.0",
+                    "isDropped": true
+                  }
+                ]
+              }
+            ],
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "ansi-regex",
+          "pkgVersion": "4.1.0",
+          "issueId": "SNYK-JS-ANSIREGEX-1583908",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.685.0"
+                  },
+                  {
+                    "name": "strip-ansi",
+                    "version": "5.2.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "ansi-regex",
+                    "version": "4.1.0",
+                    "isDropped": true
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.316.0"
+                  },
+                  {
+                    "name": "inquirer",
+                    "version": "6.5.2",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "strip-ansi",
+                    "version": "5.2.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "ansi-regex",
+                    "version": "4.1.0",
+                    "isDropped": true
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.685.0"
+                  },
+                  {
+                    "name": "wrap-ansi",
+                    "version": "5.1.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "strip-ansi",
+                    "version": "5.2.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "ansi-regex",
+                    "version": "4.1.0",
+                    "isDropped": true
+                  }
+                ]
+              },
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.685.0"
+                  },
+                  {
+                    "name": "wrap-ansi",
+                    "version": "5.1.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "string-width",
+                    "version": "3.1.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "strip-ansi",
+                    "version": "5.2.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "ansi-regex",
+                    "version": "4.1.0",
+                    "isDropped": true
+                  }
+                ]
+              }
+            ],
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "netmask",
+          "pkgVersion": "1.0.6",
+          "issueId": "SNYK-JS-NETMASK-1089716",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.518.0"
+                  },
+                  {
+                    "name": "proxy-agent",
+                    "version": "3.1.1",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "pac-proxy-agent",
+                    "version": "3.0.1",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "pac-resolver",
+                    "version": "3.0.0",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "netmask",
+                    "version": "1.0.6",
+                    "isDropped": true
+                  }
+                ]
+              }
+            ],
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        },
+        {
+          "pkgName": "pac-resolver",
+          "pkgVersion": "3.0.0",
+          "issueId": "SNYK-JS-PACRESOLVER-1564857",
+          "fixInfo": {
+            "isPatchable": false,
+            "upgradePaths": [
+              {
+                "path": [
+                  {
+                    "name": "goof",
+                    "version": "1.0.1"
+                  },
+                  {
+                    "name": "snyk",
+                    "version": "1.290.2",
+                    "newVersion": "1.518.0"
+                  },
+                  {
+                    "name": "proxy-agent",
+                    "version": "3.1.1",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "pac-proxy-agent",
+                    "version": "3.0.1",
+                    "isDropped": true
+                  },
+                  {
+                    "name": "pac-resolver",
+                    "version": "3.0.0",
+                    "isDropped": true
+                  }
+                ]
+              }
+            ],
+            "isRuntime": false,
+            "isPinnable": false
+          }
+        }
+      ],
+      "docker": {},
+      "remediation": {
+        "unresolved": [],
+        "upgrade": {
+          "snyk@1.290.2": {
+            "upgradeTo": "snyk@1.685.0",
+            "upgrades": [
+              "ansi-regex@4.1.0",
+              "netmask@1.0.6",
+              "pac-resolver@3.0.0"
+            ],
+            "vulns": [
+              "SNYK-JS-ANSIREGEX-1583908",
+              "SNYK-JS-NETMASK-1089716",
+              "SNYK-JS-PACRESOLVER-1564857"
+            ]
+          }
+        },
+        "patch": {},
+        "ignore": {},
+        "pin": {}
+      },
+      "depGraphData": {
+        "schemaVersion": "1.2.0",
+        "pkgManager": {
+          "name": "npm"
+        },
+        "pkgs": [
+          {
+            "id": "goof@1.0.1",
+            "info": {
+              "name": "goof",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "tslib@1.14.1",
+            "info": {
+              "name": "tslib",
+              "version": "1.14.1"
+            }
+          },
+          {
+            "id": "@snyk/cli-interface@2.3.0",
+            "info": {
+              "name": "@snyk/cli-interface",
+              "version": "2.3.0"
+            }
+          },
+          {
+            "id": "is-obj@2.0.0",
+            "info": {
+              "name": "is-obj",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "dot-prop@5.3.0",
+            "info": {
+              "name": "dot-prop",
+              "version": "5.3.0"
+            }
+          },
+          {
+            "id": "graceful-fs@4.2.8",
+            "info": {
+              "name": "graceful-fs",
+              "version": "4.2.8"
+            }
+          },
+          {
+            "id": "pify@3.0.0",
+            "info": {
+              "name": "pify",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "make-dir@1.3.0",
+            "info": {
+              "name": "make-dir",
+              "version": "1.3.0"
+            }
+          },
+          {
+            "id": "crypto-random-string@1.0.0",
+            "info": {
+              "name": "crypto-random-string",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "unique-string@1.0.0",
+            "info": {
+              "name": "unique-string",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "imurmurhash@0.1.4",
+            "info": {
+              "name": "imurmurhash",
+              "version": "0.1.4"
+            }
+          },
+          {
+            "id": "signal-exit@3.0.6",
+            "info": {
+              "name": "signal-exit",
+              "version": "3.0.6"
+            }
+          },
+          {
+            "id": "write-file-atomic@2.4.3",
+            "info": {
+              "name": "write-file-atomic",
+              "version": "2.4.3"
+            }
+          },
+          {
+            "id": "xdg-basedir@3.0.0",
+            "info": {
+              "name": "xdg-basedir",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "@snyk/configstore@3.2.0-rc1",
+            "info": {
+              "name": "@snyk/configstore",
+              "version": "3.2.0-rc1"
+            }
+          },
+          {
+            "id": "lodash@4.17.21",
+            "info": {
+              "name": "lodash",
+              "version": "4.17.21"
+            }
+          },
+          {
+            "id": "graphlib@2.1.8",
+            "info": {
+              "name": "graphlib",
+              "version": "2.1.8"
+            }
+          },
+          {
+            "id": "object-hash@1.3.1",
+            "info": {
+              "name": "object-hash",
+              "version": "1.3.1"
+            }
+          },
+          {
+            "id": "semver@6.3.0",
+            "info": {
+              "name": "semver",
+              "version": "6.3.0"
+            }
+          },
+          {
+            "id": "buffer-from@1.1.2",
+            "info": {
+              "name": "buffer-from",
+              "version": "1.1.2"
+            }
+          },
+          {
+            "id": "source-map@0.6.1",
+            "info": {
+              "name": "source-map",
+              "version": "0.6.1"
+            }
+          },
+          {
+            "id": "source-map-support@0.5.21",
+            "info": {
+              "name": "source-map-support",
+              "version": "0.5.21"
+            }
+          },
+          {
+            "id": "@snyk/dep-graph@1.13.1",
+            "info": {
+              "name": "@snyk/dep-graph",
+              "version": "1.13.1"
+            }
+          },
+          {
+            "id": "@snyk/gemfile@1.2.0",
+            "info": {
+              "name": "@snyk/gemfile",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "@snyk/cli-interface@1.5.0",
+            "info": {
+              "name": "@snyk/cli-interface",
+              "version": "1.5.0"
+            }
+          },
+          {
+            "id": "lodash.escaperegexp@4.1.2",
+            "info": {
+              "name": "lodash.escaperegexp",
+              "version": "4.1.2"
+            }
+          },
+          {
+            "id": "lodash.flatten@4.4.0",
+            "info": {
+              "name": "lodash.flatten",
+              "version": "4.4.0"
+            }
+          },
+          {
+            "id": "lodash.uniq@4.5.0",
+            "info": {
+              "name": "lodash.uniq",
+              "version": "4.5.0"
+            }
+          },
+          {
+            "id": "@snyk/ruby-semver@2.2.2",
+            "info": {
+              "name": "@snyk/ruby-semver",
+              "version": "2.2.2"
+            }
+          },
+          {
+            "id": "@types/js-yaml@3.12.7",
+            "info": {
+              "name": "@types/js-yaml",
+              "version": "3.12.7"
+            }
+          },
+          {
+            "id": "core-js@3.19.3",
+            "info": {
+              "name": "core-js",
+              "version": "3.19.3"
+            }
+          },
+          {
+            "id": "sprintf-js@1.0.3",
+            "info": {
+              "name": "sprintf-js",
+              "version": "1.0.3"
+            }
+          },
+          {
+            "id": "argparse@1.0.10",
+            "info": {
+              "name": "argparse",
+              "version": "1.0.10"
+            }
+          },
+          {
+            "id": "esprima@4.0.1",
+            "info": {
+              "name": "esprima",
+              "version": "4.0.1"
+            }
+          },
+          {
+            "id": "js-yaml@3.14.1",
+            "info": {
+              "name": "js-yaml",
+              "version": "3.14.1"
+            }
+          },
+          {
+            "id": "@snyk/cocoapods-lockfile-parser@3.0.0",
+            "info": {
+              "name": "@snyk/cocoapods-lockfile-parser",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "@snyk/snyk-cocoapods-plugin@2.0.1",
+            "info": {
+              "name": "@snyk/snyk-cocoapods-plugin",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "is-fullwidth-code-point@2.0.0",
+            "info": {
+              "name": "is-fullwidth-code-point",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "ansi-regex@3.0.0",
+            "info": {
+              "name": "ansi-regex",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "strip-ansi@4.0.0",
+            "info": {
+              "name": "strip-ansi",
+              "version": "4.0.0"
+            }
+          },
+          {
+            "id": "string-width@2.1.1",
+            "info": {
+              "name": "string-width",
+              "version": "2.1.1"
+            }
+          },
+          {
+            "id": "ansi-align@2.0.0",
+            "info": {
+              "name": "ansi-align",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "camelcase@4.1.0",
+            "info": {
+              "name": "camelcase",
+              "version": "4.1.0"
+            }
+          },
+          {
+            "id": "color-name@1.1.3",
+            "info": {
+              "name": "color-name",
+              "version": "1.1.3"
+            }
+          },
+          {
+            "id": "color-convert@1.9.3",
+            "info": {
+              "name": "color-convert",
+              "version": "1.9.3"
+            }
+          },
+          {
+            "id": "ansi-styles@3.2.1",
+            "info": {
+              "name": "ansi-styles",
+              "version": "3.2.1"
+            }
+          },
+          {
+            "id": "escape-string-regexp@1.0.5",
+            "info": {
+              "name": "escape-string-regexp",
+              "version": "1.0.5"
+            }
+          },
+          {
+            "id": "has-flag@3.0.0",
+            "info": {
+              "name": "has-flag",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "supports-color@5.5.0",
+            "info": {
+              "name": "supports-color",
+              "version": "5.5.0"
+            }
+          },
+          {
+            "id": "chalk@2.4.2",
+            "info": {
+              "name": "chalk",
+              "version": "2.4.2"
+            }
+          },
+          {
+            "id": "cli-boxes@1.0.0",
+            "info": {
+              "name": "cli-boxes",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "pseudomap@1.0.2",
+            "info": {
+              "name": "pseudomap",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "yallist@2.1.2",
+            "info": {
+              "name": "yallist",
+              "version": "2.1.2"
+            }
+          },
+          {
+            "id": "lru-cache@4.1.5",
+            "info": {
+              "name": "lru-cache",
+              "version": "4.1.5"
+            }
+          },
+          {
+            "id": "shebang-regex@1.0.0",
+            "info": {
+              "name": "shebang-regex",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "shebang-command@1.2.0",
+            "info": {
+              "name": "shebang-command",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "isexe@2.0.0",
+            "info": {
+              "name": "isexe",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "which@1.3.1",
+            "info": {
+              "name": "which",
+              "version": "1.3.1"
+            }
+          },
+          {
+            "id": "cross-spawn@5.1.0",
+            "info": {
+              "name": "cross-spawn",
+              "version": "5.1.0"
+            }
+          },
+          {
+            "id": "get-stream@3.0.0",
+            "info": {
+              "name": "get-stream",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "is-stream@1.1.0",
+            "info": {
+              "name": "is-stream",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "path-key@2.0.1",
+            "info": {
+              "name": "path-key",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "npm-run-path@2.0.2",
+            "info": {
+              "name": "npm-run-path",
+              "version": "2.0.2"
+            }
+          },
+          {
+            "id": "p-finally@1.0.0",
+            "info": {
+              "name": "p-finally",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "strip-eof@1.0.0",
+            "info": {
+              "name": "strip-eof",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "execa@0.7.0",
+            "info": {
+              "name": "execa",
+              "version": "0.7.0"
+            }
+          },
+          {
+            "id": "term-size@1.2.0",
+            "info": {
+              "name": "term-size",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "widest-line@2.0.1",
+            "info": {
+              "name": "widest-line",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "boxen@1.3.0",
+            "info": {
+              "name": "boxen",
+              "version": "1.3.0"
+            }
+          },
+          {
+            "id": "import-lazy@2.1.0",
+            "info": {
+              "name": "import-lazy",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "ci-info@1.6.0",
+            "info": {
+              "name": "ci-info",
+              "version": "1.6.0"
+            }
+          },
+          {
+            "id": "is-ci@1.2.1",
+            "info": {
+              "name": "is-ci",
+              "version": "1.2.1"
+            }
+          },
+          {
+            "id": "ini@1.3.8",
+            "info": {
+              "name": "ini",
+              "version": "1.3.8"
+            }
+          },
+          {
+            "id": "global-dirs@0.1.1",
+            "info": {
+              "name": "global-dirs",
+              "version": "0.1.1"
+            }
+          },
+          {
+            "id": "path-is-inside@1.0.2",
+            "info": {
+              "name": "path-is-inside",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "is-path-inside@1.0.1",
+            "info": {
+              "name": "is-path-inside",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "is-installed-globally@0.1.0",
+            "info": {
+              "name": "is-installed-globally",
+              "version": "0.1.0"
+            }
+          },
+          {
+            "id": "is-npm@1.0.0",
+            "info": {
+              "name": "is-npm",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "capture-stack-trace@1.0.1",
+            "info": {
+              "name": "capture-stack-trace",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "create-error-class@3.0.2",
+            "info": {
+              "name": "create-error-class",
+              "version": "3.0.2"
+            }
+          },
+          {
+            "id": "duplexer3@0.1.4",
+            "info": {
+              "name": "duplexer3",
+              "version": "0.1.4"
+            }
+          },
+          {
+            "id": "is-redirect@1.0.0",
+            "info": {
+              "name": "is-redirect",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "is-retry-allowed@1.2.0",
+            "info": {
+              "name": "is-retry-allowed",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "lowercase-keys@1.0.1",
+            "info": {
+              "name": "lowercase-keys",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "safe-buffer@5.2.1",
+            "info": {
+              "name": "safe-buffer",
+              "version": "5.2.1"
+            }
+          },
+          {
+            "id": "timed-out@4.0.1",
+            "info": {
+              "name": "timed-out",
+              "version": "4.0.1"
+            }
+          },
+          {
+            "id": "unzip-response@2.0.1",
+            "info": {
+              "name": "unzip-response",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "prepend-http@1.0.4",
+            "info": {
+              "name": "prepend-http",
+              "version": "1.0.4"
+            }
+          },
+          {
+            "id": "url-parse-lax@1.0.0",
+            "info": {
+              "name": "url-parse-lax",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "got@6.7.1",
+            "info": {
+              "name": "got",
+              "version": "6.7.1"
+            }
+          },
+          {
+            "id": "deep-extend@0.6.0",
+            "info": {
+              "name": "deep-extend",
+              "version": "0.6.0"
+            }
+          },
+          {
+            "id": "minimist@1.2.5",
+            "info": {
+              "name": "minimist",
+              "version": "1.2.5"
+            }
+          },
+          {
+            "id": "strip-json-comments@2.0.1",
+            "info": {
+              "name": "strip-json-comments",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "rc@1.2.8",
+            "info": {
+              "name": "rc",
+              "version": "1.2.8"
+            }
+          },
+          {
+            "id": "registry-auth-token@3.4.0",
+            "info": {
+              "name": "registry-auth-token",
+              "version": "3.4.0"
+            }
+          },
+          {
+            "id": "registry-url@3.1.0",
+            "info": {
+              "name": "registry-url",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "semver@5.7.1",
+            "info": {
+              "name": "semver",
+              "version": "5.7.1"
+            }
+          },
+          {
+            "id": "package-json@4.0.1",
+            "info": {
+              "name": "package-json",
+              "version": "4.0.1"
+            }
+          },
+          {
+            "id": "latest-version@3.1.0",
+            "info": {
+              "name": "latest-version",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "semver-diff@2.1.0",
+            "info": {
+              "name": "semver-diff",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "@snyk/update-notifier@2.5.1-rc2",
+            "info": {
+              "name": "@snyk/update-notifier",
+              "version": "2.5.1-rc2"
+            }
+          },
+          {
+            "id": "@types/node@16.11.11",
+            "info": {
+              "name": "@types/node",
+              "version": "16.11.11"
+            }
+          },
+          {
+            "id": "@types/agent-base@4.2.2",
+            "info": {
+              "name": "@types/agent-base",
+              "version": "4.2.2"
+            }
+          },
+          {
+            "id": "@types/bunyan@1.8.8",
+            "info": {
+              "name": "@types/bunyan",
+              "version": "1.8.8"
+            }
+          },
+          {
+            "id": "@types/restify@4.3.8",
+            "info": {
+              "name": "@types/restify",
+              "version": "4.3.8"
+            }
+          },
+          {
+            "id": "abbrev@1.1.1",
+            "info": {
+              "name": "abbrev",
+              "version": "1.1.1"
+            }
+          },
+          {
+            "id": "ansi-escapes@3.2.0",
+            "info": {
+              "name": "ansi-escapes",
+              "version": "3.2.0"
+            }
+          },
+          {
+            "id": "cli-spinner@0.2.10",
+            "info": {
+              "name": "cli-spinner",
+              "version": "0.2.10"
+            }
+          },
+          {
+            "id": "ms@2.1.3",
+            "info": {
+              "name": "ms",
+              "version": "2.1.3"
+            }
+          },
+          {
+            "id": "debug@3.2.7",
+            "info": {
+              "name": "debug",
+              "version": "3.2.7"
+            }
+          },
+          {
+            "id": "diff@4.0.2",
+            "info": {
+              "name": "diff",
+              "version": "4.0.2"
+            }
+          },
+          {
+            "id": "protocols@1.4.8",
+            "info": {
+              "name": "protocols",
+              "version": "1.4.8"
+            }
+          },
+          {
+            "id": "is-ssh@1.3.3",
+            "info": {
+              "name": "is-ssh",
+              "version": "1.3.3"
+            }
+          },
+          {
+            "id": "normalize-url@6.1.0",
+            "info": {
+              "name": "normalize-url",
+              "version": "6.1.0"
+            }
+          },
+          {
+            "id": "function-bind@1.1.1",
+            "info": {
+              "name": "function-bind",
+              "version": "1.1.1"
+            }
+          },
+          {
+            "id": "has@1.0.3",
+            "info": {
+              "name": "has",
+              "version": "1.0.3"
+            }
+          },
+          {
+            "id": "has-symbols@1.0.2",
+            "info": {
+              "name": "has-symbols",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "get-intrinsic@1.1.1",
+            "info": {
+              "name": "get-intrinsic",
+              "version": "1.1.1"
+            }
+          },
+          {
+            "id": "call-bind@1.0.2",
+            "info": {
+              "name": "call-bind",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "object-inspect@1.11.1",
+            "info": {
+              "name": "object-inspect",
+              "version": "1.11.1"
+            }
+          },
+          {
+            "id": "side-channel@1.0.4",
+            "info": {
+              "name": "side-channel",
+              "version": "1.0.4"
+            }
+          },
+          {
+            "id": "qs@6.10.2",
+            "info": {
+              "name": "qs",
+              "version": "6.10.2"
+            }
+          },
+          {
+            "id": "decode-uri-component@0.2.0",
+            "info": {
+              "name": "decode-uri-component",
+              "version": "0.2.0"
+            }
+          },
+          {
+            "id": "filter-obj@1.1.0",
+            "info": {
+              "name": "filter-obj",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "split-on-first@1.1.0",
+            "info": {
+              "name": "split-on-first",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "strict-uri-encode@2.0.0",
+            "info": {
+              "name": "strict-uri-encode",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "query-string@6.14.1",
+            "info": {
+              "name": "query-string",
+              "version": "6.14.1"
+            }
+          },
+          {
+            "id": "parse-path@4.0.3",
+            "info": {
+              "name": "parse-path",
+              "version": "4.0.3"
+            }
+          },
+          {
+            "id": "parse-url@6.0.0",
+            "info": {
+              "name": "parse-url",
+              "version": "6.0.0"
+            }
+          },
+          {
+            "id": "git-up@4.0.5",
+            "info": {
+              "name": "git-up",
+              "version": "4.0.5"
+            }
+          },
+          {
+            "id": "git-url-parse@11.1.2",
+            "info": {
+              "name": "git-url-parse",
+              "version": "11.1.2"
+            }
+          },
+          {
+            "id": "fs.realpath@1.0.0",
+            "info": {
+              "name": "fs.realpath",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "wrappy@1.0.2",
+            "info": {
+              "name": "wrappy",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "once@1.4.0",
+            "info": {
+              "name": "once",
+              "version": "1.4.0"
+            }
+          },
+          {
+            "id": "inflight@1.0.6",
+            "info": {
+              "name": "inflight",
+              "version": "1.0.6"
+            }
+          },
+          {
+            "id": "inherits@2.0.4",
+            "info": {
+              "name": "inherits",
+              "version": "2.0.4"
+            }
+          },
+          {
+            "id": "balanced-match@1.0.2",
+            "info": {
+              "name": "balanced-match",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "concat-map@0.0.1",
+            "info": {
+              "name": "concat-map",
+              "version": "0.0.1"
+            }
+          },
+          {
+            "id": "brace-expansion@1.1.11",
+            "info": {
+              "name": "brace-expansion",
+              "version": "1.1.11"
+            }
+          },
+          {
+            "id": "minimatch@3.0.4",
+            "info": {
+              "name": "minimatch",
+              "version": "3.0.4"
+            }
+          },
+          {
+            "id": "path-is-absolute@1.0.1",
+            "info": {
+              "name": "path-is-absolute",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "glob@7.2.0",
+            "info": {
+              "name": "glob",
+              "version": "7.2.0"
+            }
+          },
+          {
+            "id": "mimic-fn@1.2.0",
+            "info": {
+              "name": "mimic-fn",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "onetime@2.0.1",
+            "info": {
+              "name": "onetime",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "restore-cursor@2.0.0",
+            "info": {
+              "name": "restore-cursor",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "cli-cursor@2.1.0",
+            "info": {
+              "name": "cli-cursor",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "cli-width@2.2.1",
+            "info": {
+              "name": "cli-width",
+              "version": "2.2.1"
+            }
+          },
+          {
+            "id": "chardet@0.7.0",
+            "info": {
+              "name": "chardet",
+              "version": "0.7.0"
+            }
+          },
+          {
+            "id": "safer-buffer@2.1.2",
+            "info": {
+              "name": "safer-buffer",
+              "version": "2.1.2"
+            }
+          },
+          {
+            "id": "iconv-lite@0.4.24",
+            "info": {
+              "name": "iconv-lite",
+              "version": "0.4.24"
+            }
+          },
+          {
+            "id": "os-tmpdir@1.0.2",
+            "info": {
+              "name": "os-tmpdir",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "tmp@0.0.33",
+            "info": {
+              "name": "tmp",
+              "version": "0.0.33"
+            }
+          },
+          {
+            "id": "external-editor@3.1.0",
+            "info": {
+              "name": "external-editor",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "figures@2.0.0",
+            "info": {
+              "name": "figures",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "mute-stream@0.0.7",
+            "info": {
+              "name": "mute-stream",
+              "version": "0.0.7"
+            }
+          },
+          {
+            "id": "run-async@2.4.1",
+            "info": {
+              "name": "run-async",
+              "version": "2.4.1"
+            }
+          },
+          {
+            "id": "rxjs@6.6.7",
+            "info": {
+              "name": "rxjs",
+              "version": "6.6.7"
+            }
+          },
+          {
+            "id": "ansi-regex@4.1.0",
+            "info": {
+              "name": "ansi-regex",
+              "version": "4.1.0"
+            }
+          },
+          {
+            "id": "strip-ansi@5.2.0",
+            "info": {
+              "name": "strip-ansi",
+              "version": "5.2.0"
+            }
+          },
+          {
+            "id": "through@2.3.8",
+            "info": {
+              "name": "through",
+              "version": "2.3.8"
+            }
+          },
+          {
+            "id": "inquirer@6.5.2",
+            "info": {
+              "name": "inquirer",
+              "version": "6.5.2"
+            }
+          },
+          {
+            "id": "sax@1.2.4",
+            "info": {
+              "name": "sax",
+              "version": "1.2.4"
+            }
+          },
+          {
+            "id": "needle@2.9.1",
+            "info": {
+              "name": "needle",
+              "version": "2.9.1"
+            }
+          },
+          {
+            "id": "is-wsl@1.1.0",
+            "info": {
+              "name": "is-wsl",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "opn@5.5.0",
+            "info": {
+              "name": "opn",
+              "version": "5.5.0"
+            }
+          },
+          {
+            "id": "macos-release@2.5.0",
+            "info": {
+              "name": "macos-release",
+              "version": "2.5.0"
+            }
+          },
+          {
+            "id": "nice-try@1.0.5",
+            "info": {
+              "name": "nice-try",
+              "version": "1.0.5"
+            }
+          },
+          {
+            "id": "cross-spawn@6.0.5",
+            "info": {
+              "name": "cross-spawn",
+              "version": "6.0.5"
+            }
+          },
+          {
+            "id": "end-of-stream@1.4.4",
+            "info": {
+              "name": "end-of-stream",
+              "version": "1.4.4"
+            }
+          },
+          {
+            "id": "pump@3.0.0",
+            "info": {
+              "name": "pump",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "get-stream@4.1.0",
+            "info": {
+              "name": "get-stream",
+              "version": "4.1.0"
+            }
+          },
+          {
+            "id": "execa@1.0.0",
+            "info": {
+              "name": "execa",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "windows-release@3.3.3",
+            "info": {
+              "name": "windows-release",
+              "version": "3.3.3"
+            }
+          },
+          {
+            "id": "os-name@3.1.0",
+            "info": {
+              "name": "os-name",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "es6-promise@4.2.8",
+            "info": {
+              "name": "es6-promise",
+              "version": "4.2.8"
+            }
+          },
+          {
+            "id": "es6-promisify@5.0.0",
+            "info": {
+              "name": "es6-promisify",
+              "version": "5.0.0"
+            }
+          },
+          {
+            "id": "agent-base@4.3.0",
+            "info": {
+              "name": "agent-base",
+              "version": "4.3.0"
+            }
+          },
+          {
+            "id": "ms@2.1.2",
+            "info": {
+              "name": "ms",
+              "version": "2.1.2"
+            }
+          },
+          {
+            "id": "debug@4.3.3",
+            "info": {
+              "name": "debug",
+              "version": "4.3.3"
+            }
+          },
+          {
+            "id": "ms@2.0.0",
+            "info": {
+              "name": "ms",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "debug@3.1.0",
+            "info": {
+              "name": "debug",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "http-proxy-agent@2.1.0",
+            "info": {
+              "name": "http-proxy-agent",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "https-proxy-agent@3.0.1",
+            "info": {
+              "name": "https-proxy-agent",
+              "version": "3.0.1"
+            }
+          },
+          {
+            "id": "yallist@3.1.1",
+            "info": {
+              "name": "yallist",
+              "version": "3.1.1"
+            }
+          },
+          {
+            "id": "lru-cache@5.1.1",
+            "info": {
+              "name": "lru-cache",
+              "version": "5.1.1"
+            }
+          },
+          {
+            "id": "data-uri-to-buffer@1.2.0",
+            "info": {
+              "name": "data-uri-to-buffer",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "debug@2.6.9",
+            "info": {
+              "name": "debug",
+              "version": "2.6.9"
+            }
+          },
+          {
+            "id": "extend@3.0.2",
+            "info": {
+              "name": "extend",
+              "version": "3.0.2"
+            }
+          },
+          {
+            "id": "file-uri-to-path@1.0.0",
+            "info": {
+              "name": "file-uri-to-path",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "core-util-is@1.0.3",
+            "info": {
+              "name": "core-util-is",
+              "version": "1.0.3"
+            }
+          },
+          {
+            "id": "isarray@0.0.1",
+            "info": {
+              "name": "isarray",
+              "version": "0.0.1"
+            }
+          },
+          {
+            "id": "string_decoder@0.10.31",
+            "info": {
+              "name": "string_decoder",
+              "version": "0.10.31"
+            }
+          },
+          {
+            "id": "readable-stream@1.1.14",
+            "info": {
+              "name": "readable-stream",
+              "version": "1.1.14"
+            }
+          },
+          {
+            "id": "xregexp@2.0.0",
+            "info": {
+              "name": "xregexp",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "ftp@0.3.10",
+            "info": {
+              "name": "ftp",
+              "version": "0.3.10"
+            }
+          },
+          {
+            "id": "isarray@1.0.0",
+            "info": {
+              "name": "isarray",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "process-nextick-args@2.0.1",
+            "info": {
+              "name": "process-nextick-args",
+              "version": "2.0.1"
+            }
+          },
+          {
+            "id": "safe-buffer@5.1.2",
+            "info": {
+              "name": "safe-buffer",
+              "version": "5.1.2"
+            }
+          },
+          {
+            "id": "string_decoder@1.1.1",
+            "info": {
+              "name": "string_decoder",
+              "version": "1.1.1"
+            }
+          },
+          {
+            "id": "util-deprecate@1.0.2",
+            "info": {
+              "name": "util-deprecate",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "readable-stream@2.3.7",
+            "info": {
+              "name": "readable-stream",
+              "version": "2.3.7"
+            }
+          },
+          {
+            "id": "get-uri@2.0.4",
+            "info": {
+              "name": "get-uri",
+              "version": "2.0.4"
+            }
+          },
+          {
+            "id": "co@4.6.0",
+            "info": {
+              "name": "co",
+              "version": "4.6.0"
+            }
+          },
+          {
+            "id": "tslib@2.3.1",
+            "info": {
+              "name": "tslib",
+              "version": "2.3.1"
+            }
+          },
+          {
+            "id": "ast-types@0.14.2",
+            "info": {
+              "name": "ast-types",
+              "version": "0.14.2"
+            }
+          },
+          {
+            "id": "estraverse@4.3.0",
+            "info": {
+              "name": "estraverse",
+              "version": "4.3.0"
+            }
+          },
+          {
+            "id": "esutils@2.0.3",
+            "info": {
+              "name": "esutils",
+              "version": "2.0.3"
+            }
+          },
+          {
+            "id": "deep-is@0.1.4",
+            "info": {
+              "name": "deep-is",
+              "version": "0.1.4"
+            }
+          },
+          {
+            "id": "fast-levenshtein@2.0.6",
+            "info": {
+              "name": "fast-levenshtein",
+              "version": "2.0.6"
+            }
+          },
+          {
+            "id": "prelude-ls@1.1.2",
+            "info": {
+              "name": "prelude-ls",
+              "version": "1.1.2"
+            }
+          },
+          {
+            "id": "type-check@0.3.2",
+            "info": {
+              "name": "type-check",
+              "version": "0.3.2"
+            }
+          },
+          {
+            "id": "levn@0.3.0",
+            "info": {
+              "name": "levn",
+              "version": "0.3.0"
+            }
+          },
+          {
+            "id": "word-wrap@1.2.3",
+            "info": {
+              "name": "word-wrap",
+              "version": "1.2.3"
+            }
+          },
+          {
+            "id": "optionator@0.8.3",
+            "info": {
+              "name": "optionator",
+              "version": "0.8.3"
+            }
+          },
+          {
+            "id": "escodegen@1.14.3",
+            "info": {
+              "name": "escodegen",
+              "version": "1.14.3"
+            }
+          },
+          {
+            "id": "esprima@3.1.3",
+            "info": {
+              "name": "esprima",
+              "version": "3.1.3"
+            }
+          },
+          {
+            "id": "degenerator@1.0.4",
+            "info": {
+              "name": "degenerator",
+              "version": "1.0.4"
+            }
+          },
+          {
+            "id": "ip@1.1.5",
+            "info": {
+              "name": "ip",
+              "version": "1.1.5"
+            }
+          },
+          {
+            "id": "netmask@1.0.6",
+            "info": {
+              "name": "netmask",
+              "version": "1.0.6"
+            }
+          },
+          {
+            "id": "thunkify@2.1.2",
+            "info": {
+              "name": "thunkify",
+              "version": "2.1.2"
+            }
+          },
+          {
+            "id": "pac-resolver@3.0.0",
+            "info": {
+              "name": "pac-resolver",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "bytes@3.1.1",
+            "info": {
+              "name": "bytes",
+              "version": "3.1.1"
+            }
+          },
+          {
+            "id": "depd@1.1.2",
+            "info": {
+              "name": "depd",
+              "version": "1.1.2"
+            }
+          },
+          {
+            "id": "setprototypeof@1.2.0",
+            "info": {
+              "name": "setprototypeof",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "statuses@1.5.0",
+            "info": {
+              "name": "statuses",
+              "version": "1.5.0"
+            }
+          },
+          {
+            "id": "toidentifier@1.0.1",
+            "info": {
+              "name": "toidentifier",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "http-errors@1.8.1",
+            "info": {
+              "name": "http-errors",
+              "version": "1.8.1"
+            }
+          },
+          {
+            "id": "unpipe@1.0.0",
+            "info": {
+              "name": "unpipe",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "raw-body@2.4.2",
+            "info": {
+              "name": "raw-body",
+              "version": "2.4.2"
+            }
+          },
+          {
+            "id": "agent-base@4.2.1",
+            "info": {
+              "name": "agent-base",
+              "version": "4.2.1"
+            }
+          },
+          {
+            "id": "smart-buffer@4.2.0",
+            "info": {
+              "name": "smart-buffer",
+              "version": "4.2.0"
+            }
+          },
+          {
+            "id": "socks@2.3.3",
+            "info": {
+              "name": "socks",
+              "version": "2.3.3"
+            }
+          },
+          {
+            "id": "socks-proxy-agent@4.0.2",
+            "info": {
+              "name": "socks-proxy-agent",
+              "version": "4.0.2"
+            }
+          },
+          {
+            "id": "pac-proxy-agent@3.0.1",
+            "info": {
+              "name": "pac-proxy-agent",
+              "version": "3.0.1"
+            }
+          },
+          {
+            "id": "proxy-from-env@1.1.0",
+            "info": {
+              "name": "proxy-from-env",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "proxy-agent@3.1.1",
+            "info": {
+              "name": "proxy-agent",
+              "version": "3.1.1"
+            }
+          },
+          {
+            "id": "async@1.5.2",
+            "info": {
+              "name": "async",
+              "version": "1.5.2"
+            }
+          },
+          {
+            "id": "secure-keys@1.0.0",
+            "info": {
+              "name": "secure-keys",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "camelcase@2.1.1",
+            "info": {
+              "name": "camelcase",
+              "version": "2.1.1"
+            }
+          },
+          {
+            "id": "code-point-at@1.1.0",
+            "info": {
+              "name": "code-point-at",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "number-is-nan@1.0.1",
+            "info": {
+              "name": "number-is-nan",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "is-fullwidth-code-point@1.0.0",
+            "info": {
+              "name": "is-fullwidth-code-point",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "ansi-regex@2.1.1",
+            "info": {
+              "name": "ansi-regex",
+              "version": "2.1.1"
+            }
+          },
+          {
+            "id": "strip-ansi@3.0.1",
+            "info": {
+              "name": "strip-ansi",
+              "version": "3.0.1"
+            }
+          },
+          {
+            "id": "string-width@1.0.2",
+            "info": {
+              "name": "string-width",
+              "version": "1.0.2"
+            }
+          },
+          {
+            "id": "wrap-ansi@2.1.0",
+            "info": {
+              "name": "wrap-ansi",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "cliui@3.2.0",
+            "info": {
+              "name": "cliui",
+              "version": "3.2.0"
+            }
+          },
+          {
+            "id": "decamelize@1.2.0",
+            "info": {
+              "name": "decamelize",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "invert-kv@1.0.0",
+            "info": {
+              "name": "invert-kv",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "lcid@1.0.0",
+            "info": {
+              "name": "lcid",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "os-locale@1.4.0",
+            "info": {
+              "name": "os-locale",
+              "version": "1.4.0"
+            }
+          },
+          {
+            "id": "window-size@0.1.4",
+            "info": {
+              "name": "window-size",
+              "version": "0.1.4"
+            }
+          },
+          {
+            "id": "y18n@3.2.2",
+            "info": {
+              "name": "y18n",
+              "version": "3.2.2"
+            }
+          },
+          {
+            "id": "yargs@3.32.0",
+            "info": {
+              "name": "yargs",
+              "version": "3.32.0"
+            }
+          },
+          {
+            "id": "nconf@0.10.0",
+            "info": {
+              "name": "nconf",
+              "version": "0.10.0"
+            }
+          },
+          {
+            "id": "snyk-config@2.2.3",
+            "info": {
+              "name": "snyk-config",
+              "version": "2.2.3"
+            }
+          },
+          {
+            "id": "vscode-languageserver-types@3.16.0",
+            "info": {
+              "name": "vscode-languageserver-types",
+              "version": "3.16.0"
+            }
+          },
+          {
+            "id": "dockerfile-ast@0.0.18",
+            "info": {
+              "name": "dockerfile-ast",
+              "version": "0.0.18"
+            }
+          },
+          {
+            "id": "event-loop-spinner@1.1.0",
+            "info": {
+              "name": "event-loop-spinner",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "base64-js@1.5.1",
+            "info": {
+              "name": "base64-js",
+              "version": "1.5.1"
+            }
+          },
+          {
+            "id": "ieee754@1.2.1",
+            "info": {
+              "name": "ieee754",
+              "version": "1.2.1"
+            }
+          },
+          {
+            "id": "buffer@5.7.1",
+            "info": {
+              "name": "buffer",
+              "version": "5.7.1"
+            }
+          },
+          {
+            "id": "readable-stream@3.6.0",
+            "info": {
+              "name": "readable-stream",
+              "version": "3.6.0"
+            }
+          },
+          {
+            "id": "bl@4.1.0",
+            "info": {
+              "name": "bl",
+              "version": "4.1.0"
+            }
+          },
+          {
+            "id": "fs-constants@1.0.0",
+            "info": {
+              "name": "fs-constants",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "tar-stream@2.2.0",
+            "info": {
+              "name": "tar-stream",
+              "version": "2.2.0"
+            }
+          },
+          {
+            "id": "snyk-docker-plugin@1.38.0",
+            "info": {
+              "name": "snyk-docker-plugin",
+              "version": "1.38.0"
+            }
+          },
+          {
+            "id": "toml@3.0.0",
+            "info": {
+              "name": "toml",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "snyk-go-parser@1.3.1",
+            "info": {
+              "name": "snyk-go-parser",
+              "version": "1.3.1"
+            }
+          },
+          {
+            "id": "snyk-go-plugin@1.11.1",
+            "info": {
+              "name": "snyk-go-plugin",
+              "version": "1.11.1"
+            }
+          },
+          {
+            "id": "@types/ms@0.7.31",
+            "info": {
+              "name": "@types/ms",
+              "version": "0.7.31"
+            }
+          },
+          {
+            "id": "@types/debug@4.1.7",
+            "info": {
+              "name": "@types/debug",
+              "version": "4.1.7"
+            }
+          },
+          {
+            "id": "snyk-gradle-plugin@3.2.4",
+            "info": {
+              "name": "snyk-gradle-plugin",
+              "version": "3.2.4"
+            }
+          },
+          {
+            "id": "hosted-git-info@2.8.9",
+            "info": {
+              "name": "hosted-git-info",
+              "version": "2.8.9"
+            }
+          },
+          {
+            "id": "snyk-module@1.9.1",
+            "info": {
+              "name": "snyk-module",
+              "version": "1.9.1"
+            }
+          },
+          {
+            "id": "tslib@1.9.3",
+            "info": {
+              "name": "tslib",
+              "version": "1.9.3"
+            }
+          },
+          {
+            "id": "@snyk/cli-interface@2.3.1",
+            "info": {
+              "name": "@snyk/cli-interface",
+              "version": "2.3.1"
+            }
+          },
+          {
+            "id": "rimraf@2.7.1",
+            "info": {
+              "name": "rimraf",
+              "version": "2.7.1"
+            }
+          },
+          {
+            "id": "tmp@0.1.0",
+            "info": {
+              "name": "tmp",
+              "version": "0.1.0"
+            }
+          },
+          {
+            "id": "snyk-mvn-plugin@2.8.0",
+            "info": {
+              "name": "snyk-mvn-plugin",
+              "version": "2.8.0"
+            }
+          },
+          {
+            "id": "@yarnpkg/lockfile@1.1.0",
+            "info": {
+              "name": "@yarnpkg/lockfile",
+              "version": "1.1.0"
+            }
+          },
+          {
+            "id": "p-map@2.1.0",
+            "info": {
+              "name": "p-map",
+              "version": "2.1.0"
+            }
+          },
+          {
+            "id": "uuid@3.4.0",
+            "info": {
+              "name": "uuid",
+              "version": "3.4.0"
+            }
+          },
+          {
+            "id": "snyk-nodejs-lockfile-parser@1.17.0",
+            "info": {
+              "name": "snyk-nodejs-lockfile-parser",
+              "version": "1.17.0"
+            }
+          },
+          {
+            "id": "@types/events@3.0.0",
+            "info": {
+              "name": "@types/events",
+              "version": "3.0.0"
+            }
+          },
+          {
+            "id": "@types/xml2js@0.4.3",
+            "info": {
+              "name": "@types/xml2js",
+              "version": "0.4.3"
+            }
+          },
+          {
+            "id": "xmlbuilder@9.0.7",
+            "info": {
+              "name": "xmlbuilder",
+              "version": "9.0.7"
+            }
+          },
+          {
+            "id": "xml2js@0.4.19",
+            "info": {
+              "name": "xml2js",
+              "version": "0.4.19"
+            }
+          },
+          {
+            "id": "dotnet-deps-parser@4.9.0",
+            "info": {
+              "name": "dotnet-deps-parser",
+              "version": "4.9.0"
+            }
+          },
+          {
+            "id": "immediate@3.0.6",
+            "info": {
+              "name": "immediate",
+              "version": "3.0.6"
+            }
+          },
+          {
+            "id": "lie@3.3.0",
+            "info": {
+              "name": "lie",
+              "version": "3.3.0"
+            }
+          },
+          {
+            "id": "pako@1.0.11",
+            "info": {
+              "name": "pako",
+              "version": "1.0.11"
+            }
+          },
+          {
+            "id": "set-immediate-shim@1.0.1",
+            "info": {
+              "name": "set-immediate-shim",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "jszip@3.7.1",
+            "info": {
+              "name": "jszip",
+              "version": "3.7.1"
+            }
+          },
+          {
+            "id": "snyk-paket-parser@1.5.0",
+            "info": {
+              "name": "snyk-paket-parser",
+              "version": "1.5.0"
+            }
+          },
+          {
+            "id": "xmlbuilder@11.0.1",
+            "info": {
+              "name": "xmlbuilder",
+              "version": "11.0.1"
+            }
+          },
+          {
+            "id": "xml2js@0.4.23",
+            "info": {
+              "name": "xml2js",
+              "version": "0.4.23"
+            }
+          },
+          {
+            "id": "snyk-nuget-plugin@1.16.0",
+            "info": {
+              "name": "snyk-nuget-plugin",
+              "version": "1.16.0"
+            }
+          },
+          {
+            "id": "@snyk/cli-interface@2.2.0",
+            "info": {
+              "name": "@snyk/cli-interface",
+              "version": "2.2.0"
+            }
+          },
+          {
+            "id": "@snyk/composer-lockfile-parser@1.2.0",
+            "info": {
+              "name": "@snyk/composer-lockfile-parser",
+              "version": "1.2.0"
+            }
+          },
+          {
+            "id": "snyk-php-plugin@1.7.0",
+            "info": {
+              "name": "snyk-php-plugin",
+              "version": "1.7.0"
+            }
+          },
+          {
+            "id": "email-validator@2.0.4",
+            "info": {
+              "name": "email-validator",
+              "version": "2.0.4"
+            }
+          },
+          {
+            "id": "lodash.clonedeep@4.5.0",
+            "info": {
+              "name": "lodash.clonedeep",
+              "version": "4.5.0"
+            }
+          },
+          {
+            "id": "asap@2.0.6",
+            "info": {
+              "name": "asap",
+              "version": "2.0.6"
+            }
+          },
+          {
+            "id": "promise@7.3.1",
+            "info": {
+              "name": "promise",
+              "version": "7.3.1"
+            }
+          },
+          {
+            "id": "then-fs@2.0.0",
+            "info": {
+              "name": "then-fs",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "snyk-resolve@1.0.1",
+            "info": {
+              "name": "snyk-resolve",
+              "version": "1.0.1"
+            }
+          },
+          {
+            "id": "snyk-try-require@1.3.1",
+            "info": {
+              "name": "snyk-try-require",
+              "version": "1.3.1"
+            }
+          },
+          {
+            "id": "snyk-policy@1.13.5",
+            "info": {
+              "name": "snyk-policy",
+              "version": "1.13.5"
+            }
+          },
+          {
+            "id": "snyk-python-plugin@1.17.0",
+            "info": {
+              "name": "snyk-python-plugin",
+              "version": "1.17.0"
+            }
+          },
+          {
+            "id": "@types/node@6.14.13",
+            "info": {
+              "name": "@types/node",
+              "version": "6.14.13"
+            }
+          },
+          {
+            "id": "@types/semver@5.5.0",
+            "info": {
+              "name": "@types/semver",
+              "version": "5.5.0"
+            }
+          },
+          {
+            "id": "ansicolors@0.3.2",
+            "info": {
+              "name": "ansicolors",
+              "version": "0.3.2"
+            }
+          },
+          {
+            "id": "lodash.assign@4.2.0",
+            "info": {
+              "name": "lodash.assign",
+              "version": "4.2.0"
+            }
+          },
+          {
+            "id": "lodash.assignin@4.2.0",
+            "info": {
+              "name": "lodash.assignin",
+              "version": "4.2.0"
+            }
+          },
+          {
+            "id": "lodash.clone@4.5.0",
+            "info": {
+              "name": "lodash.clone",
+              "version": "4.5.0"
+            }
+          },
+          {
+            "id": "lodash.get@4.4.2",
+            "info": {
+              "name": "lodash.get",
+              "version": "4.4.2"
+            }
+          },
+          {
+            "id": "lodash.set@4.3.2",
+            "info": {
+              "name": "lodash.set",
+              "version": "4.3.2"
+            }
+          },
+          {
+            "id": "archy@1.0.0",
+            "info": {
+              "name": "archy",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "snyk-tree@1.0.0",
+            "info": {
+              "name": "snyk-tree",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "snyk-resolve-deps@4.4.0",
+            "info": {
+              "name": "snyk-resolve-deps",
+              "version": "4.4.0"
+            }
+          },
+          {
+            "id": "tree-kill@1.2.2",
+            "info": {
+              "name": "tree-kill",
+              "version": "1.2.2"
+            }
+          },
+          {
+            "id": "snyk-sbt-plugin@2.11.0",
+            "info": {
+              "name": "snyk-sbt-plugin",
+              "version": "2.11.0"
+            }
+          },
+          {
+            "id": "temp-dir@1.0.0",
+            "info": {
+              "name": "temp-dir",
+              "version": "1.0.0"
+            }
+          },
+          {
+            "id": "tempfile@2.0.0",
+            "info": {
+              "name": "tempfile",
+              "version": "2.0.0"
+            }
+          },
+          {
+            "id": "emoji-regex@7.0.3",
+            "info": {
+              "name": "emoji-regex",
+              "version": "7.0.3"
+            }
+          },
+          {
+            "id": "string-width@3.1.0",
+            "info": {
+              "name": "string-width",
+              "version": "3.1.0"
+            }
+          },
+          {
+            "id": "wrap-ansi@5.1.0",
+            "info": {
+              "name": "wrap-ansi",
+              "version": "5.1.0"
+            }
+          },
+          {
+            "id": "snyk@1.290.2",
+            "info": {
+              "name": "snyk",
+              "version": "1.290.2"
+            }
+          }
+        ],
+        "graph": {
+          "rootNodeId": "root-node",
+          "nodes": [
+            {
+              "nodeId": "root-node",
+              "pkgId": "goof@1.0.1",
+              "deps": [
+                {
+                  "nodeId": "snyk@1.290.2"
+                }
+              ]
+            },
+            {
+              "nodeId": "tslib@1.14.1",
+              "pkgId": "tslib@1.14.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/cli-interface@2.3.0",
+              "pkgId": "@snyk/cli-interface@2.3.0",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-obj@2.0.0",
+              "pkgId": "is-obj@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "dot-prop@5.3.0",
+              "pkgId": "dot-prop@5.3.0",
+              "deps": [
+                {
+                  "nodeId": "is-obj@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "graceful-fs@4.2.8",
+              "pkgId": "graceful-fs@4.2.8",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pify@3.0.0",
+              "pkgId": "pify@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "make-dir@1.3.0",
+              "pkgId": "make-dir@1.3.0",
+              "deps": [
+                {
+                  "nodeId": "pify@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "crypto-random-string@1.0.0",
+              "pkgId": "crypto-random-string@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "unique-string@1.0.0",
+              "pkgId": "unique-string@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "crypto-random-string@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "imurmurhash@0.1.4",
+              "pkgId": "imurmurhash@0.1.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "signal-exit@3.0.6",
+              "pkgId": "signal-exit@3.0.6",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "write-file-atomic@2.4.3",
+              "pkgId": "write-file-atomic@2.4.3",
+              "deps": [
+                {
+                  "nodeId": "graceful-fs@4.2.8"
+                },
+                {
+                  "nodeId": "imurmurhash@0.1.4"
+                },
+                {
+                  "nodeId": "signal-exit@3.0.6"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xdg-basedir@3.0.0",
+              "pkgId": "xdg-basedir@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/configstore@3.2.0-rc1",
+              "pkgId": "@snyk/configstore@3.2.0-rc1",
+              "deps": [
+                {
+                  "nodeId": "dot-prop@5.3.0"
+                },
+                {
+                  "nodeId": "graceful-fs@4.2.8"
+                },
+                {
+                  "nodeId": "make-dir@1.3.0"
+                },
+                {
+                  "nodeId": "unique-string@1.0.0"
+                },
+                {
+                  "nodeId": "write-file-atomic@2.4.3"
+                },
+                {
+                  "nodeId": "xdg-basedir@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash@4.17.21",
+              "pkgId": "lodash@4.17.21",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "graphlib@2.1.8",
+              "pkgId": "graphlib@2.1.8",
+              "deps": [
+                {
+                  "nodeId": "lodash@4.17.21"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "object-hash@1.3.1",
+              "pkgId": "object-hash@1.3.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "semver@6.3.0",
+              "pkgId": "semver@6.3.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "buffer-from@1.1.2",
+              "pkgId": "buffer-from@1.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "source-map@0.6.1",
+              "pkgId": "source-map@0.6.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "source-map-support@0.5.21",
+              "pkgId": "source-map-support@0.5.21",
+              "deps": [
+                {
+                  "nodeId": "buffer-from@1.1.2"
+                },
+                {
+                  "nodeId": "source-map@0.6.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/dep-graph@1.13.1",
+              "pkgId": "@snyk/dep-graph@1.13.1",
+              "deps": [
+                {
+                  "nodeId": "graphlib@2.1.8"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "object-hash@1.3.1"
+                },
+                {
+                  "nodeId": "semver@6.3.0"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/gemfile@1.2.0",
+              "pkgId": "@snyk/gemfile@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/cli-interface@1.5.0",
+              "pkgId": "@snyk/cli-interface@1.5.0",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.escaperegexp@4.1.2",
+              "pkgId": "lodash.escaperegexp@4.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.flatten@4.4.0",
+              "pkgId": "lodash.flatten@4.4.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.uniq@4.5.0",
+              "pkgId": "lodash.uniq@4.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/ruby-semver@2.2.2",
+              "pkgId": "@snyk/ruby-semver@2.2.2",
+              "deps": [
+                {
+                  "nodeId": "lodash.escaperegexp@4.1.2"
+                },
+                {
+                  "nodeId": "lodash.flatten@4.4.0"
+                },
+                {
+                  "nodeId": "lodash.uniq@4.5.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/js-yaml@3.12.7",
+              "pkgId": "@types/js-yaml@3.12.7",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "core-js@3.19.3",
+              "pkgId": "core-js@3.19.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "sprintf-js@1.0.3",
+              "pkgId": "sprintf-js@1.0.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "argparse@1.0.10",
+              "pkgId": "argparse@1.0.10",
+              "deps": [
+                {
+                  "nodeId": "sprintf-js@1.0.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "esprima@4.0.1",
+              "pkgId": "esprima@4.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "js-yaml@3.14.1",
+              "pkgId": "js-yaml@3.14.1",
+              "deps": [
+                {
+                  "nodeId": "argparse@1.0.10"
+                },
+                {
+                  "nodeId": "esprima@4.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/cocoapods-lockfile-parser@3.0.0",
+              "pkgId": "@snyk/cocoapods-lockfile-parser@3.0.0",
+              "deps": [
+                {
+                  "nodeId": "@snyk/dep-graph@1.13.1"
+                },
+                {
+                  "nodeId": "@snyk/ruby-semver@2.2.2"
+                },
+                {
+                  "nodeId": "@types/js-yaml@3.12.7"
+                },
+                {
+                  "nodeId": "core-js@3.19.3"
+                },
+                {
+                  "nodeId": "js-yaml@3.14.1"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/snyk-cocoapods-plugin@2.0.1",
+              "pkgId": "@snyk/snyk-cocoapods-plugin@2.0.1",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@1.5.0"
+                },
+                {
+                  "nodeId": "@snyk/cocoapods-lockfile-parser@3.0.0"
+                },
+                {
+                  "nodeId": "@snyk/dep-graph@1.13.1"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@2.0.0",
+              "pkgId": "is-fullwidth-code-point@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-regex@3.0.0",
+              "pkgId": "ansi-regex@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strip-ansi@4.0.0",
+              "pkgId": "strip-ansi@4.0.0",
+              "deps": [
+                {
+                  "nodeId": "ansi-regex@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "string-width@2.1.1",
+              "pkgId": "string-width@2.1.1",
+              "deps": [
+                {
+                  "nodeId": "is-fullwidth-code-point@2.0.0"
+                },
+                {
+                  "nodeId": "strip-ansi@4.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-align@2.0.0",
+              "pkgId": "ansi-align@2.0.0",
+              "deps": [
+                {
+                  "nodeId": "string-width@2.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "camelcase@4.1.0",
+              "pkgId": "camelcase@4.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "color-name@1.1.3",
+              "pkgId": "color-name@1.1.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "color-convert@1.9.3",
+              "pkgId": "color-convert@1.9.3",
+              "deps": [
+                {
+                  "nodeId": "color-name@1.1.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-styles@3.2.1",
+              "pkgId": "ansi-styles@3.2.1",
+              "deps": [
+                {
+                  "nodeId": "color-convert@1.9.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "escape-string-regexp@1.0.5",
+              "pkgId": "escape-string-regexp@1.0.5",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "has-flag@3.0.0",
+              "pkgId": "has-flag@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "supports-color@5.5.0",
+              "pkgId": "supports-color@5.5.0",
+              "deps": [
+                {
+                  "nodeId": "has-flag@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "chalk@2.4.2",
+              "pkgId": "chalk@2.4.2",
+              "deps": [
+                {
+                  "nodeId": "ansi-styles@3.2.1"
+                },
+                {
+                  "nodeId": "escape-string-regexp@1.0.5"
+                },
+                {
+                  "nodeId": "supports-color@5.5.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cli-boxes@1.0.0",
+              "pkgId": "cli-boxes@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pseudomap@1.0.2",
+              "pkgId": "pseudomap@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "yallist@2.1.2",
+              "pkgId": "yallist@2.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lru-cache@4.1.5",
+              "pkgId": "lru-cache@4.1.5",
+              "deps": [
+                {
+                  "nodeId": "pseudomap@1.0.2"
+                },
+                {
+                  "nodeId": "yallist@2.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "shebang-regex@1.0.0",
+              "pkgId": "shebang-regex@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "shebang-command@1.2.0",
+              "pkgId": "shebang-command@1.2.0",
+              "deps": [
+                {
+                  "nodeId": "shebang-regex@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "isexe@2.0.0",
+              "pkgId": "isexe@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "which@1.3.1",
+              "pkgId": "which@1.3.1",
+              "deps": [
+                {
+                  "nodeId": "isexe@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cross-spawn@5.1.0",
+              "pkgId": "cross-spawn@5.1.0",
+              "deps": [
+                {
+                  "nodeId": "lru-cache@4.1.5"
+                },
+                {
+                  "nodeId": "shebang-command@1.2.0"
+                },
+                {
+                  "nodeId": "which@1.3.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "get-stream@3.0.0",
+              "pkgId": "get-stream@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-stream@1.1.0",
+              "pkgId": "is-stream@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "path-key@2.0.1",
+              "pkgId": "path-key@2.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "npm-run-path@2.0.2",
+              "pkgId": "npm-run-path@2.0.2",
+              "deps": [
+                {
+                  "nodeId": "path-key@2.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "p-finally@1.0.0",
+              "pkgId": "p-finally@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strip-eof@1.0.0",
+              "pkgId": "strip-eof@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "execa@0.7.0",
+              "pkgId": "execa@0.7.0",
+              "deps": [
+                {
+                  "nodeId": "cross-spawn@5.1.0"
+                },
+                {
+                  "nodeId": "get-stream@3.0.0"
+                },
+                {
+                  "nodeId": "is-stream@1.1.0"
+                },
+                {
+                  "nodeId": "npm-run-path@2.0.2"
+                },
+                {
+                  "nodeId": "p-finally@1.0.0"
+                },
+                {
+                  "nodeId": "signal-exit@3.0.6"
+                },
+                {
+                  "nodeId": "strip-eof@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "term-size@1.2.0",
+              "pkgId": "term-size@1.2.0",
+              "deps": [
+                {
+                  "nodeId": "execa@0.7.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "widest-line@2.0.1",
+              "pkgId": "widest-line@2.0.1",
+              "deps": [
+                {
+                  "nodeId": "string-width@2.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "boxen@1.3.0",
+              "pkgId": "boxen@1.3.0",
+              "deps": [
+                {
+                  "nodeId": "ansi-align@2.0.0"
+                },
+                {
+                  "nodeId": "camelcase@4.1.0"
+                },
+                {
+                  "nodeId": "chalk@2.4.2"
+                },
+                {
+                  "nodeId": "cli-boxes@1.0.0"
+                },
+                {
+                  "nodeId": "string-width@2.1.1"
+                },
+                {
+                  "nodeId": "term-size@1.2.0"
+                },
+                {
+                  "nodeId": "widest-line@2.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "import-lazy@2.1.0",
+              "pkgId": "import-lazy@2.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ci-info@1.6.0",
+              "pkgId": "ci-info@1.6.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-ci@1.2.1",
+              "pkgId": "is-ci@1.2.1",
+              "deps": [
+                {
+                  "nodeId": "ci-info@1.6.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ini@1.3.8",
+              "pkgId": "ini@1.3.8",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "global-dirs@0.1.1",
+              "pkgId": "global-dirs@0.1.1",
+              "deps": [
+                {
+                  "nodeId": "ini@1.3.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "path-is-inside@1.0.2",
+              "pkgId": "path-is-inside@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-path-inside@1.0.1",
+              "pkgId": "is-path-inside@1.0.1",
+              "deps": [
+                {
+                  "nodeId": "path-is-inside@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-installed-globally@0.1.0",
+              "pkgId": "is-installed-globally@0.1.0",
+              "deps": [
+                {
+                  "nodeId": "global-dirs@0.1.1"
+                },
+                {
+                  "nodeId": "is-path-inside@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-npm@1.0.0",
+              "pkgId": "is-npm@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "capture-stack-trace@1.0.1",
+              "pkgId": "capture-stack-trace@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "create-error-class@3.0.2",
+              "pkgId": "create-error-class@3.0.2",
+              "deps": [
+                {
+                  "nodeId": "capture-stack-trace@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "duplexer3@0.1.4",
+              "pkgId": "duplexer3@0.1.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-redirect@1.0.0",
+              "pkgId": "is-redirect@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-retry-allowed@1.2.0",
+              "pkgId": "is-retry-allowed@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lowercase-keys@1.0.1",
+              "pkgId": "lowercase-keys@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "safe-buffer@5.2.1",
+              "pkgId": "safe-buffer@5.2.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "timed-out@4.0.1",
+              "pkgId": "timed-out@4.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "unzip-response@2.0.1",
+              "pkgId": "unzip-response@2.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "prepend-http@1.0.4",
+              "pkgId": "prepend-http@1.0.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "url-parse-lax@1.0.0",
+              "pkgId": "url-parse-lax@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "prepend-http@1.0.4"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "got@6.7.1",
+              "pkgId": "got@6.7.1",
+              "deps": [
+                {
+                  "nodeId": "create-error-class@3.0.2"
+                },
+                {
+                  "nodeId": "duplexer3@0.1.4"
+                },
+                {
+                  "nodeId": "get-stream@3.0.0"
+                },
+                {
+                  "nodeId": "is-redirect@1.0.0"
+                },
+                {
+                  "nodeId": "is-retry-allowed@1.2.0"
+                },
+                {
+                  "nodeId": "is-stream@1.1.0"
+                },
+                {
+                  "nodeId": "lowercase-keys@1.0.1"
+                },
+                {
+                  "nodeId": "safe-buffer@5.2.1"
+                },
+                {
+                  "nodeId": "timed-out@4.0.1"
+                },
+                {
+                  "nodeId": "unzip-response@2.0.1"
+                },
+                {
+                  "nodeId": "url-parse-lax@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "deep-extend@0.6.0",
+              "pkgId": "deep-extend@0.6.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "minimist@1.2.5",
+              "pkgId": "minimist@1.2.5",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strip-json-comments@2.0.1",
+              "pkgId": "strip-json-comments@2.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "rc@1.2.8",
+              "pkgId": "rc@1.2.8",
+              "deps": [
+                {
+                  "nodeId": "deep-extend@0.6.0"
+                },
+                {
+                  "nodeId": "ini@1.3.8"
+                },
+                {
+                  "nodeId": "minimist@1.2.5"
+                },
+                {
+                  "nodeId": "strip-json-comments@2.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "registry-auth-token@3.4.0",
+              "pkgId": "registry-auth-token@3.4.0",
+              "deps": [
+                {
+                  "nodeId": "rc@1.2.8"
+                },
+                {
+                  "nodeId": "safe-buffer@5.2.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "registry-url@3.1.0",
+              "pkgId": "registry-url@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "rc@1.2.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "semver@5.7.1",
+              "pkgId": "semver@5.7.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "package-json@4.0.1",
+              "pkgId": "package-json@4.0.1",
+              "deps": [
+                {
+                  "nodeId": "got@6.7.1"
+                },
+                {
+                  "nodeId": "registry-auth-token@3.4.0"
+                },
+                {
+                  "nodeId": "registry-url@3.1.0"
+                },
+                {
+                  "nodeId": "semver@5.7.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "latest-version@3.1.0",
+              "pkgId": "latest-version@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "package-json@4.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "semver-diff@2.1.0",
+              "pkgId": "semver-diff@2.1.0",
+              "deps": [
+                {
+                  "nodeId": "semver@5.7.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/update-notifier@2.5.1-rc2",
+              "pkgId": "@snyk/update-notifier@2.5.1-rc2",
+              "deps": [
+                {
+                  "nodeId": "@snyk/configstore@3.2.0-rc1"
+                },
+                {
+                  "nodeId": "boxen@1.3.0"
+                },
+                {
+                  "nodeId": "chalk@2.4.2"
+                },
+                {
+                  "nodeId": "import-lazy@2.1.0"
+                },
+                {
+                  "nodeId": "is-ci@1.2.1"
+                },
+                {
+                  "nodeId": "is-installed-globally@0.1.0"
+                },
+                {
+                  "nodeId": "is-npm@1.0.0"
+                },
+                {
+                  "nodeId": "latest-version@3.1.0"
+                },
+                {
+                  "nodeId": "semver-diff@2.1.0"
+                },
+                {
+                  "nodeId": "xdg-basedir@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/node@16.11.11",
+              "pkgId": "@types/node@16.11.11",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/agent-base@4.2.2",
+              "pkgId": "@types/agent-base@4.2.2",
+              "deps": [
+                {
+                  "nodeId": "@types/node@16.11.11"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/bunyan@1.8.8",
+              "pkgId": "@types/bunyan@1.8.8",
+              "deps": [
+                {
+                  "nodeId": "@types/node@16.11.11"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/restify@4.3.8",
+              "pkgId": "@types/restify@4.3.8",
+              "deps": [
+                {
+                  "nodeId": "@types/bunyan@1.8.8"
+                },
+                {
+                  "nodeId": "@types/node@16.11.11"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "abbrev@1.1.1",
+              "pkgId": "abbrev@1.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-escapes@3.2.0",
+              "pkgId": "ansi-escapes@3.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cli-spinner@0.2.10",
+              "pkgId": "cli-spinner@0.2.10",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ms@2.1.3",
+              "pkgId": "ms@2.1.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "debug@3.2.7",
+              "pkgId": "debug@3.2.7",
+              "deps": [
+                {
+                  "nodeId": "ms@2.1.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "diff@4.0.2",
+              "pkgId": "diff@4.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "protocols@1.4.8",
+              "pkgId": "protocols@1.4.8",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-ssh@1.3.3",
+              "pkgId": "is-ssh@1.3.3",
+              "deps": [
+                {
+                  "nodeId": "protocols@1.4.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "normalize-url@6.1.0",
+              "pkgId": "normalize-url@6.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "function-bind@1.1.1",
+              "pkgId": "function-bind@1.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "has@1.0.3",
+              "pkgId": "has@1.0.3",
+              "deps": [
+                {
+                  "nodeId": "function-bind@1.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "has-symbols@1.0.2",
+              "pkgId": "has-symbols@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "get-intrinsic@1.1.1",
+              "pkgId": "get-intrinsic@1.1.1",
+              "deps": [
+                {
+                  "nodeId": "function-bind@1.1.1"
+                },
+                {
+                  "nodeId": "has@1.0.3"
+                },
+                {
+                  "nodeId": "has-symbols@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "call-bind@1.0.2",
+              "pkgId": "call-bind@1.0.2",
+              "deps": [
+                {
+                  "nodeId": "function-bind@1.1.1"
+                },
+                {
+                  "nodeId": "get-intrinsic@1.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "object-inspect@1.11.1",
+              "pkgId": "object-inspect@1.11.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "side-channel@1.0.4",
+              "pkgId": "side-channel@1.0.4",
+              "deps": [
+                {
+                  "nodeId": "call-bind@1.0.2"
+                },
+                {
+                  "nodeId": "get-intrinsic@1.1.1"
+                },
+                {
+                  "nodeId": "object-inspect@1.11.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "qs@6.10.2",
+              "pkgId": "qs@6.10.2",
+              "deps": [
+                {
+                  "nodeId": "side-channel@1.0.4"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "decode-uri-component@0.2.0",
+              "pkgId": "decode-uri-component@0.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "filter-obj@1.1.0",
+              "pkgId": "filter-obj@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "split-on-first@1.1.0",
+              "pkgId": "split-on-first@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strict-uri-encode@2.0.0",
+              "pkgId": "strict-uri-encode@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "query-string@6.14.1",
+              "pkgId": "query-string@6.14.1",
+              "deps": [
+                {
+                  "nodeId": "decode-uri-component@0.2.0"
+                },
+                {
+                  "nodeId": "filter-obj@1.1.0"
+                },
+                {
+                  "nodeId": "split-on-first@1.1.0"
+                },
+                {
+                  "nodeId": "strict-uri-encode@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "parse-path@4.0.3",
+              "pkgId": "parse-path@4.0.3",
+              "deps": [
+                {
+                  "nodeId": "is-ssh@1.3.3"
+                },
+                {
+                  "nodeId": "protocols@1.4.8"
+                },
+                {
+                  "nodeId": "qs@6.10.2"
+                },
+                {
+                  "nodeId": "query-string@6.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "parse-url@6.0.0",
+              "pkgId": "parse-url@6.0.0",
+              "deps": [
+                {
+                  "nodeId": "is-ssh@1.3.3"
+                },
+                {
+                  "nodeId": "normalize-url@6.1.0"
+                },
+                {
+                  "nodeId": "parse-path@4.0.3"
+                },
+                {
+                  "nodeId": "protocols@1.4.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "git-up@4.0.5",
+              "pkgId": "git-up@4.0.5",
+              "deps": [
+                {
+                  "nodeId": "is-ssh@1.3.3"
+                },
+                {
+                  "nodeId": "parse-url@6.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "git-url-parse@11.1.2",
+              "pkgId": "git-url-parse@11.1.2",
+              "deps": [
+                {
+                  "nodeId": "git-up@4.0.5"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "fs.realpath@1.0.0",
+              "pkgId": "fs.realpath@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "wrappy@1.0.2",
+              "pkgId": "wrappy@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "once@1.4.0",
+              "pkgId": "once@1.4.0",
+              "deps": [
+                {
+                  "nodeId": "wrappy@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "inflight@1.0.6",
+              "pkgId": "inflight@1.0.6",
+              "deps": [
+                {
+                  "nodeId": "once@1.4.0"
+                },
+                {
+                  "nodeId": "wrappy@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "inherits@2.0.4",
+              "pkgId": "inherits@2.0.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "balanced-match@1.0.2",
+              "pkgId": "balanced-match@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "concat-map@0.0.1",
+              "pkgId": "concat-map@0.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "brace-expansion@1.1.11",
+              "pkgId": "brace-expansion@1.1.11",
+              "deps": [
+                {
+                  "nodeId": "balanced-match@1.0.2"
+                },
+                {
+                  "nodeId": "concat-map@0.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "minimatch@3.0.4",
+              "pkgId": "minimatch@3.0.4",
+              "deps": [
+                {
+                  "nodeId": "brace-expansion@1.1.11"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "path-is-absolute@1.0.1",
+              "pkgId": "path-is-absolute@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "glob@7.2.0",
+              "pkgId": "glob@7.2.0",
+              "deps": [
+                {
+                  "nodeId": "fs.realpath@1.0.0"
+                },
+                {
+                  "nodeId": "inflight@1.0.6"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "minimatch@3.0.4"
+                },
+                {
+                  "nodeId": "once@1.4.0"
+                },
+                {
+                  "nodeId": "path-is-absolute@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "mimic-fn@1.2.0",
+              "pkgId": "mimic-fn@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "onetime@2.0.1",
+              "pkgId": "onetime@2.0.1",
+              "deps": [
+                {
+                  "nodeId": "mimic-fn@1.2.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "restore-cursor@2.0.0",
+              "pkgId": "restore-cursor@2.0.0",
+              "deps": [
+                {
+                  "nodeId": "onetime@2.0.1"
+                },
+                {
+                  "nodeId": "signal-exit@3.0.6"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cli-cursor@2.1.0",
+              "pkgId": "cli-cursor@2.1.0",
+              "deps": [
+                {
+                  "nodeId": "restore-cursor@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cli-width@2.2.1",
+              "pkgId": "cli-width@2.2.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "chardet@0.7.0",
+              "pkgId": "chardet@0.7.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "safer-buffer@2.1.2",
+              "pkgId": "safer-buffer@2.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24",
+              "pkgId": "iconv-lite@0.4.24",
+              "deps": [
+                {
+                  "nodeId": "safer-buffer@2.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "os-tmpdir@1.0.2",
+              "pkgId": "os-tmpdir@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tmp@0.0.33",
+              "pkgId": "tmp@0.0.33",
+              "deps": [
+                {
+                  "nodeId": "os-tmpdir@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "external-editor@3.1.0",
+              "pkgId": "external-editor@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "chardet@0.7.0"
+                },
+                {
+                  "nodeId": "iconv-lite@0.4.24"
+                },
+                {
+                  "nodeId": "tmp@0.0.33"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "figures@2.0.0",
+              "pkgId": "figures@2.0.0",
+              "deps": [
+                {
+                  "nodeId": "escape-string-regexp@1.0.5"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "mute-stream@0.0.7",
+              "pkgId": "mute-stream@0.0.7",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "run-async@2.4.1",
+              "pkgId": "run-async@2.4.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "rxjs@6.6.7",
+              "pkgId": "rxjs@6.6.7",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-regex@4.1.0",
+              "pkgId": "ansi-regex@4.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0",
+              "pkgId": "strip-ansi@5.2.0",
+              "deps": [
+                {
+                  "nodeId": "ansi-regex@4.1.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "through@2.3.8",
+              "pkgId": "through@2.3.8",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "inquirer@6.5.2",
+              "pkgId": "inquirer@6.5.2",
+              "deps": [
+                {
+                  "nodeId": "ansi-escapes@3.2.0"
+                },
+                {
+                  "nodeId": "chalk@2.4.2"
+                },
+                {
+                  "nodeId": "cli-cursor@2.1.0"
+                },
+                {
+                  "nodeId": "cli-width@2.2.1"
+                },
+                {
+                  "nodeId": "external-editor@3.1.0"
+                },
+                {
+                  "nodeId": "figures@2.0.0"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "mute-stream@0.0.7"
+                },
+                {
+                  "nodeId": "run-async@2.4.1"
+                },
+                {
+                  "nodeId": "rxjs@6.6.7"
+                },
+                {
+                  "nodeId": "string-width@2.1.1"
+                },
+                {
+                  "nodeId": "strip-ansi@5.2.0"
+                },
+                {
+                  "nodeId": "through@2.3.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "sax@1.2.4",
+              "pkgId": "sax@1.2.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "needle@2.9.1",
+              "pkgId": "needle@2.9.1",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "iconv-lite@0.4.24"
+                },
+                {
+                  "nodeId": "sax@1.2.4"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-wsl@1.1.0",
+              "pkgId": "is-wsl@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "opn@5.5.0",
+              "pkgId": "opn@5.5.0",
+              "deps": [
+                {
+                  "nodeId": "is-wsl@1.1.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "macos-release@2.5.0",
+              "pkgId": "macos-release@2.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "nice-try@1.0.5",
+              "pkgId": "nice-try@1.0.5",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cross-spawn@6.0.5",
+              "pkgId": "cross-spawn@6.0.5",
+              "deps": [
+                {
+                  "nodeId": "nice-try@1.0.5"
+                },
+                {
+                  "nodeId": "path-key@2.0.1"
+                },
+                {
+                  "nodeId": "semver@5.7.1"
+                },
+                {
+                  "nodeId": "shebang-command@1.2.0"
+                },
+                {
+                  "nodeId": "which@1.3.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "end-of-stream@1.4.4",
+              "pkgId": "end-of-stream@1.4.4",
+              "deps": [
+                {
+                  "nodeId": "once@1.4.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pump@3.0.0",
+              "pkgId": "pump@3.0.0",
+              "deps": [
+                {
+                  "nodeId": "end-of-stream@1.4.4"
+                },
+                {
+                  "nodeId": "once@1.4.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "get-stream@4.1.0",
+              "pkgId": "get-stream@4.1.0",
+              "deps": [
+                {
+                  "nodeId": "pump@3.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "execa@1.0.0",
+              "pkgId": "execa@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "cross-spawn@6.0.5"
+                },
+                {
+                  "nodeId": "get-stream@4.1.0"
+                },
+                {
+                  "nodeId": "is-stream@1.1.0"
+                },
+                {
+                  "nodeId": "npm-run-path@2.0.2"
+                },
+                {
+                  "nodeId": "p-finally@1.0.0"
+                },
+                {
+                  "nodeId": "signal-exit@3.0.6"
+                },
+                {
+                  "nodeId": "strip-eof@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "windows-release@3.3.3",
+              "pkgId": "windows-release@3.3.3",
+              "deps": [
+                {
+                  "nodeId": "execa@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "os-name@3.1.0",
+              "pkgId": "os-name@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "macos-release@2.5.0"
+                },
+                {
+                  "nodeId": "windows-release@3.3.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "es6-promise@4.2.8",
+              "pkgId": "es6-promise@4.2.8",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "es6-promisify@5.0.0",
+              "pkgId": "es6-promisify@5.0.0",
+              "deps": [
+                {
+                  "nodeId": "es6-promise@4.2.8"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "agent-base@4.3.0",
+              "pkgId": "agent-base@4.3.0",
+              "deps": [
+                {
+                  "nodeId": "es6-promisify@5.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ms@2.1.2",
+              "pkgId": "ms@2.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "debug@4.3.3",
+              "pkgId": "debug@4.3.3",
+              "deps": [
+                {
+                  "nodeId": "ms@2.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ms@2.0.0",
+              "pkgId": "ms@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "debug@3.1.0",
+              "pkgId": "debug@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "ms@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "http-proxy-agent@2.1.0",
+              "pkgId": "http-proxy-agent@2.1.0",
+              "deps": [
+                {
+                  "nodeId": "agent-base@4.3.0"
+                },
+                {
+                  "nodeId": "debug@3.1.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "https-proxy-agent@3.0.1",
+              "pkgId": "https-proxy-agent@3.0.1",
+              "deps": [
+                {
+                  "nodeId": "agent-base@4.3.0"
+                },
+                {
+                  "nodeId": "debug@3.2.7"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "yallist@3.1.1",
+              "pkgId": "yallist@3.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lru-cache@5.1.1",
+              "pkgId": "lru-cache@5.1.1",
+              "deps": [
+                {
+                  "nodeId": "yallist@3.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "data-uri-to-buffer@1.2.0",
+              "pkgId": "data-uri-to-buffer@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "debug@2.6.9",
+              "pkgId": "debug@2.6.9",
+              "deps": [
+                {
+                  "nodeId": "ms@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "extend@3.0.2",
+              "pkgId": "extend@3.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "file-uri-to-path@1.0.0",
+              "pkgId": "file-uri-to-path@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "core-util-is@1.0.3",
+              "pkgId": "core-util-is@1.0.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "isarray@0.0.1",
+              "pkgId": "isarray@0.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "string_decoder@0.10.31",
+              "pkgId": "string_decoder@0.10.31",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "readable-stream@1.1.14",
+              "pkgId": "readable-stream@1.1.14",
+              "deps": [
+                {
+                  "nodeId": "core-util-is@1.0.3"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "isarray@0.0.1"
+                },
+                {
+                  "nodeId": "string_decoder@0.10.31"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xregexp@2.0.0",
+              "pkgId": "xregexp@2.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ftp@0.3.10",
+              "pkgId": "ftp@0.3.10",
+              "deps": [
+                {
+                  "nodeId": "readable-stream@1.1.14"
+                },
+                {
+                  "nodeId": "xregexp@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "isarray@1.0.0",
+              "pkgId": "isarray@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "process-nextick-args@2.0.1",
+              "pkgId": "process-nextick-args@2.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2",
+              "pkgId": "safe-buffer@5.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "string_decoder@1.1.1",
+              "pkgId": "string_decoder@1.1.1",
+              "deps": [
+                {
+                  "nodeId": "safe-buffer@5.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "util-deprecate@1.0.2",
+              "pkgId": "util-deprecate@1.0.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "readable-stream@2.3.7",
+              "pkgId": "readable-stream@2.3.7",
+              "deps": [
+                {
+                  "nodeId": "core-util-is@1.0.3"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "isarray@1.0.0"
+                },
+                {
+                  "nodeId": "process-nextick-args@2.0.1"
+                },
+                {
+                  "nodeId": "safe-buffer@5.1.2"
+                },
+                {
+                  "nodeId": "string_decoder@1.1.1"
+                },
+                {
+                  "nodeId": "util-deprecate@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "get-uri@2.0.4",
+              "pkgId": "get-uri@2.0.4",
+              "deps": [
+                {
+                  "nodeId": "data-uri-to-buffer@1.2.0"
+                },
+                {
+                  "nodeId": "debug@2.6.9"
+                },
+                {
+                  "nodeId": "extend@3.0.2"
+                },
+                {
+                  "nodeId": "file-uri-to-path@1.0.0"
+                },
+                {
+                  "nodeId": "ftp@0.3.10"
+                },
+                {
+                  "nodeId": "readable-stream@2.3.7"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "co@4.6.0",
+              "pkgId": "co@4.6.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tslib@2.3.1",
+              "pkgId": "tslib@2.3.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ast-types@0.14.2",
+              "pkgId": "ast-types@0.14.2",
+              "deps": [
+                {
+                  "nodeId": "tslib@2.3.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "estraverse@4.3.0",
+              "pkgId": "estraverse@4.3.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "esutils@2.0.3",
+              "pkgId": "esutils@2.0.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "deep-is@0.1.4",
+              "pkgId": "deep-is@0.1.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "fast-levenshtein@2.0.6",
+              "pkgId": "fast-levenshtein@2.0.6",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "prelude-ls@1.1.2",
+              "pkgId": "prelude-ls@1.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "type-check@0.3.2",
+              "pkgId": "type-check@0.3.2",
+              "deps": [
+                {
+                  "nodeId": "prelude-ls@1.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "levn@0.3.0",
+              "pkgId": "levn@0.3.0",
+              "deps": [
+                {
+                  "nodeId": "prelude-ls@1.1.2"
+                },
+                {
+                  "nodeId": "type-check@0.3.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "word-wrap@1.2.3",
+              "pkgId": "word-wrap@1.2.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "optionator@0.8.3",
+              "pkgId": "optionator@0.8.3",
+              "deps": [
+                {
+                  "nodeId": "deep-is@0.1.4"
+                },
+                {
+                  "nodeId": "fast-levenshtein@2.0.6"
+                },
+                {
+                  "nodeId": "levn@0.3.0"
+                },
+                {
+                  "nodeId": "prelude-ls@1.1.2"
+                },
+                {
+                  "nodeId": "type-check@0.3.2"
+                },
+                {
+                  "nodeId": "word-wrap@1.2.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "escodegen@1.14.3",
+              "pkgId": "escodegen@1.14.3",
+              "deps": [
+                {
+                  "nodeId": "esprima@4.0.1"
+                },
+                {
+                  "nodeId": "estraverse@4.3.0"
+                },
+                {
+                  "nodeId": "esutils@2.0.3"
+                },
+                {
+                  "nodeId": "optionator@0.8.3"
+                },
+                {
+                  "nodeId": "source-map@0.6.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "esprima@3.1.3",
+              "pkgId": "esprima@3.1.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "degenerator@1.0.4",
+              "pkgId": "degenerator@1.0.4",
+              "deps": [
+                {
+                  "nodeId": "ast-types@0.14.2"
+                },
+                {
+                  "nodeId": "escodegen@1.14.3"
+                },
+                {
+                  "nodeId": "esprima@3.1.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ip@1.1.5",
+              "pkgId": "ip@1.1.5",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "netmask@1.0.6",
+              "pkgId": "netmask@1.0.6",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "thunkify@2.1.2",
+              "pkgId": "thunkify@2.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pac-resolver@3.0.0",
+              "pkgId": "pac-resolver@3.0.0",
+              "deps": [
+                {
+                  "nodeId": "co@4.6.0"
+                },
+                {
+                  "nodeId": "degenerator@1.0.4"
+                },
+                {
+                  "nodeId": "ip@1.1.5"
+                },
+                {
+                  "nodeId": "netmask@1.0.6"
+                },
+                {
+                  "nodeId": "thunkify@2.1.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "bytes@3.1.1",
+              "pkgId": "bytes@3.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "depd@1.1.2",
+              "pkgId": "depd@1.1.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "setprototypeof@1.2.0",
+              "pkgId": "setprototypeof@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "statuses@1.5.0",
+              "pkgId": "statuses@1.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "toidentifier@1.0.1",
+              "pkgId": "toidentifier@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "http-errors@1.8.1",
+              "pkgId": "http-errors@1.8.1",
+              "deps": [
+                {
+                  "nodeId": "depd@1.1.2"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "setprototypeof@1.2.0"
+                },
+                {
+                  "nodeId": "statuses@1.5.0"
+                },
+                {
+                  "nodeId": "toidentifier@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "unpipe@1.0.0",
+              "pkgId": "unpipe@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "raw-body@2.4.2",
+              "pkgId": "raw-body@2.4.2",
+              "deps": [
+                {
+                  "nodeId": "bytes@3.1.1"
+                },
+                {
+                  "nodeId": "http-errors@1.8.1"
+                },
+                {
+                  "nodeId": "iconv-lite@0.4.24"
+                },
+                {
+                  "nodeId": "unpipe@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "agent-base@4.2.1",
+              "pkgId": "agent-base@4.2.1",
+              "deps": [
+                {
+                  "nodeId": "es6-promisify@5.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "smart-buffer@4.2.0",
+              "pkgId": "smart-buffer@4.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "socks@2.3.3",
+              "pkgId": "socks@2.3.3",
+              "deps": [
+                {
+                  "nodeId": "ip@1.1.5"
+                },
+                {
+                  "nodeId": "smart-buffer@4.2.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "socks-proxy-agent@4.0.2",
+              "pkgId": "socks-proxy-agent@4.0.2",
+              "deps": [
+                {
+                  "nodeId": "agent-base@4.2.1"
+                },
+                {
+                  "nodeId": "socks@2.3.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pac-proxy-agent@3.0.1",
+              "pkgId": "pac-proxy-agent@3.0.1",
+              "deps": [
+                {
+                  "nodeId": "agent-base@4.3.0"
+                },
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "get-uri@2.0.4"
+                },
+                {
+                  "nodeId": "http-proxy-agent@2.1.0"
+                },
+                {
+                  "nodeId": "https-proxy-agent@3.0.1"
+                },
+                {
+                  "nodeId": "pac-resolver@3.0.0"
+                },
+                {
+                  "nodeId": "raw-body@2.4.2"
+                },
+                {
+                  "nodeId": "socks-proxy-agent@4.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "proxy-from-env@1.1.0",
+              "pkgId": "proxy-from-env@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "proxy-agent@3.1.1",
+              "pkgId": "proxy-agent@3.1.1",
+              "deps": [
+                {
+                  "nodeId": "agent-base@4.3.0"
+                },
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "http-proxy-agent@2.1.0"
+                },
+                {
+                  "nodeId": "https-proxy-agent@3.0.1"
+                },
+                {
+                  "nodeId": "lru-cache@5.1.1"
+                },
+                {
+                  "nodeId": "pac-proxy-agent@3.0.1"
+                },
+                {
+                  "nodeId": "proxy-from-env@1.1.0"
+                },
+                {
+                  "nodeId": "socks-proxy-agent@4.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "async@1.5.2",
+              "pkgId": "async@1.5.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "secure-keys@1.0.0",
+              "pkgId": "secure-keys@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "camelcase@2.1.1",
+              "pkgId": "camelcase@2.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "code-point-at@1.1.0",
+              "pkgId": "code-point-at@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "number-is-nan@1.0.1",
+              "pkgId": "number-is-nan@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@1.0.0",
+              "pkgId": "is-fullwidth-code-point@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "number-is-nan@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansi-regex@2.1.1",
+              "pkgId": "ansi-regex@2.1.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1",
+              "pkgId": "strip-ansi@3.0.1",
+              "deps": [
+                {
+                  "nodeId": "ansi-regex@2.1.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "string-width@1.0.2",
+              "pkgId": "string-width@1.0.2",
+              "deps": [
+                {
+                  "nodeId": "code-point-at@1.1.0"
+                },
+                {
+                  "nodeId": "is-fullwidth-code-point@1.0.0"
+                },
+                {
+                  "nodeId": "strip-ansi@3.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "wrap-ansi@2.1.0",
+              "pkgId": "wrap-ansi@2.1.0",
+              "deps": [
+                {
+                  "nodeId": "string-width@1.0.2"
+                },
+                {
+                  "nodeId": "strip-ansi@3.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "cliui@3.2.0",
+              "pkgId": "cliui@3.2.0",
+              "deps": [
+                {
+                  "nodeId": "string-width@1.0.2"
+                },
+                {
+                  "nodeId": "strip-ansi@3.0.1"
+                },
+                {
+                  "nodeId": "wrap-ansi@2.1.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "decamelize@1.2.0",
+              "pkgId": "decamelize@1.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "invert-kv@1.0.0",
+              "pkgId": "invert-kv@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lcid@1.0.0",
+              "pkgId": "lcid@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "invert-kv@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "os-locale@1.4.0",
+              "pkgId": "os-locale@1.4.0",
+              "deps": [
+                {
+                  "nodeId": "lcid@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "window-size@0.1.4",
+              "pkgId": "window-size@0.1.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "y18n@3.2.2",
+              "pkgId": "y18n@3.2.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "yargs@3.32.0",
+              "pkgId": "yargs@3.32.0",
+              "deps": [
+                {
+                  "nodeId": "camelcase@2.1.1"
+                },
+                {
+                  "nodeId": "cliui@3.2.0"
+                },
+                {
+                  "nodeId": "decamelize@1.2.0"
+                },
+                {
+                  "nodeId": "os-locale@1.4.0"
+                },
+                {
+                  "nodeId": "string-width@1.0.2"
+                },
+                {
+                  "nodeId": "window-size@0.1.4"
+                },
+                {
+                  "nodeId": "y18n@3.2.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "nconf@0.10.0",
+              "pkgId": "nconf@0.10.0",
+              "deps": [
+                {
+                  "nodeId": "async@1.5.2"
+                },
+                {
+                  "nodeId": "ini@1.3.8"
+                },
+                {
+                  "nodeId": "secure-keys@1.0.0"
+                },
+                {
+                  "nodeId": "yargs@3.32.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-config@2.2.3",
+              "pkgId": "snyk-config@2.2.3",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "nconf@0.10.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "vscode-languageserver-types@3.16.0",
+              "pkgId": "vscode-languageserver-types@3.16.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "dockerfile-ast@0.0.18",
+              "pkgId": "dockerfile-ast@0.0.18",
+              "deps": [
+                {
+                  "nodeId": "vscode-languageserver-types@3.16.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "event-loop-spinner@1.1.0",
+              "pkgId": "event-loop-spinner@1.1.0",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "base64-js@1.5.1",
+              "pkgId": "base64-js@1.5.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ieee754@1.2.1",
+              "pkgId": "ieee754@1.2.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "buffer@5.7.1",
+              "pkgId": "buffer@5.7.1",
+              "deps": [
+                {
+                  "nodeId": "base64-js@1.5.1"
+                },
+                {
+                  "nodeId": "ieee754@1.2.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "readable-stream@3.6.0",
+              "pkgId": "readable-stream@3.6.0",
+              "deps": [
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "string_decoder@1.1.1"
+                },
+                {
+                  "nodeId": "util-deprecate@1.0.2"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "bl@4.1.0",
+              "pkgId": "bl@4.1.0",
+              "deps": [
+                {
+                  "nodeId": "buffer@5.7.1"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "readable-stream@3.6.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "fs-constants@1.0.0",
+              "pkgId": "fs-constants@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tar-stream@2.2.0",
+              "pkgId": "tar-stream@2.2.0",
+              "deps": [
+                {
+                  "nodeId": "bl@4.1.0"
+                },
+                {
+                  "nodeId": "end-of-stream@1.4.4"
+                },
+                {
+                  "nodeId": "fs-constants@1.0.0"
+                },
+                {
+                  "nodeId": "inherits@2.0.4"
+                },
+                {
+                  "nodeId": "readable-stream@3.6.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-docker-plugin@1.38.0",
+              "pkgId": "snyk-docker-plugin@1.38.0",
+              "deps": [
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "dockerfile-ast@0.0.18"
+                },
+                {
+                  "nodeId": "event-loop-spinner@1.1.0"
+                },
+                {
+                  "nodeId": "semver@6.3.0"
+                },
+                {
+                  "nodeId": "tar-stream@2.2.0"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "toml@3.0.0",
+              "pkgId": "toml@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-go-parser@1.3.1",
+              "pkgId": "snyk-go-parser@1.3.1",
+              "deps": [
+                {
+                  "nodeId": "toml@3.0.0"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-go-plugin@1.11.1",
+              "pkgId": "snyk-go-plugin@1.11.1",
+              "deps": [
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "graphlib@2.1.8"
+                },
+                {
+                  "nodeId": "snyk-go-parser@1.3.1"
+                },
+                {
+                  "nodeId": "tmp@0.0.33"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/ms@0.7.31",
+              "pkgId": "@types/ms@0.7.31",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/debug@4.1.7",
+              "pkgId": "@types/debug@4.1.7",
+              "deps": [
+                {
+                  "nodeId": "@types/ms@0.7.31"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-gradle-plugin@3.2.4",
+              "pkgId": "snyk-gradle-plugin@3.2.4",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@2.3.0"
+                },
+                {
+                  "nodeId": "@types/debug@4.1.7"
+                },
+                {
+                  "nodeId": "chalk@2.4.2"
+                },
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "tmp@0.0.33"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "hosted-git-info@2.8.9",
+              "pkgId": "hosted-git-info@2.8.9",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-module@1.9.1",
+              "pkgId": "snyk-module@1.9.1",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "hosted-git-info@2.8.9"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tslib@1.9.3",
+              "pkgId": "tslib@1.9.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/cli-interface@2.3.1",
+              "pkgId": "@snyk/cli-interface@2.3.1",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.9.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "rimraf@2.7.1",
+              "pkgId": "rimraf@2.7.1",
+              "deps": [
+                {
+                  "nodeId": "glob@7.2.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tmp@0.1.0",
+              "pkgId": "tmp@0.1.0",
+              "deps": [
+                {
+                  "nodeId": "rimraf@2.7.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-mvn-plugin@2.8.0",
+              "pkgId": "snyk-mvn-plugin@2.8.0",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@2.3.1"
+                },
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "needle@2.9.1"
+                },
+                {
+                  "nodeId": "tmp@0.1.0"
+                },
+                {
+                  "nodeId": "tslib@1.9.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@yarnpkg/lockfile@1.1.0",
+              "pkgId": "@yarnpkg/lockfile@1.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "p-map@2.1.0",
+              "pkgId": "p-map@2.1.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "uuid@3.4.0",
+              "pkgId": "uuid@3.4.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-nodejs-lockfile-parser@1.17.0",
+              "pkgId": "snyk-nodejs-lockfile-parser@1.17.0",
+              "deps": [
+                {
+                  "nodeId": "@yarnpkg/lockfile@1.1.0"
+                },
+                {
+                  "nodeId": "graphlib@2.1.8"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "p-map@2.1.0"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                },
+                {
+                  "nodeId": "uuid@3.4.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/events@3.0.0",
+              "pkgId": "@types/events@3.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/xml2js@0.4.3",
+              "pkgId": "@types/xml2js@0.4.3",
+              "deps": [
+                {
+                  "nodeId": "@types/events@3.0.0"
+                },
+                {
+                  "nodeId": "@types/node@16.11.11"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xmlbuilder@9.0.7",
+              "pkgId": "xmlbuilder@9.0.7",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xml2js@0.4.19",
+              "pkgId": "xml2js@0.4.19",
+              "deps": [
+                {
+                  "nodeId": "sax@1.2.4"
+                },
+                {
+                  "nodeId": "xmlbuilder@9.0.7"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "dotnet-deps-parser@4.9.0",
+              "pkgId": "dotnet-deps-parser@4.9.0",
+              "deps": [
+                {
+                  "nodeId": "@types/xml2js@0.4.3"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                },
+                {
+                  "nodeId": "xml2js@0.4.19"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "immediate@3.0.6",
+              "pkgId": "immediate@3.0.6",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lie@3.3.0",
+              "pkgId": "lie@3.3.0",
+              "deps": [
+                {
+                  "nodeId": "immediate@3.0.6"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "pako@1.0.11",
+              "pkgId": "pako@1.0.11",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "set-immediate-shim@1.0.1",
+              "pkgId": "set-immediate-shim@1.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "jszip@3.7.1",
+              "pkgId": "jszip@3.7.1",
+              "deps": [
+                {
+                  "nodeId": "lie@3.3.0"
+                },
+                {
+                  "nodeId": "pako@1.0.11"
+                },
+                {
+                  "nodeId": "readable-stream@2.3.7"
+                },
+                {
+                  "nodeId": "set-immediate-shim@1.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-paket-parser@1.5.0",
+              "pkgId": "snyk-paket-parser@1.5.0",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xmlbuilder@11.0.1",
+              "pkgId": "xmlbuilder@11.0.1",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "xml2js@0.4.23",
+              "pkgId": "xml2js@0.4.23",
+              "deps": [
+                {
+                  "nodeId": "sax@1.2.4"
+                },
+                {
+                  "nodeId": "xmlbuilder@11.0.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-nuget-plugin@1.16.0",
+              "pkgId": "snyk-nuget-plugin@1.16.0",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "dotnet-deps-parser@4.9.0"
+                },
+                {
+                  "nodeId": "jszip@3.7.1"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "snyk-paket-parser@1.5.0"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                },
+                {
+                  "nodeId": "xml2js@0.4.23"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/cli-interface@2.2.0",
+              "pkgId": "@snyk/cli-interface@2.2.0",
+              "deps": [
+                {
+                  "nodeId": "tslib@1.9.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@snyk/composer-lockfile-parser@1.2.0",
+              "pkgId": "@snyk/composer-lockfile-parser@1.2.0",
+              "deps": [
+                {
+                  "nodeId": "lodash@4.17.21"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-php-plugin@1.7.0",
+              "pkgId": "snyk-php-plugin@1.7.0",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@2.2.0"
+                },
+                {
+                  "nodeId": "@snyk/composer-lockfile-parser@1.2.0"
+                },
+                {
+                  "nodeId": "tslib@1.9.3"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "email-validator@2.0.4",
+              "pkgId": "email-validator@2.0.4",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.clonedeep@4.5.0",
+              "pkgId": "lodash.clonedeep@4.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "asap@2.0.6",
+              "pkgId": "asap@2.0.6",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "promise@7.3.1",
+              "pkgId": "promise@7.3.1",
+              "deps": [
+                {
+                  "nodeId": "asap@2.0.6"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "then-fs@2.0.0",
+              "pkgId": "then-fs@2.0.0",
+              "deps": [
+                {
+                  "nodeId": "promise@7.3.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1",
+              "pkgId": "snyk-resolve@1.0.1",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "then-fs@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1",
+              "pkgId": "snyk-try-require@1.3.1",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "lodash.clonedeep@4.5.0"
+                },
+                {
+                  "nodeId": "lru-cache@4.1.5"
+                },
+                {
+                  "nodeId": "then-fs@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-policy@1.13.5",
+              "pkgId": "snyk-policy@1.13.5",
+              "deps": [
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "email-validator@2.0.4"
+                },
+                {
+                  "nodeId": "js-yaml@3.14.1"
+                },
+                {
+                  "nodeId": "lodash.clonedeep@4.5.0"
+                },
+                {
+                  "nodeId": "semver@6.3.0"
+                },
+                {
+                  "nodeId": "snyk-module@1.9.1"
+                },
+                {
+                  "nodeId": "snyk-resolve@1.0.1"
+                },
+                {
+                  "nodeId": "snyk-try-require@1.3.1"
+                },
+                {
+                  "nodeId": "then-fs@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-python-plugin@1.17.0",
+              "pkgId": "snyk-python-plugin@1.17.0",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@2.3.0"
+                },
+                {
+                  "nodeId": "tmp@0.0.33"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/node@6.14.13",
+              "pkgId": "@types/node@6.14.13",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "@types/semver@5.5.0",
+              "pkgId": "@types/semver@5.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "ansicolors@0.3.2",
+              "pkgId": "ansicolors@0.3.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.assign@4.2.0",
+              "pkgId": "lodash.assign@4.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.assignin@4.2.0",
+              "pkgId": "lodash.assignin@4.2.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.clone@4.5.0",
+              "pkgId": "lodash.clone@4.5.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.get@4.4.2",
+              "pkgId": "lodash.get@4.4.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "lodash.set@4.3.2",
+              "pkgId": "lodash.set@4.3.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "archy@1.0.0",
+              "pkgId": "archy@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-tree@1.0.0",
+              "pkgId": "snyk-tree@1.0.0",
+              "deps": [
+                {
+                  "nodeId": "archy@1.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-resolve-deps@4.4.0",
+              "pkgId": "snyk-resolve-deps@4.4.0",
+              "deps": [
+                {
+                  "nodeId": "@types/node@6.14.13"
+                },
+                {
+                  "nodeId": "@types/semver@5.5.0"
+                },
+                {
+                  "nodeId": "ansicolors@0.3.2"
+                },
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "lodash.assign@4.2.0"
+                },
+                {
+                  "nodeId": "lodash.assignin@4.2.0"
+                },
+                {
+                  "nodeId": "lodash.clone@4.5.0"
+                },
+                {
+                  "nodeId": "lodash.flatten@4.4.0"
+                },
+                {
+                  "nodeId": "lodash.get@4.4.2"
+                },
+                {
+                  "nodeId": "lodash.set@4.3.2"
+                },
+                {
+                  "nodeId": "lru-cache@4.1.5"
+                },
+                {
+                  "nodeId": "semver@5.7.1"
+                },
+                {
+                  "nodeId": "snyk-module@1.9.1"
+                },
+                {
+                  "nodeId": "snyk-resolve@1.0.1"
+                },
+                {
+                  "nodeId": "snyk-tree@1.0.0"
+                },
+                {
+                  "nodeId": "snyk-try-require@1.3.1"
+                },
+                {
+                  "nodeId": "then-fs@2.0.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tree-kill@1.2.2",
+              "pkgId": "tree-kill@1.2.2",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk-sbt-plugin@2.11.0",
+              "pkgId": "snyk-sbt-plugin@2.11.0",
+              "deps": [
+                {
+                  "nodeId": "debug@4.3.3"
+                },
+                {
+                  "nodeId": "semver@6.3.0"
+                },
+                {
+                  "nodeId": "tmp@0.1.0"
+                },
+                {
+                  "nodeId": "tree-kill@1.2.2"
+                },
+                {
+                  "nodeId": "tslib@1.14.1"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "temp-dir@1.0.0",
+              "pkgId": "temp-dir@1.0.0",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "tempfile@2.0.0",
+              "pkgId": "tempfile@2.0.0",
+              "deps": [
+                {
+                  "nodeId": "temp-dir@1.0.0"
+                },
+                {
+                  "nodeId": "uuid@3.4.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "emoji-regex@7.0.3",
+              "pkgId": "emoji-regex@7.0.3",
+              "deps": [],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "string-width@3.1.0",
+              "pkgId": "string-width@3.1.0",
+              "deps": [
+                {
+                  "nodeId": "emoji-regex@7.0.3"
+                },
+                {
+                  "nodeId": "is-fullwidth-code-point@2.0.0"
+                },
+                {
+                  "nodeId": "strip-ansi@5.2.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "wrap-ansi@5.1.0",
+              "pkgId": "wrap-ansi@5.1.0",
+              "deps": [
+                {
+                  "nodeId": "ansi-styles@3.2.1"
+                },
+                {
+                  "nodeId": "string-width@3.1.0"
+                },
+                {
+                  "nodeId": "strip-ansi@5.2.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            },
+            {
+              "nodeId": "snyk@1.290.2",
+              "pkgId": "snyk@1.290.2",
+              "deps": [
+                {
+                  "nodeId": "@snyk/cli-interface@2.3.0"
+                },
+                {
+                  "nodeId": "@snyk/configstore@3.2.0-rc1"
+                },
+                {
+                  "nodeId": "@snyk/dep-graph@1.13.1"
+                },
+                {
+                  "nodeId": "@snyk/gemfile@1.2.0"
+                },
+                {
+                  "nodeId": "@snyk/snyk-cocoapods-plugin@2.0.1"
+                },
+                {
+                  "nodeId": "@snyk/update-notifier@2.5.1-rc2"
+                },
+                {
+                  "nodeId": "@types/agent-base@4.2.2"
+                },
+                {
+                  "nodeId": "@types/restify@4.3.8"
+                },
+                {
+                  "nodeId": "abbrev@1.1.1"
+                },
+                {
+                  "nodeId": "ansi-escapes@3.2.0"
+                },
+                {
+                  "nodeId": "chalk@2.4.2"
+                },
+                {
+                  "nodeId": "cli-spinner@0.2.10"
+                },
+                {
+                  "nodeId": "debug@3.2.7"
+                },
+                {
+                  "nodeId": "diff@4.0.2"
+                },
+                {
+                  "nodeId": "git-url-parse@11.1.2"
+                },
+                {
+                  "nodeId": "glob@7.2.0"
+                },
+                {
+                  "nodeId": "inquirer@6.5.2"
+                },
+                {
+                  "nodeId": "lodash@4.17.21"
+                },
+                {
+                  "nodeId": "needle@2.9.1"
+                },
+                {
+                  "nodeId": "opn@5.5.0"
+                },
+                {
+                  "nodeId": "os-name@3.1.0"
+                },
+                {
+                  "nodeId": "proxy-agent@3.1.1"
+                },
+                {
+                  "nodeId": "proxy-from-env@1.1.0"
+                },
+                {
+                  "nodeId": "semver@6.3.0"
+                },
+                {
+                  "nodeId": "snyk-config@2.2.3"
+                },
+                {
+                  "nodeId": "snyk-docker-plugin@1.38.0"
+                },
+                {
+                  "nodeId": "snyk-go-plugin@1.11.1"
+                },
+                {
+                  "nodeId": "snyk-gradle-plugin@3.2.4"
+                },
+                {
+                  "nodeId": "snyk-module@1.9.1"
+                },
+                {
+                  "nodeId": "snyk-mvn-plugin@2.8.0"
+                },
+                {
+                  "nodeId": "snyk-nodejs-lockfile-parser@1.17.0"
+                },
+                {
+                  "nodeId": "snyk-nuget-plugin@1.16.0"
+                },
+                {
+                  "nodeId": "snyk-php-plugin@1.7.0"
+                },
+                {
+                  "nodeId": "snyk-policy@1.13.5"
+                },
+                {
+                  "nodeId": "snyk-python-plugin@1.17.0"
+                },
+                {
+                  "nodeId": "snyk-resolve@1.0.1"
+                },
+                {
+                  "nodeId": "snyk-resolve-deps@4.4.0"
+                },
+                {
+                  "nodeId": "snyk-sbt-plugin@2.11.0"
+                },
+                {
+                  "nodeId": "snyk-tree@1.0.0"
+                },
+                {
+                  "nodeId": "snyk-try-require@1.3.1"
+                },
+                {
+                  "nodeId": "source-map-support@0.5.21"
+                },
+                {
+                  "nodeId": "strip-ansi@5.2.0"
+                },
+                {
+                  "nodeId": "tempfile@2.0.0"
+                },
+                {
+                  "nodeId": "then-fs@2.0.0"
+                },
+                {
+                  "nodeId": "uuid@3.4.0"
+                },
+                {
+                  "nodeId": "wrap-ansi@5.1.0"
+                }
+              ],
+              "info": {
+                "labels": {
+                  "scope": "prod"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "affectedPkgs": {
+        "ansi-regex@3.0.0": {
+          "pkg": {
+            "name": "ansi-regex",
+            "version": "3.0.0"
+          },
+          "issues": {
+            "SNYK-JS-ANSIREGEX-1583908": {
+              "pkgName": "ansi-regex",
+              "pkgVersion": "3.0.0",
+              "issueId": "SNYK-JS-ANSIREGEX-1583908",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.316.0"
+                      },
+                      {
+                        "name": "inquirer",
+                        "version": "6.5.2",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "string-width",
+                        "version": "2.1.1",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "strip-ansi",
+                        "version": "4.0.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "ansi-regex",
+                        "version": "3.0.0",
+                        "isDropped": true
+                      }
+                    ]
+                  }
+                ],
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "ansi-regex@4.1.0": {
+          "pkg": {
+            "name": "ansi-regex",
+            "version": "4.1.0"
+          },
+          "issues": {
+            "SNYK-JS-ANSIREGEX-1583908": {
+              "pkgName": "ansi-regex",
+              "pkgVersion": "4.1.0",
+              "issueId": "SNYK-JS-ANSIREGEX-1583908",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.685.0"
+                      },
+                      {
+                        "name": "strip-ansi",
+                        "version": "5.2.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "ansi-regex",
+                        "version": "4.1.0",
+                        "isDropped": true
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.316.0"
+                      },
+                      {
+                        "name": "inquirer",
+                        "version": "6.5.2",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "strip-ansi",
+                        "version": "5.2.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "ansi-regex",
+                        "version": "4.1.0",
+                        "isDropped": true
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.685.0"
+                      },
+                      {
+                        "name": "wrap-ansi",
+                        "version": "5.1.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "strip-ansi",
+                        "version": "5.2.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "ansi-regex",
+                        "version": "4.1.0",
+                        "isDropped": true
+                      }
+                    ]
+                  },
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.685.0"
+                      },
+                      {
+                        "name": "wrap-ansi",
+                        "version": "5.1.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "string-width",
+                        "version": "3.1.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "strip-ansi",
+                        "version": "5.2.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "ansi-regex",
+                        "version": "4.1.0",
+                        "isDropped": true
+                      }
+                    ]
+                  }
+                ],
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "netmask@1.0.6": {
+          "pkg": {
+            "name": "netmask",
+            "version": "1.0.6"
+          },
+          "issues": {
+            "SNYK-JS-NETMASK-1089716": {
+              "pkgName": "netmask",
+              "pkgVersion": "1.0.6",
+              "issueId": "SNYK-JS-NETMASK-1089716",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.518.0"
+                      },
+                      {
+                        "name": "proxy-agent",
+                        "version": "3.1.1",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "pac-proxy-agent",
+                        "version": "3.0.1",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "pac-resolver",
+                        "version": "3.0.0",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "netmask",
+                        "version": "1.0.6",
+                        "isDropped": true
+                      }
+                    ]
+                  }
+                ],
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        },
+        "pac-resolver@3.0.0": {
+          "pkg": {
+            "name": "pac-resolver",
+            "version": "3.0.0"
+          },
+          "issues": {
+            "SNYK-JS-PACRESOLVER-1564857": {
+              "pkgName": "pac-resolver",
+              "pkgVersion": "3.0.0",
+              "issueId": "SNYK-JS-PACRESOLVER-1564857",
+              "fixInfo": {
+                "isPatchable": false,
+                "upgradePaths": [
+                  {
+                    "path": [
+                      {
+                        "name": "goof",
+                        "version": "1.0.1"
+                      },
+                      {
+                        "name": "snyk",
+                        "version": "1.290.2",
+                        "newVersion": "1.518.0"
+                      },
+                      {
+                        "name": "proxy-agent",
+                        "version": "3.1.1",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "pac-proxy-agent",
+                        "version": "3.0.1",
+                        "isDropped": true
+                      },
+                      {
+                        "name": "pac-resolver",
+                        "version": "3.0.0",
+                        "isDropped": true
+                      }
+                    ]
+                  }
+                ],
+                "isRuntime": false,
+                "isPinnable": false
+              }
+            }
+          }
+        }
+      }
+    },
+    "filesystemPolicy": false
+  },
+  "depGraph": {
+    "schemaVersion": "1.2.0",
+    "pkgManager": {
+      "name": "npm"
+    },
+    "pkgs": [
+      {
+        "id": "goof@1.0.1",
+        "info": {
+          "name": "goof",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "tslib@1.14.1",
+        "info": {
+          "name": "tslib",
+          "version": "1.14.1"
+        }
+      },
+      {
+        "id": "@snyk/cli-interface@2.3.0",
+        "info": {
+          "name": "@snyk/cli-interface",
+          "version": "2.3.0"
+        }
+      },
+      {
+        "id": "is-obj@2.0.0",
+        "info": {
+          "name": "is-obj",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "dot-prop@5.3.0",
+        "info": {
+          "name": "dot-prop",
+          "version": "5.3.0"
+        }
+      },
+      {
+        "id": "graceful-fs@4.2.8",
+        "info": {
+          "name": "graceful-fs",
+          "version": "4.2.8"
+        }
+      },
+      {
+        "id": "pify@3.0.0",
+        "info": {
+          "name": "pify",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "make-dir@1.3.0",
+        "info": {
+          "name": "make-dir",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "id": "crypto-random-string@1.0.0",
+        "info": {
+          "name": "crypto-random-string",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "unique-string@1.0.0",
+        "info": {
+          "name": "unique-string",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "imurmurhash@0.1.4",
+        "info": {
+          "name": "imurmurhash",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "signal-exit@3.0.6",
+        "info": {
+          "name": "signal-exit",
+          "version": "3.0.6"
+        }
+      },
+      {
+        "id": "write-file-atomic@2.4.3",
+        "info": {
+          "name": "write-file-atomic",
+          "version": "2.4.3"
+        }
+      },
+      {
+        "id": "xdg-basedir@3.0.0",
+        "info": {
+          "name": "xdg-basedir",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "@snyk/configstore@3.2.0-rc1",
+        "info": {
+          "name": "@snyk/configstore",
+          "version": "3.2.0-rc1"
+        }
+      },
+      {
+        "id": "lodash@4.17.21",
+        "info": {
+          "name": "lodash",
+          "version": "4.17.21"
+        }
+      },
+      {
+        "id": "graphlib@2.1.8",
+        "info": {
+          "name": "graphlib",
+          "version": "2.1.8"
+        }
+      },
+      {
+        "id": "object-hash@1.3.1",
+        "info": {
+          "name": "object-hash",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "semver@6.3.0",
+        "info": {
+          "name": "semver",
+          "version": "6.3.0"
+        }
+      },
+      {
+        "id": "buffer-from@1.1.2",
+        "info": {
+          "name": "buffer-from",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "source-map@0.6.1",
+        "info": {
+          "name": "source-map",
+          "version": "0.6.1"
+        }
+      },
+      {
+        "id": "source-map-support@0.5.21",
+        "info": {
+          "name": "source-map-support",
+          "version": "0.5.21"
+        }
+      },
+      {
+        "id": "@snyk/dep-graph@1.13.1",
+        "info": {
+          "name": "@snyk/dep-graph",
+          "version": "1.13.1"
+        }
+      },
+      {
+        "id": "@snyk/gemfile@1.2.0",
+        "info": {
+          "name": "@snyk/gemfile",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "@snyk/cli-interface@1.5.0",
+        "info": {
+          "name": "@snyk/cli-interface",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "lodash.escaperegexp@4.1.2",
+        "info": {
+          "name": "lodash.escaperegexp",
+          "version": "4.1.2"
+        }
+      },
+      {
+        "id": "lodash.flatten@4.4.0",
+        "info": {
+          "name": "lodash.flatten",
+          "version": "4.4.0"
+        }
+      },
+      {
+        "id": "lodash.uniq@4.5.0",
+        "info": {
+          "name": "lodash.uniq",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "@snyk/ruby-semver@2.2.2",
+        "info": {
+          "name": "@snyk/ruby-semver",
+          "version": "2.2.2"
+        }
+      },
+      {
+        "id": "@types/js-yaml@3.12.7",
+        "info": {
+          "name": "@types/js-yaml",
+          "version": "3.12.7"
+        }
+      },
+      {
+        "id": "core-js@3.19.3",
+        "info": {
+          "name": "core-js",
+          "version": "3.19.3"
+        }
+      },
+      {
+        "id": "sprintf-js@1.0.3",
+        "info": {
+          "name": "sprintf-js",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "argparse@1.0.10",
+        "info": {
+          "name": "argparse",
+          "version": "1.0.10"
+        }
+      },
+      {
+        "id": "esprima@4.0.1",
+        "info": {
+          "name": "esprima",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "js-yaml@3.14.1",
+        "info": {
+          "name": "js-yaml",
+          "version": "3.14.1"
+        }
+      },
+      {
+        "id": "@snyk/cocoapods-lockfile-parser@3.0.0",
+        "info": {
+          "name": "@snyk/cocoapods-lockfile-parser",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "@snyk/snyk-cocoapods-plugin@2.0.1",
+        "info": {
+          "name": "@snyk/snyk-cocoapods-plugin",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "is-fullwidth-code-point@2.0.0",
+        "info": {
+          "name": "is-fullwidth-code-point",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "ansi-regex@3.0.0",
+        "info": {
+          "name": "ansi-regex",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "strip-ansi@4.0.0",
+        "info": {
+          "name": "strip-ansi",
+          "version": "4.0.0"
+        }
+      },
+      {
+        "id": "string-width@2.1.1",
+        "info": {
+          "name": "string-width",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "ansi-align@2.0.0",
+        "info": {
+          "name": "ansi-align",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "camelcase@4.1.0",
+        "info": {
+          "name": "camelcase",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "color-name@1.1.3",
+        "info": {
+          "name": "color-name",
+          "version": "1.1.3"
+        }
+      },
+      {
+        "id": "color-convert@1.9.3",
+        "info": {
+          "name": "color-convert",
+          "version": "1.9.3"
+        }
+      },
+      {
+        "id": "ansi-styles@3.2.1",
+        "info": {
+          "name": "ansi-styles",
+          "version": "3.2.1"
+        }
+      },
+      {
+        "id": "escape-string-regexp@1.0.5",
+        "info": {
+          "name": "escape-string-regexp",
+          "version": "1.0.5"
+        }
+      },
+      {
+        "id": "has-flag@3.0.0",
+        "info": {
+          "name": "has-flag",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "supports-color@5.5.0",
+        "info": {
+          "name": "supports-color",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "chalk@2.4.2",
+        "info": {
+          "name": "chalk",
+          "version": "2.4.2"
+        }
+      },
+      {
+        "id": "cli-boxes@1.0.0",
+        "info": {
+          "name": "cli-boxes",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "pseudomap@1.0.2",
+        "info": {
+          "name": "pseudomap",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "yallist@2.1.2",
+        "info": {
+          "name": "yallist",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "lru-cache@4.1.5",
+        "info": {
+          "name": "lru-cache",
+          "version": "4.1.5"
+        }
+      },
+      {
+        "id": "shebang-regex@1.0.0",
+        "info": {
+          "name": "shebang-regex",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "shebang-command@1.2.0",
+        "info": {
+          "name": "shebang-command",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "isexe@2.0.0",
+        "info": {
+          "name": "isexe",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "which@1.3.1",
+        "info": {
+          "name": "which",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "cross-spawn@5.1.0",
+        "info": {
+          "name": "cross-spawn",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "id": "get-stream@3.0.0",
+        "info": {
+          "name": "get-stream",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "is-stream@1.1.0",
+        "info": {
+          "name": "is-stream",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "path-key@2.0.1",
+        "info": {
+          "name": "path-key",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "npm-run-path@2.0.2",
+        "info": {
+          "name": "npm-run-path",
+          "version": "2.0.2"
+        }
+      },
+      {
+        "id": "p-finally@1.0.0",
+        "info": {
+          "name": "p-finally",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "strip-eof@1.0.0",
+        "info": {
+          "name": "strip-eof",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "execa@0.7.0",
+        "info": {
+          "name": "execa",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "id": "term-size@1.2.0",
+        "info": {
+          "name": "term-size",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "widest-line@2.0.1",
+        "info": {
+          "name": "widest-line",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "boxen@1.3.0",
+        "info": {
+          "name": "boxen",
+          "version": "1.3.0"
+        }
+      },
+      {
+        "id": "import-lazy@2.1.0",
+        "info": {
+          "name": "import-lazy",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "ci-info@1.6.0",
+        "info": {
+          "name": "ci-info",
+          "version": "1.6.0"
+        }
+      },
+      {
+        "id": "is-ci@1.2.1",
+        "info": {
+          "name": "is-ci",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "ini@1.3.8",
+        "info": {
+          "name": "ini",
+          "version": "1.3.8"
+        }
+      },
+      {
+        "id": "global-dirs@0.1.1",
+        "info": {
+          "name": "global-dirs",
+          "version": "0.1.1"
+        }
+      },
+      {
+        "id": "path-is-inside@1.0.2",
+        "info": {
+          "name": "path-is-inside",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "is-path-inside@1.0.1",
+        "info": {
+          "name": "is-path-inside",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "is-installed-globally@0.1.0",
+        "info": {
+          "name": "is-installed-globally",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "id": "is-npm@1.0.0",
+        "info": {
+          "name": "is-npm",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "capture-stack-trace@1.0.1",
+        "info": {
+          "name": "capture-stack-trace",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "create-error-class@3.0.2",
+        "info": {
+          "name": "create-error-class",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "duplexer3@0.1.4",
+        "info": {
+          "name": "duplexer3",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "is-redirect@1.0.0",
+        "info": {
+          "name": "is-redirect",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "is-retry-allowed@1.2.0",
+        "info": {
+          "name": "is-retry-allowed",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "lowercase-keys@1.0.1",
+        "info": {
+          "name": "lowercase-keys",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "safe-buffer@5.2.1",
+        "info": {
+          "name": "safe-buffer",
+          "version": "5.2.1"
+        }
+      },
+      {
+        "id": "timed-out@4.0.1",
+        "info": {
+          "name": "timed-out",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "unzip-response@2.0.1",
+        "info": {
+          "name": "unzip-response",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "prepend-http@1.0.4",
+        "info": {
+          "name": "prepend-http",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "url-parse-lax@1.0.0",
+        "info": {
+          "name": "url-parse-lax",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "got@6.7.1",
+        "info": {
+          "name": "got",
+          "version": "6.7.1"
+        }
+      },
+      {
+        "id": "deep-extend@0.6.0",
+        "info": {
+          "name": "deep-extend",
+          "version": "0.6.0"
+        }
+      },
+      {
+        "id": "minimist@1.2.5",
+        "info": {
+          "name": "minimist",
+          "version": "1.2.5"
+        }
+      },
+      {
+        "id": "strip-json-comments@2.0.1",
+        "info": {
+          "name": "strip-json-comments",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "rc@1.2.8",
+        "info": {
+          "name": "rc",
+          "version": "1.2.8"
+        }
+      },
+      {
+        "id": "registry-auth-token@3.4.0",
+        "info": {
+          "name": "registry-auth-token",
+          "version": "3.4.0"
+        }
+      },
+      {
+        "id": "registry-url@3.1.0",
+        "info": {
+          "name": "registry-url",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "semver@5.7.1",
+        "info": {
+          "name": "semver",
+          "version": "5.7.1"
+        }
+      },
+      {
+        "id": "package-json@4.0.1",
+        "info": {
+          "name": "package-json",
+          "version": "4.0.1"
+        }
+      },
+      {
+        "id": "latest-version@3.1.0",
+        "info": {
+          "name": "latest-version",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "semver-diff@2.1.0",
+        "info": {
+          "name": "semver-diff",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "@snyk/update-notifier@2.5.1-rc2",
+        "info": {
+          "name": "@snyk/update-notifier",
+          "version": "2.5.1-rc2"
+        }
+      },
+      {
+        "id": "@types/node@16.11.11",
+        "info": {
+          "name": "@types/node",
+          "version": "16.11.11"
+        }
+      },
+      {
+        "id": "@types/agent-base@4.2.2",
+        "info": {
+          "name": "@types/agent-base",
+          "version": "4.2.2"
+        }
+      },
+      {
+        "id": "@types/bunyan@1.8.8",
+        "info": {
+          "name": "@types/bunyan",
+          "version": "1.8.8"
+        }
+      },
+      {
+        "id": "@types/restify@4.3.8",
+        "info": {
+          "name": "@types/restify",
+          "version": "4.3.8"
+        }
+      },
+      {
+        "id": "abbrev@1.1.1",
+        "info": {
+          "name": "abbrev",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "ansi-escapes@3.2.0",
+        "info": {
+          "name": "ansi-escapes",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "cli-spinner@0.2.10",
+        "info": {
+          "name": "cli-spinner",
+          "version": "0.2.10"
+        }
+      },
+      {
+        "id": "ms@2.1.3",
+        "info": {
+          "name": "ms",
+          "version": "2.1.3"
+        }
+      },
+      {
+        "id": "debug@3.2.7",
+        "info": {
+          "name": "debug",
+          "version": "3.2.7"
+        }
+      },
+      {
+        "id": "diff@4.0.2",
+        "info": {
+          "name": "diff",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "id": "protocols@1.4.8",
+        "info": {
+          "name": "protocols",
+          "version": "1.4.8"
+        }
+      },
+      {
+        "id": "is-ssh@1.3.3",
+        "info": {
+          "name": "is-ssh",
+          "version": "1.3.3"
+        }
+      },
+      {
+        "id": "normalize-url@6.1.0",
+        "info": {
+          "name": "normalize-url",
+          "version": "6.1.0"
+        }
+      },
+      {
+        "id": "function-bind@1.1.1",
+        "info": {
+          "name": "function-bind",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "has@1.0.3",
+        "info": {
+          "name": "has",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "has-symbols@1.0.2",
+        "info": {
+          "name": "has-symbols",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "get-intrinsic@1.1.1",
+        "info": {
+          "name": "get-intrinsic",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "call-bind@1.0.2",
+        "info": {
+          "name": "call-bind",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "object-inspect@1.11.1",
+        "info": {
+          "name": "object-inspect",
+          "version": "1.11.1"
+        }
+      },
+      {
+        "id": "side-channel@1.0.4",
+        "info": {
+          "name": "side-channel",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "qs@6.10.2",
+        "info": {
+          "name": "qs",
+          "version": "6.10.2"
+        }
+      },
+      {
+        "id": "decode-uri-component@0.2.0",
+        "info": {
+          "name": "decode-uri-component",
+          "version": "0.2.0"
+        }
+      },
+      {
+        "id": "filter-obj@1.1.0",
+        "info": {
+          "name": "filter-obj",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "split-on-first@1.1.0",
+        "info": {
+          "name": "split-on-first",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "strict-uri-encode@2.0.0",
+        "info": {
+          "name": "strict-uri-encode",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "query-string@6.14.1",
+        "info": {
+          "name": "query-string",
+          "version": "6.14.1"
+        }
+      },
+      {
+        "id": "parse-path@4.0.3",
+        "info": {
+          "name": "parse-path",
+          "version": "4.0.3"
+        }
+      },
+      {
+        "id": "parse-url@6.0.0",
+        "info": {
+          "name": "parse-url",
+          "version": "6.0.0"
+        }
+      },
+      {
+        "id": "git-up@4.0.5",
+        "info": {
+          "name": "git-up",
+          "version": "4.0.5"
+        }
+      },
+      {
+        "id": "git-url-parse@11.1.2",
+        "info": {
+          "name": "git-url-parse",
+          "version": "11.1.2"
+        }
+      },
+      {
+        "id": "fs.realpath@1.0.0",
+        "info": {
+          "name": "fs.realpath",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "wrappy@1.0.2",
+        "info": {
+          "name": "wrappy",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "once@1.4.0",
+        "info": {
+          "name": "once",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "id": "inflight@1.0.6",
+        "info": {
+          "name": "inflight",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "inherits@2.0.4",
+        "info": {
+          "name": "inherits",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "balanced-match@1.0.2",
+        "info": {
+          "name": "balanced-match",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "concat-map@0.0.1",
+        "info": {
+          "name": "concat-map",
+          "version": "0.0.1"
+        }
+      },
+      {
+        "id": "brace-expansion@1.1.11",
+        "info": {
+          "name": "brace-expansion",
+          "version": "1.1.11"
+        }
+      },
+      {
+        "id": "minimatch@3.0.4",
+        "info": {
+          "name": "minimatch",
+          "version": "3.0.4"
+        }
+      },
+      {
+        "id": "path-is-absolute@1.0.1",
+        "info": {
+          "name": "path-is-absolute",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "glob@7.2.0",
+        "info": {
+          "name": "glob",
+          "version": "7.2.0"
+        }
+      },
+      {
+        "id": "mimic-fn@1.2.0",
+        "info": {
+          "name": "mimic-fn",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "onetime@2.0.1",
+        "info": {
+          "name": "onetime",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "restore-cursor@2.0.0",
+        "info": {
+          "name": "restore-cursor",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "cli-cursor@2.1.0",
+        "info": {
+          "name": "cli-cursor",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "cli-width@2.2.1",
+        "info": {
+          "name": "cli-width",
+          "version": "2.2.1"
+        }
+      },
+      {
+        "id": "chardet@0.7.0",
+        "info": {
+          "name": "chardet",
+          "version": "0.7.0"
+        }
+      },
+      {
+        "id": "safer-buffer@2.1.2",
+        "info": {
+          "name": "safer-buffer",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "iconv-lite@0.4.24",
+        "info": {
+          "name": "iconv-lite",
+          "version": "0.4.24"
+        }
+      },
+      {
+        "id": "os-tmpdir@1.0.2",
+        "info": {
+          "name": "os-tmpdir",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "tmp@0.0.33",
+        "info": {
+          "name": "tmp",
+          "version": "0.0.33"
+        }
+      },
+      {
+        "id": "external-editor@3.1.0",
+        "info": {
+          "name": "external-editor",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "figures@2.0.0",
+        "info": {
+          "name": "figures",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "mute-stream@0.0.7",
+        "info": {
+          "name": "mute-stream",
+          "version": "0.0.7"
+        }
+      },
+      {
+        "id": "run-async@2.4.1",
+        "info": {
+          "name": "run-async",
+          "version": "2.4.1"
+        }
+      },
+      {
+        "id": "rxjs@6.6.7",
+        "info": {
+          "name": "rxjs",
+          "version": "6.6.7"
+        }
+      },
+      {
+        "id": "ansi-regex@4.1.0",
+        "info": {
+          "name": "ansi-regex",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "strip-ansi@5.2.0",
+        "info": {
+          "name": "strip-ansi",
+          "version": "5.2.0"
+        }
+      },
+      {
+        "id": "through@2.3.8",
+        "info": {
+          "name": "through",
+          "version": "2.3.8"
+        }
+      },
+      {
+        "id": "inquirer@6.5.2",
+        "info": {
+          "name": "inquirer",
+          "version": "6.5.2"
+        }
+      },
+      {
+        "id": "sax@1.2.4",
+        "info": {
+          "name": "sax",
+          "version": "1.2.4"
+        }
+      },
+      {
+        "id": "needle@2.9.1",
+        "info": {
+          "name": "needle",
+          "version": "2.9.1"
+        }
+      },
+      {
+        "id": "is-wsl@1.1.0",
+        "info": {
+          "name": "is-wsl",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "opn@5.5.0",
+        "info": {
+          "name": "opn",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "macos-release@2.5.0",
+        "info": {
+          "name": "macos-release",
+          "version": "2.5.0"
+        }
+      },
+      {
+        "id": "nice-try@1.0.5",
+        "info": {
+          "name": "nice-try",
+          "version": "1.0.5"
+        }
+      },
+      {
+        "id": "cross-spawn@6.0.5",
+        "info": {
+          "name": "cross-spawn",
+          "version": "6.0.5"
+        }
+      },
+      {
+        "id": "end-of-stream@1.4.4",
+        "info": {
+          "name": "end-of-stream",
+          "version": "1.4.4"
+        }
+      },
+      {
+        "id": "pump@3.0.0",
+        "info": {
+          "name": "pump",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "get-stream@4.1.0",
+        "info": {
+          "name": "get-stream",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "execa@1.0.0",
+        "info": {
+          "name": "execa",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "windows-release@3.3.3",
+        "info": {
+          "name": "windows-release",
+          "version": "3.3.3"
+        }
+      },
+      {
+        "id": "os-name@3.1.0",
+        "info": {
+          "name": "os-name",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "es6-promise@4.2.8",
+        "info": {
+          "name": "es6-promise",
+          "version": "4.2.8"
+        }
+      },
+      {
+        "id": "es6-promisify@5.0.0",
+        "info": {
+          "name": "es6-promisify",
+          "version": "5.0.0"
+        }
+      },
+      {
+        "id": "agent-base@4.3.0",
+        "info": {
+          "name": "agent-base",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "ms@2.1.2",
+        "info": {
+          "name": "ms",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "debug@4.3.3",
+        "info": {
+          "name": "debug",
+          "version": "4.3.3"
+        }
+      },
+      {
+        "id": "ms@2.0.0",
+        "info": {
+          "name": "ms",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "debug@3.1.0",
+        "info": {
+          "name": "debug",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "http-proxy-agent@2.1.0",
+        "info": {
+          "name": "http-proxy-agent",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "https-proxy-agent@3.0.1",
+        "info": {
+          "name": "https-proxy-agent",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "yallist@3.1.1",
+        "info": {
+          "name": "yallist",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "id": "lru-cache@5.1.1",
+        "info": {
+          "name": "lru-cache",
+          "version": "5.1.1"
+        }
+      },
+      {
+        "id": "data-uri-to-buffer@1.2.0",
+        "info": {
+          "name": "data-uri-to-buffer",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "debug@2.6.9",
+        "info": {
+          "name": "debug",
+          "version": "2.6.9"
+        }
+      },
+      {
+        "id": "extend@3.0.2",
+        "info": {
+          "name": "extend",
+          "version": "3.0.2"
+        }
+      },
+      {
+        "id": "file-uri-to-path@1.0.0",
+        "info": {
+          "name": "file-uri-to-path",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "core-util-is@1.0.3",
+        "info": {
+          "name": "core-util-is",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "id": "isarray@0.0.1",
+        "info": {
+          "name": "isarray",
+          "version": "0.0.1"
+        }
+      },
+      {
+        "id": "string_decoder@0.10.31",
+        "info": {
+          "name": "string_decoder",
+          "version": "0.10.31"
+        }
+      },
+      {
+        "id": "readable-stream@1.1.14",
+        "info": {
+          "name": "readable-stream",
+          "version": "1.1.14"
+        }
+      },
+      {
+        "id": "xregexp@2.0.0",
+        "info": {
+          "name": "xregexp",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "ftp@0.3.10",
+        "info": {
+          "name": "ftp",
+          "version": "0.3.10"
+        }
+      },
+      {
+        "id": "isarray@1.0.0",
+        "info": {
+          "name": "isarray",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "process-nextick-args@2.0.1",
+        "info": {
+          "name": "process-nextick-args",
+          "version": "2.0.1"
+        }
+      },
+      {
+        "id": "safe-buffer@5.1.2",
+        "info": {
+          "name": "safe-buffer",
+          "version": "5.1.2"
+        }
+      },
+      {
+        "id": "string_decoder@1.1.1",
+        "info": {
+          "name": "string_decoder",
+          "version": "1.1.1"
+        }
+      },
+      {
+        "id": "util-deprecate@1.0.2",
+        "info": {
+          "name": "util-deprecate",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "readable-stream@2.3.7",
+        "info": {
+          "name": "readable-stream",
+          "version": "2.3.7"
+        }
+      },
+      {
+        "id": "get-uri@2.0.4",
+        "info": {
+          "name": "get-uri",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "co@4.6.0",
+        "info": {
+          "name": "co",
+          "version": "4.6.0"
+        }
+      },
+      {
+        "id": "tslib@2.3.1",
+        "info": {
+          "name": "tslib",
+          "version": "2.3.1"
+        }
+      },
+      {
+        "id": "ast-types@0.14.2",
+        "info": {
+          "name": "ast-types",
+          "version": "0.14.2"
+        }
+      },
+      {
+        "id": "estraverse@4.3.0",
+        "info": {
+          "name": "estraverse",
+          "version": "4.3.0"
+        }
+      },
+      {
+        "id": "esutils@2.0.3",
+        "info": {
+          "name": "esutils",
+          "version": "2.0.3"
+        }
+      },
+      {
+        "id": "deep-is@0.1.4",
+        "info": {
+          "name": "deep-is",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "fast-levenshtein@2.0.6",
+        "info": {
+          "name": "fast-levenshtein",
+          "version": "2.0.6"
+        }
+      },
+      {
+        "id": "prelude-ls@1.1.2",
+        "info": {
+          "name": "prelude-ls",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "type-check@0.3.2",
+        "info": {
+          "name": "type-check",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "id": "levn@0.3.0",
+        "info": {
+          "name": "levn",
+          "version": "0.3.0"
+        }
+      },
+      {
+        "id": "word-wrap@1.2.3",
+        "info": {
+          "name": "word-wrap",
+          "version": "1.2.3"
+        }
+      },
+      {
+        "id": "optionator@0.8.3",
+        "info": {
+          "name": "optionator",
+          "version": "0.8.3"
+        }
+      },
+      {
+        "id": "escodegen@1.14.3",
+        "info": {
+          "name": "escodegen",
+          "version": "1.14.3"
+        }
+      },
+      {
+        "id": "esprima@3.1.3",
+        "info": {
+          "name": "esprima",
+          "version": "3.1.3"
+        }
+      },
+      {
+        "id": "degenerator@1.0.4",
+        "info": {
+          "name": "degenerator",
+          "version": "1.0.4"
+        }
+      },
+      {
+        "id": "ip@1.1.5",
+        "info": {
+          "name": "ip",
+          "version": "1.1.5"
+        }
+      },
+      {
+        "id": "netmask@1.0.6",
+        "info": {
+          "name": "netmask",
+          "version": "1.0.6"
+        }
+      },
+      {
+        "id": "thunkify@2.1.2",
+        "info": {
+          "name": "thunkify",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "id": "pac-resolver@3.0.0",
+        "info": {
+          "name": "pac-resolver",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "bytes@3.1.1",
+        "info": {
+          "name": "bytes",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "id": "depd@1.1.2",
+        "info": {
+          "name": "depd",
+          "version": "1.1.2"
+        }
+      },
+      {
+        "id": "setprototypeof@1.2.0",
+        "info": {
+          "name": "setprototypeof",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "statuses@1.5.0",
+        "info": {
+          "name": "statuses",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "toidentifier@1.0.1",
+        "info": {
+          "name": "toidentifier",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "http-errors@1.8.1",
+        "info": {
+          "name": "http-errors",
+          "version": "1.8.1"
+        }
+      },
+      {
+        "id": "unpipe@1.0.0",
+        "info": {
+          "name": "unpipe",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "raw-body@2.4.2",
+        "info": {
+          "name": "raw-body",
+          "version": "2.4.2"
+        }
+      },
+      {
+        "id": "agent-base@4.2.1",
+        "info": {
+          "name": "agent-base",
+          "version": "4.2.1"
+        }
+      },
+      {
+        "id": "smart-buffer@4.2.0",
+        "info": {
+          "name": "smart-buffer",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "socks@2.3.3",
+        "info": {
+          "name": "socks",
+          "version": "2.3.3"
+        }
+      },
+      {
+        "id": "socks-proxy-agent@4.0.2",
+        "info": {
+          "name": "socks-proxy-agent",
+          "version": "4.0.2"
+        }
+      },
+      {
+        "id": "pac-proxy-agent@3.0.1",
+        "info": {
+          "name": "pac-proxy-agent",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "proxy-from-env@1.1.0",
+        "info": {
+          "name": "proxy-from-env",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "proxy-agent@3.1.1",
+        "info": {
+          "name": "proxy-agent",
+          "version": "3.1.1"
+        }
+      },
+      {
+        "id": "async@1.5.2",
+        "info": {
+          "name": "async",
+          "version": "1.5.2"
+        }
+      },
+      {
+        "id": "secure-keys@1.0.0",
+        "info": {
+          "name": "secure-keys",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "camelcase@2.1.1",
+        "info": {
+          "name": "camelcase",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "code-point-at@1.1.0",
+        "info": {
+          "name": "code-point-at",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "number-is-nan@1.0.1",
+        "info": {
+          "name": "number-is-nan",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "is-fullwidth-code-point@1.0.0",
+        "info": {
+          "name": "is-fullwidth-code-point",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "ansi-regex@2.1.1",
+        "info": {
+          "name": "ansi-regex",
+          "version": "2.1.1"
+        }
+      },
+      {
+        "id": "strip-ansi@3.0.1",
+        "info": {
+          "name": "strip-ansi",
+          "version": "3.0.1"
+        }
+      },
+      {
+        "id": "string-width@1.0.2",
+        "info": {
+          "name": "string-width",
+          "version": "1.0.2"
+        }
+      },
+      {
+        "id": "wrap-ansi@2.1.0",
+        "info": {
+          "name": "wrap-ansi",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "cliui@3.2.0",
+        "info": {
+          "name": "cliui",
+          "version": "3.2.0"
+        }
+      },
+      {
+        "id": "decamelize@1.2.0",
+        "info": {
+          "name": "decamelize",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "invert-kv@1.0.0",
+        "info": {
+          "name": "invert-kv",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "lcid@1.0.0",
+        "info": {
+          "name": "lcid",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "os-locale@1.4.0",
+        "info": {
+          "name": "os-locale",
+          "version": "1.4.0"
+        }
+      },
+      {
+        "id": "window-size@0.1.4",
+        "info": {
+          "name": "window-size",
+          "version": "0.1.4"
+        }
+      },
+      {
+        "id": "y18n@3.2.2",
+        "info": {
+          "name": "y18n",
+          "version": "3.2.2"
+        }
+      },
+      {
+        "id": "yargs@3.32.0",
+        "info": {
+          "name": "yargs",
+          "version": "3.32.0"
+        }
+      },
+      {
+        "id": "nconf@0.10.0",
+        "info": {
+          "name": "nconf",
+          "version": "0.10.0"
+        }
+      },
+      {
+        "id": "snyk-config@2.2.3",
+        "info": {
+          "name": "snyk-config",
+          "version": "2.2.3"
+        }
+      },
+      {
+        "id": "vscode-languageserver-types@3.16.0",
+        "info": {
+          "name": "vscode-languageserver-types",
+          "version": "3.16.0"
+        }
+      },
+      {
+        "id": "dockerfile-ast@0.0.18",
+        "info": {
+          "name": "dockerfile-ast",
+          "version": "0.0.18"
+        }
+      },
+      {
+        "id": "event-loop-spinner@1.1.0",
+        "info": {
+          "name": "event-loop-spinner",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "base64-js@1.5.1",
+        "info": {
+          "name": "base64-js",
+          "version": "1.5.1"
+        }
+      },
+      {
+        "id": "ieee754@1.2.1",
+        "info": {
+          "name": "ieee754",
+          "version": "1.2.1"
+        }
+      },
+      {
+        "id": "buffer@5.7.1",
+        "info": {
+          "name": "buffer",
+          "version": "5.7.1"
+        }
+      },
+      {
+        "id": "readable-stream@3.6.0",
+        "info": {
+          "name": "readable-stream",
+          "version": "3.6.0"
+        }
+      },
+      {
+        "id": "bl@4.1.0",
+        "info": {
+          "name": "bl",
+          "version": "4.1.0"
+        }
+      },
+      {
+        "id": "fs-constants@1.0.0",
+        "info": {
+          "name": "fs-constants",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "tar-stream@2.2.0",
+        "info": {
+          "name": "tar-stream",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "snyk-docker-plugin@1.38.0",
+        "info": {
+          "name": "snyk-docker-plugin",
+          "version": "1.38.0"
+        }
+      },
+      {
+        "id": "toml@3.0.0",
+        "info": {
+          "name": "toml",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "snyk-go-parser@1.3.1",
+        "info": {
+          "name": "snyk-go-parser",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "snyk-go-plugin@1.11.1",
+        "info": {
+          "name": "snyk-go-plugin",
+          "version": "1.11.1"
+        }
+      },
+      {
+        "id": "@types/ms@0.7.31",
+        "info": {
+          "name": "@types/ms",
+          "version": "0.7.31"
+        }
+      },
+      {
+        "id": "@types/debug@4.1.7",
+        "info": {
+          "name": "@types/debug",
+          "version": "4.1.7"
+        }
+      },
+      {
+        "id": "snyk-gradle-plugin@3.2.4",
+        "info": {
+          "name": "snyk-gradle-plugin",
+          "version": "3.2.4"
+        }
+      },
+      {
+        "id": "hosted-git-info@2.8.9",
+        "info": {
+          "name": "hosted-git-info",
+          "version": "2.8.9"
+        }
+      },
+      {
+        "id": "snyk-module@1.9.1",
+        "info": {
+          "name": "snyk-module",
+          "version": "1.9.1"
+        }
+      },
+      {
+        "id": "tslib@1.9.3",
+        "info": {
+          "name": "tslib",
+          "version": "1.9.3"
+        }
+      },
+      {
+        "id": "@snyk/cli-interface@2.3.1",
+        "info": {
+          "name": "@snyk/cli-interface",
+          "version": "2.3.1"
+        }
+      },
+      {
+        "id": "rimraf@2.7.1",
+        "info": {
+          "name": "rimraf",
+          "version": "2.7.1"
+        }
+      },
+      {
+        "id": "tmp@0.1.0",
+        "info": {
+          "name": "tmp",
+          "version": "0.1.0"
+        }
+      },
+      {
+        "id": "snyk-mvn-plugin@2.8.0",
+        "info": {
+          "name": "snyk-mvn-plugin",
+          "version": "2.8.0"
+        }
+      },
+      {
+        "id": "@yarnpkg/lockfile@1.1.0",
+        "info": {
+          "name": "@yarnpkg/lockfile",
+          "version": "1.1.0"
+        }
+      },
+      {
+        "id": "p-map@2.1.0",
+        "info": {
+          "name": "p-map",
+          "version": "2.1.0"
+        }
+      },
+      {
+        "id": "uuid@3.4.0",
+        "info": {
+          "name": "uuid",
+          "version": "3.4.0"
+        }
+      },
+      {
+        "id": "snyk-nodejs-lockfile-parser@1.17.0",
+        "info": {
+          "name": "snyk-nodejs-lockfile-parser",
+          "version": "1.17.0"
+        }
+      },
+      {
+        "id": "@types/events@3.0.0",
+        "info": {
+          "name": "@types/events",
+          "version": "3.0.0"
+        }
+      },
+      {
+        "id": "@types/xml2js@0.4.3",
+        "info": {
+          "name": "@types/xml2js",
+          "version": "0.4.3"
+        }
+      },
+      {
+        "id": "xmlbuilder@9.0.7",
+        "info": {
+          "name": "xmlbuilder",
+          "version": "9.0.7"
+        }
+      },
+      {
+        "id": "xml2js@0.4.19",
+        "info": {
+          "name": "xml2js",
+          "version": "0.4.19"
+        }
+      },
+      {
+        "id": "dotnet-deps-parser@4.9.0",
+        "info": {
+          "name": "dotnet-deps-parser",
+          "version": "4.9.0"
+        }
+      },
+      {
+        "id": "immediate@3.0.6",
+        "info": {
+          "name": "immediate",
+          "version": "3.0.6"
+        }
+      },
+      {
+        "id": "lie@3.3.0",
+        "info": {
+          "name": "lie",
+          "version": "3.3.0"
+        }
+      },
+      {
+        "id": "pako@1.0.11",
+        "info": {
+          "name": "pako",
+          "version": "1.0.11"
+        }
+      },
+      {
+        "id": "set-immediate-shim@1.0.1",
+        "info": {
+          "name": "set-immediate-shim",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "jszip@3.7.1",
+        "info": {
+          "name": "jszip",
+          "version": "3.7.1"
+        }
+      },
+      {
+        "id": "snyk-paket-parser@1.5.0",
+        "info": {
+          "name": "snyk-paket-parser",
+          "version": "1.5.0"
+        }
+      },
+      {
+        "id": "xmlbuilder@11.0.1",
+        "info": {
+          "name": "xmlbuilder",
+          "version": "11.0.1"
+        }
+      },
+      {
+        "id": "xml2js@0.4.23",
+        "info": {
+          "name": "xml2js",
+          "version": "0.4.23"
+        }
+      },
+      {
+        "id": "snyk-nuget-plugin@1.16.0",
+        "info": {
+          "name": "snyk-nuget-plugin",
+          "version": "1.16.0"
+        }
+      },
+      {
+        "id": "@snyk/cli-interface@2.2.0",
+        "info": {
+          "name": "@snyk/cli-interface",
+          "version": "2.2.0"
+        }
+      },
+      {
+        "id": "@snyk/composer-lockfile-parser@1.2.0",
+        "info": {
+          "name": "@snyk/composer-lockfile-parser",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "id": "snyk-php-plugin@1.7.0",
+        "info": {
+          "name": "snyk-php-plugin",
+          "version": "1.7.0"
+        }
+      },
+      {
+        "id": "email-validator@2.0.4",
+        "info": {
+          "name": "email-validator",
+          "version": "2.0.4"
+        }
+      },
+      {
+        "id": "lodash.clonedeep@4.5.0",
+        "info": {
+          "name": "lodash.clonedeep",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "asap@2.0.6",
+        "info": {
+          "name": "asap",
+          "version": "2.0.6"
+        }
+      },
+      {
+        "id": "promise@7.3.1",
+        "info": {
+          "name": "promise",
+          "version": "7.3.1"
+        }
+      },
+      {
+        "id": "then-fs@2.0.0",
+        "info": {
+          "name": "then-fs",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "snyk-resolve@1.0.1",
+        "info": {
+          "name": "snyk-resolve",
+          "version": "1.0.1"
+        }
+      },
+      {
+        "id": "snyk-try-require@1.3.1",
+        "info": {
+          "name": "snyk-try-require",
+          "version": "1.3.1"
+        }
+      },
+      {
+        "id": "snyk-policy@1.13.5",
+        "info": {
+          "name": "snyk-policy",
+          "version": "1.13.5"
+        }
+      },
+      {
+        "id": "snyk-python-plugin@1.17.0",
+        "info": {
+          "name": "snyk-python-plugin",
+          "version": "1.17.0"
+        }
+      },
+      {
+        "id": "@types/node@6.14.13",
+        "info": {
+          "name": "@types/node",
+          "version": "6.14.13"
+        }
+      },
+      {
+        "id": "@types/semver@5.5.0",
+        "info": {
+          "name": "@types/semver",
+          "version": "5.5.0"
+        }
+      },
+      {
+        "id": "ansicolors@0.3.2",
+        "info": {
+          "name": "ansicolors",
+          "version": "0.3.2"
+        }
+      },
+      {
+        "id": "lodash.assign@4.2.0",
+        "info": {
+          "name": "lodash.assign",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "lodash.assignin@4.2.0",
+        "info": {
+          "name": "lodash.assignin",
+          "version": "4.2.0"
+        }
+      },
+      {
+        "id": "lodash.clone@4.5.0",
+        "info": {
+          "name": "lodash.clone",
+          "version": "4.5.0"
+        }
+      },
+      {
+        "id": "lodash.get@4.4.2",
+        "info": {
+          "name": "lodash.get",
+          "version": "4.4.2"
+        }
+      },
+      {
+        "id": "lodash.set@4.3.2",
+        "info": {
+          "name": "lodash.set",
+          "version": "4.3.2"
+        }
+      },
+      {
+        "id": "archy@1.0.0",
+        "info": {
+          "name": "archy",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "snyk-tree@1.0.0",
+        "info": {
+          "name": "snyk-tree",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "snyk-resolve-deps@4.4.0",
+        "info": {
+          "name": "snyk-resolve-deps",
+          "version": "4.4.0"
+        }
+      },
+      {
+        "id": "tree-kill@1.2.2",
+        "info": {
+          "name": "tree-kill",
+          "version": "1.2.2"
+        }
+      },
+      {
+        "id": "snyk-sbt-plugin@2.11.0",
+        "info": {
+          "name": "snyk-sbt-plugin",
+          "version": "2.11.0"
+        }
+      },
+      {
+        "id": "temp-dir@1.0.0",
+        "info": {
+          "name": "temp-dir",
+          "version": "1.0.0"
+        }
+      },
+      {
+        "id": "tempfile@2.0.0",
+        "info": {
+          "name": "tempfile",
+          "version": "2.0.0"
+        }
+      },
+      {
+        "id": "emoji-regex@7.0.3",
+        "info": {
+          "name": "emoji-regex",
+          "version": "7.0.3"
+        }
+      },
+      {
+        "id": "string-width@3.1.0",
+        "info": {
+          "name": "string-width",
+          "version": "3.1.0"
+        }
+      },
+      {
+        "id": "wrap-ansi@5.1.0",
+        "info": {
+          "name": "wrap-ansi",
+          "version": "5.1.0"
+        }
+      },
+      {
+        "id": "snyk@1.290.2",
+        "info": {
+          "name": "snyk",
+          "version": "1.290.2"
+        }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "goof@1.0.1",
+          "deps": [
+            {
+              "nodeId": "snyk@1.290.2"
+            }
+          ]
+        },
+        {
+          "nodeId": "tslib@1.14.1",
+          "pkgId": "tslib@1.14.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cli-interface@2.3.0",
+          "pkgId": "@snyk/cli-interface@2.3.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-obj@2.0.0",
+          "pkgId": "is-obj@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dot-prop@5.3.0",
+          "pkgId": "dot-prop@5.3.0",
+          "deps": [
+            {
+              "nodeId": "is-obj@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "graceful-fs@4.2.8",
+          "pkgId": "graceful-fs@4.2.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pify@3.0.0",
+          "pkgId": "pify@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "make-dir@1.3.0",
+          "pkgId": "make-dir@1.3.0",
+          "deps": [
+            {
+              "nodeId": "pify@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "crypto-random-string@1.0.0",
+          "pkgId": "crypto-random-string@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unique-string@1.0.0",
+          "pkgId": "unique-string@1.0.0",
+          "deps": [
+            {
+              "nodeId": "crypto-random-string@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "imurmurhash@0.1.4",
+          "pkgId": "imurmurhash@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "signal-exit@3.0.6",
+          "pkgId": "signal-exit@3.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "write-file-atomic@2.4.3",
+          "pkgId": "write-file-atomic@2.4.3",
+          "deps": [
+            {
+              "nodeId": "graceful-fs@4.2.8"
+            },
+            {
+              "nodeId": "imurmurhash@0.1.4"
+            },
+            {
+              "nodeId": "signal-exit@3.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xdg-basedir@3.0.0",
+          "pkgId": "xdg-basedir@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/configstore@3.2.0-rc1",
+          "pkgId": "@snyk/configstore@3.2.0-rc1",
+          "deps": [
+            {
+              "nodeId": "dot-prop@5.3.0"
+            },
+            {
+              "nodeId": "graceful-fs@4.2.8"
+            },
+            {
+              "nodeId": "make-dir@1.3.0"
+            },
+            {
+              "nodeId": "unique-string@1.0.0"
+            },
+            {
+              "nodeId": "write-file-atomic@2.4.3"
+            },
+            {
+              "nodeId": "xdg-basedir@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash@4.17.21",
+          "pkgId": "lodash@4.17.21",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "graphlib@2.1.8",
+          "pkgId": "graphlib@2.1.8",
+          "deps": [
+            {
+              "nodeId": "lodash@4.17.21"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object-hash@1.3.1",
+          "pkgId": "object-hash@1.3.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver@6.3.0",
+          "pkgId": "semver@6.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "buffer-from@1.1.2",
+          "pkgId": "buffer-from@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "source-map@0.6.1",
+          "pkgId": "source-map@0.6.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "source-map-support@0.5.21",
+          "pkgId": "source-map-support@0.5.21",
+          "deps": [
+            {
+              "nodeId": "buffer-from@1.1.2"
+            },
+            {
+              "nodeId": "source-map@0.6.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/dep-graph@1.13.1",
+          "pkgId": "@snyk/dep-graph@1.13.1",
+          "deps": [
+            {
+              "nodeId": "graphlib@2.1.8"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "object-hash@1.3.1"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/gemfile@1.2.0",
+          "pkgId": "@snyk/gemfile@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cli-interface@1.5.0",
+          "pkgId": "@snyk/cli-interface@1.5.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.escaperegexp@4.1.2",
+          "pkgId": "lodash.escaperegexp@4.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.flatten@4.4.0",
+          "pkgId": "lodash.flatten@4.4.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.uniq@4.5.0",
+          "pkgId": "lodash.uniq@4.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/ruby-semver@2.2.2",
+          "pkgId": "@snyk/ruby-semver@2.2.2",
+          "deps": [
+            {
+              "nodeId": "lodash.escaperegexp@4.1.2"
+            },
+            {
+              "nodeId": "lodash.flatten@4.4.0"
+            },
+            {
+              "nodeId": "lodash.uniq@4.5.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/js-yaml@3.12.7",
+          "pkgId": "@types/js-yaml@3.12.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "core-js@3.19.3",
+          "pkgId": "core-js@3.19.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "sprintf-js@1.0.3",
+          "pkgId": "sprintf-js@1.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "argparse@1.0.10",
+          "pkgId": "argparse@1.0.10",
+          "deps": [
+            {
+              "nodeId": "sprintf-js@1.0.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esprima@4.0.1",
+          "pkgId": "esprima@4.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "js-yaml@3.14.1",
+          "pkgId": "js-yaml@3.14.1",
+          "deps": [
+            {
+              "nodeId": "argparse@1.0.10"
+            },
+            {
+              "nodeId": "esprima@4.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cocoapods-lockfile-parser@3.0.0",
+          "pkgId": "@snyk/cocoapods-lockfile-parser@3.0.0",
+          "deps": [
+            {
+              "nodeId": "@snyk/dep-graph@1.13.1"
+            },
+            {
+              "nodeId": "@snyk/ruby-semver@2.2.2"
+            },
+            {
+              "nodeId": "@types/js-yaml@3.12.7"
+            },
+            {
+              "nodeId": "core-js@3.19.3"
+            },
+            {
+              "nodeId": "js-yaml@3.14.1"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/snyk-cocoapods-plugin@2.0.1",
+          "pkgId": "@snyk/snyk-cocoapods-plugin@2.0.1",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@1.5.0"
+            },
+            {
+              "nodeId": "@snyk/cocoapods-lockfile-parser@3.0.0"
+            },
+            {
+              "nodeId": "@snyk/dep-graph@1.13.1"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-fullwidth-code-point@2.0.0",
+          "pkgId": "is-fullwidth-code-point@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@3.0.0",
+          "pkgId": "ansi-regex@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@4.0.0",
+          "pkgId": "strip-ansi@4.0.0",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@2.1.1",
+          "pkgId": "string-width@2.1.1",
+          "deps": [
+            {
+              "nodeId": "is-fullwidth-code-point@2.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@4.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-align@2.0.0",
+          "pkgId": "ansi-align@2.0.0",
+          "deps": [
+            {
+              "nodeId": "string-width@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "camelcase@4.1.0",
+          "pkgId": "camelcase@4.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "color-name@1.1.3",
+          "pkgId": "color-name@1.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "color-convert@1.9.3",
+          "pkgId": "color-convert@1.9.3",
+          "deps": [
+            {
+              "nodeId": "color-name@1.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-styles@3.2.1",
+          "pkgId": "ansi-styles@3.2.1",
+          "deps": [
+            {
+              "nodeId": "color-convert@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "escape-string-regexp@1.0.5",
+          "pkgId": "escape-string-regexp@1.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has-flag@3.0.0",
+          "pkgId": "has-flag@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "supports-color@5.5.0",
+          "pkgId": "supports-color@5.5.0",
+          "deps": [
+            {
+              "nodeId": "has-flag@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "chalk@2.4.2",
+          "pkgId": "chalk@2.4.2",
+          "deps": [
+            {
+              "nodeId": "ansi-styles@3.2.1"
+            },
+            {
+              "nodeId": "escape-string-regexp@1.0.5"
+            },
+            {
+              "nodeId": "supports-color@5.5.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-boxes@1.0.0",
+          "pkgId": "cli-boxes@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pseudomap@1.0.2",
+          "pkgId": "pseudomap@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "yallist@2.1.2",
+          "pkgId": "yallist@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lru-cache@4.1.5",
+          "pkgId": "lru-cache@4.1.5",
+          "deps": [
+            {
+              "nodeId": "pseudomap@1.0.2"
+            },
+            {
+              "nodeId": "yallist@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "shebang-regex@1.0.0",
+          "pkgId": "shebang-regex@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "shebang-command@1.2.0",
+          "pkgId": "shebang-command@1.2.0",
+          "deps": [
+            {
+              "nodeId": "shebang-regex@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isexe@2.0.0",
+          "pkgId": "isexe@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "which@1.3.1",
+          "pkgId": "which@1.3.1",
+          "deps": [
+            {
+              "nodeId": "isexe@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cross-spawn@5.1.0",
+          "pkgId": "cross-spawn@5.1.0",
+          "deps": [
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "shebang-command@1.2.0"
+            },
+            {
+              "nodeId": "which@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-stream@3.0.0",
+          "pkgId": "get-stream@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-stream@1.1.0",
+          "pkgId": "is-stream@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-key@2.0.1",
+          "pkgId": "path-key@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "npm-run-path@2.0.2",
+          "pkgId": "npm-run-path@2.0.2",
+          "deps": [
+            {
+              "nodeId": "path-key@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "p-finally@1.0.0",
+          "pkgId": "p-finally@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-eof@1.0.0",
+          "pkgId": "strip-eof@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "execa@0.7.0",
+          "pkgId": "execa@0.7.0",
+          "deps": [
+            {
+              "nodeId": "cross-spawn@5.1.0"
+            },
+            {
+              "nodeId": "get-stream@3.0.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "npm-run-path@2.0.2"
+            },
+            {
+              "nodeId": "p-finally@1.0.0"
+            },
+            {
+              "nodeId": "signal-exit@3.0.6"
+            },
+            {
+              "nodeId": "strip-eof@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "term-size@1.2.0",
+          "pkgId": "term-size@1.2.0",
+          "deps": [
+            {
+              "nodeId": "execa@0.7.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "widest-line@2.0.1",
+          "pkgId": "widest-line@2.0.1",
+          "deps": [
+            {
+              "nodeId": "string-width@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "boxen@1.3.0",
+          "pkgId": "boxen@1.3.0",
+          "deps": [
+            {
+              "nodeId": "ansi-align@2.0.0"
+            },
+            {
+              "nodeId": "camelcase@4.1.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "cli-boxes@1.0.0"
+            },
+            {
+              "nodeId": "string-width@2.1.1"
+            },
+            {
+              "nodeId": "term-size@1.2.0"
+            },
+            {
+              "nodeId": "widest-line@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "import-lazy@2.1.0",
+          "pkgId": "import-lazy@2.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ci-info@1.6.0",
+          "pkgId": "ci-info@1.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-ci@1.2.1",
+          "pkgId": "is-ci@1.2.1",
+          "deps": [
+            {
+              "nodeId": "ci-info@1.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ini@1.3.8",
+          "pkgId": "ini@1.3.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "global-dirs@0.1.1",
+          "pkgId": "global-dirs@0.1.1",
+          "deps": [
+            {
+              "nodeId": "ini@1.3.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-is-inside@1.0.2",
+          "pkgId": "path-is-inside@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-path-inside@1.0.1",
+          "pkgId": "is-path-inside@1.0.1",
+          "deps": [
+            {
+              "nodeId": "path-is-inside@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-installed-globally@0.1.0",
+          "pkgId": "is-installed-globally@0.1.0",
+          "deps": [
+            {
+              "nodeId": "global-dirs@0.1.1"
+            },
+            {
+              "nodeId": "is-path-inside@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-npm@1.0.0",
+          "pkgId": "is-npm@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "capture-stack-trace@1.0.1",
+          "pkgId": "capture-stack-trace@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "create-error-class@3.0.2",
+          "pkgId": "create-error-class@3.0.2",
+          "deps": [
+            {
+              "nodeId": "capture-stack-trace@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "duplexer3@0.1.4",
+          "pkgId": "duplexer3@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-redirect@1.0.0",
+          "pkgId": "is-redirect@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-retry-allowed@1.2.0",
+          "pkgId": "is-retry-allowed@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lowercase-keys@1.0.1",
+          "pkgId": "lowercase-keys@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safe-buffer@5.2.1",
+          "pkgId": "safe-buffer@5.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "timed-out@4.0.1",
+          "pkgId": "timed-out@4.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unzip-response@2.0.1",
+          "pkgId": "unzip-response@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "prepend-http@1.0.4",
+          "pkgId": "prepend-http@1.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "url-parse-lax@1.0.0",
+          "pkgId": "url-parse-lax@1.0.0",
+          "deps": [
+            {
+              "nodeId": "prepend-http@1.0.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "got@6.7.1",
+          "pkgId": "got@6.7.1",
+          "deps": [
+            {
+              "nodeId": "create-error-class@3.0.2"
+            },
+            {
+              "nodeId": "duplexer3@0.1.4"
+            },
+            {
+              "nodeId": "get-stream@3.0.0"
+            },
+            {
+              "nodeId": "is-redirect@1.0.0"
+            },
+            {
+              "nodeId": "is-retry-allowed@1.2.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "lowercase-keys@1.0.1"
+            },
+            {
+              "nodeId": "safe-buffer@5.2.1"
+            },
+            {
+              "nodeId": "timed-out@4.0.1"
+            },
+            {
+              "nodeId": "unzip-response@2.0.1"
+            },
+            {
+              "nodeId": "url-parse-lax@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "deep-extend@0.6.0",
+          "pkgId": "deep-extend@0.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimist@1.2.5",
+          "pkgId": "minimist@1.2.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-json-comments@2.0.1",
+          "pkgId": "strip-json-comments@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rc@1.2.8",
+          "pkgId": "rc@1.2.8",
+          "deps": [
+            {
+              "nodeId": "deep-extend@0.6.0"
+            },
+            {
+              "nodeId": "ini@1.3.8"
+            },
+            {
+              "nodeId": "minimist@1.2.5"
+            },
+            {
+              "nodeId": "strip-json-comments@2.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "registry-auth-token@3.4.0",
+          "pkgId": "registry-auth-token@3.4.0",
+          "deps": [
+            {
+              "nodeId": "rc@1.2.8"
+            },
+            {
+              "nodeId": "safe-buffer@5.2.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "registry-url@3.1.0",
+          "pkgId": "registry-url@3.1.0",
+          "deps": [
+            {
+              "nodeId": "rc@1.2.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver@5.7.1",
+          "pkgId": "semver@5.7.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "package-json@4.0.1",
+          "pkgId": "package-json@4.0.1",
+          "deps": [
+            {
+              "nodeId": "got@6.7.1"
+            },
+            {
+              "nodeId": "registry-auth-token@3.4.0"
+            },
+            {
+              "nodeId": "registry-url@3.1.0"
+            },
+            {
+              "nodeId": "semver@5.7.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "latest-version@3.1.0",
+          "pkgId": "latest-version@3.1.0",
+          "deps": [
+            {
+              "nodeId": "package-json@4.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "semver-diff@2.1.0",
+          "pkgId": "semver-diff@2.1.0",
+          "deps": [
+            {
+              "nodeId": "semver@5.7.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/update-notifier@2.5.1-rc2",
+          "pkgId": "@snyk/update-notifier@2.5.1-rc2",
+          "deps": [
+            {
+              "nodeId": "@snyk/configstore@3.2.0-rc1"
+            },
+            {
+              "nodeId": "boxen@1.3.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "import-lazy@2.1.0"
+            },
+            {
+              "nodeId": "is-ci@1.2.1"
+            },
+            {
+              "nodeId": "is-installed-globally@0.1.0"
+            },
+            {
+              "nodeId": "is-npm@1.0.0"
+            },
+            {
+              "nodeId": "latest-version@3.1.0"
+            },
+            {
+              "nodeId": "semver-diff@2.1.0"
+            },
+            {
+              "nodeId": "xdg-basedir@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/node@16.11.11",
+          "pkgId": "@types/node@16.11.11",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/agent-base@4.2.2",
+          "pkgId": "@types/agent-base@4.2.2",
+          "deps": [
+            {
+              "nodeId": "@types/node@16.11.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/bunyan@1.8.8",
+          "pkgId": "@types/bunyan@1.8.8",
+          "deps": [
+            {
+              "nodeId": "@types/node@16.11.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/restify@4.3.8",
+          "pkgId": "@types/restify@4.3.8",
+          "deps": [
+            {
+              "nodeId": "@types/bunyan@1.8.8"
+            },
+            {
+              "nodeId": "@types/node@16.11.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "abbrev@1.1.1",
+          "pkgId": "abbrev@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-escapes@3.2.0",
+          "pkgId": "ansi-escapes@3.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-spinner@0.2.10",
+          "pkgId": "cli-spinner@0.2.10",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.1.3",
+          "pkgId": "ms@2.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@3.2.7",
+          "pkgId": "debug@3.2.7",
+          "deps": [
+            {
+              "nodeId": "ms@2.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "diff@4.0.2",
+          "pkgId": "diff@4.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "protocols@1.4.8",
+          "pkgId": "protocols@1.4.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-ssh@1.3.3",
+          "pkgId": "is-ssh@1.3.3",
+          "deps": [
+            {
+              "nodeId": "protocols@1.4.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "normalize-url@6.1.0",
+          "pkgId": "normalize-url@6.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "function-bind@1.1.1",
+          "pkgId": "function-bind@1.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has@1.0.3",
+          "pkgId": "has@1.0.3",
+          "deps": [
+            {
+              "nodeId": "function-bind@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "has-symbols@1.0.2",
+          "pkgId": "has-symbols@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-intrinsic@1.1.1",
+          "pkgId": "get-intrinsic@1.1.1",
+          "deps": [
+            {
+              "nodeId": "function-bind@1.1.1"
+            },
+            {
+              "nodeId": "has@1.0.3"
+            },
+            {
+              "nodeId": "has-symbols@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "call-bind@1.0.2",
+          "pkgId": "call-bind@1.0.2",
+          "deps": [
+            {
+              "nodeId": "function-bind@1.1.1"
+            },
+            {
+              "nodeId": "get-intrinsic@1.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "object-inspect@1.11.1",
+          "pkgId": "object-inspect@1.11.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "side-channel@1.0.4",
+          "pkgId": "side-channel@1.0.4",
+          "deps": [
+            {
+              "nodeId": "call-bind@1.0.2"
+            },
+            {
+              "nodeId": "get-intrinsic@1.1.1"
+            },
+            {
+              "nodeId": "object-inspect@1.11.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "qs@6.10.2",
+          "pkgId": "qs@6.10.2",
+          "deps": [
+            {
+              "nodeId": "side-channel@1.0.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "decode-uri-component@0.2.0",
+          "pkgId": "decode-uri-component@0.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "filter-obj@1.1.0",
+          "pkgId": "filter-obj@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "split-on-first@1.1.0",
+          "pkgId": "split-on-first@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strict-uri-encode@2.0.0",
+          "pkgId": "strict-uri-encode@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "query-string@6.14.1",
+          "pkgId": "query-string@6.14.1",
+          "deps": [
+            {
+              "nodeId": "decode-uri-component@0.2.0"
+            },
+            {
+              "nodeId": "filter-obj@1.1.0"
+            },
+            {
+              "nodeId": "split-on-first@1.1.0"
+            },
+            {
+              "nodeId": "strict-uri-encode@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "parse-path@4.0.3",
+          "pkgId": "parse-path@4.0.3",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.3"
+            },
+            {
+              "nodeId": "protocols@1.4.8"
+            },
+            {
+              "nodeId": "qs@6.10.2"
+            },
+            {
+              "nodeId": "query-string@6.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "parse-url@6.0.0",
+          "pkgId": "parse-url@6.0.0",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.3"
+            },
+            {
+              "nodeId": "normalize-url@6.1.0"
+            },
+            {
+              "nodeId": "parse-path@4.0.3"
+            },
+            {
+              "nodeId": "protocols@1.4.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "git-up@4.0.5",
+          "pkgId": "git-up@4.0.5",
+          "deps": [
+            {
+              "nodeId": "is-ssh@1.3.3"
+            },
+            {
+              "nodeId": "parse-url@6.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "git-url-parse@11.1.2",
+          "pkgId": "git-url-parse@11.1.2",
+          "deps": [
+            {
+              "nodeId": "git-up@4.0.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fs.realpath@1.0.0",
+          "pkgId": "fs.realpath@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrappy@1.0.2",
+          "pkgId": "wrappy@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "once@1.4.0",
+          "pkgId": "once@1.4.0",
+          "deps": [
+            {
+              "nodeId": "wrappy@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inflight@1.0.6",
+          "pkgId": "inflight@1.0.6",
+          "deps": [
+            {
+              "nodeId": "once@1.4.0"
+            },
+            {
+              "nodeId": "wrappy@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inherits@2.0.4",
+          "pkgId": "inherits@2.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "balanced-match@1.0.2",
+          "pkgId": "balanced-match@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "concat-map@0.0.1",
+          "pkgId": "concat-map@0.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "brace-expansion@1.1.11",
+          "pkgId": "brace-expansion@1.1.11",
+          "deps": [
+            {
+              "nodeId": "balanced-match@1.0.2"
+            },
+            {
+              "nodeId": "concat-map@0.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "minimatch@3.0.4",
+          "pkgId": "minimatch@3.0.4",
+          "deps": [
+            {
+              "nodeId": "brace-expansion@1.1.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "path-is-absolute@1.0.1",
+          "pkgId": "path-is-absolute@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "glob@7.2.0",
+          "pkgId": "glob@7.2.0",
+          "deps": [
+            {
+              "nodeId": "fs.realpath@1.0.0"
+            },
+            {
+              "nodeId": "inflight@1.0.6"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "minimatch@3.0.4"
+            },
+            {
+              "nodeId": "once@1.4.0"
+            },
+            {
+              "nodeId": "path-is-absolute@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mimic-fn@1.2.0",
+          "pkgId": "mimic-fn@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "onetime@2.0.1",
+          "pkgId": "onetime@2.0.1",
+          "deps": [
+            {
+              "nodeId": "mimic-fn@1.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "restore-cursor@2.0.0",
+          "pkgId": "restore-cursor@2.0.0",
+          "deps": [
+            {
+              "nodeId": "onetime@2.0.1"
+            },
+            {
+              "nodeId": "signal-exit@3.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-cursor@2.1.0",
+          "pkgId": "cli-cursor@2.1.0",
+          "deps": [
+            {
+              "nodeId": "restore-cursor@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cli-width@2.2.1",
+          "pkgId": "cli-width@2.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "chardet@0.7.0",
+          "pkgId": "chardet@0.7.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safer-buffer@2.1.2",
+          "pkgId": "safer-buffer@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "iconv-lite@0.4.24",
+          "pkgId": "iconv-lite@0.4.24",
+          "deps": [
+            {
+              "nodeId": "safer-buffer@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-tmpdir@1.0.2",
+          "pkgId": "os-tmpdir@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tmp@0.0.33",
+          "pkgId": "tmp@0.0.33",
+          "deps": [
+            {
+              "nodeId": "os-tmpdir@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "external-editor@3.1.0",
+          "pkgId": "external-editor@3.1.0",
+          "deps": [
+            {
+              "nodeId": "chardet@0.7.0"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "figures@2.0.0",
+          "pkgId": "figures@2.0.0",
+          "deps": [
+            {
+              "nodeId": "escape-string-regexp@1.0.5"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "mute-stream@0.0.7",
+          "pkgId": "mute-stream@0.0.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "run-async@2.4.1",
+          "pkgId": "run-async@2.4.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rxjs@6.6.7",
+          "pkgId": "rxjs@6.6.7",
+          "deps": [
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@4.1.0",
+          "pkgId": "ansi-regex@4.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@5.2.0",
+          "pkgId": "strip-ansi@5.2.0",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@4.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "through@2.3.8",
+          "pkgId": "through@2.3.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "inquirer@6.5.2",
+          "pkgId": "inquirer@6.5.2",
+          "deps": [
+            {
+              "nodeId": "ansi-escapes@3.2.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "cli-cursor@2.1.0"
+            },
+            {
+              "nodeId": "cli-width@2.2.1"
+            },
+            {
+              "nodeId": "external-editor@3.1.0"
+            },
+            {
+              "nodeId": "figures@2.0.0"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "mute-stream@0.0.7"
+            },
+            {
+              "nodeId": "run-async@2.4.1"
+            },
+            {
+              "nodeId": "rxjs@6.6.7"
+            },
+            {
+              "nodeId": "string-width@2.1.1"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            },
+            {
+              "nodeId": "through@2.3.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "sax@1.2.4",
+          "pkgId": "sax@1.2.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "needle@2.9.1",
+          "pkgId": "needle@2.9.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "sax@1.2.4"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-wsl@1.1.0",
+          "pkgId": "is-wsl@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "opn@5.5.0",
+          "pkgId": "opn@5.5.0",
+          "deps": [
+            {
+              "nodeId": "is-wsl@1.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "macos-release@2.5.0",
+          "pkgId": "macos-release@2.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "nice-try@1.0.5",
+          "pkgId": "nice-try@1.0.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cross-spawn@6.0.5",
+          "pkgId": "cross-spawn@6.0.5",
+          "deps": [
+            {
+              "nodeId": "nice-try@1.0.5"
+            },
+            {
+              "nodeId": "path-key@2.0.1"
+            },
+            {
+              "nodeId": "semver@5.7.1"
+            },
+            {
+              "nodeId": "shebang-command@1.2.0"
+            },
+            {
+              "nodeId": "which@1.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "end-of-stream@1.4.4",
+          "pkgId": "end-of-stream@1.4.4",
+          "deps": [
+            {
+              "nodeId": "once@1.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pump@3.0.0",
+          "pkgId": "pump@3.0.0",
+          "deps": [
+            {
+              "nodeId": "end-of-stream@1.4.4"
+            },
+            {
+              "nodeId": "once@1.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-stream@4.1.0",
+          "pkgId": "get-stream@4.1.0",
+          "deps": [
+            {
+              "nodeId": "pump@3.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "execa@1.0.0",
+          "pkgId": "execa@1.0.0",
+          "deps": [
+            {
+              "nodeId": "cross-spawn@6.0.5"
+            },
+            {
+              "nodeId": "get-stream@4.1.0"
+            },
+            {
+              "nodeId": "is-stream@1.1.0"
+            },
+            {
+              "nodeId": "npm-run-path@2.0.2"
+            },
+            {
+              "nodeId": "p-finally@1.0.0"
+            },
+            {
+              "nodeId": "signal-exit@3.0.6"
+            },
+            {
+              "nodeId": "strip-eof@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "windows-release@3.3.3",
+          "pkgId": "windows-release@3.3.3",
+          "deps": [
+            {
+              "nodeId": "execa@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-name@3.1.0",
+          "pkgId": "os-name@3.1.0",
+          "deps": [
+            {
+              "nodeId": "macos-release@2.5.0"
+            },
+            {
+              "nodeId": "windows-release@3.3.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es6-promise@4.2.8",
+          "pkgId": "es6-promise@4.2.8",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "es6-promisify@5.0.0",
+          "pkgId": "es6-promisify@5.0.0",
+          "deps": [
+            {
+              "nodeId": "es6-promise@4.2.8"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "agent-base@4.3.0",
+          "pkgId": "agent-base@4.3.0",
+          "deps": [
+            {
+              "nodeId": "es6-promisify@5.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.1.2",
+          "pkgId": "ms@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@4.3.3",
+          "pkgId": "debug@4.3.3",
+          "deps": [
+            {
+              "nodeId": "ms@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ms@2.0.0",
+          "pkgId": "ms@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@3.1.0",
+          "pkgId": "debug@3.1.0",
+          "deps": [
+            {
+              "nodeId": "ms@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-proxy-agent@2.1.0",
+          "pkgId": "http-proxy-agent@2.1.0",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "https-proxy-agent@3.0.1",
+          "pkgId": "https-proxy-agent@3.0.1",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@3.2.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "yallist@3.1.1",
+          "pkgId": "yallist@3.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lru-cache@5.1.1",
+          "pkgId": "lru-cache@5.1.1",
+          "deps": [
+            {
+              "nodeId": "yallist@3.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "data-uri-to-buffer@1.2.0",
+          "pkgId": "data-uri-to-buffer@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "debug@2.6.9",
+          "pkgId": "debug@2.6.9",
+          "deps": [
+            {
+              "nodeId": "ms@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "extend@3.0.2",
+          "pkgId": "extend@3.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "file-uri-to-path@1.0.0",
+          "pkgId": "file-uri-to-path@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "core-util-is@1.0.3",
+          "pkgId": "core-util-is@1.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isarray@0.0.1",
+          "pkgId": "isarray@0.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string_decoder@0.10.31",
+          "pkgId": "string_decoder@0.10.31",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@1.1.14",
+          "pkgId": "readable-stream@1.1.14",
+          "deps": [
+            {
+              "nodeId": "core-util-is@1.0.3"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "isarray@0.0.1"
+            },
+            {
+              "nodeId": "string_decoder@0.10.31"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xregexp@2.0.0",
+          "pkgId": "xregexp@2.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ftp@0.3.10",
+          "pkgId": "ftp@0.3.10",
+          "deps": [
+            {
+              "nodeId": "readable-stream@1.1.14"
+            },
+            {
+              "nodeId": "xregexp@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "isarray@1.0.0",
+          "pkgId": "isarray@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "process-nextick-args@2.0.1",
+          "pkgId": "process-nextick-args@2.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "safe-buffer@5.1.2",
+          "pkgId": "safe-buffer@5.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string_decoder@1.1.1",
+          "pkgId": "string_decoder@1.1.1",
+          "deps": [
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "util-deprecate@1.0.2",
+          "pkgId": "util-deprecate@1.0.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@2.3.7",
+          "pkgId": "readable-stream@2.3.7",
+          "deps": [
+            {
+              "nodeId": "core-util-is@1.0.3"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "isarray@1.0.0"
+            },
+            {
+              "nodeId": "process-nextick-args@2.0.1"
+            },
+            {
+              "nodeId": "safe-buffer@5.1.2"
+            },
+            {
+              "nodeId": "string_decoder@1.1.1"
+            },
+            {
+              "nodeId": "util-deprecate@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "get-uri@2.0.4",
+          "pkgId": "get-uri@2.0.4",
+          "deps": [
+            {
+              "nodeId": "data-uri-to-buffer@1.2.0"
+            },
+            {
+              "nodeId": "debug@2.6.9"
+            },
+            {
+              "nodeId": "extend@3.0.2"
+            },
+            {
+              "nodeId": "file-uri-to-path@1.0.0"
+            },
+            {
+              "nodeId": "ftp@0.3.10"
+            },
+            {
+              "nodeId": "readable-stream@2.3.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "co@4.6.0",
+          "pkgId": "co@4.6.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tslib@2.3.1",
+          "pkgId": "tslib@2.3.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ast-types@0.14.2",
+          "pkgId": "ast-types@0.14.2",
+          "deps": [
+            {
+              "nodeId": "tslib@2.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "estraverse@4.3.0",
+          "pkgId": "estraverse@4.3.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esutils@2.0.3",
+          "pkgId": "esutils@2.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "deep-is@0.1.4",
+          "pkgId": "deep-is@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fast-levenshtein@2.0.6",
+          "pkgId": "fast-levenshtein@2.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "prelude-ls@1.1.2",
+          "pkgId": "prelude-ls@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "type-check@0.3.2",
+          "pkgId": "type-check@0.3.2",
+          "deps": [
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "levn@0.3.0",
+          "pkgId": "levn@0.3.0",
+          "deps": [
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            },
+            {
+              "nodeId": "type-check@0.3.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "word-wrap@1.2.3",
+          "pkgId": "word-wrap@1.2.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "optionator@0.8.3",
+          "pkgId": "optionator@0.8.3",
+          "deps": [
+            {
+              "nodeId": "deep-is@0.1.4"
+            },
+            {
+              "nodeId": "fast-levenshtein@2.0.6"
+            },
+            {
+              "nodeId": "levn@0.3.0"
+            },
+            {
+              "nodeId": "prelude-ls@1.1.2"
+            },
+            {
+              "nodeId": "type-check@0.3.2"
+            },
+            {
+              "nodeId": "word-wrap@1.2.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "escodegen@1.14.3",
+          "pkgId": "escodegen@1.14.3",
+          "deps": [
+            {
+              "nodeId": "esprima@4.0.1"
+            },
+            {
+              "nodeId": "estraverse@4.3.0"
+            },
+            {
+              "nodeId": "esutils@2.0.3"
+            },
+            {
+              "nodeId": "optionator@0.8.3"
+            },
+            {
+              "nodeId": "source-map@0.6.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "esprima@3.1.3",
+          "pkgId": "esprima@3.1.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "degenerator@1.0.4",
+          "pkgId": "degenerator@1.0.4",
+          "deps": [
+            {
+              "nodeId": "ast-types@0.14.2"
+            },
+            {
+              "nodeId": "escodegen@1.14.3"
+            },
+            {
+              "nodeId": "esprima@3.1.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ip@1.1.5",
+          "pkgId": "ip@1.1.5",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "netmask@1.0.6",
+          "pkgId": "netmask@1.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "thunkify@2.1.2",
+          "pkgId": "thunkify@2.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pac-resolver@3.0.0",
+          "pkgId": "pac-resolver@3.0.0",
+          "deps": [
+            {
+              "nodeId": "co@4.6.0"
+            },
+            {
+              "nodeId": "degenerator@1.0.4"
+            },
+            {
+              "nodeId": "ip@1.1.5"
+            },
+            {
+              "nodeId": "netmask@1.0.6"
+            },
+            {
+              "nodeId": "thunkify@2.1.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bytes@3.1.1",
+          "pkgId": "bytes@3.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "depd@1.1.2",
+          "pkgId": "depd@1.1.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "setprototypeof@1.2.0",
+          "pkgId": "setprototypeof@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "statuses@1.5.0",
+          "pkgId": "statuses@1.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "toidentifier@1.0.1",
+          "pkgId": "toidentifier@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "http-errors@1.8.1",
+          "pkgId": "http-errors@1.8.1",
+          "deps": [
+            {
+              "nodeId": "depd@1.1.2"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "setprototypeof@1.2.0"
+            },
+            {
+              "nodeId": "statuses@1.5.0"
+            },
+            {
+              "nodeId": "toidentifier@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "unpipe@1.0.0",
+          "pkgId": "unpipe@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "raw-body@2.4.2",
+          "pkgId": "raw-body@2.4.2",
+          "deps": [
+            {
+              "nodeId": "bytes@3.1.1"
+            },
+            {
+              "nodeId": "http-errors@1.8.1"
+            },
+            {
+              "nodeId": "iconv-lite@0.4.24"
+            },
+            {
+              "nodeId": "unpipe@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "agent-base@4.2.1",
+          "pkgId": "agent-base@4.2.1",
+          "deps": [
+            {
+              "nodeId": "es6-promisify@5.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "smart-buffer@4.2.0",
+          "pkgId": "smart-buffer@4.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "socks@2.3.3",
+          "pkgId": "socks@2.3.3",
+          "deps": [
+            {
+              "nodeId": "ip@1.1.5"
+            },
+            {
+              "nodeId": "smart-buffer@4.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "socks-proxy-agent@4.0.2",
+          "pkgId": "socks-proxy-agent@4.0.2",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.2.1"
+            },
+            {
+              "nodeId": "socks@2.3.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pac-proxy-agent@3.0.1",
+          "pkgId": "pac-proxy-agent@3.0.1",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "get-uri@2.0.4"
+            },
+            {
+              "nodeId": "http-proxy-agent@2.1.0"
+            },
+            {
+              "nodeId": "https-proxy-agent@3.0.1"
+            },
+            {
+              "nodeId": "pac-resolver@3.0.0"
+            },
+            {
+              "nodeId": "raw-body@2.4.2"
+            },
+            {
+              "nodeId": "socks-proxy-agent@4.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proxy-from-env@1.1.0",
+          "pkgId": "proxy-from-env@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "proxy-agent@3.1.1",
+          "pkgId": "proxy-agent@3.1.1",
+          "deps": [
+            {
+              "nodeId": "agent-base@4.3.0"
+            },
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "http-proxy-agent@2.1.0"
+            },
+            {
+              "nodeId": "https-proxy-agent@3.0.1"
+            },
+            {
+              "nodeId": "lru-cache@5.1.1"
+            },
+            {
+              "nodeId": "pac-proxy-agent@3.0.1"
+            },
+            {
+              "nodeId": "proxy-from-env@1.1.0"
+            },
+            {
+              "nodeId": "socks-proxy-agent@4.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "async@1.5.2",
+          "pkgId": "async@1.5.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "secure-keys@1.0.0",
+          "pkgId": "secure-keys@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "camelcase@2.1.1",
+          "pkgId": "camelcase@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "code-point-at@1.1.0",
+          "pkgId": "code-point-at@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "number-is-nan@1.0.1",
+          "pkgId": "number-is-nan@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "is-fullwidth-code-point@1.0.0",
+          "pkgId": "is-fullwidth-code-point@1.0.0",
+          "deps": [
+            {
+              "nodeId": "number-is-nan@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansi-regex@2.1.1",
+          "pkgId": "ansi-regex@2.1.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "strip-ansi@3.0.1",
+          "pkgId": "strip-ansi@3.0.1",
+          "deps": [
+            {
+              "nodeId": "ansi-regex@2.1.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@1.0.2",
+          "pkgId": "string-width@1.0.2",
+          "deps": [
+            {
+              "nodeId": "code-point-at@1.1.0"
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@1.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrap-ansi@2.1.0",
+          "pkgId": "wrap-ansi@2.1.0",
+          "deps": [
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "cliui@3.2.0",
+          "pkgId": "cliui@3.2.0",
+          "deps": [
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "strip-ansi@3.0.1"
+            },
+            {
+              "nodeId": "wrap-ansi@2.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "decamelize@1.2.0",
+          "pkgId": "decamelize@1.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "invert-kv@1.0.0",
+          "pkgId": "invert-kv@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lcid@1.0.0",
+          "pkgId": "lcid@1.0.0",
+          "deps": [
+            {
+              "nodeId": "invert-kv@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "os-locale@1.4.0",
+          "pkgId": "os-locale@1.4.0",
+          "deps": [
+            {
+              "nodeId": "lcid@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "window-size@0.1.4",
+          "pkgId": "window-size@0.1.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "y18n@3.2.2",
+          "pkgId": "y18n@3.2.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "yargs@3.32.0",
+          "pkgId": "yargs@3.32.0",
+          "deps": [
+            {
+              "nodeId": "camelcase@2.1.1"
+            },
+            {
+              "nodeId": "cliui@3.2.0"
+            },
+            {
+              "nodeId": "decamelize@1.2.0"
+            },
+            {
+              "nodeId": "os-locale@1.4.0"
+            },
+            {
+              "nodeId": "string-width@1.0.2"
+            },
+            {
+              "nodeId": "window-size@0.1.4"
+            },
+            {
+              "nodeId": "y18n@3.2.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "nconf@0.10.0",
+          "pkgId": "nconf@0.10.0",
+          "deps": [
+            {
+              "nodeId": "async@1.5.2"
+            },
+            {
+              "nodeId": "ini@1.3.8"
+            },
+            {
+              "nodeId": "secure-keys@1.0.0"
+            },
+            {
+              "nodeId": "yargs@3.32.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-config@2.2.3",
+          "pkgId": "snyk-config@2.2.3",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "nconf@0.10.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "vscode-languageserver-types@3.16.0",
+          "pkgId": "vscode-languageserver-types@3.16.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dockerfile-ast@0.0.18",
+          "pkgId": "dockerfile-ast@0.0.18",
+          "deps": [
+            {
+              "nodeId": "vscode-languageserver-types@3.16.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "event-loop-spinner@1.1.0",
+          "pkgId": "event-loop-spinner@1.1.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "base64-js@1.5.1",
+          "pkgId": "base64-js@1.5.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ieee754@1.2.1",
+          "pkgId": "ieee754@1.2.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "buffer@5.7.1",
+          "pkgId": "buffer@5.7.1",
+          "deps": [
+            {
+              "nodeId": "base64-js@1.5.1"
+            },
+            {
+              "nodeId": "ieee754@1.2.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "readable-stream@3.6.0",
+          "pkgId": "readable-stream@3.6.0",
+          "deps": [
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "string_decoder@1.1.1"
+            },
+            {
+              "nodeId": "util-deprecate@1.0.2"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "bl@4.1.0",
+          "pkgId": "bl@4.1.0",
+          "deps": [
+            {
+              "nodeId": "buffer@5.7.1"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "readable-stream@3.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "fs-constants@1.0.0",
+          "pkgId": "fs-constants@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tar-stream@2.2.0",
+          "pkgId": "tar-stream@2.2.0",
+          "deps": [
+            {
+              "nodeId": "bl@4.1.0"
+            },
+            {
+              "nodeId": "end-of-stream@1.4.4"
+            },
+            {
+              "nodeId": "fs-constants@1.0.0"
+            },
+            {
+              "nodeId": "inherits@2.0.4"
+            },
+            {
+              "nodeId": "readable-stream@3.6.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-docker-plugin@1.38.0",
+          "pkgId": "snyk-docker-plugin@1.38.0",
+          "deps": [
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "dockerfile-ast@0.0.18"
+            },
+            {
+              "nodeId": "event-loop-spinner@1.1.0"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "tar-stream@2.2.0"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "toml@3.0.0",
+          "pkgId": "toml@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-go-parser@1.3.1",
+          "pkgId": "snyk-go-parser@1.3.1",
+          "deps": [
+            {
+              "nodeId": "toml@3.0.0"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-go-plugin@1.11.1",
+          "pkgId": "snyk-go-plugin@1.11.1",
+          "deps": [
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "graphlib@2.1.8"
+            },
+            {
+              "nodeId": "snyk-go-parser@1.3.1"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/ms@0.7.31",
+          "pkgId": "@types/ms@0.7.31",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/debug@4.1.7",
+          "pkgId": "@types/debug@4.1.7",
+          "deps": [
+            {
+              "nodeId": "@types/ms@0.7.31"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-gradle-plugin@3.2.4",
+          "pkgId": "snyk-gradle-plugin@3.2.4",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.3.0"
+            },
+            {
+              "nodeId": "@types/debug@4.1.7"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "hosted-git-info@2.8.9",
+          "pkgId": "hosted-git-info@2.8.9",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-module@1.9.1",
+          "pkgId": "snyk-module@1.9.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "hosted-git-info@2.8.9"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tslib@1.9.3",
+          "pkgId": "tslib@1.9.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cli-interface@2.3.1",
+          "pkgId": "@snyk/cli-interface@2.3.1",
+          "deps": [
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "rimraf@2.7.1",
+          "pkgId": "rimraf@2.7.1",
+          "deps": [
+            {
+              "nodeId": "glob@7.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tmp@0.1.0",
+          "pkgId": "tmp@0.1.0",
+          "deps": [
+            {
+              "nodeId": "rimraf@2.7.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-mvn-plugin@2.8.0",
+          "pkgId": "snyk-mvn-plugin@2.8.0",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.3.1"
+            },
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "needle@2.9.1"
+            },
+            {
+              "nodeId": "tmp@0.1.0"
+            },
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@yarnpkg/lockfile@1.1.0",
+          "pkgId": "@yarnpkg/lockfile@1.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "p-map@2.1.0",
+          "pkgId": "p-map@2.1.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "uuid@3.4.0",
+          "pkgId": "uuid@3.4.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-nodejs-lockfile-parser@1.17.0",
+          "pkgId": "snyk-nodejs-lockfile-parser@1.17.0",
+          "deps": [
+            {
+              "nodeId": "@yarnpkg/lockfile@1.1.0"
+            },
+            {
+              "nodeId": "graphlib@2.1.8"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "p-map@2.1.0"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            },
+            {
+              "nodeId": "uuid@3.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/events@3.0.0",
+          "pkgId": "@types/events@3.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/xml2js@0.4.3",
+          "pkgId": "@types/xml2js@0.4.3",
+          "deps": [
+            {
+              "nodeId": "@types/events@3.0.0"
+            },
+            {
+              "nodeId": "@types/node@16.11.11"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xmlbuilder@9.0.7",
+          "pkgId": "xmlbuilder@9.0.7",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xml2js@0.4.19",
+          "pkgId": "xml2js@0.4.19",
+          "deps": [
+            {
+              "nodeId": "sax@1.2.4"
+            },
+            {
+              "nodeId": "xmlbuilder@9.0.7"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "dotnet-deps-parser@4.9.0",
+          "pkgId": "dotnet-deps-parser@4.9.0",
+          "deps": [
+            {
+              "nodeId": "@types/xml2js@0.4.3"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            },
+            {
+              "nodeId": "xml2js@0.4.19"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "immediate@3.0.6",
+          "pkgId": "immediate@3.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lie@3.3.0",
+          "pkgId": "lie@3.3.0",
+          "deps": [
+            {
+              "nodeId": "immediate@3.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "pako@1.0.11",
+          "pkgId": "pako@1.0.11",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "set-immediate-shim@1.0.1",
+          "pkgId": "set-immediate-shim@1.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "jszip@3.7.1",
+          "pkgId": "jszip@3.7.1",
+          "deps": [
+            {
+              "nodeId": "lie@3.3.0"
+            },
+            {
+              "nodeId": "pako@1.0.11"
+            },
+            {
+              "nodeId": "readable-stream@2.3.7"
+            },
+            {
+              "nodeId": "set-immediate-shim@1.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-paket-parser@1.5.0",
+          "pkgId": "snyk-paket-parser@1.5.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xmlbuilder@11.0.1",
+          "pkgId": "xmlbuilder@11.0.1",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "xml2js@0.4.23",
+          "pkgId": "xml2js@0.4.23",
+          "deps": [
+            {
+              "nodeId": "sax@1.2.4"
+            },
+            {
+              "nodeId": "xmlbuilder@11.0.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-nuget-plugin@1.16.0",
+          "pkgId": "snyk-nuget-plugin@1.16.0",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "dotnet-deps-parser@4.9.0"
+            },
+            {
+              "nodeId": "jszip@3.7.1"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "snyk-paket-parser@1.5.0"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            },
+            {
+              "nodeId": "xml2js@0.4.23"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/cli-interface@2.2.0",
+          "pkgId": "@snyk/cli-interface@2.2.0",
+          "deps": [
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@snyk/composer-lockfile-parser@1.2.0",
+          "pkgId": "@snyk/composer-lockfile-parser@1.2.0",
+          "deps": [
+            {
+              "nodeId": "lodash@4.17.21"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-php-plugin@1.7.0",
+          "pkgId": "snyk-php-plugin@1.7.0",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.2.0"
+            },
+            {
+              "nodeId": "@snyk/composer-lockfile-parser@1.2.0"
+            },
+            {
+              "nodeId": "tslib@1.9.3"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "email-validator@2.0.4",
+          "pkgId": "email-validator@2.0.4",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.clonedeep@4.5.0",
+          "pkgId": "lodash.clonedeep@4.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "asap@2.0.6",
+          "pkgId": "asap@2.0.6",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "promise@7.3.1",
+          "pkgId": "promise@7.3.1",
+          "deps": [
+            {
+              "nodeId": "asap@2.0.6"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "then-fs@2.0.0",
+          "pkgId": "then-fs@2.0.0",
+          "deps": [
+            {
+              "nodeId": "promise@7.3.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-resolve@1.0.1",
+          "pkgId": "snyk-resolve@1.0.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-try-require@1.3.1",
+          "pkgId": "snyk-try-require@1.3.1",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "lodash.clonedeep@4.5.0"
+            },
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-policy@1.13.5",
+          "pkgId": "snyk-policy@1.13.5",
+          "deps": [
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "email-validator@2.0.4"
+            },
+            {
+              "nodeId": "js-yaml@3.14.1"
+            },
+            {
+              "nodeId": "lodash.clonedeep@4.5.0"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-python-plugin@1.17.0",
+          "pkgId": "snyk-python-plugin@1.17.0",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.3.0"
+            },
+            {
+              "nodeId": "tmp@0.0.33"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/node@6.14.13",
+          "pkgId": "@types/node@6.14.13",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "@types/semver@5.5.0",
+          "pkgId": "@types/semver@5.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "ansicolors@0.3.2",
+          "pkgId": "ansicolors@0.3.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.assign@4.2.0",
+          "pkgId": "lodash.assign@4.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.assignin@4.2.0",
+          "pkgId": "lodash.assignin@4.2.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.clone@4.5.0",
+          "pkgId": "lodash.clone@4.5.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.get@4.4.2",
+          "pkgId": "lodash.get@4.4.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "lodash.set@4.3.2",
+          "pkgId": "lodash.set@4.3.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "archy@1.0.0",
+          "pkgId": "archy@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-tree@1.0.0",
+          "pkgId": "snyk-tree@1.0.0",
+          "deps": [
+            {
+              "nodeId": "archy@1.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-resolve-deps@4.4.0",
+          "pkgId": "snyk-resolve-deps@4.4.0",
+          "deps": [
+            {
+              "nodeId": "@types/node@6.14.13"
+            },
+            {
+              "nodeId": "@types/semver@5.5.0"
+            },
+            {
+              "nodeId": "ansicolors@0.3.2"
+            },
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "lodash.assign@4.2.0"
+            },
+            {
+              "nodeId": "lodash.assignin@4.2.0"
+            },
+            {
+              "nodeId": "lodash.clone@4.5.0"
+            },
+            {
+              "nodeId": "lodash.flatten@4.4.0"
+            },
+            {
+              "nodeId": "lodash.get@4.4.2"
+            },
+            {
+              "nodeId": "lodash.set@4.3.2"
+            },
+            {
+              "nodeId": "lru-cache@4.1.5"
+            },
+            {
+              "nodeId": "semver@5.7.1"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-tree@1.0.0"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tree-kill@1.2.2",
+          "pkgId": "tree-kill@1.2.2",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk-sbt-plugin@2.11.0",
+          "pkgId": "snyk-sbt-plugin@2.11.0",
+          "deps": [
+            {
+              "nodeId": "debug@4.3.3"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "tmp@0.1.0"
+            },
+            {
+              "nodeId": "tree-kill@1.2.2"
+            },
+            {
+              "nodeId": "tslib@1.14.1"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "temp-dir@1.0.0",
+          "pkgId": "temp-dir@1.0.0",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "tempfile@2.0.0",
+          "pkgId": "tempfile@2.0.0",
+          "deps": [
+            {
+              "nodeId": "temp-dir@1.0.0"
+            },
+            {
+              "nodeId": "uuid@3.4.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "emoji-regex@7.0.3",
+          "pkgId": "emoji-regex@7.0.3",
+          "deps": [],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "string-width@3.1.0",
+          "pkgId": "string-width@3.1.0",
+          "deps": [
+            {
+              "nodeId": "emoji-regex@7.0.3"
+            },
+            {
+              "nodeId": "is-fullwidth-code-point@2.0.0"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "wrap-ansi@5.1.0",
+          "pkgId": "wrap-ansi@5.1.0",
+          "deps": [
+            {
+              "nodeId": "ansi-styles@3.2.1"
+            },
+            {
+              "nodeId": "string-width@3.1.0"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        },
+        {
+          "nodeId": "snyk@1.290.2",
+          "pkgId": "snyk@1.290.2",
+          "deps": [
+            {
+              "nodeId": "@snyk/cli-interface@2.3.0"
+            },
+            {
+              "nodeId": "@snyk/configstore@3.2.0-rc1"
+            },
+            {
+              "nodeId": "@snyk/dep-graph@1.13.1"
+            },
+            {
+              "nodeId": "@snyk/gemfile@1.2.0"
+            },
+            {
+              "nodeId": "@snyk/snyk-cocoapods-plugin@2.0.1"
+            },
+            {
+              "nodeId": "@snyk/update-notifier@2.5.1-rc2"
+            },
+            {
+              "nodeId": "@types/agent-base@4.2.2"
+            },
+            {
+              "nodeId": "@types/restify@4.3.8"
+            },
+            {
+              "nodeId": "abbrev@1.1.1"
+            },
+            {
+              "nodeId": "ansi-escapes@3.2.0"
+            },
+            {
+              "nodeId": "chalk@2.4.2"
+            },
+            {
+              "nodeId": "cli-spinner@0.2.10"
+            },
+            {
+              "nodeId": "debug@3.2.7"
+            },
+            {
+              "nodeId": "diff@4.0.2"
+            },
+            {
+              "nodeId": "git-url-parse@11.1.2"
+            },
+            {
+              "nodeId": "glob@7.2.0"
+            },
+            {
+              "nodeId": "inquirer@6.5.2"
+            },
+            {
+              "nodeId": "lodash@4.17.21"
+            },
+            {
+              "nodeId": "needle@2.9.1"
+            },
+            {
+              "nodeId": "opn@5.5.0"
+            },
+            {
+              "nodeId": "os-name@3.1.0"
+            },
+            {
+              "nodeId": "proxy-agent@3.1.1"
+            },
+            {
+              "nodeId": "proxy-from-env@1.1.0"
+            },
+            {
+              "nodeId": "semver@6.3.0"
+            },
+            {
+              "nodeId": "snyk-config@2.2.3"
+            },
+            {
+              "nodeId": "snyk-docker-plugin@1.38.0"
+            },
+            {
+              "nodeId": "snyk-go-plugin@1.11.1"
+            },
+            {
+              "nodeId": "snyk-gradle-plugin@3.2.4"
+            },
+            {
+              "nodeId": "snyk-module@1.9.1"
+            },
+            {
+              "nodeId": "snyk-mvn-plugin@2.8.0"
+            },
+            {
+              "nodeId": "snyk-nodejs-lockfile-parser@1.17.0"
+            },
+            {
+              "nodeId": "snyk-nuget-plugin@1.16.0"
+            },
+            {
+              "nodeId": "snyk-php-plugin@1.7.0"
+            },
+            {
+              "nodeId": "snyk-policy@1.13.5"
+            },
+            {
+              "nodeId": "snyk-python-plugin@1.17.0"
+            },
+            {
+              "nodeId": "snyk-resolve@1.0.1"
+            },
+            {
+              "nodeId": "snyk-resolve-deps@4.4.0"
+            },
+            {
+              "nodeId": "snyk-sbt-plugin@2.11.0"
+            },
+            {
+              "nodeId": "snyk-tree@1.0.0"
+            },
+            {
+              "nodeId": "snyk-try-require@1.3.1"
+            },
+            {
+              "nodeId": "source-map-support@0.5.21"
+            },
+            {
+              "nodeId": "strip-ansi@5.2.0"
+            },
+            {
+              "nodeId": "tempfile@2.0.0"
+            },
+            {
+              "nodeId": "then-fs@2.0.0"
+            },
+            {
+              "nodeId": "uuid@3.4.0"
+            },
+            {
+              "nodeId": "wrap-ansi@5.1.0"
+            }
+          ],
+          "info": {
+            "labels": {
+              "scope": "prod"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "packageManager": "npm",
+  "options": {
+    "path": "alpine:1",
+    "showVulnPaths": "all",
+    "docker": true,
+    "file": "testDir/Dockerfile",
+    "app-vulns": true,
+    "exclude-base-image-vulns": true
+  }
+}

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -1,0 +1,60 @@
+import { createFromJSON, DepGraphData } from '@snyk/dep-graph';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as legacy from '../../../../src/lib/snyk-test/legacy';
+import {
+  Options,
+  SupportedProjectTypes,
+  TestOptions,
+} from '../../../../src/lib/types';
+
+describe('container test projects behavior with --app-vulns, --file and --exclude-base-image-vulns flags', () => {
+  const fixturePath = path.normalize('test/fixtures/container-projects');
+
+  function readFixture(filename: string) {
+    const filePath = path.join(fixturePath, filename);
+    console.log(filePath);
+    return fs.readFileSync(filePath, 'utf8');
+  }
+
+  function readJsonFixture(filename: string) {
+    const contents = readFixture(filename);
+    return JSON.parse(contents);
+  }
+
+  interface fixture {
+    res: legacy.TestDepGraphResponse;
+    depGraph: DepGraphData;
+    packageManager: SupportedProjectTypes;
+    options: Options & TestOptions;
+  }
+
+  const mockApkFixture = readJsonFixture(
+    'app-vuln-apk-fixture.json',
+  ) as fixture;
+  const mockNpmFixture = readJsonFixture(
+    'app-vuln-npm-fixture.json',
+  ) as fixture;
+
+  it('should return no vulnerability for apk fixture', async () => {
+    const result = legacy.convertTestDepGraphResultToLegacy(
+      mockApkFixture.res,
+      createFromJSON(mockApkFixture.depGraph),
+      mockApkFixture.packageManager,
+      mockApkFixture.options,
+    );
+    expect(result.vulnerabilities).toHaveLength(0);
+    expect(result.ok).toEqual(true);
+  });
+
+  it('should return vulnerabilities for npm fixture', async () => {
+    const result = legacy.convertTestDepGraphResultToLegacy(
+      mockNpmFixture.res,
+      createFromJSON(mockNpmFixture.depGraph),
+      mockNpmFixture.packageManager,
+      mockNpmFixture.options,
+    );
+    expect(result.vulnerabilities).toHaveLength(10);
+    expect(result.ok).toEqual(false);
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Currently if using `--file` and `--exclude-base-image-vulns` flag would filter
out all the vulnerabilities including application vulnerabilites which is not
related to the base image. We want to only filter out the base image vulnerabilites.

#### Where should the reviewer start?

src/lib/snyk-test/legacy.ts

#### How should this be manually tested?

* npm run build
* build an image with this project
* `snyk container test <image-has-been-built> --app-vulns --file=Dockerfile --exclude-base-image-vulns; echo $?`
* exit code should be 1 instead of 0

#### Any background context you want to provide?

[zendesk ticket](https://snyk.zendesk.com/agent/tickets/16119)
