### PR TITLE
fix: allow escape characters in json parsing [CFG-1322]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "dependencies": {
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.12.0",
+        "@snyk/cloud-config-parser": "^1.13.1",
         "@snyk/code-client": "^4.5.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
@@ -4890,9 +4890,9 @@
       }
     },
     "node_modules/@snyk/cloud-config-parser": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.12.0.tgz",
-      "integrity": "sha512-8HZ4zp/vQCJR8as5Ndv5AsOgGKqj9h3rcWmy6Bk+IQd3IOTXQWh0w4U6+89j/IPpyjYEJNTnV/MDtUS/+fU/uw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.13.1.tgz",
+      "integrity": "sha512-PWtcANOvL51qpVkHIG+6332Cb//xf8eQKOcje8vFfl0tAEkDuNXmoPrIeZfVs/+1GxIqtLSDSGCVd5GLfxumgw==",
       "dependencies": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",
@@ -30598,9 +30598,9 @@
       }
     },
     "@snyk/cloud-config-parser": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.12.0.tgz",
-      "integrity": "sha512-8HZ4zp/vQCJR8as5Ndv5AsOgGKqj9h3rcWmy6Bk+IQd3IOTXQWh0w4U6+89j/IPpyjYEJNTnV/MDtUS/+fU/uw==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.13.1.tgz",
+      "integrity": "sha512-PWtcANOvL51qpVkHIG+6332Cb//xf8eQKOcje8vFfl0tAEkDuNXmoPrIeZfVs/+1GxIqtLSDSGCVd5GLfxumgw==",
       "requires": {
         "esprima": "^4.0.1",
         "peggy": "^1.2.0",
@@ -44406,10 +44406,10 @@
     "snyk": {
       "version": "file:",
       "requires": {
-        "@open-policy-agent/opa-wasm": "1.6.0",
+        "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-alert": "file:packages/cli-alert",
         "@snyk/cli-interface": "2.11.0",
-        "@snyk/cloud-config-parser": "^1.12.0",
+        "@snyk/cloud-config-parser": "^1.13.1",
         "@snyk/code-client": "^4.5.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
@@ -48413,9 +48413,9 @@
           }
         },
         "@snyk/cloud-config-parser": {
-          "version": "1.12.0",
-          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.12.0.tgz",
-          "integrity": "sha512-8HZ4zp/vQCJR8as5Ndv5AsOgGKqj9h3rcWmy6Bk+IQd3IOTXQWh0w4U6+89j/IPpyjYEJNTnV/MDtUS/+fU/uw==",
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@snyk/cloud-config-parser/-/cloud-config-parser-1.13.1.tgz",
+          "integrity": "sha512-PWtcANOvL51qpVkHIG+6332Cb//xf8eQKOcje8vFfl0tAEkDuNXmoPrIeZfVs/+1GxIqtLSDSGCVd5GLfxumgw==",
           "requires": {
             "esprima": "^4.0.1",
             "peggy": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
-    "@snyk/cloud-config-parser": "^1.12.0",
+    "@snyk/cloud-config-parser": "^1.13.1",
     "@snyk/code-client": "^4.5.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",

--- a/src/cli/commands/test/iac-local-execution/yaml-parser.ts
+++ b/src/cli/commands/test/iac-local-execution/yaml-parser.ts
@@ -1,11 +1,15 @@
 import { CustomError } from '../../../../lib/errors';
 import { getErrorStringCode } from './error-utils';
 import { IaCErrorCodes, IacFileData } from './types';
-import { parseFileContent } from '@snyk/cloud-config-parser';
+import { ParserFileType, parseFileContent } from '@snyk/cloud-config-parser';
 
 export function parseYAMLOrJSONFileData(fileData: IacFileData): any[] {
   try {
-    return parseFileContent(fileData.fileContent);
+    // this function will always be called with the file types recognised by the parser
+    return parseFileContent(
+      fileData.fileContent,
+      fileData.fileType as ParserFileType,
+    );
   } catch (e) {
     if (fileData.fileType === 'json') {
       throw new InvalidJsonFileError(fileData.filePath);

--- a/src/lib/iac/constants.ts
+++ b/src/lib/iac/constants.ts
@@ -1,3 +1,5 @@
+import { ParserFileType } from '@snyk/cloud-config-parser';
+
 export type IacProjectTypes =
   | 'k8sconfig'
   | 'terraformconfig'
@@ -5,7 +7,7 @@ export type IacProjectTypes =
   | 'armconfig'
   | 'customconfig'
   | 'multiiacconfig';
-export type IacFileTypes = 'yaml' | 'yml' | 'json' | 'tf';
+export type IacFileTypes = ParserFileType | 'tf';
 
 export enum IacProjectType {
   K8S = 'k8sconfig',


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the bug in https://snyksec.atlassian.net/browse/CFG-1322 by making sure if the parsed file is JSON we don't fail upon finding `\\/`. 

#### How should this be manually tested?
In https://github.com/snyk/cloud-config-parser/pull/39:
1. `npm run build`
2. `npm link`

In this branch:
1. `npm run build`
2. Create a file `test.json` containing:
```
{
      "DescribePackagesFilterValue":{
        "type":"string",
        "pattern":"^[0-9a-zA-Z\\*\\.\\\\/\\?-]*$"
      }
}
```
3. Run `snyk iac test test.json` - see an error
4. Run `snyk-dev iac test test.json` - see no errors


#### Any background context you want to provide?
A while ago we combined the parsing for JSON and YAML to both use the YAML parser, since they are more or less the same. We know from https://snyksec.atlassian.net/browse/CFG-364, however, that `\\/` is not valid YAML - and we added this check that throws an error when a YAML/JSON file contains `\\/`. Now, we're improving this logic so that if the content is JSON, we don't throw an error.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1322

#### Screenshots
`snyk iac test test.json`
![Screenshot 2022-01-06 at 13 38 21](https://user-images.githubusercontent.com/81559517/148391349-e6123bb9-ae54-4b47-8e74-3351babd5a8e.png)

![Screenshot 2022-01-06 at 12 09 22](https://user-images.githubusercontent.com/81559517/148391129-18eb730e-6410-48b3-af86-0774251bb7e5.png)

`snyk-dev iac test test.json`
![Screenshot 2022-01-06 at 13 38 24](https://user-images.githubusercontent.com/81559517/148391354-6c1cfd17-1348-4651-b6da-0c609f009f6c.png)

![Screenshot 2022-01-06 at 12 11 57](https://user-images.githubusercontent.com/81559517/148391151-0556f24b-d62d-4406-a0b7-6f4aab7b2014.png)
