### PR TITLE
fix: custom rules output for sarif

### DIFF
--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -192,20 +192,43 @@ export function extractReportingDescriptor(
     if (tool[issue.id]) {
       return;
     }
+    // custom rules may not have some of these fields so we check them first
+    const fullDescriptionText = issue.subType
+      ? `${upperFirst(issue.severity)} severity - ${issue.subType}`
+      : `${upperFirst(issue.severity)} severity`;
+    const issueText = issue.iacDescription.issue
+      ? `The issue is... \n${issue.iacDescription.issue}\n\n`
+      : '';
+    const issueMarkdown = issue.iacDescription.issue
+      ? `**The issue is...** \n${issue.iacDescription.issue}\n\n`
+      : '';
+    const impactText = issue.iacDescription.impact
+      ? ` The impact of this is... \n ${issue.iacDescription.impact}\n\n`
+      : '';
+    const impactMarkdown = issue.iacDescription.impact
+      ? ` **The impact of this is...** \n ${issue.iacDescription.impact}\n\n`
+      : '';
+    const resolveText = issue.iacDescription.resolve
+      ? ` You can resolve this by... \n${issue.iacDescription.resolve}`
+      : '';
+    const resolveMarkdown = issue.iacDescription.resolve
+      ? ` **You can resolve this by...** \n${issue.iacDescription.resolve}`
+      : '';
+    const tags = ['security'];
+    if (issue.subType) {
+      tags.push(issue.subType);
+    }
     tool[issue.id] = {
       id: issue.id,
       shortDescription: {
         text: `${upperFirst(issue.severity)} severity - ${issue.title}`,
       },
       fullDescription: {
-        text: `${upperFirst(issue.severity)} severity - ${issue.subType}`,
+        text: fullDescriptionText,
       },
       help: {
-        text: `The issue is... \n${issue.iacDescription.issue}\n\n The impact of this is... \n ${issue.iacDescription.impact}\n\n You can resolve this by... \n${issue.iacDescription.resolve}`.replace(
-          /^\s+/g,
-          '',
-        ),
-        markdown: `**The issue is...** \n${issue.iacDescription.issue}\n\n **The impact of this is...** \n ${issue.iacDescription.impact}\n\n **You can resolve this by...** \n${issue.iacDescription.resolve}`.replace(
+        text: `${issueText}${impactText}${resolveText}`.replace(/^\s+/g, ''),
+        markdown: `${issueMarkdown}${impactMarkdown}${resolveMarkdown}`.replace(
           /^\s+/g,
           '',
         ),
@@ -214,7 +237,7 @@ export function extractReportingDescriptor(
         level: getIssueLevel(issue.severity),
       },
       properties: {
-        tags: ['security', `${issue.subType}`],
+        tags,
         documentation: issue.documentation,
       },
     };
@@ -228,10 +251,14 @@ export function mapIacTestResponseToSarifResults(
 ): sarif.Result[] {
   return issues.map(({ targetPath, issue }) => {
     const hasLineNumber = issue.lineNumber && issue.lineNumber >= 0;
+    // custom rules may not have some of these fields so we check them first
+    const affectingText = issue.subType
+      ? ` affecting the ${issue.subType}`
+      : '';
     return {
       ruleId: issue.id,
       message: {
-        text: `This line contains a potential ${issue.severity} severity misconfiguration affecting the ${issue.subType}`,
+        text: `This line contains a potential ${issue.severity} severity misconfiguration${affectingText}`,
       },
       locations: [
         {


### PR DESCRIPTION
#### What does this PR do?
This PR makes sure that when custom rules are used for SARIF output we don't include `undefined` for undefined fields.

#### How should this be manually tested?
1. Download [bundle.tar.gz](https://github.com/snyk/snyk/files/7788826/bundle.tar.gz)
2. Clone https://github.com/snyk/custom-rules-example.
3. Run `npm run build` in `snyk/snyk`
4. Run ` snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures/denied.tf --rules=bundle.tar.gz` in `snyk/custom-rules-example` to see custom rule `CUSTOM-RULE-3` being flagged up, as an example
5. Run `snyk-dev iac test ./rules/CUSTOM-RULE-1/fixtures/denied.tf --rules=bundle.tar.gz --sarif`  in `snyk/custom-rules-example`  to see that there are no more mentions of `undefined` for `CUSTOM-RULE-3`

#### Any background context you want to provide?
This is a byproduct of Snyk IaC investigating our existing SARIF output in https://snyksec.atlassian.net/browse/CFG-1278 and reading the documentation at https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#supported-sarif-output-file-properties to find out if anything is missing.

#### Screenshots
![Screenshot 2021-12-21 at 14 39 02](https://user-images.githubusercontent.com/81559517/146947827-335de843-68b4-4c3c-8150-ef1729458a83.png)
![Screenshot 2021-12-21 at 14 52 18](https://user-images.githubusercontent.com/81559517/146950986-e488efb6-70fd-435f-b607-94290bbd5c76.png)

![Screenshot 2021-12-21 at 14 58 46](https://user-images.githubusercontent.com/81559517/146950966-10f4ad7d-ae81-46d0-b38d-0510883c9dd2.png)

