### PR TITLE
chore: fix generated help

### DIFF
--- a/help/commands-md/snyk-auth.md
+++ b/help/commands-md/snyk-auth.md
@@ -75,13 +75,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-code.md
+++ b/help/commands-md/snyk-code.md
@@ -98,13 +98,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-config.md
+++ b/help/commands-md/snyk-config.md
@@ -113,13 +113,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-container.md
+++ b/help/commands-md/snyk-container.md
@@ -134,13 +134,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-help.md
+++ b/help/commands-md/snyk-help.md
@@ -67,13 +67,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-iac.md
+++ b/help/commands-md/snyk-iac.md
@@ -8,7 +8,7 @@
 
 Find security issues in your Infrastructure as Code files.
 
-[For more information see IaC help page](https://snyk.co/ucT6Q)
+[For more information see the help page](https://docs.snyk.io/products/snyk-infrastructure-as-code)
 
 ## Commands
 
@@ -117,23 +117,25 @@ Prints a help text. You may specify a `<COMMAND>` to get more details.
 
 [For more information see IaC help page](https://snyk.co/ucT6Q)
 
-### `Test CloudFormation file`
+### `Test a CloudFormation file`
 
 \$ snyk iac test /path/to/cloudformation_file.yaml
 
-### `Test kubernetes file`
+### `Test a Kubernetes file`
 
 \$ snyk iac test /path/to/kubernetes_file.yaml
 
-### `Test terraform file`
+### `Test a Terraform file`
 
 \$ snyk iac test /path/to/terraform_file.tf
 
-### `Test terraform plan file`
+### `Test a Terraform plan file`
 
-\$ snyk iac test /path/to/tf-plan.json
+\$ terraform plan -out=tfplan.binary
+\$ terraform show -json tfplan.binary > tf-plan.json
+\$ snyk iac test tf-plan.json
 
-### `Test ARM file`
+### `Test an ARM file`
 
 \$ snyk iac test /path/to/arm_file.json
 
@@ -175,13 +177,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-ignore.md
+++ b/help/commands-md/snyk-ignore.md
@@ -92,13 +92,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-monitor.md
+++ b/help/commands-md/snyk-monitor.md
@@ -93,7 +93,7 @@ Specify a custom Snyk project name.
 
 ### `--target-reference=<TARGET_REFERENCE>`
 
-  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
+A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 ### `--project-environment=<ENVIRONMENT>[,<ENVIRONMENT>]...>`
 
@@ -329,13 +329,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-policy.md
+++ b/help/commands-md/snyk-policy.md
@@ -71,13 +71,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-protect.md
+++ b/help/commands-md/snyk-protect.md
@@ -77,13 +77,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-test.md
+++ b/help/commands-md/snyk-test.md
@@ -93,7 +93,7 @@ Specify a custom Snyk project name.
 
 ### `--target-reference=<TARGET_REFERENCE>`
 
-  A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
+A reference which differentiates this project. For example, a branch name or version. Projects using the same reference can be used for grouping. Only supported for Snyk Open Source. [More information](https://snyk.info/3B0vTPs).
 
 ### `--project-environment=<ENVIRONMENT>[,<ENVIRONMENT>]...>`
 
@@ -329,13 +329,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-wizard.md
+++ b/help/commands-md/snyk-wizard.md
@@ -72,13 +72,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 

--- a/help/commands-md/snyk-woof.md
+++ b/help/commands-md/snyk-woof.md
@@ -71,13 +71,11 @@ E.g. `SNYK_CFG_ORG=myorg` will override default org option in `config` with "myo
 
 ### `SNYK_REGISTRY_USERNAME`
 
-Specify a username to use when connecting to a container registry. Note that using the `--username` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a username to use when connecting to a container registry. Note that using the `--username` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ### `SNYK_REGISTRY_PASSWORD`
 
-Specify a password to use when connecting to a container registry. Note that using the `--password` flag will
-override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
+Specify a password to use when connecting to a container registry. Note that using the `--password` flag will override this value. This will be ignored in favour of local Docker binary credentials when Docker is present.
 
 ## Connecting to Snyk API
 


### PR DESCRIPTION
While we wait for #2405, this PR fixes the generated docs as they keep showing up in change lists even though the doc sources aren't touched.