### PR TITLE
spike: rejig test pipeline

### DIFF
--- a/.circleci/chocolatey.config
+++ b/.circleci/chocolatey.config
@@ -3,4 +3,5 @@
     <package id="maven" version="3.8.2" />
     <package id="gradle" version="6.8.3" />
     <package id="sbt" version="1.5.5" />
+    <package id="awscli" version="2.4.7" />
 </packages>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,25 +20,26 @@ orbs:
 #     https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
 #
 executors:
-  linux-x64-node14:
+  linux-x64-node14: &linux-x64-node14
     docker:
       - image: cimg/node:14.17.5
-  linux-x64-node12:
+  linux-x64-node12: &linux-x64-node12
     docker:
       - image: cimg/node:12.22.5
-  linux-x64:
+  linux-x64: &linux-x64
     machine:
       image: ubuntu-2004:202111-02
-  linux-arm64:
+  linux-arm64: &linux-arm64
     machine:
       image: ubuntu-2004:202101-01
     resource_class: arm.medium
-  darwin-x64:
+  darwin-x64: &darwin-x64
     macos:
       xcode: '13.2.1'
-  win32-x64:
+  win32-x64: &win32-x64
     machine:
       image: 'windows-server-2019-vs2019:stable'
+    resource_class: windows.medium
 
 #
 # Command Definitions
@@ -83,7 +84,11 @@ commands:
     steps:
       - when:
           condition:
-            matches: { pattern: '^linux.*$', value: << parameters.executor >> }
+            or:
+              - equal: [*linux-x64-node14, << parameters.executor >>]
+              - equal: [*linux-x64-node12, << parameters.executor >>]
+              - equal: [*linux-x64, << parameters.executor >>]
+              - equal: [*linux-arm64, << parameters.executor >>]
           steps:
             - restore_cache:
                 name: Restoring SDKMAN install cache
@@ -121,7 +126,8 @@ commands:
                   - ~/.sdkman/archives
       - when:
           condition:
-            matches: { pattern: '^win32.*$', value: << parameters.executor >> }
+            or:
+              - equal: [*win32-x64, << parameters.executor >>]
           steps:
             - restore_cache:
                 name: Restoring Chocolatey cache
@@ -244,7 +250,6 @@ jobs:
         type: executor
     executor: << parameters.executor >>
     steps:
-      - checkout
       - install_sdks:
           executor: << parameters.executor >>
       # TODO: conditionally install npm package or binary

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,6 +219,92 @@ jobs:
             unset SNYK_API
             unset SNYK_API_KEY
             shellspec -f d -e REGRESSION_TEST=1
