### PR TITLE
chore(ci): reduce resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    resource_class: large
     steps:
       - checkout
       - install_project_dependencies:
@@ -278,7 +277,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    resource_class: large
     environment:
       TEMP: /mnt/ramdisk/tmp
     steps:
@@ -345,7 +343,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    resource_class: large
     steps:
       - checkout
       - install_release_dependencies
@@ -378,7 +375,6 @@ jobs:
     <<: *defaults
     docker:
       - image: circleci/node:<< parameters.node_version >>
-    resource_class: large
     steps:
       - checkout
       - run:

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "test:jest-unit": "jest --runInBand \"/test/jest/unit/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:jest-system": "jest --runInBand \"/test/jest/system/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:jest-acceptance": "jest --runInBand \"/test/jest/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
-    "test:packages-unit": "jest \"/packages/(.+)/test/unit/((.+)/)*[^/]+\\.spec\\.ts\"",
-    "test:packages-acceptance": "jest \"/packages/(.+)/test/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
+    "test:packages-unit": "jest --runInBand \"/packages/(.+)/test/unit/((.+)/)*[^/]+\\.spec\\.ts\"",
+    "test:packages-acceptance": "jest --runInBand \"/packages/(.+)/test/acceptance/((.+)/)*[^/]+\\.spec\\.ts\"",
     "test:test": "tap test/*.test.* -Rspec --timeout=300 --node-arg=-r --node-arg=ts-node/register",
     "test:smoke": "./scripts/run-smoke-tests-locally.sh"
   },


### PR DESCRIPTION
These jobs utilise less than 50% of a large's resource. It's a waste. Go back to default (medium). For numbers see the "Resources" tab for any job in CircleCI.

I had to add `runInBand` for some of our Jest "package" tests to avoid timeouts.

https://app.circleci.com/pipelines/github/snyk/snyk/8808/workflows/00296f85-f15c-4135-b74b-46a2ce284b0a/jobs/67106

So this could be why we setup "large" resources. "medium" can't handle parallel tests. However, I think adding "runInBand" is fine for now. We do it for other tests too so it's consistent. For parallelism, CircleCI has its own feature which would be a better fit here (see #2232)

## To Do

- [x] Take note of and compare new resource usage and timings once the pipeline passes.
  - Pretty much the same numbers.