### PR TITLE
feat: support unmanaged snyk security url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.14.1",
+        "snyk-cpp-plugin": "2.15.0",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22349,9 +22349,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
-      "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
+      "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -44495,7 +44495,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.14.1",
+        "snyk-cpp-plugin": "2.15.0",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -62230,9 +62230,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.14.1",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
-          "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
+          "version": "2.15.0",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
+          "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -65584,9 +65584,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.14.1.tgz",
-      "integrity": "sha512-Wjp8hQa8vq9MuVue+9xFCyrVlDbBBo+Kteik3czBddR/4RO32v3YjVqnpGKS0Y8B88WliKha4cyX+cAdTwyCTg==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
+      "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.14.1",
+    "snyk-cpp-plugin": "2.15.0",
     "snyk-docker-plugin": "^4.33.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",

--- a/src/lib/ecosystems/common.ts
+++ b/src/lib/ecosystems/common.ts
@@ -1,0 +1,5 @@
+import { Ecosystem } from './types';
+
+export function isUnmanagedEcosystem(ecosystem: Ecosystem): boolean {
+  return ecosystem === 'cpp';
+}

--- a/src/lib/ecosystems/monitor.ts
+++ b/src/lib/ecosystems/monitor.ts
@@ -31,6 +31,7 @@ import {
   validateProjectAttributes,
   validateTags,
 } from '../../cli/commands/monitor';
+import { isUnmanagedEcosystem } from './common';
 
 const SEPARATOR = '\n-------------------------------------------------------\n';
 
@@ -81,8 +82,7 @@ async function selectAndExecuteMonitorStrategy(
   scanResultsByPath: { [dir: string]: ScanResult[] },
   options: Options,
 ): Promise<[EcosystemMonitorResult[], EcosystemMonitorError[]]> {
-  const isUnmanagedEcosystem = ecosystem === 'cpp';
-  return isUnmanagedEcosystem
+  return isUnmanagedEcosystem(ecosystem)
     ? await resolveAndMonitorFacts(scanResultsByPath, options)
     : await monitorDependencies(scanResultsByPath, options);
 }

--- a/src/lib/feature-flags/index.ts
+++ b/src/lib/feature-flags/index.ts
@@ -3,6 +3,8 @@ import { getAuthHeader } from '../api-token';
 import config from '../config';
 import { assembleQueryString } from '../snyk-test/common';
 import { OrgFeatureFlagResponse } from './types';
+import { Options } from '../types';
+import { AuthFailedError } from '../errors';
 
 export async function isFeatureFlagSupportedForOrg(
   featureFlag: string,
@@ -20,4 +22,19 @@ export async function isFeatureFlagSupportedForOrg(
   });
 
   return (response as any).body;
+}
+
+export async function hasFeatureFlag(
+  featureFlag: string,
+  options: Options,
+): Promise<boolean | undefined> {
+  const { code, error, ok } = await isFeatureFlagSupportedForOrg(
+    featureFlag,
+    options.org,
+  );
+
+  if (code === 401 || code === 403) {
+    throw AuthFailedError(error, code);
+  }
+  return ok;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,7 @@ export interface Options {
   tags?: string;
   'target-reference'?: string;
   'exclude-base-image-vulns'?: boolean;
+  supportUnmanagedVulnDB?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/jest/unit/lib/ecosystems/common.spec.ts
+++ b/test/jest/unit/lib/ecosystems/common.spec.ts
@@ -1,0 +1,15 @@
+import { isUnmanagedEcosystem } from '../../../../../src/lib/ecosystems/common';
+
+describe('isUnmanagedEcosystem fn', () => {
+  it.each`
+    actual      | expected
+    ${'cpp'}    | ${true}
+    ${'docker'} | ${false}
+    ${'code'}   | ${false}
+  `(
+    'should validate that given $actual as input, is considered or not an unmanaged ecosystem',
+    ({ actual, expected }) => {
+      expect(isUnmanagedEcosystem(actual)).toEqual(expected);
+    },
+  );
+});

--- a/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
+++ b/test/jest/unit/lib/feature-flags/feature-flags.spec.ts
@@ -1,0 +1,37 @@
+import { hasFeatureFlag } from '../../../../../src/lib/feature-flags';
+import * as request from '../../../../../src/lib/request';
+
+describe('hasFeatureFlag fn', () => {
+  it.each`
+    hasFlag  | expected
+    ${true}  | ${true}
+    ${false} | ${false}
+  `(
+    'should validate that given an org with feature flag $hasFlag as input, hasFeatureFlag returns $expected',
+    async ({ hasFlag, expected }) => {
+      jest
+        .spyOn(request, 'makeRequest')
+        .mockResolvedValue({ body: { code: 200, ok: hasFlag } } as any);
+
+      const result = await hasFeatureFlag('test-ff', { path: 'test-path' });
+      expect(result).toEqual(expected);
+    },
+  );
+
+  it('should throw error if there are authentication/authorization failures', async () => {
+    jest.spyOn(request, 'makeRequest').mockResolvedValue({
+      body: { code: 401, error: 'Unauthorized', ok: false },
+    } as any);
+
+    await expect(
+      hasFeatureFlag('test-ff', { path: 'test-path' }),
+    ).rejects.toThrowError('Unauthorized');
+
+    jest.spyOn(request, 'makeRequest').mockResolvedValue({
+      body: { code: 403, error: 'Forbidden', ok: false },
+    } as any);
+    await expect(
+      hasFeatureFlag('test-ff', { path: 'test-path' }),
+    ).rejects.toThrowError('Forbidden');
+  });
+});


### PR DESCRIPTION
Co-authored-by: @danlucian lucian.rosu@snyk.io

Allows users with snykUnmanagedVulnDB ff in org level to visualize
https://security.snyk.io/vuln/SNYK-UNMANAGED-CURL-2317584 rather than
nvd url

Depends on https://github.com/snyk/snyk-cpp-plugin/pull/61

with feature flag
<img width="470" alt="Screen Shot 2022-01-11 at 11 53 47" src="https://user-images.githubusercontent.com/40601533/148922100-369c9d87-73c2-4dcc-881c-4dffac170758.png">

without feature flag
<img width="809" alt="Screen Shot 2022-01-11 at 11 53 03" src="https://user-images.githubusercontent.com/40601533/148922121-d03f6ac3-165c-4539-b8bc-f7ef5ce93ecb.png">

