### PR TITLE
feat: create docker desktop bundle for darwin/arm64

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -48,7 +48,7 @@ jobs:
             os: ubuntu
           - snyk_install_method: docker-bundle
             os: macos
-            snyk_cli_dl_file: docker-mac-signed-bundle.tar.gz
+            snyk_cli_dl_file: snyk-for-docker-desktop-darwin-x64.tar.gz
 
     steps:
       - uses: actions/checkout@v2
@@ -91,13 +91,11 @@ jobs:
       - name: Install snyk from Docker bundle
         if: ${{ matrix.snyk_install_method == 'docker-bundle' }}
         run: |
-          curl -Lo ./snyk-cli.tar.gz 'https://static.snyk.io/cli/latest/${{ matrix.snyk_cli_dl_file }}'
-          sudo mkdir -p /usr/local/bin/snyk-mac
-          sudo mv ./snyk-cli.tar.gz /usr/local/bin/snyk-mac
-          sudo tar -xf /usr/local/bin/snyk-mac/snyk-cli.tar.gz -C /usr/local/bin/snyk-mac  # makes a folder called docker
-          sudo ln -s /usr/local/bin/snyk-mac/docker/snyk-mac.sh /usr/local/bin/snyk-mac/docker/snyk
-          ls -la /usr/local/bin/snyk-mac/docker
-          export PATH="/usr/local/bin/snyk-mac/docker:$PATH"
+          pushd "$(mktemp -d)"
+          curl 'https://static.snyk.io/cli/latest/${{ matrix.snyk_cli_dl_file }}' | tar -xz --strip-components=1
+          ls -la
+          sudo ln -s "$(pwd)/entrypoint.sh" /usr/local/bin/snyk
+          popd
           which snyk
           snyk version
 

