### PR TITLE
feat: Change getVersion() from async to sync

### DIFF
--- a/src/cli/commands/version.ts
+++ b/src/cli/commands/version.ts
@@ -1,7 +1,7 @@
 import { getVersion, isStandaloneBuild } from '../../lib/version';
 
 export default async function version() {
-  let version = await getVersion();
+  let version = getVersion();
   if (isStandaloneBuild()) {
     version += ' (standalone)';
   }

--- a/src/lib/analytics/getStandardData.ts
+++ b/src/lib/analytics/getStandardData.ts
@@ -34,7 +34,7 @@ export async function getStandardData(
   args: ArgsOptions[],
 ): Promise<StandardAnalyticsData> {
   const isStandalone = version.isStandaloneBuild();
-  const snykVersion = await version.getVersion();
+  const snykVersion = version.getVersion();
   const seed = uuidv4();
   const shasum = crypto.createHash('sha1');
   const environment = isStandalone

--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -30,7 +30,7 @@ export async function makeRequest(
       process.env.HTTPS_PROXY || process.env.https_proxy;
   }
 
-  const versionNumber = await getVersion();
+  const versionNumber = getVersion();
   const body = payload.body;
   let data;
 

--- a/src/lib/version.ts
+++ b/src/lib/version.ts
@@ -1,35 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { executeCommand } from './exec';
 
-export async function getVersion(): Promise<string> {
+export function getVersion(): string {
   const root = path.resolve(__dirname, '../..');
 
   const { version } = JSON.parse(
     fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
   );
 
-  if (version && version !== '0.0.0') {
-    return version;
-  }
-
-  try {
-    const [branchName, commitStr, filesCount] = await Promise.all([
-      executeCommand('git rev-parse HEAD', root),
-      executeCommand('git rev-parse --abbrev-ref HEAD', root),
-      executeCommand('git diff --shortstat', root),
-    ]);
-
-    const dirtyCount = parseInt(filesCount as string, 10) || 0;
-    let curr = `${branchName}: ${commitStr}`;
-    if (dirtyCount !== 0) {
-      curr += ` (${dirtyCount} dirty files)`;
-    }
-
-    return curr;
-  } catch (_err) {
-    return 'unknown';
-  }
+  return version;
 }
 
 /**


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Currently the `getVersion` function is an async function that is being used like a sync one ( by using `await` everywhere).
This PR removes the need for `await` by changing the function to be a sync function.