### PR TITLE
feat: IaC SARIF output improvements [CFG-1313] [CFG-1314]

### DIFF
--- a/test/jest/acceptance/iac/file-output.spec.ts
+++ b/test/jest/acceptance/iac/file-output.spec.ts
@@ -100,9 +100,11 @@ describe('iac test --sarif-file-output', () => {
         .artifactLocation.uri;
     const actualProjectRoot =
       jsonObj?.runs?.[0].originalUriBaseIds.PROJECTROOT.uri;
-    expect(actualPhysicalLocation).toEqual('./iac/file-output/sg_open_ssh.tf');
+    expect(actualPhysicalLocation).toEqual(
+      'test/fixtures/iac/file-output/sg_open_ssh.tf',
+    );
     expect(actualProjectRoot).toEqual(
-      pathToFileURL(path.join(path.resolve('./test/fixtures/'), '/')).href,
+      pathToFileURL(path.join(path.resolve(''), '/')).href,
     );
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
The snyk CLI generate SARIF output, which is then used for [code scanning by GitHub]( https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning).
We would like to improve our SARIF output which will enhance the UX when using GH code scanning.

#### How should this be manually tested?
1. Test an IaC file/directory and save the output using `snyk-dev iac test {path to the file/directory} --sarif > sarif.snyk`
2. Create a test repo and upload the `sarif.snyk` file to it
3. Configure the Snyk IaC scanning tool in your repo
4. Commit any changes and check the scanning results in the Securit tab.

#### Any background context you want to provide?
The [following Notion page](https://www.notion.so/snyk/SARIF-output-for-GitHub-Security-Alerts-65a89cfa82a74ee79e5d41dfbe452cef) provides additional context.

#### What are the relevant tickets?
- [CFG-1313](https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1313)
- [CFG-1314](https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1314)

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/71096571/148236967-9757b435-d82c-4fee-90cd-751a489951a4.png)
After
![image](https://user-images.githubusercontent.com/71096571/148237021-23711aac-74f7-4a22-a5b1-05d8ff75d5ec.png)


#### Additional questions
