### PR TITLE
fix: IaC SARIF output

### DIFF
--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -138,7 +138,7 @@ export function createSarifOutputForIac(
   const basePath = isLocalFolder(iacTestResponses[0].path)
     ? pathLib.resolve('.', iacTestResponses[0].path)
     : pathLib.resolve('.');
-  const repoRoot = getRepoRoot();
+  const repoRoot = getRepoRoot(basePath);
   const issues = iacTestResponses.reduce((collect: ResponseIssues, res) => {
     if (res.result) {
       // targetFile is the computed relative path of the scanned file
@@ -294,13 +294,17 @@ export function mapIacTestResponseToSarifResults(
   });
 }
 
-function getRepoRoot() {
-  const cwd = process.cwd();
-  const stdout = execSync('git rev-parse --show-toplevel', {
-    encoding: 'utf8',
-    cwd,
-  });
-  return stdout.trim() + '/';
+function getRepoRoot(basePath: string) {
+  try {
+    const cwd = process.cwd();
+    const stdout = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      cwd,
+    });
+    return stdout.trim() + '/';
+  } catch {
+    return basePath;
+  }
 }
 
 function getPathRelativeToRepoRoot(


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Currently when running the snyk cli by using a docker image we cannot get the repo root cause the container doesn't have git installed which caused the scan to fail.

#### How should this be manually tested?
1. Scan an IaC file / directory inside of a repo
2. Scan an IaC file / directory outside of a repo
Both of the scans should run without any problem.
