### PR TITLE
chore: fix docker bundle smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -93,11 +93,12 @@ jobs:
         run: |
           pushd "$(mktemp -d)"
           curl 'https://static.snyk.io/cli/latest/${{ matrix.snyk_cli_dl_file }}' | tar -xz
-          ls -la docker
-          mkdir ./bin
-          sudo ln -s "$(pwd)/docker/snyk-mac.sh" ./bin/snyk
-          export PATH="$(pwd)/bin:${PATH}"
-          echo "$(pwd)/bin" >> "${GITHUB_PATH}"
+          pushd ./docker
+          ls -la
+          sudo ln -s "$(pwd)/snyk-mac.sh" ./snyk
+          export PATH="$(pwd):${PATH}"
+          echo "$(pwd)" >> "${GITHUB_PATH}"
+          popd
           popd
           which snyk
           snyk version


### PR DESCRIPTION
symlink needs to be in the same directory as snyk-mac.

Follow up to #2536 