### PR TITLE
fix: add '.ear' support for the log4shell command

### DIFF
--- a/src/cli/commands/log4shell.ts
+++ b/src/cli/commands/log4shell.ts
@@ -152,7 +152,9 @@ async function traverse(path: Path, handle: FileHandler) {
 }
 
 function isJavaArchive(path: Path) {
-  return path.endsWith('.jar') || path.endsWith('.war');
+  return (
+    path.endsWith('.jar') || path.endsWith('.war') || path.endsWith('.ear')
+  );
 }
 
 function isJvmFile(path: Path) {


### PR DESCRIPTION
#### What does this PR do?

Adds support for the '.ear' format while scanning for log4shell.
