### PR TITLE
fix: parse nuspecs with utf BOM encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.2",
-        "snyk-nuget-plugin": "1.23.1",
+        "snyk-nuget-plugin": "1.23.2",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
         "snyk-python-plugin": "1.22.2",
@@ -22933,9 +22933,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-nuget-plugin": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.1.tgz",
-      "integrity": "sha512-Rgc0bBetvxIMiViV7m5bGp0dIkvWJUPioek3kGAy3+4zHMQbin5Srw/9oMXzkdppkRFmxxb3FgfNnk4HiQGTRQ==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.2.tgz",
+      "integrity": "sha512-A+8k9ddWDMJNIlykQRvdWIUIoTk0RvtHdbhqeMsZo1YZH4YVNWn0Ar8j89E5jCjBphYzMK0GtB27MHkk0SkZ3A==",
       "dependencies": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",
@@ -44529,7 +44529,7 @@
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.2",
         "snyk-nodejs-lockfile-parser": "1.37.2",
-        "snyk-nuget-plugin": "1.23.1",
+        "snyk-nuget-plugin": "1.23.2",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
         "snyk-python-plugin": "1.22.2",
@@ -62715,9 +62715,9 @@
           }
         },
         "snyk-nuget-plugin": {
-          "version": "1.23.1",
-          "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.1.tgz",
-          "integrity": "sha512-Rgc0bBetvxIMiViV7m5bGp0dIkvWJUPioek3kGAy3+4zHMQbin5Srw/9oMXzkdppkRFmxxb3FgfNnk4HiQGTRQ==",
+          "version": "1.23.2",
+          "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.2.tgz",
+          "integrity": "sha512-A+8k9ddWDMJNIlykQRvdWIUIoTk0RvtHdbhqeMsZo1YZH4YVNWn0Ar8j89E5jCjBphYzMK0GtB27MHkk0SkZ3A==",
           "requires": {
             "debug": "^4.1.1",
             "dotnet-deps-parser": "5.1.0",
@@ -66109,9 +66109,9 @@
       }
     },
     "snyk-nuget-plugin": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.1.tgz",
-      "integrity": "sha512-Rgc0bBetvxIMiViV7m5bGp0dIkvWJUPioek3kGAy3+4zHMQbin5Srw/9oMXzkdppkRFmxxb3FgfNnk4HiQGTRQ==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/snyk-nuget-plugin/-/snyk-nuget-plugin-1.23.2.tgz",
+      "integrity": "sha512-A+8k9ddWDMJNIlykQRvdWIUIoTk0RvtHdbhqeMsZo1YZH4YVNWn0Ar8j89E5jCjBphYzMK0GtB27MHkk0SkZ3A==",
       "requires": {
         "debug": "^4.1.1",
         "dotnet-deps-parser": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.2",
     "snyk-nodejs-lockfile-parser": "1.37.2",
-    "snyk-nuget-plugin": "1.23.1",
+    "snyk-nuget-plugin": "1.23.2",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.1",
     "snyk-python-plugin": "1.22.2",


### PR DESCRIPTION
Bump `snyk-nuget-plugin` which contains [fix](https://github.com/snyk/snyk-nuget-plugin/pull/111) to parse `.nuspec` files that are encoded in UTF-8 with BOM 