+  unit-test:
+    <<: *defaults
+    docker:
+      - image: cimg/node:<< parameters.node_version >>
+    environment:
+      TEMP: /mnt/ramdisk/tmp
+    steps:
+      - run:
+          name: Creating temporary directory
+          command: mkdir /mnt/ramdisk/tmp
+      - checkout
+      - install_sdks_linux
+      - install_project_dependencies:
+          node_version: << parameters.node_version >>
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configuring Snyk CLI
+          command: node ./bin/snyk config set "api=${SNYK_API_KEY}"
+      - run:
+          name: Running unit tests (Packages)
+          command: npm run test:packages-unit -- --ci
+      - run:
+          name: Running unit tests (Jest)
+          command: npm run test:jest-unit -- --ci
+      - run:
+          name: Running system tests (Jest)
+          command: npm run test:jest-system -- --ci
+      - run:
+          name: Running root tests (Jest)
+          command: npm run test:jest -- --ci
+  acceptance-test:
+    <<: *defaults
+    docker:
+      - image: cimg/node:<< parameters.node_version >>
+    environment:
+      TEMP: /mnt/ramdisk/tmp
+    steps:
+      - run:
+          name: Creating temporary directory
+          command: mkdir /mnt/ramdisk/tmp
+      - checkout
+      - install_sdks_linux
+      - aws-cli/install:
+          version: 2.2.32
+      - install_project_dependencies:
+          node_version: << parameters.node_version >>
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configuring Snyk CLI
+          command: node ./bin/snyk config set "api=${SNYK_API_KEY}"
+      - run:
+          name: Running acceptance tests (Packages)
+          command: npm run test:packages-acceptance -- --ci
+      - run:
+          name: Running acceptance tests (Jest)
+          command: npm run test:jest-acceptance -- --ci
+  tap-test:
+    <<: *defaults
+    docker:
+      - image: cimg/node:<< parameters.node_version >>
+    environment:
+      TEMP: /mnt/ramdisk/tmp
+    steps:
+      - run:
+          name: Creating temporary directory
+          command: mkdir /mnt/ramdisk/tmp
+      - checkout
+      - install_sdks_linux
+      - install_project_dependencies:
+          node_version: << parameters.node_version >>
+      - attach_workspace:
+          at: .
+      - run:
+          name: Configuring Snyk CLI
+          command: node ./bin/snyk config set "api=${SNYK_API_KEY}"
+      - run:
+          name: Running root tests (Tap)
+          command: npm run test:test
+      - run:
+          name: Running system tests (Tap)
+          command: npm run test:system
+      - run:
+          name: Running acceptance tests (Tap)
+          command: npm run test:acceptance
   test-windows:
     <<: *defaults
     executor: win/default
