### PR TITLE
fix: block user from scanning IAC files if not entitled [CFG-1090]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -28,6 +28,7 @@ import {
   scanFiles,
   trackUsage,
 } from './measurable-methods';
+import { UnsupportedEntitlementError } from '../../../../lib/errors/unsupported-entitlement-error';
 import { UnsupportedEntitlementFlagError } from './assert-iac-options-flag';
 import { config as userConfig } from '../../../../lib/user-config';
 import config from '../../../../lib/config';
@@ -56,6 +57,10 @@ export async function test(
     const orgPublicId = options.org ?? config.org;
 
     const iacOrgSettings = await getIacOrgSettings(orgPublicId);
+
+    if (!iacOrgSettings.entitlements?.infrastructureAsCode) {
+      throw new UnsupportedEntitlementError('infrastructureAsCode');
+    }
 
     if (options.rules) {
       if (!iacOrgSettings.entitlements?.iacCustomRulesEntitlement) {

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -75,6 +75,7 @@ export interface IacCustomRules {
 }
 
 export interface IacEntitlements {
+  infrastructureAsCode?: boolean;
   iacCustomRulesEntitlement?: boolean;
 }
 

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -391,14 +391,26 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       customPolicies: {},
       customRules: {},
       entitlements: {
+        infrastructureAsCode: true,
         iacCustomRulesEntitlement: true,
       },
     };
 
-    if (req.query.org === 'no-entitlements') {
+    if (req.query.org === 'no-iac-entitlements') {
       return res.status(200).send({
         ...baseResponse,
         entitlements: {
+          ...baseResponse.entitlements,
+          infrastructureAsCode: false,
+        },
+      });
+    }
+
+    if (req.query.org === 'no-custom-rules-entitlements') {
+      return res.status(200).send({
+        ...baseResponse,
+        entitlements: {
+          ...baseResponse.entitlements,
           iacCustomRulesEntitlement: false,
         },
       });

--- a/test/jest/acceptance/iac/custom-rules.spec.ts
+++ b/test/jest/acceptance/iac/custom-rules.spec.ts
@@ -59,7 +59,7 @@ describe('iac test --rules', () => {
 
   it('presents an error message when the user is not entitled to custom-rules', async () => {
     const { stdout, exitCode } = await run(
-      `snyk iac test --org=no-entitlements --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
+      `snyk iac test --org=no-custom-rules-entitlements --rules=./iac/custom-rules/custom.tar.gz ./iac/terraform/sg_open_ssh.tf`,
     );
 
     expect(exitCode).toBe(2);
@@ -215,7 +215,7 @@ describe('custom rules pull from a remote OCI registry', () => {
 
   it('presents an error message when the user is not entitled to custom-rules', async () => {
     const { stdout, exitCode } = await run(
-      `snyk iac test --org=no-entitlements ./iac/terraform/sg_open_ssh.tf`,
+      `snyk iac test --org=no-custom-rules-entitlements ./iac/terraform/sg_open_ssh.tf`,
       {
         SNYK_CFG_OCI_REGISTRY_URL: process.env.OCI_DOCKER_REGISTRY_URL!,
         SNYK_CFG_OCI_REGISTRY_USERNAME: process.env

--- a/test/jest/acceptance/iac/iac-entitlement.spec.ts
+++ b/test/jest/acceptance/iac/iac-entitlement.spec.ts
@@ -1,0 +1,26 @@
+import { startMockServer, run as Run } from './helpers';
+
+jest.setTimeout(50000);
+
+describe('iac test with infrastructureAsCode entitlement', () => {
+  let run: typeof Run;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const result = await startMockServer();
+    run = result.run;
+    teardown = result.teardown;
+  });
+
+  afterAll(async () => teardown());
+
+  it('fails to scan because the user is not entitled to infrastructureAsCode', async () => {
+    const { stdout, exitCode } = await run(
+      `snyk iac test --org=no-iac-entitlements ./iac/terraform/sg_open_ssh.tf`,
+    );
+    expect(exitCode).toBe(2);
+    expect(stdout).toContain(
+      'This feature is currently not enabled for your org. To enable it, please contact snyk support.',
+    );
+  });
+});

--- a/test/jest/unit/iac-unit-tests/index.spec.ts
+++ b/test/jest/unit/iac-unit-tests/index.spec.ts
@@ -67,6 +67,7 @@ jest.mock(
         ociRegistryTag: 'latest',
       },
       entitlements: {
+        infrastructureAsCode: true,
         iacCustomRulesEntitlement: true,
       },
     }),


### PR DESCRIPTION
#### What does this PR do?

The `snyk iac test` command is now looking at the `infrastructureAsCode` entitlement before scanning.

#### How should this be manually tested?

1. Verify that `infrastructureAsCode` is true (by default).
2. Run `snyk iac test` command without any errors.
3. Change your `infrastructureAsCode` entitlement to false.
4. Re-run the above command, you should have now an error.

#### Background context

Will copy-paste what I wrote in registry:

We don’t check in the Snyk CLI if a customer has the infrastructureAsCode entitlement. Thus, for customers not entitled to use IAC, they can't import via the web UI but they still can test IAC files via the CLI.

#### More

- [Jira ticket CFG-1090](https://snyksec.atlassian.net/browse/CFG-1090)
- [Registry PR](https://github.com/snyk/registry/pull/25610)