### PR TITLE
feat: build binaries with Node 16

### DIFF
--- a/release-scripts/make-binaries.sh
+++ b/release-scripts/make-binaries.sh
@@ -3,10 +3,10 @@ set -euo pipefail
 
 mkdir binary-releases
 
-npx pkg . --compress Brotli -t node14-alpine-x64 -o binary-releases/snyk-alpine
-npx pkg . --compress Brotli -t node14-linux-x64  -o binary-releases/snyk-linux
-npx pkg . --compress Brotli -t node14-macos-x64  -o binary-releases/snyk-macos
-npx pkg . --compress Brotli -t node14-win-x64    -o binary-releases/snyk-win-unsigned.exe
+npx pkg . --compress Brotli -t node16-alpine-x64 -o binary-releases/snyk-alpine
+npx pkg . --compress Brotli -t node16-linux-x64  -o binary-releases/snyk-linux
+npx pkg . --compress Brotli -t node16-macos-x64  -o binary-releases/snyk-macos
+npx pkg . --compress Brotli -t node16-win-x64    -o binary-releases/snyk-win-unsigned.exe
 
 ./docker-desktop/build.sh darwin x64
 ./docker-desktop/build.sh darwin arm64


### PR DESCRIPTION
Node 16 is the latest LTS. We already have a Node 16 test pipeline and these binaries are covered by production/smoke tests.

Further improvements to the test pipeline will be introduced when we introduce arm64 in #2495.