### PR TITLE
feat: Remove snyk wizard hint

### DIFF
--- a/src/lib/formatters/legacy-format-issue.ts
+++ b/src/lib/formatters/legacy-format-issue.ts
@@ -6,7 +6,6 @@ import { Options, TestOptions, ShowVulnPaths } from '../../lib/types';
 import { isLocalFolder } from '../../lib/detect';
 import { parsePackageString as snykModule } from 'snyk-module';
 import {
-  WIZARD_SUPPORTED_PACKAGE_MANAGERS,
   PINNING_SUPPORTED_PACKAGE_MANAGERS,
   SupportedPackageManagers,
 } from '../../lib/package-managers';
@@ -195,11 +194,6 @@ function createRemediationText(
   vuln: GroupedVuln,
   packageManager: SupportedPackageManagers,
 ): string {
-  let wizardHintText = '';
-  if (WIZARD_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)) {
-    wizardHintText = 'Run `snyk wizard` to explore remediation options.';
-  }
-
   if (
     vuln.fixedIn &&
     PINNING_SUPPORTED_PACKAGE_MANAGERS.includes(packageManager)
@@ -250,10 +244,7 @@ function createRemediationText(
           return `Upgrade direct dependency ${v.from[1]} to ${v.upgradePath[1]}${upgradeTextInfo}`;
         }
 
-        return (
-          'Some paths have no direct dependency upgrade that' +
-          ` can address this issue. ${wizardHintText}`
-        );
+        return 'Some paths have no direct dependency upgrade that can address this issue.';
       }),
     );
     return chalk.bold(

--- a/src/lib/formatters/show-fix-tip.ts
+++ b/src/lib/formatters/show-fix-tip.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { isLocalFolder } from '../detect';
-import { WIZARD_SUPPORTED_PACKAGE_MANAGERS } from '../package-managers';
 import { TestResult } from '../snyk-test/legacy';
 import { Options, SupportedProjectTypes, TestOptions } from '../types';
 
@@ -10,10 +9,6 @@ export function showFixTip(
   res: TestResult,
   options: TestOptions & Options,
 ): string {
-  if (WIZARD_SUPPORTED_PACKAGE_MANAGERS.includes(projectType)) {
-    return `Tip: Run ${chalk.bold('`snyk wizard`')} to address these issues.`;
-  }
-
   const snykFixSupported: SupportedProjectTypes[] = ['pip', 'poetry'];
   if (!snykFixSupported.includes(projectType) || !isLocalFolder(options.path)) {
     return '';

--- a/test/jest/unit/lib/formatters/show-fix-tip.spec.ts
+++ b/test/jest/unit/lib/formatters/show-fix-tip.spec.ts
@@ -5,25 +5,6 @@ import stripAnsi from 'strip-ansi';
 import { getFixturePath } from '../../../util/getFixturePath';
 
 describe('showFixTip', () => {
-  test.each(['yarn', 'npm'])('%p shows `snyk wizard` tip', (p) => {
-    const withRemediation = JSON.parse(
-      fs.readFileSync(
-        getFixturePath(
-          'npm-package-with-severity-override/test-graph-result-patches.json',
-        ),
-        'utf8',
-      ),
-    );
-    expect(
-      stripAnsi(
-        showFixTip(p as SupportedProjectTypes, withRemediation, {
-          path: 'src',
-          showVulnPaths: 'none',
-        }),
-      ),
-    ).toBe('Tip: Run `snyk wizard` to address these issues.');
-  });
-
   test.each(['pip', 'poetry'])('%p shows `snyk fix` tip', (p) => {
     const withRemediation = JSON.parse(
       fs.readFileSync(

--- a/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
+++ b/test/jest/unit/lib/formatters/test/__snapshots__/display-result.spec.ts.snap
@@ -20,7 +20,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r0 (triggers upgrades to expat@2.2.7-r0)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r0
 
 ✗ High severity vulnerability found in expat
@@ -32,7 +32,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r1 (triggers upgrades to expat@2.2.7-r1)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r1
 
 
@@ -72,7 +72,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r0 (triggers upgrades to expat@2.2.7-r0)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r0
 
 ✗ High severity vulnerability found in expat
@@ -84,7 +84,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r1 (triggers upgrades to expat@2.2.7-r1)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r1
 
 
@@ -186,7 +186,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r0 (triggers upgrades to expat@2.2.7-r0)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r0
 
 ✗ High severity vulnerability found in expat
@@ -198,7 +198,7 @@ Testing src...
   From: git@2.18.2-r0 > expat@2.2.5-r0
   Remediation:
     Upgrade direct dependency expat@2.2.5-r0 to expat@2.2.7-r1 (triggers upgrades to expat@2.2.7-r1)
-    Some paths have no direct dependency upgrade that can address this issue. 
+    Some paths have no direct dependency upgrade that can address this issue.
   Fixed in: 2.2.7-r1
 
 
@@ -299,8 +299,6 @@ Target file:       package-lock.json
 Project name:      shallow-goof
 Open source:       no
 Project path:      src
-
-Tip: Run \`snyk wizard\` to address these issues.
 
 Tip: Detected multiple supported manifests (3), use --all-projects to scan all of them at once."
 `;


### PR DESCRIPTION
Wizard is relatively outdated and advertising it is not necessarily helpful across the board given how Snyk is used. For example, some setups may not want their users to use `wizard`.

Rather than mess with controls or disabling the hint, lets do the simple thing and just remove it
