### PR TITLE
fix: Update snyk-docker-plugin to v4.28.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.14.1",
-        "snyk-docker-plugin": "^4.27.1",
+        "snyk-docker-plugin": "^4.28.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
@@ -22465,9 +22465,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.27.1.tgz",
-      "integrity": "sha512-RmU25nazaBK6k14KD0HnmhxzaO6NK4dyiXhHi/GCMjHOZnSp2aZpC5LFivkGKG/30Os2uyB+Nc2GAcdwtpimxQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.28.1.tgz",
+      "integrity": "sha512-TNRn1fH73Hd+VBbawC2BH327svO7R1Z1kYeuXVr/idwCvXFHrIGt/OY/f5IU4u5FJrNr93NHayMB1TYlVYRlTQ==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -22482,7 +22482,7 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.36.0",
+        "snyk-nodejs-lockfile-parser": "1.37.2",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
@@ -22490,22 +22490,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/snyk-docker-plugin/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-    },
-    "node_modules/snyk-docker-plugin/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/snyk-docker-plugin/node_modules/lru-cache": {
@@ -22553,34 +22537,6 @@
       },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.36.0",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.36.0.tgz",
-      "integrity": "sha512-IYg1Kbz/juuXrZNe7UoWTyHV+QKDveahxM3y1h/gZDwoOC9fgyVlC0p0v/RyeYRtvScxQcJchCr94V1VStwroA==",
-      "dependencies": {
-        "@snyk/dep-graph": "^1.28.0",
-        "@snyk/graphlib": "2.1.9-patch.3",
-        "@yarnpkg/core": "^2.4.0",
-        "@yarnpkg/lockfile": "^1.1.0",
-        "event-loop-spinner": "^2.0.0",
-        "js-yaml": "^4.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.flatmap": "^4.5.0",
-        "lodash.isempty": "^4.4.0",
-        "lodash.set": "^4.3.2",
-        "lodash.topairs": "^4.3.0",
-        "semver": "^7.3.5",
-        "snyk-config": "^4.0.0-rc.2",
-        "tslib": "^1.9.3",
-        "uuid": "^8.3.0"
-      },
-      "bin": {
-        "parse-nodejs-lockfile": "bin/index.js"
       },
       "engines": {
         "node": ">=10"
@@ -44523,7 +44479,7 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.14.1",
-        "snyk-docker-plugin": "^4.27.1",
+        "snyk-docker-plugin": "^4.28.1",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
@@ -62338,9 +62294,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.27.1",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.27.1.tgz",
-          "integrity": "sha512-RmU25nazaBK6k14KD0HnmhxzaO6NK4dyiXhHi/GCMjHOZnSp2aZpC5LFivkGKG/30Os2uyB+Nc2GAcdwtpimxQ==",
+          "version": "4.28.1",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.28.1.tgz",
+          "integrity": "sha512-TNRn1fH73Hd+VBbawC2BH327svO7R1Z1kYeuXVr/idwCvXFHrIGt/OY/f5IU4u5FJrNr93NHayMB1TYlVYRlTQ==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -62355,26 +62311,13 @@
             "gunzip-maybe": "^1.4.2",
             "mkdirp": "^1.0.4",
             "semver": "^7.3.4",
-            "snyk-nodejs-lockfile-parser": "1.36.0",
+            "snyk-nodejs-lockfile-parser": "1.37.2",
             "tar-stream": "^2.1.0",
             "tmp": "^0.2.1",
             "tslib": "^1",
             "uuid": "^8.2.0"
           },
           "dependencies": {
-            "argparse": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-            },
-            "js-yaml": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-              "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-              "requires": {
-                "argparse": "^2.0.1"
-              }
-            },
             "lru-cache": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -62402,28 +62345,6 @@
               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
               "requires": {
                 "lru-cache": "^6.0.0"
-              }
-            },
-            "snyk-nodejs-lockfile-parser": {
-              "version": "1.36.0",
-              "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.36.0.tgz",
-              "integrity": "sha512-IYg1Kbz/juuXrZNe7UoWTyHV+QKDveahxM3y1h/gZDwoOC9fgyVlC0p0v/RyeYRtvScxQcJchCr94V1VStwroA==",
-              "requires": {
-                "@snyk/dep-graph": "^1.28.0",
-                "@snyk/graphlib": "2.1.9-patch.3",
-                "@yarnpkg/core": "^2.4.0",
-                "@yarnpkg/lockfile": "^1.1.0",
-                "event-loop-spinner": "^2.0.0",
-                "js-yaml": "^4.1.0",
-                "lodash.clonedeep": "^4.5.0",
-                "lodash.flatmap": "^4.5.0",
-                "lodash.isempty": "^4.4.0",
-                "lodash.set": "^4.3.2",
-                "lodash.topairs": "^4.3.0",
-                "semver": "^7.3.5",
-                "snyk-config": "^4.0.0-rc.2",
-                "tslib": "^1.9.3",
-                "uuid": "^8.3.0"
               }
             },
             "tmp": {
@@ -65732,9 +65653,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.27.1",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.27.1.tgz",
-      "integrity": "sha512-RmU25nazaBK6k14KD0HnmhxzaO6NK4dyiXhHi/GCMjHOZnSp2aZpC5LFivkGKG/30Os2uyB+Nc2GAcdwtpimxQ==",
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.28.1.tgz",
+      "integrity": "sha512-TNRn1fH73Hd+VBbawC2BH327svO7R1Z1kYeuXVr/idwCvXFHrIGt/OY/f5IU4u5FJrNr93NHayMB1TYlVYRlTQ==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -65749,26 +65670,13 @@
         "gunzip-maybe": "^1.4.2",
         "mkdirp": "^1.0.4",
         "semver": "^7.3.4",
-        "snyk-nodejs-lockfile-parser": "1.36.0",
+        "snyk-nodejs-lockfile-parser": "1.37.2",
         "tar-stream": "^2.1.0",
         "tmp": "^0.2.1",
         "tslib": "^1",
         "uuid": "^8.2.0"
       },
       "dependencies": {
-        "argparse": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
-        },
-        "js-yaml": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-          "requires": {
-            "argparse": "^2.0.1"
-          }
-        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -65796,28 +65704,6 @@
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "snyk-nodejs-lockfile-parser": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.36.0.tgz",
-          "integrity": "sha512-IYg1Kbz/juuXrZNe7UoWTyHV+QKDveahxM3y1h/gZDwoOC9fgyVlC0p0v/RyeYRtvScxQcJchCr94V1VStwroA==",
-          "requires": {
-            "@snyk/dep-graph": "^1.28.0",
-            "@snyk/graphlib": "2.1.9-patch.3",
-            "@yarnpkg/core": "^2.4.0",
-            "@yarnpkg/lockfile": "^1.1.0",
-            "event-loop-spinner": "^2.0.0",
-            "js-yaml": "^4.1.0",
-            "lodash.clonedeep": "^4.5.0",
-            "lodash.flatmap": "^4.5.0",
-            "lodash.isempty": "^4.4.0",
-            "lodash.set": "^4.3.2",
-            "lodash.topairs": "^4.3.0",
-            "semver": "^7.3.5",
-            "snyk-config": "^4.0.0-rc.2",
-            "tslib": "^1.9.3",
-            "uuid": "^8.3.0"
           }
         },
         "tmp": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.14.1",
-    "snyk-docker-plugin": "^4.27.1",
+    "snyk-docker-plugin": "^4.28.1",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR updates the version of snyk-docker-plugin to v4.28.1 to support deeply out of sync lockfiles added in a recent version of snyk-nodejs-lockfile-parser.

#### Any background context you want to provide?

https://snyk.slack.com/archives/C01EPSMGZML/p1639590254212300