@@ -277,72 +363,6 @@ jobs:
                   [Environment]::SetEnvironmentVariable("Path", $env:PATH + `
                   ";c:\Program Files\Amazon\AWSCLIV2", "Machine")
                 shell: powershell.exe
-            - run:
-                name: Running acceptance tests (Jest)
-                command: npm run test:jest-acceptance -- --ci
-      - when:
-          condition: << parameters.acceptance_tests >>
-          steps:
-            - run:
-                name: Running acceptance tests (Tap)
-                command: npm run test:acceptance
-      - when:
-          condition: << parameters.system_tests >>
-          steps:
-            - run:
-                name: Running system tests (Tap)
-                command: npm run test:system
-  test-linux:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
-    environment:
-      TEMP: /mnt/ramdisk/tmp
-    steps:
-      - run:
-          name: Creating temporary directory
-          command: mkdir /mnt/ramdisk/tmp
-      - checkout
-      - install_sdks_linux
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
-      - attach_workspace:
-          at: .
-      - run:
-          name: Configuring Snyk CLI
-          command: node ./bin/snyk config set "api=${SNYK_API_KEY}"
-      - when:
-          condition: << parameters.package_tests >>
-          steps:
-            - run:
-                name: Running unit tests (Packages)
-                command: npm run test:packages-unit -- --ci
-      - when:
-          condition: << parameters.package_tests >>
-          steps:
-            - run:
-                name: Running acceptance tests (Packages)
-                command: npm run test:packages-acceptance -- --ci
-      - when:
-          condition: << parameters.root_tap_tests >>
-          steps:
-            - run:
-                name: Running root tests (Tap)
-                command: npm run test:test
-      - when:
-          condition: << parameters.jest_tests >>
-          steps:
-            - run:
-                name: Running root tests (Jest)
-                command: npm run test:jest -- --ci
-            - run:
-                name: Running unit tests (Jest)
-                command: npm run test:jest-unit -- --ci
-            - run:
-                name: Running system tests (Jest)
-                command: npm run test:jest-system -- --ci
-            - aws-cli/install:
-                version: 2.2.32
             - run:
                 name: Running acceptance tests (Jest)
                 command: npm run test:jest-acceptance -- --ci
@@ -453,108 +473,68 @@ workflows:
       - build:
           name: Build
 
+      - unit-test:
+          name: Unit Test
+          context: nodejs-install
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - Build # needed for importing local packages like @snyk/fix
+
+      - acceptance-test:
+          name: Acceptance Test (Node v<< matrix.node_version >>)
+          context: nodejs-install
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - Unit Test
+          matrix:
+            parameters:
+              node_version: ['12.22.5', '14.17.5']
+
+      - tap-test:
+          name: Tap Test (Node v<< matrix.node_version >>)
+          context: nodejs-install
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - Build
+          matrix:
+            parameters:
+              node_version: ['12.22.5', '14.17.5']
+
       - regression-test:
           name: Regression Tests
           context: nodejs-install
-          requires:
-            - Build
           filters:
             branches:
               ignore:
                 - master
-
-      - test-windows:
-          name: Windows, Node v14.17.5 - Packages, Jest, System Tests
-          context: nodejs-install
           requires:
             - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          jest_tests: true
-          system_tests: true
-          package_tests: true
-      - test-windows:
-          name: Windows, Node v14.17.5 - Acceptance Tests
-          context: nodejs-install
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          acceptance_tests: true
-      - test-windows:
-          name: Windows, Node v14.17.5 - Root Tap Tests
-          context: nodejs-install
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          root_tap_tests: true
-
-      - test-linux:
-          name: Linux, Node v<< matrix.node_version >> - Packages, Jest, System Tests
-          context: nodejs-install
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          matrix:
-            parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5', '16.13.0']
-          jest_tests: true
-          system_tests: true
-          package_tests: true
-      - test-linux:
-          name: Linux, Node v<< matrix.node_version >> - Acceptance Tests
-          context: nodejs-install
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          matrix:
-            parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5', '16.13.0']
-          acceptance_tests: true
-      - test-linux:
-          name: Linux, Node v<< matrix.node_version >> - Root Tap Tests
-          context: nodejs-install
-          requires:
-            - Build
-          filters:
-            branches:
-              ignore:
-                - master
-          matrix:
-            parameters:
-              node_version: ['10.24.1', '12.22.5', '14.17.5', '16.13.0']
-          root_tap_tests: true
 
       - dev-release:
           name: Development Release
-          requires:
-            - Lint
-            - Build
           filters:
             branches:
               ignore:
                 - master
-
-      - prod-release:
-          name: Production Release
-          context: nodejs-app-release
-          filters:
-            branches:
-              only:
-                - master
           requires:
             - Lint
             - Build
+      # - prod-release:
+      #     name: Production Release
+      #     context: nodejs-app-release
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #     requires:
+      #       - Lint
+      #       - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,17 +73,6 @@ commands:
           key: npm-cache-v2-{{ arch }}-node<< parameters.node_version >>-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
           paths:
             - << parameters.npm_cache_directory >>
-  build_project:
-    steps:
-      - run:
-          name: Building project
-          command: npm run build:prod
-      - persist_to_workspace:
-          root: .
-          paths:
-            - dist/
-            - packages/*/dist
-            - pysrc
   install_sdks_windows:
     steps:
       - restore_cache:
@@ -170,7 +159,7 @@ commands:
             sudo apt update
             sudo apt install osslsigncode
 jobs:
-  build:
+  lint:
     <<: *defaults
     docker:
       - image: cimg/node:<< parameters.node_version >>
@@ -181,7 +170,23 @@ jobs:
       - run:
           name: Linting project
           command: npm run lint
-      - build_project
+  build:
+    <<: *defaults
+    docker:
+      - image: circleci/node:<< parameters.node_version >>
+    steps:
+      - checkout
+      - install_project_dependencies:
+          node_version: << parameters.node_version >>
+      - run:
+          name: Building project
+          command: npm run build:prod
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist/
+            - packages/*/dist
+            - pysrc
   regression-test:
     <<: *defaults
     docker:
@@ -443,9 +448,10 @@ workflows:
   version: 2
   test_and_release:
     jobs:
+      - lint:
+          name: Lint
       - build:
           name: Build
-          context: nodejs-install
 
       - regression-test:
           name: Regression Tests
@@ -535,6 +541,7 @@ workflows:
       - dev-release:
           name: Development Release
           requires:
+            - Lint
             - Build
           filters:
             branches:
@@ -549,4 +556,5 @@ workflows:
               only:
                 - master
           requires:
+            - Lint
             - Build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,64 +1,66 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.4.1
-  aws-cli: circleci/aws-cli@2.0.3
   gh: circleci/github-cli@1.0.4
 
-defaults: &defaults
-  parameters:
-    node_version:
-      type: string
-      default: '14.17.5'
-    root_tap_tests:
-      type: boolean
-      default: false
-    jest_tests:
-      type: boolean
-      default: false
-    acceptance_tests:
-      type: boolean
-      default: false
-    system_tests:
-      type: boolean
-      default: false
-    package_tests:
-      type: boolean
-      default: false
-  working_directory: /mnt/ramdisk/snyk
+#
+# Executor Definitions
+# https://circleci.com/docs/2.0/executor-types
+#
+#   NodeJS Variants:
+#     https://circleci.com/developer/images/image/cimg/node
+#
+#   Linux Variants:
+#     https://circleci.com/developer/machine/image/ubuntu-2004
+#
+#   Windows Variants:
+#     https://circleci.com/developer/orbs/orb/circleci/windows
+#
+#   macOS Variants:
+#     https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
+#
+executors:
+  linux-x64-node14:
+    docker:
+      - image: cimg/node:14.17.5
+  linux-x64-node12:
+    docker:
+      - image: cimg/node:12.22.5
+  linux-x64:
+    machine:
+      image: ubuntu-2004:202111-02
+  linux-arm64:
+    machine:
+      image: ubuntu-2004:202101-01
+    resource_class: arm.medium
+  darwin-x64:
+    macos:
+      xcode: '13.2.1'
+  win32-x64:
+    machine:
+      image: 'windows-server-2019-vs2019:stable'
 
+#
+# Command Definitions
+# https://circleci.com/docs/2.0/reusing-config/#authoring-reusable-commands
+#
 commands:
   install_project_dependencies:
     parameters:
-      node_version:
-        type: string
       npm_version:
         type: string
         default: '7.21.1'
       npm_cache_directory:
         type: string
-        default: /mnt/ramdisk/.npm
-      npm_global_sudo:
-        type: boolean
-        default: true
+        default: ~/.npm
     steps:
       - restore_cache:
           name: Restoring npm cache
           keys:
-            - npm-cache-v2-{{ arch }}-node<< parameters.node_version >>-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
-      - when:
-          condition:
-            not: << parameters.npm_global_sudo >>
-          steps:
-            run:
-              name: Installing npm
-              command: npm install -g npm@<< parameters.npm_version >>
-      - when:
-          condition: << parameters.npm_global_sudo >>
-          steps:
-            run:
-              name: Installing npm
-              command: sudo npm install -g npm@<< parameters.npm_version >>
+            - npm-cache-v2-{{ arch }}-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
+      - run:
+          name: Installing npm
+          command: sudo npm install -g npm@<< parameters.npm_version >>
       - run:
           name: Configuring npm
           command: |
@@ -70,79 +72,69 @@ commands:
           command: npm ci
       - save_cache:
           name: Saving npm cache
-          key: npm-cache-v2-{{ arch }}-node<< parameters.node_version >>-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
+          key: npm-cache-v2-{{ arch }}-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
           paths:
             - << parameters.npm_cache_directory >>
-  install_sdks_windows:
-    steps:
-      - restore_cache:
-          name: Restoring Chocolatey cache
-          keys:
-            - chocolatey-cache-v2-{{ arch }}-{{ checksum ".circleci/chocolatey.config" }}
-      - run:
-          name: Installing SDKs
-          command: choco install .circleci/chocolatey.config --no-progress
-      - save_cache:
-          name: Saving Chocolatey cache
-          key: chocolatey-cache-v2-{{ arch }}-{{ checksum ".circleci/chocolatey.config" }}
-          paths:
-            - ~\AppData\Local\Temp\chocolatey
-  install_sdks_linux:
-    steps:
-      - restore_cache:
-          name: Restoring SDKMAN install cache
-          keys:
-            - sdkman-install-cache-v3-{{ arch }}-{{ checksum ".circleci/vendor/sdkman-install.sh" }}
-      - run:
-          name: Installing Python
-          command: |
-            sudo apt update
-            sudo apt install python3 python3-pip python-is-python3
-      - run:
-          name: Installing SDKMAN
-          # The install script comes from https://get.sdkman.io/?rcupdate=false
-          # We need to disable rcupdate as CircleCI uses a different setup.
-          command: |
-            ./.circleci/vendor/sdkman-install.sh
-            echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
-            source $BASH_ENV
-      - save_cache:
-          name: Saving SDKMAN install cache
-          key: sdkman-install-cache-v3-{{ arch }}-{{ checksum ".circleci/vendor/sdkman-install.sh" }}
-          paths:
-            - ~/.sdkman
-      - restore_cache:
-          name: Restoring SDKMAN archive cache
-          keys:
-            - sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-linux.sh" }}
-      - run:
-          name: Installing SDKs
-          command: ./.circleci/install-sdks-linux.sh
-      - save_cache:
-          name: Saving SDKMAN archive cache
-          key: sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-linux.sh" }}
-          paths:
-            - ~/.sdkman/archives
-  install_node_windows:
+  install_sdks:
     parameters:
-      node_version:
-        type: string
+      executor:
+        type: executor
+        default: linux-x64-node14
     steps:
-      - run:
-          name: Removing pre-installed NodeJS
-          command: |
-            $current_node_version = node --version
-            nvm uninstall $current_node_version
-      - run:
-          name: Installing NodeJS
-          command: choco install nodejs --version=<< parameters.node_version >> --no-progress
-  install_shellspec_dependencies:
-    steps:
-      - run:
-          name: Installing ShellSpec
-          command: |
-            curl -fsSL https://git.io/shellspec | sh -s -- -y
-            sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec
+      - when:
+          condition:
+            matches: { pattern: '^linux.*$', value: << parameters.executor >> }
+          steps:
+            - restore_cache:
+                name: Restoring SDKMAN install cache
+                keys:
+                  - sdkman-install-cache-v3-{{ arch }}-{{ checksum ".circleci/vendor/sdkman-install.sh" }}
+            - run:
+                name: Installing Python, AWS CLI
+                command: |
+                  sudo apt update
+                  sudo apt install python3 python3-pip python-is-python3 awscli
+            - run:
+                name: Installing SDKMAN
+                # The install script comes from https://get.sdkman.io/?rcupdate=false
+                # We need to disable rcupdate as CircleCI uses a different setup.
+                command: |
+                  ./.circleci/vendor/sdkman-install.sh
+                  echo -e '\nsource "/home/circleci/.sdkman/bin/sdkman-init.sh"' >> $BASH_ENV
+                  source $BASH_ENV
+            - save_cache:
+                name: Saving SDKMAN install cache
+                key: sdkman-install-cache-v3-{{ arch }}-{{ checksum ".circleci/vendor/sdkman-install.sh" }}
+                paths:
+                  - ~/.sdkman
+            - restore_cache:
+                name: Restoring SDKMAN archive cache
+                keys:
+                  - sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-linux.sh" }}
+            - run:
+                name: Installing SDKs
+                command: ./.circleci/install-sdks-linux.sh
+            - save_cache:
+                name: Saving SDKMAN archive cache
+                key: sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-linux.sh" }}
+                paths:
+                  - ~/.sdkman/archives
+      - when:
+          condition:
+            matches: { pattern: '^win32.*$', value: << parameters.executor >> }
+          steps:
+            - restore_cache:
+                name: Restoring Chocolatey cache
+                keys:
+                  - chocolatey-cache-v2-{{ arch }}-{{ checksum ".circleci/chocolatey.config" }}
+            - run:
+                name: Installing SDKs
+                command: choco install .circleci/chocolatey.config --no-progress
+            - save_cache:
+                name: Saving Chocolatey cache
+                key: chocolatey-cache-v2-{{ arch }}-{{ checksum ".circleci/chocolatey.config" }}
+                paths:
+                  - ~\AppData\Local\Temp\chocolatey
   pack_snyk_cli:
     steps:
       - run:
@@ -158,26 +150,26 @@ commands:
           command: |
             sudo apt update
             sudo apt install osslsigncode
+
+#
+# Job Definitions
+# https://circleci.com/docs/2.0/configuration-reference/#jobs
+#
 jobs:
   lint:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
+    executor: linux-x64-node14
     steps:
       - checkout
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_project_dependencies
       - run:
           name: Linting project
           command: npm run lint
+
   build:
-    <<: *defaults
-    docker:
-      - image: circleci/node:<< parameters.node_version >>
+    executor: linux-x64-node14
     steps:
       - checkout
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_project_dependencies
       - run:
           name: Building project
           command: npm run build:prod
@@ -187,16 +179,13 @@ jobs:
             - dist/
             - packages/*/dist
             - pysrc
+
   regression-test:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
+    executor: linux-x64-node14
     steps:
       - checkout
-      - install_sdks_linux
-      - install_shellspec_dependencies
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_sdks
+      - install_project_dependencies
       - attach_workspace:
           at: .
       - run:
@@ -212,6 +201,11 @@ jobs:
           command: sudo npm install -g snyk-*.tgz
           path: ./dist-pack
       - run:
+          name: Installing ShellSpec
+          command: |
+            curl -fsSL https://git.io/shellspec | sh -s -- -y
+            sudo ln -s ${HOME}/.local/lib/shellspec/shellspec /usr/local/bin/shellspec
+      - run:
           name: Running ShellSpec tests
           working_directory: ./test/smoke
           command: |
@@ -219,20 +213,13 @@ jobs:
             unset SNYK_API
             unset SNYK_API_KEY
             shellspec -f d -e REGRESSION_TEST=1
+
   unit-test:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
-    environment:
-      TEMP: /mnt/ramdisk/tmp
+    executor: linux-x64-node14
     steps:
-      - run:
-          name: Creating temporary directory
-          command: mkdir /mnt/ramdisk/tmp
       - checkout
-      - install_sdks_linux
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_sdks
+      - install_project_dependencies
       - attach_workspace:
           at: .
       - run:
@@ -250,47 +237,35 @@ jobs:
       - run:
           name: Running root tests (Jest)
           command: npm run test:jest -- --ci
+
   acceptance-test:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
-    environment:
-      TEMP: /mnt/ramdisk/tmp
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
     steps:
-      - run:
-          name: Creating temporary directory
-          command: mkdir /mnt/ramdisk/tmp
       - checkout
-      - install_sdks_linux
-      - aws-cli/install:
-          version: 2.2.32
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
-      - attach_workspace:
-          at: .
-      - run:
-          name: Configuring Snyk CLI
-          command: node ./bin/snyk config set "api=${SNYK_API_KEY}"
-      - run:
-          name: Running acceptance tests (Packages)
-          command: npm run test:packages-acceptance -- --ci
-      - run:
-          name: Running acceptance tests (Jest)
-          command: npm run test:jest-acceptance -- --ci
+      - install_sdks:
+          executor: << parameters.executor >>
+      # TODO: conditionally install npm package or binary
+      # TODO: download relevant test binary and run tests
+      # - run:
+      #     name: Running acceptance tests (Packages)
+      #     command: npm run test:packages-acceptance -- --ci
+      # - run:
+      #     name: Running acceptance tests (Jest)
+      #     command: npm run test:jest-acceptance -- --ci
+
   tap-test:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
-    environment:
-      TEMP: /mnt/ramdisk/tmp
+    parameters:
+      executor:
+        type: executor
+    executor: << parameters.executor >>
     steps:
-      - run:
-          name: Creating temporary directory
-          command: mkdir /mnt/ramdisk/tmp
       - checkout
-      - install_sdks_linux
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_sdks:
+          executor: << parameters.executor >>
+      - install_project_dependencies
       - attach_workspace:
           at: .
       - run:
@@ -305,88 +280,13 @@ jobs:
       - run:
           name: Running acceptance tests (Tap)
           command: npm run test:acceptance
-  test-windows:
-    <<: *defaults
-    executor: win/default
-    working_directory: ~\snyk
-    steps:
-      - run:
-          name: Configuring Git
-          command: git config --global core.autocrlf false
-      - checkout
-      - install_node_windows:
-          node_version: << parameters.node_version >>
-      - install_sdks_windows
-      - install_project_dependencies:
-          npm_cache_directory: ~\AppData\Local\npm-cache
-          node_version: << parameters.node_version >>
-          npm_global_sudo: false
-      - attach_workspace:
-          at: .
-      - run:
-          name: Configuring Snyk CLI
-          command: node ./bin/snyk config set "api=$env:SNYK_API_KEY"
-      - when:
-          condition: << parameters.package_tests >>
-          steps:
-            - run:
-                name: Running unit tests (Packages)
-                command: npm run test:packages-unit -- --ci
-      - when:
-          condition: << parameters.package_tests >>
-          steps:
-            - run:
-                name: Running acceptance tests (Packages)
-                command: npm run test:packages-acceptance -- --ci
-      - when:
-          condition: << parameters.root_tap_tests >>
-          steps:
-            - run:
-                name: Running root tests (Tap)
-                command: npm run test:test
-      - when:
-          condition: << parameters.jest_tests >>
-          steps:
-            - run:
-                name: Running root tests (Jest)
-                command: npm run test:jest -- --ci
-            - run:
-                name: Running unit tests (Jest)
-                command: npm run test:jest-unit -- --ci
-            - run:
-                name: Running system tests (Jest)
-                command: npm run test:jest-system -- --ci
-            - run:
-                name: Download AWS CLI
-                command: |
-                  msiexec.exe /i AWSCLIV2.msi /quiet
-                  [Environment]::SetEnvironmentVariable("Path", $env:PATH + `
-                  ";c:\Program Files\Amazon\AWSCLIV2", "Machine")
-                shell: powershell.exe
-            - run:
-                name: Running acceptance tests (Jest)
-                command: npm run test:jest-acceptance -- --ci
-      - when:
-          condition: << parameters.acceptance_tests >>
-          steps:
-            - run:
-                name: Running acceptance tests (Tap)
-                command: npm run test:acceptance
-      - when:
-          condition: << parameters.system_tests >>
-          steps:
-            - run:
-                name: Running system tests (Tap)
-                command: npm run test:system
+
   dev-release:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
