### PR TITLE
[ASK-HAMMER] add drift command for iac [CFG-1299] 

### DIFF
--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -1,0 +1,12 @@
+import { MethodArgs } from '../args';
+import { processCommandArgs } from './process-command-args';
+
+export default async function drift(...args: MethodArgs): Promise<any> {
+  const { options, paths } = processCommandArgs(...args);
+  console.log(options);
+  console.log(paths);
+  if (options.iac != true) {
+    throw new Error('BAD MODE');
+  }
+  console.log('snyk iac drift');
+}

--- a/src/cli/commands/index.js
+++ b/src/cli/commands/index.js
@@ -9,6 +9,7 @@ async function callModule(mod, args) {
 const commands = {
   auth: async (...args) => callModule(import('./auth'), args),
   config: async (...args) => callModule(import('./config'), args),
+  drift: async (...args) => callModule(import('./drift'), args),
   help: async (...args) => callModule(import('./help'), args),
   ignore: async (...args) => callModule(import('./ignore'), args),
   monitor: async (...args) => callModule(import('./monitor'), args),

--- a/src/cli/modes.ts
+++ b/src/cli/modes.ts
@@ -23,7 +23,7 @@ const modes: Record<string, ModeData> = {
     },
   },
   iac: {
-    allowedCommands: ['test'],
+    allowedCommands: ['test', 'drift'],
     config: (args): [] => {
       args['iac'] = true;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -250,6 +250,7 @@ export enum SupportedCliCommands {
   wizard = 'wizard',
   woof = 'woof',
   log4shell = 'log4shell',
+  drift = 'drift',
 }
 
 export interface IacFileInDirectory {


### PR DESCRIPTION
Hi, just creating this PR to show an exemple of what we want to do and ask questions.

For driftctl integration into snyk cli ([CFG-1299](https://snyksec.atlassian.net/browse/CFG-1299)) we want to have new `snyk iac drift` subcommand. That command will need to have it's own subcommand like `snyk iac drift scan` or `snyk iac drift test` for example. These subcommand will also need to have their own flags.

We looked into how we could be integrating that into how our cli and arg parsing in currently working and this show what we thought will be the best way to do.
So to add this subcommand with its own subcommands and flags we are planning to add a drift global command that will error when called without the `iac` mode. We would then have to do with the option given to drift command and do our own parsing.

It sounds odd to us to have a global drift command and we will need to look how we will do the help display. So please tell us if you think there is a better way to do this.
