### PR TITLE
feat: return JAR dependencies from pom.properties files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.14.1",
-        "snyk-docker-plugin": "^4.29.0",
+        "snyk-docker-plugin": "^4.30.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
@@ -22466,9 +22466,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-docker-plugin": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.29.0.tgz",
-      "integrity": "sha512-q9gIPJdv8agv6S+hKEg6Mg+e6rbx3rEJ20rdaJy4Eo8JNMp6+wyDPDrQscVFDDovXV9xzEG8XfMvQcsZJsK+Ww==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.30.0.tgz",
+      "integrity": "sha512-xJkxat32OBIbomXAHT16zbogee++BU+X29YHP7C039ELtD1+PobDKe1Gy/fSCI8xf/2re+LLg2pfeMLe+WMkNg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",
@@ -44419,7 +44419,7 @@
         "@typescript-eslint/eslint-plugin": "^4.30.0",
         "@typescript-eslint/parser": "^4.30.0",
         "abbrev": "^1.1.1",
-        "adm-zip": "*",
+        "adm-zip": "^0.5.9",
         "ajv": "^6.12.6",
         "ansi-escapes": "3.2.0",
         "body-parser": "^1.19.0",
@@ -44481,7 +44481,7 @@
         "snyk": "file:",
         "snyk-config": "4.0.0",
         "snyk-cpp-plugin": "2.14.1",
-        "snyk-docker-plugin": "^4.29.0",
+        "snyk-docker-plugin": "^4.30.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
@@ -62296,9 +62296,9 @@
           }
         },
         "snyk-docker-plugin": {
-          "version": "4.29.0",
-          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.29.0.tgz",
-          "integrity": "sha512-q9gIPJdv8agv6S+hKEg6Mg+e6rbx3rEJ20rdaJy4Eo8JNMp6+wyDPDrQscVFDDovXV9xzEG8XfMvQcsZJsK+Ww==",
+          "version": "4.30.0",
+          "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.30.0.tgz",
+          "integrity": "sha512-xJkxat32OBIbomXAHT16zbogee++BU+X29YHP7C039ELtD1+PobDKe1Gy/fSCI8xf/2re+LLg2pfeMLe+WMkNg==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/rpm-parser": "^2.0.0",
@@ -65655,9 +65655,9 @@
       }
     },
     "snyk-docker-plugin": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.29.0.tgz",
-      "integrity": "sha512-q9gIPJdv8agv6S+hKEg6Mg+e6rbx3rEJ20rdaJy4Eo8JNMp6+wyDPDrQscVFDDovXV9xzEG8XfMvQcsZJsK+Ww==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/snyk-docker-plugin/-/snyk-docker-plugin-4.30.0.tgz",
+      "integrity": "sha512-xJkxat32OBIbomXAHT16zbogee++BU+X29YHP7C039ELtD1+PobDKe1Gy/fSCI8xf/2re+LLg2pfeMLe+WMkNg==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/rpm-parser": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
     "snyk-cpp-plugin": "2.14.1",
-    "snyk-docker-plugin": "^4.29.0",
+    "snyk-docker-plugin": "^4.30.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Bumps snyk-docker-plugin to 4.30.0
This version of the plugin looks for dependencies of a JAR by parsing the pom.properties after unpacking it and adding to the jarFingerprints fact when using the --app-vulns and --nested-jars-depth=n flags tested?