+    executor: linux-x64-node14
     steps:
       - checkout
       - install_release_dependencies
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
+      - install_project_dependencies
       - attach_workspace:
           at: .
       - run:
@@ -410,60 +310,11 @@ jobs:
       - pack_snyk_cli
       - store_artifacts:
           path: ./dist-pack
-  prod-release:
-    <<: *defaults
-    docker:
-      - image: cimg/node:<< parameters.node_version >>
-    steps:
-      - checkout
-      - run:
-          name: Should I release?
-          command: ./release-scripts/should-i-release.sh
-      - gh/setup:
-          token: GH_TOKEN
-          version: 1.9.2
-      - aws-cli/install:
-          version: 2.2.32
-      - install_release_dependencies
-      - install_project_dependencies:
-          node_version: << parameters.node_version >>
-      - attach_workspace:
-          at: .
-      - run:
-          name: Updating package versions
-          command: |
-            ./release-scripts/update-versions.sh
-            git update-index --skip-worktree -- ./lerna.json
-            git update-index --skip-worktree -- ./package.json
-            git update-index --skip-worktree -- ./packages/snyk-protect/package.json
-      - run:
-          name: Pruning Snyk CLI dependencies
-          command: npx ts-node ./release-scripts/prune-dependencies-in-packagejson.ts
-      - run:
-          name: Bumping versions and publishing packages
-          command: npx lerna publish minor --yes --no-push --no-git-tag-version --exact
-      - run:
-          name: Building binaries
-          command: |
-            ./release-scripts/make-binaries.sh
-            ls -la ./binary-releases
-      - store_artifacts:
-          path: ./binary-releases
-      - run:
-          name: Validating binaries
-          working_directory: ./binary-releases
-          command: ../release-scripts/validate-checksums.sh
-      - run:
-          name: Generating release notes
-          command: npx conventional-changelog-cli -p angular -l -r 1 > RELEASE_NOTES.txt
-      - run:
-          name: Publishing binaries
-          command: ./release-scripts/upload-artifacts.sh
-      - run:
-          name: Handling failed release
-          command: ./release-scripts/handle-failed-release.sh
-          when: on_fail
 
