### PR TITLE
fix: fix the cpp package id creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.14.0",
+        "snyk-cpp-plugin": "2.14.1",
         "snyk-docker-plugin": "^4.27.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22339,9 +22339,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
-      "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
+      "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -44522,7 +44522,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.14.0",
+        "snyk-cpp-plugin": "2.14.1",
         "snyk-docker-plugin": "^4.27.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -62246,9 +62246,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.14.0",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
-          "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
+          "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -65640,9 +65640,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.0.tgz",
-      "integrity": "sha512-u/IqZYI59TyvnD39RGbvkJgtuxnEn8zrk+vQLETRw+ZaJ7e8MH/3cFPdw0hvHLZHHAi1uzCthAjm/NoCW9U+rg==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
+      "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.14.0",
+    "snyk-cpp-plugin": "2.14.1",
     "snyk-docker-plugin": "^4.27.1",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
On the server side, when we construct the package id we
make the output lower cased. We need to align also the
client to mirror that logic in order to successfully
find and extract the required data.

- bump the version of the cpp plugin to include the changes
also in the CLI

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules