### PR TITLE
feat: use same folder and script name as before for docker-desktop tars

### DIFF
--- a/docker-desktop/README.md
+++ b/docker-desktop/README.md
@@ -32,5 +32,5 @@ To test it, you can do the following:
 ```sh
 cd ./binary-releases
 tar xzf snyk-for-docker-desktop-darwin-x64.tar.gz
-./snyk-for-docker-desktop-darwin-x64/entrypoint.sh woof
+./docker/snyk-mac.sh woof
 ```

--- a/docker-desktop/build.sh
+++ b/docker-desktop/build.sh
@@ -8,8 +8,8 @@ node_url="https://nodejs.org/dist/${node_version}/node-${node_version}-${platfor
 build_name="snyk-for-docker-desktop-${platform}-${arch}"
 build_filename="${build_name}.tar.gz"
 build_sha_filename="${build_filename}.sha256"
-build_root="./docker-desktop/dist"
-build_dir="${build_root}/${build_name}"
+build_root="./docker-desktop/dist/${build_name}"
+build_dir="${build_root}/docker"
 output_dir="./binary-releases"
 
 if [[ -d "${build_dir}" ]]; then
@@ -22,7 +22,7 @@ mkdir -p "${build_dir}"
 mkdir -p "${output_dir}"
 
 # Include entrypoint.
-cp ./docker-desktop/src/entrypoint.sh "${build_dir}"
+cp ./docker-desktop/src/entrypoint.sh "${build_dir}/snyk-mac.sh"
 
 # Include Snyk CLI build.
 cp              ./package.json        "${build_dir}"
@@ -47,7 +47,7 @@ popd
 # We build from build_root so that build_name is the top-level directory in the
 # tarball. We want a top-level directory to avoid tarbombs.
 pushd "${build_root}"
-tar czfh "${build_filename}" "${build_name}"
+tar czfh "${build_filename}" docker
 shasum -a 256 "${build_filename}" > "${build_sha_filename}"
 popd
 


### PR DESCRIPTION
Signed-off-by: Stefan Scherer <stefan.scherer@docker.com>

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR changes the contents of the docker-desktop tars a bit to keep them compatible with the previous `docker-mac-signed-bundle.tar.gz` to make updates easier.

#### Where should the reviewer start?


#### How should this be manually tested?

Build snyk, then build the tarball with eg. `./docker-desktop/build.sh darwin arm64`

#### Any background context you want to provide?

The old tarball `docker-mac-signed-bundle.tar.gz` has this content:

```
docker/
docker/package.json
docker/...
docker/snyk-mac.sh
```

The new tarballs have a platform specific subfolder, here an example for Mac arm64:

```
snyk-for-docker-desktop-darwin-arm64/
snyk-for-docker-desktop-darwin-arm64/package.json
snyk-for-docker-desktop-darwin-arm64/...
snyk-for-docker-desktop-darwin-arm64/entrypoint.sh
```

When we looked at the new platform specific Mac tarballs they look different and this makes the update scenario for our users more problematic. We would have to change the `~/.docker/scan/config.json` file and adjust the path to the snyk shell script.

We thought about renaming the contents a bit to keep it compatible, but then we came to the conclusion it would make more sense to produce the new tarballs already with this structure, so we don't hide our change.

With this PR the two tarballs are still created at the same place, so your CI should pick them up correctly. Only the contents of the two tarballs now look again like the old tarball:

```
docker/
docker/package.json
docker/...
docker/snyk-mac.sh
```

#### What are the relevant tickets?

Follow-up of #2444

#### Screenshots


#### Additional questions