+#
+# Workflow Definitions
+# https://circleci.com/docs/2.0/configuration-reference/#workflows
+#
 workflows:
   version: 2
   test_and_release:
@@ -484,20 +335,7 @@ workflows:
             - Build # needed for importing local packages like @snyk/fix
 
       - acceptance-test:
-          name: Acceptance Test (Node v<< matrix.node_version >>)
-          context: nodejs-install
-          filters:
-            branches:
-              ignore:
-                - master
-          requires:
-            - Unit Test
-          matrix:
-            parameters:
-              node_version: ['12.22.5', '14.17.5']
-
-      - tap-test:
-          name: Tap Test (Node v<< matrix.node_version >>)
+          name: Acceptance Test (<< matrix.executor >>)
           context: nodejs-install
           filters:
             branches:
@@ -507,7 +345,20 @@ workflows:
             - Build
           matrix:
             parameters:
-              node_version: ['12.22.5', '14.17.5']
+              executor: [linux-x64-node14, linux-x64-node12, win32-x64]
+
+      - tap-test:
+          name: Tap Test (<< matrix.executor >>)
+          context: nodejs-install
+          filters:
+            branches:
+              ignore:
+                - master
+          requires:
+            - Build
+          matrix:
+            parameters:
+              executor: [linux-x64-node14, linux-x64-node12]
 
       - regression-test:
           name: Regression Tests