--- a/docker-desktop/README.md
+++ b/docker-desktop/README.md
@@ -1,0 +1,36 @@
+# Snyk CLI for Docker Desktop on macOS
+
+This distribution is not for customers! Releases are included with
+[Docker Desktop on macOS](https://www.docker.com/products/docker-desktop).
+
+If you are looking for Snyk CLI Docker Images, see
+[Docker Hub](https://hub.docker.com/r/snyk/snyk-cli).
+
+## How it works
+
+Unlike the `snyk-mac` binary build, the NodeJS release included with this
+distribution is a signed executable, which allows Docker Desktop to use it to
+execute Snyk CLI's underlying JavaScript build.
+
+## Building
+
+You must be at the root of the workspace. That is, one directory up from this
+repository. Then you can run:
+
+```sh
+./docker-desktop/build.sh darwin x64
+```
+
+This will create a tarball at:
+
+```sh
+./binary-releases/snyk-for-docker-desktop-darwin-x64.tar.gz
+```
+
+To test it, you can do the following:
+
+```sh
+cd ./binary-releases
+tar xzf snyk-for-docker-desktop-darwin-x64.tar.gz
+./snyk-for-docker-desktop-darwin-x64/entrypoint.sh woof
+```

--- a/docker-desktop/build.sh
+++ b/docker-desktop/build.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+platform="${1}"
+arch="${2}"
+node_version="v16.13.1"
+node_url="https://nodejs.org/dist/${node_version}/node-${node_version}-${platform}-${arch}.tar.gz"
+build_name="snyk-for-docker-desktop-${platform}-${arch}"
+build_filename="${build_name}.tar.gz"
+build_sha_filename="${build_filename}.sha256"
+build_root="./docker-desktop/dist"
+build_dir="${build_root}/${build_name}"
+output_dir="./binary-releases"
+
+if [[ -d "${build_dir}" ]]; then
+  echo "ERROR: Build directory already exists."
+  echo "  - ${build_dir}"
+  exit 1
+fi
+
+mkdir -p "${build_dir}"
+mkdir -p "${output_dir}"
+
+# Include entrypoint.
+cp ./docker-desktop/src/entrypoint.sh "${build_dir}"
+
+# Include Snyk CLI build.
+cp              ./package.json        "${build_dir}"
+cp              ./config.default.json "${build_dir}"
+cp -r           ./dist                "${build_dir}"
+cp -r           ./bin                 "${build_dir}"
+cp -r           ./pysrc               "${build_dir}"
+cp -r --parents ./help/cli-commands   "${build_dir}"
+
+# Include NodeJS.
+#
+# --strip-components=1 removes the versioned NodeJS directory so that we can
+# refer to the contents without needing to know the exact release name it came
+# from.
+mkdir "${build_dir}/node-release"
+pushd "${build_dir}/node-release"
+curl "${node_url}" | tar -xz --strip-components=1
+popd
+
+# Create Snyk CLI for Docker Desktop build
+#
+# We build from build_root so that build_name is the top-level directory in the
+# tarball. We want a top-level directory to avoid tarbombs.
+pushd "${build_root}"
+tar czfh "${build_filename}" "${build_name}"
+shasum -a 256 "${build_filename}" > "${build_sha_filename}"
+popd
+
+mv "${build_root}/${build_filename}"     "${output_dir}"
+mv "${build_root}/${build_sha_filename}" "${output_dir}"

--- a/docker-desktop/src/entrypoint.sh
+++ b/docker-desktop/src/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(dirname "$0")"
+"${script_dir}/node-release/bin/node" "${script_dir}/bin/snyk" "$@"

--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -8,7 +8,8 @@ npx pkg . --compress Brotli -t node14-linux-x64  -o binary-releases/snyk-linux
 npx pkg . --compress Brotli -t node14-macos-x64  -o binary-releases/snyk-macos
 npx pkg . --compress Brotli -t node14-win-x64    -o binary-releases/snyk-win-unsigned.exe
 
-# build docker package
+./docker-desktop/build.sh darwin x64
+./docker-desktop/build.sh darwin arm64
 ./release-scripts/docker-desktop-release.sh
 
 # sign the windows binary

--- a/release-scripts/upload-artifacts.sh
+++ b/release-scripts/upload-artifacts.sh
@@ -6,11 +6,15 @@ declare -a StaticFiles=(
   "binary-releases/snyk-linux"
   "binary-releases/snyk-macos"
   "binary-releases/snyk-win.exe"
+  "binary-releases/snyk-for-docker-desktop-darwin-x64.tar.gz"
+  "binary-releases/snyk-for-docker-desktop-darwin-arm64.tar.gz"
   "binary-releases/docker-mac-signed-bundle.tar.gz"
   "binary-releases/snyk-alpine.sha256"
   "binary-releases/snyk-linux.sha256"
   "binary-releases/snyk-macos.sha256"
   "binary-releases/snyk-win.exe.sha256"
+  "binary-releases/snyk-for-docker-desktop-darwin-x64.tar.gz.sha256"
+  "binary-releases/snyk-for-docker-desktop-darwin-arm64.tar.gz.sha256"
   "binary-releases/docker-mac-signed-bundle.tar.gz.sha256"
 )
 

--- a/release-scripts/validate-checksums.sh
+++ b/release-scripts/validate-checksums.sh
@@ -5,4 +5,6 @@ shasum -a 256 -c snyk-alpine.sha256
 shasum -a 256 -c snyk-linux.sha256
 shasum -a 256 -c snyk-macos.sha256
 shasum -a 256 -c snyk-win.exe.sha256
+shasum -a 256 -c snyk-for-docker-desktop-darwin-x64.tar.gz.sha256
+shasum -a 256 -c snyk-for-docker-desktop-darwin-arm64.tar.gz.sha256
 shasum -a 256 -c docker-mac-signed-bundle.tar.gz.sha256


### PR DESCRIPTION
We need darwin/arm64 support for our Docker Desktop integration.

I've renamed and restructured the Docker Desktop bundle to support multiple architectures. We'll keep the old bundle format for backwards compatibility while we wait for migrations to finish. This PR is technically additive, it's not changing anything.

## Old (docker-mac-signed-bundle.tar.gz)

- Download and extract `docker-mac-signed-bundle.tar.gz` 
- Run `./docker/snyk-mac.sh`

```
docker
├── config.default.json
├── dist
├── help
├── node-v12.18.3-darwin-x64
├── package.json
├── pysrc
└── snyk-mac.sh
```

```
31M     ./docker-mac-signed-bundle.tar.gz
133M    ./docker
```

## New (snyk-for-docker-desktop-darwin-x64.tar.gz)

- Download and extract `snyk-for-docker-desktop-darwin-x64.tar.gz` 
  - Change `x64` to `arm64` accordingly. 
- Run `./snyk-for-docker-desktop-darwin-x64/entrypoint.sh`

```
snyk-for-docker-desktop-darwin-x64
├── bin
├── config.default.json
├── dist
├── entrypoint.sh
├── help
├── node-release
├── package.json
└── pysrc
```

```
38M     ./snyk-for-docker-desktop-darwin-arm64.tar.gz
142M    ./snyk-for-docker-desktop-darwin-arm64

39M     ./snyk-for-docker-desktop-darwin-x64.tar.gz
147M    ./snyk-for-docker-desktop-darwin-x64
```

- Renamed `docker` top-level directory to `snyk-for-docker-desktop-darwin-x64`
  - When the tarball is extracted, the directory name now matches the tarball name so it's clear where it came from.
- Renamed `snyk-mac.sh` to `entrypoint.sh` to make it clear what it is for.
- Changed entrypoint to use `node ./bin/snyk` instead of `node ./dist/cli/index.js`.
  - `./bin/snyk` is the public JS entrypoint for Snyk CLI.
- Renamed directory `node-v12.18.3-darwin-x64` to `node-release`.
  - This lets the entrypoint use the same path to NodeJS without needing to care which architecture it is.
- Upgraded to Node 16.
  - Node 12 does not support darwin/arm64
 
For the build script itself, I removed the `rm -rf` step as cleanup isn't always needed nor wanted. In CI it's a waste of time. To avoid pollution from a previous build, the script fails if the build directory already exists.

All Docker Desktop specific source files are now in `./docker-desktop` to make it clear that it's a separate build. Similar to how we have `./docker`. We can also use this structure to better document it.

I've also named this distribution "Snyk CLI for Docker Desktop". The goal being that the "for" will help indicate, maybe, that it's not for customers.

# Future

- [ ] Consider not publishing these artifacts to GitHub Releases.
  - People might misunderstand and start using them.
  - Docker can use Snyk's CDN instead if they aren't already.
- [x] Check if the new tarball size is okay.
  - Increase isn't much, probably fine.

# Notes

Related to #2436.