### PR TITLE
chore(ci): migrate to cimg images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,11 @@ commands:
           keys:
             - sdkman-install-cache-v3-{{ arch }}-{{ checksum ".circleci/vendor/sdkman-install.sh" }}
       - run:
+          name: Installing Python
+          command: |
+            sudo apt update
+            sudo apt install python3 python3-pip python-is-python3
+      - run:
           name: Installing SDKMAN
           # The install script comes from https://get.sdkman.io/?rcupdate=false
           # We need to disable rcupdate as CircleCI uses a different setup.
@@ -145,9 +150,6 @@ commands:
   install_shellspec_dependencies:
     steps:
       - run:
-          name: Installing test dependencies
-          command: sudo apt-get install jq python-pip
-      - run:
           name: Installing ShellSpec
           command: |
             curl -fsSL https://git.io/shellspec | sh -s -- -y
@@ -164,13 +166,14 @@ commands:
     steps:
       - run:
           name: Installing release dependencies
-          command: sudo apt-get install -y osslsigncode
-
+          command: |
+            sudo apt update
+            sudo apt install osslsigncode
 jobs:
   build:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
       - install_project_dependencies:
@@ -182,7 +185,7 @@ jobs:
   regression-test:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
       - install_sdks_linux
@@ -287,7 +290,7 @@ jobs:
   test-linux:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     environment:
       TEMP: /mnt/ramdisk/tmp
     steps:
@@ -353,7 +356,7 @@ jobs:
   dev-release:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
       - install_release_dependencies
@@ -385,7 +388,7 @@ jobs:
   prod-release:
     <<: *defaults
     docker:
-      - image: circleci/node:<< parameters.node_version >>
+      - image: cimg/node:<< parameters.node_version >>
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Old images won't be maintained after December 2021. So this PR migrates us to the new ones.

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

## Not using Node Orb

CircleCI's "node" orb handles caching for us so I tried using `cimg/base` since our Node version varies. However, it has too many issues and limitations.

- It doesn't support ramdisk (it attempts some symlink wizardry and fails, see below).
- It doesn't support Windows.
- We still need to configure `NPM_TOKEN` using `npm config`.

```
ln: failed to create hard link '/tmp/node-project-lockfile' => 'package-lock.json': Invalid cross-device link
```

So in general, it's simpler to keep using a Node image and maintain our existing manual caches and configuration.