### PR TITLE
feat: Allow json output for app vulns (experimental)

### DIFF
--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -249,11 +249,15 @@ export async function main(): Promise<void> {
       (globalArgs.options as unknown) as AllSupportedCliOptions,
     );
 
-    if (globalArgs.options['app-vulns'] && globalArgs.options['json']) {
+    if (
+      !globalArgs.options['experimental'] &&
+      globalArgs.options['app-vulns'] &&
+      globalArgs.options['json']
+    ) {
       throw new UnsupportedOptionCombinationError([
         'Application vulnerabilities is currently not supported with JSON output. ' +
-          'Please try using —app-vulns only to get application vulnerabilities, or ' +
-          '—json only to get your image vulnerabilities, excluding the application ones.',
+          'Please try using —-app-vulns only to get application vulnerabilities, or ' +
+          '—-json only to get your image vulnerabilities, excluding the application ones.',
       ]);
     }
     if (globalArgs.options['group-issues'] && globalArgs.options['iac']) {

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -18,7 +18,6 @@ const modes: Record<string, ModeData> = {
     allowedCommands: ['test', 'monitor'],
     config: (args): [] => {
       args['docker'] = true;
-      args['experimental'] = true;
 
       return args;
     },

--- a/test/args.test.ts
+++ b/test/args.test.ts
@@ -161,7 +161,6 @@ test('test command line "container test"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
-  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -174,7 +173,6 @@ test('test command line "container monitor"', (t) => {
   ];
   const result = args(cliArgs);
   t.ok(result.options.docker);
-  t.ok(result.options.experimental);
   t.end();
 });
 
@@ -187,7 +185,6 @@ test('test command line "container protect"', (t) => {
   ];
   const result = args(cliArgs);
   t.notOk(result.options.docker);
-  t.notOk(result.options.experimental);
   t.end();
 });
 

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -10,6 +10,11 @@ import {
 import { fakeServer } from '../../../acceptance/fake-server';
 import { runSnykCLI } from '../../util/runSnykCLI';
 
+const isWindows =
+  require('os-name')()
+    .toLowerCase()
+    .indexOf('windows') === 0;
+
 describe('container test projects behavior with --app-vulns, --file and --exclude-base-image-vulns flags', () => {
   const fixturePath = path.normalize('test/fixtures/container-projects');
 
@@ -61,62 +66,64 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
   });
 });
 
-describe('container test projects behavior with --app-vulns, --json flags', () => {
-  let server;
-  let env: Record<string, string>;
+if (!isWindows) {
+  describe('container test projects behavior with --app-vulns, --json flags', () => {
+    let server;
+    let env: Record<string, string>;
 
-  beforeAll((done) => {
-    const port = process.env.PORT || process.env.SNYK_PORT || '12345';
-    const baseApi = '/api/v1';
-    env = {
-      ...process.env,
-      SNYK_API: 'http://localhost:' + port + baseApi,
-      SNYK_HOST: 'http://localhost:' + port,
-      SNYK_TOKEN: '123456789',
-      SNYK_INTEGRATION_NAME: 'JENKINS',
-      SNYK_INTEGRATION_VERSION: '1.2.3',
-    };
-    server = fakeServer(baseApi, env.SNYK_TOKEN);
-    server.listen(port, () => {
-      done();
+    beforeAll((done) => {
+      const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+      const baseApi = '/api/v1';
+      env = {
+        ...process.env,
+        SNYK_API: 'http://localhost:' + port + baseApi,
+        SNYK_HOST: 'http://localhost:' + port,
+        SNYK_TOKEN: '123456789',
+        SNYK_INTEGRATION_NAME: 'JENKINS',
+        SNYK_INTEGRATION_VERSION: '1.2.3',
+      };
+      server = fakeServer(baseApi, env.SNYK_TOKEN);
+      server.listen(port, () => {
+        done();
+      });
+    });
+
+    afterEach(() => {
+      server.restore();
+    });
+
+    afterAll((done) => {
+      server.close(() => {
+        done();
+      });
+    });
+
+    it('returns a json with the --experimental flags', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `container test snykgoof/os-app:node-snykin --app-vulns --json --experimental`,
+        {
+          env,
+        },
+      );
+
+      const jsonOutput = JSON.parse(stdout);
+      expect(Array.isArray(jsonOutput)).toBeTruthy();
+      expect(jsonOutput).toHaveLength(3);
+      expect(code).toEqual(0);
+    });
+
+    it('returns an error without the --experimental flags', async () => {
+      const { code, stdout } = await runSnykCLI(
+        `container test snykgoof/os-app:node-snykin --app-vulns --json`,
+        {
+          env,
+        },
+      );
+
+      expect(stdout).toContain(
+        'Application vulnerabilities is currently not supported with JSON output',
+      );
+      expect(code).toEqual(2);
     });
   });
-
-  afterEach(() => {
-    server.restore();
-  });
-
-  afterAll((done) => {
-    server.close(() => {
-      done();
-    });
-  });
-
-  it('returns a json with the --experimental flags', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `container test snykgoof/os-app:node-snykin --app-vulns --json --experimental`,
-      {
-        env,
-      },
-    );
-
-    const jsonOutput = JSON.parse(stdout);
-    expect(Array.isArray(jsonOutput)).toBeTruthy();
-    expect(jsonOutput).toHaveLength(3);
-    expect(code).toEqual(0);
-  });
-
-  it('returns an error without the --experimental flags', async () => {
-    const { code, stdout } = await runSnykCLI(
-      `container test snykgoof/os-app:node-snykin --app-vulns --json`,
-      {
-        env,
-      },
-    );
-
-    expect(stdout).toContain(
-      'Application vulnerabilities is currently not supported with JSON output',
-    );
-    expect(code).toEqual(2);
-  });
-});
+}

--- a/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
+++ b/test/jest/acceptance/snyk-test/app-vuln-container-project.spec.ts
@@ -7,6 +7,8 @@ import {
   SupportedProjectTypes,
   TestOptions,
 } from '../../../../src/lib/types';
+import { fakeServer } from '../../../acceptance/fake-server';
+import { runSnykCLI } from '../../util/runSnykCLI';
 
 describe('container test projects behavior with --app-vulns, --file and --exclude-base-image-vulns flags', () => {
   const fixturePath = path.normalize('test/fixtures/container-projects');
@@ -56,5 +58,65 @@ describe('container test projects behavior with --app-vulns, --file and --exclud
     );
     expect(result.vulnerabilities).toHaveLength(10);
     expect(result.ok).toEqual(false);
+  });
+});
+
+describe('container test projects behavior with --app-vulns, --json flags', () => {
+  let server;
+  let env: Record<string, string>;
+
+  beforeAll((done) => {
+    const port = process.env.PORT || process.env.SNYK_PORT || '12345';
+    const baseApi = '/api/v1';
+    env = {
+      ...process.env,
+      SNYK_API: 'http://localhost:' + port + baseApi,
+      SNYK_HOST: 'http://localhost:' + port,
+      SNYK_TOKEN: '123456789',
+      SNYK_INTEGRATION_NAME: 'JENKINS',
+      SNYK_INTEGRATION_VERSION: '1.2.3',
+    };
+    server = fakeServer(baseApi, env.SNYK_TOKEN);
+    server.listen(port, () => {
+      done();
+    });
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll((done) => {
+    server.close(() => {
+      done();
+    });
+  });
+
+  it('returns a json with the --experimental flags', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test snykgoof/os-app:node-snykin --app-vulns --json --experimental`,
+      {
+        env,
+      },
+    );
+
+    const jsonOutput = JSON.parse(stdout);
+    expect(Array.isArray(jsonOutput)).toBeTruthy();
+    expect(jsonOutput).toHaveLength(3);
+    expect(code).toEqual(0);
+  });
+
+  it('returns an error without the --experimental flags', async () => {
+    const { code, stdout } = await runSnykCLI(
+      `container test snykgoof/os-app:node-snykin --app-vulns --json`,
+      {
+        env,
+      },
+    );
+
+    expect(stdout).toContain(
+      'Application vulnerabilities is currently not supported with JSON output',
+    );
+    expect(code).toEqual(2);
   });
 });

--- a/test/jest/unit/lib/util.spec.ts
+++ b/test/jest/unit/lib/util.spec.ts
@@ -53,7 +53,6 @@ describe('Sanitize args', () => {
         password: 'fakepass',
         debug: true,
         docker: true,
-        experimental: true,
       },
     ];
 

--- a/test/jest/unit/modes.spec.ts
+++ b/test/jest/unit/modes.spec.ts
@@ -121,7 +121,6 @@ describe('when have a valid mode and command', () => {
     const expectedArgs = {
       _: [],
       docker: true,
-      experimental: true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -135,7 +134,6 @@ describe('when have a valid mode and command', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
   });
 
   it('"unmanaged test" should set unmanaged option and test command', () => {
@@ -179,7 +177,6 @@ describe('when have a valid mode, command and exists a command alias', () => {
     const expectedArgs = {
       _: [],
       docker: true,
-      experimental: true,
       'package-manager': 'pip',
     };
     const cliCommand = 'container';
@@ -193,7 +190,6 @@ describe('when have a valid mode, command and exists a command alias', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeTruthy();
-    expect(cliArgs['experimental']).toBeTruthy();
   });
 });
 
@@ -215,7 +211,6 @@ describe('when have a valid mode and not allowed command', () => {
     expect(command).toBe(expectedCommand);
     expect(cliArgs).toEqual(expectedArgs);
     expect(cliArgs['docker']).toBeFalsy();
-    expect(cliArgs['experimental']).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR allows container test with --app-vulns to run with --json output, using the --experimental flag.

#### Where should the reviewer start?

The reviewer should start at src/cli/main.ts where we chaeck for the  globalArgs.options['app-vulns'] &&      globalArgs.options['json'] condition.

#### How should this be manually tested?
Run: 
`snyk container test snyk:node-snykin --app-vulns --json` with and without the --experimental flag.

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots


#### Additional questions
