### PR TITLE
fix: exclude base image vulns filtering all vulns

### DIFF
--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -367,7 +367,7 @@ function convertTestDepGraphResultToLegacy(
 
   // generate the legacy vulns array (vuln-data + metada per vulnerable path).
   //   use the upgradePathsMap to find available upgrade-paths
-  let vulns: AnnotatedIssue[] = [];
+  const vulns: AnnotatedIssue[] = [];
 
   for (const pkgInfo of values(result.affectedPkgs)) {
     for (const vulnPkgPath of depGraph.pkgPathsToRoot(pkgInfo.pkg)) {
@@ -434,14 +434,6 @@ function convertTestDepGraphResultToLegacy(
     options.severityThreshold === SEVERITY.LOW
       ? undefined
       : options.severityThreshold;
-
-  if (
-    options.docker &&
-    dockerRes?.baseImage &&
-    options['exclude-base-image-vulns']
-  ) {
-    vulns = vulns.filter((vuln) => (vuln as DockerIssue).dockerfileInstruction);
-  }
 
   const legacyRes: LegacyVulnApiResult = {
     vulnerabilities: vulns,

--- a/src/lib/snyk-test/legacy.ts
+++ b/src/lib/snyk-test/legacy.ts
@@ -1,4 +1,4 @@
-const values = require('lodash.values');
+import * as values from 'lodash.values';
 import * as depGraphLib from '@snyk/dep-graph';
 import {
   DepsFilePaths,

--- a/src/lib/snyk-test/run-test.ts
+++ b/src/lib/snyk-test/run-test.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-const get = require('lodash.get');
+import * as get from 'lodash.get';
 import * as path from 'path';
 import * as pathUtil from 'path';
 import * as debugModule from 'debug';
@@ -451,6 +451,24 @@ async function parseRes(
       (vuln as DockerIssue).dockerBaseImage = res.docker!.baseImage;
       return vuln;
     });
+  }
+  if (
+    options.docker &&
+    res.docker?.baseImage &&
+    options['exclude-base-image-vulns']
+  ) {
+    const filteredVulns = res.vulnerabilities.filter(
+      (vuln) => (vuln as DockerIssue).dockerfileInstruction,
+    );
+    // `exclude-base-image-vulns` might have left us with no vulns, so `ok` is now `true`
+    if (
+      res.vulnerabilities.length !== 0 &&
+      filteredVulns.length === 0 &&
+      !res.ok
+    ) {
+      res.ok = true;
+    }
+    res.vulnerabilities = filteredVulns;
   }
 
   res.uniqueCount = countUniqueVulns(res.vulnerabilities);

--- a/test/fixtures/container-projects/Dockerfile-vulns
+++ b/test/fixtures/container-projects/Dockerfile-vulns
@@ -1,0 +1,6 @@
+FROM alpine:3.10.3
+RUN apk add --no-cache --virtual .build-deps openssl
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
+WORKDIR /app
+


### PR DESCRIPTION
- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
A previous [change](https://github.com/snyk/snyk/pull/2138) moved the filtering out of base image vulns (based on
the existence of `dockerfileInstruction`) to be before
`dockerfileInstruction` is assigned to the vulns, so all vulns were
filtered out in case we used the `exclude-base-image-vulns` option.

This fix moves the filtering back to where it was before, and
recalculates the value of `ok`, to account for the reason it was moved
in the first place.

#### What are the relevant tickets?
https://snyk.zendesk.com/agent/tickets/16714

