### PR TITLE
fix: remove console.log for custom rules from json,sarif output.

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -71,7 +71,10 @@ export async function test(
       iacOrgSettings,
     );
 
-    if (isOCIRegistryURLProvided || customRulesPath) {
+    if (
+      (isOCIRegistryURLProvided || customRulesPath) &&
+      !(options.sarif || options.json)
+    ) {
       console.log(
         chalk.hex('#ff9b00')(
           'Using custom rules to generate misconfigurations.',

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -35,6 +35,17 @@ describe('iac test --rules', () => {
     );
   });
 
+  it('does not show custom rules message if it scans local custom rules and uses --json flag', async () => {
+    const { stdout, exitCode } = await run(
+      `snyk iac test --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf --json`,
+    );
+    expect(exitCode).toBe(1);
+
+    expect(stdout).not.toContain(
+      'Using custom rules to generate misconfigurations.',
+    );
+  });
+
   it('presents an error message when the local rules cannot be found', async () => {
     const { stdout, exitCode } = await run(
       `snyk iac test --rules=./not/a/real/path.tar.gz ./iac/terraform/sg_open_ssh.tf`,


### PR DESCRIPTION
This commit removes the recently added console.log for (IaC) custom rules from the console, when a `--json` or `--sarif` command is provided. 

I suggest this as a quick fix for a bug that consists now in the CLI and breaks snyk-to-html reports and the IDE integration with IaC.

#### How should this be manually tested?
```
npm run build
snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --json
snyk-dev iac test test/fixtures/iac/terraform/sg_open_ssh.tf --sarif
```

#### Any background context you want to provide?
Notes:
options['sarif-file-output'] and options['json-file-output'] would still have this console.log. These are different and they are not considered options, they would just return undefined if we tried to check their value:

https://github.com/snyk/snyk/blob/210ec32b93c1b1f6932bddc22f41e9e0c82aa2fc/src/cli/commands/test/iac-local-execution/types.ts#L156-L158

```
options {
  _: <ref *1> [
    'test/fixtures/iac/terraform/sg_open_ssh.tf',
    'json-file-output=/Users/ipapast/snyk-repos/snyk/hello.json',
    { _: [Circular *1], iac: true }
  ],
```

options['sarif-file-output'] undefined

Another interesting finding is that when we use --sarif-file-output or --json-file-output, we do the scan twice: https://github.com/snyk/snyk/blob/bed640abefb04b90ee6390b9a030d36eb7145f95/src/cli/commands/test/index.ts#L106

The ..args contains this in a scan:
```
test/fixtures/iac/terraform/sg_open_ssh.tf json-file-output=/Users/iliannapapastefanou/snyk-repos/snyk/hello.json <ref *1> {
  _: [
    'test/fixtures/iac/terraform/sg_open_ssh.tf',
    'json-file-output=/Users/ipapast/snyk-repos/snyk/hello.json',
    [Circular *1]
  ],
  iac: true
}
```
and we end up two paths in the paths array:
```
[
  'test/fixtures/iac/terraform/sg_open_ssh.tf',
  'json-file-output=/Users/ipapastsnyk-repos/snyk/hello.json'
]
```

Then we iterate on those two paths, resulting in two test runs.

I don't know if this was the intended behaviour but it doesn't look correct. I will continue this and refactor in a next PR, the initial test logic and the formatters are shared.

### Notes to reviewers

What do you think of this quick fix? The other option is to revert https://github.com/snyk/snyk/pull/2393 until we have a better solution.


#### What are the relevant tickets?
https://snyk.slack.com/archives/CRV0PMFDH/p1638454460117000
