### PR TITLE
chore(ci): run lint and build in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,17 +73,6 @@ commands:
           key: npm-cache-v2-{{ arch }}-node<< parameters.node_version >>-npm<< parameters.npm_version >>-{{ checksum "package-lock.json" }}
           paths:
             - << parameters.npm_cache_directory >>
-  build_project:
-    steps:
-      - run:
-          name: Building project
-          command: npm run build:prod
-      - persist_to_workspace:
-          root: .
-          paths:
-            - dist/
-            - packages/*/dist
-            - pysrc
   install_sdks_windows:
     steps:
       - restore_cache:
@@ -170,7 +159,7 @@ commands:
             sudo apt update
             sudo apt install osslsigncode
 jobs:
-  build:
+  lint:
     <<: *defaults
     docker:
       - image: cimg/node:<< parameters.node_version >>
@@ -181,7 +170,23 @@ jobs:
       - run:
           name: Linting project
           command: npm run lint
-      - build_project
+  build:
+    <<: *defaults
+    docker:
+      - image: circleci/node:<< parameters.node_version >>
+    steps:
+      - checkout
+      - install_project_dependencies:
+          node_version: << parameters.node_version >>
+      - run:
+          name: Building project
+          command: npm run build:prod
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist/
+            - packages/*/dist
+            - pysrc
   regression-test:
     <<: *defaults
     docker:
@@ -443,9 +448,10 @@ workflows:
   version: 2
   test_and_release:
     jobs:
+      - lint:
+          name: Lint
       - build:
           name: Build
-          context: nodejs-install
 
       - regression-test:
           name: Regression Tests
@@ -535,6 +541,7 @@ workflows:
       - dev-release:
           name: Development Release
           requires:
+            - Lint
             - Build
           filters:
             branches:
@@ -549,4 +556,5 @@ workflows:
               only:
                 - master
           requires:
+            - Lint
             - Build

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check-dev-environment": "ts-node ./scripts/check-dev-environment.ts",
     "format": "prettier --write '**/*.{js,ts,json,yaml,yml,md}'",
     "format:changes": "./scripts/format/prettier-changes.sh",
-    "lint": "run-p --aggregate-output lint:*",
+    "lint": "npm-run-all --serial --continue-on-error lint:*",
     "lint:js": "eslint --color --cache '**/*.{js,ts}'",
     "lint:formatting": "prettier --check '**/*.{js,ts,json,yaml,yml,md}'",
     "build": "npm run build:dev",


### PR DESCRIPTION
By moving the linter to its own job, we don't need to block test runs on minor linter errors. This lets contributors first get their work done without needing to polish and fix linter errors constantly throughout.

Running the linter in parallel also saves 30s to 3 minutes (linter time varies).

I've kept the linter requirement for dev-release as it should mirror prod-release as much as possible. And of course the linter (and every other job) should pass before we run a prod-release.

Example: https://app.circleci.com/pipelines/github/snyk/snyk/8914/workflows/ed13ac3a-92ec-4aa6-91e7-c2e593354770