@@ -528,13 +379,3 @@ workflows:
           requires:
             - Lint
             - Build
-      # - prod-release:
-      #     name: Production Release
-      #     context: nodejs-app-release
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #     requires:
-      #       - Lint
-      #       - Build


### PR DESCRIPTION
WIP

Looking into changing our pipeline to better handle testing in different builds/archs.

The main goal is to provide a way to run our acceptance tests across Windows/x64, macOS/x64, and Linux/arm64 (#2495 ) with minimal configuration and complexity. Ideally this repo and dev tools should only be needing for the initial builds, other platforms should not need to support our build pipeline.

It would also be nice to re-organise tests so we can make usre of CircleCI's parallelism (#2232).

## To Do

- [x] Split lint/build jobs.
  - Do not block tests on linter errors.
  - https://github.com/snyk/snyk/pull/2528
- [x] Move Tap tests into their own job.
  - https://github.com/snyk/snyk/pull/2530
- [ ] For Windows, only run acceptance tests.
- [ ] For Windows, run tests against binary.
- [ ] Run all tests on master branch.
- [ ] Make Windows tests optional in PRs.
- [ ] Remove NodeJS variant tests.
  - Configure NodeJS variants like Windows.
    - Using npm tarball instead of binaries.
- [ ] Add macOS tests
- [ ] Add Linux/arm64 tests
  - #2495 