### PR TITLE
feat: add driver version to IaC sarif outout

### DIFF
--- a/src/lib/formatters/iac-output.ts
+++ b/src/lib/formatters/iac-output.ts
@@ -19,6 +19,7 @@ import { IacFileInDirectory } from '../../lib/types';
 import { isLocalFolder } from '../../lib/detect';
 import { getSeverityValue } from './get-severity-value';
 import { getIssueLevel } from './sarif-output';
+import { getVersion } from '../version';
 const debug = Debug('iac-output');
 
 function formatIacIssue(
@@ -161,6 +162,7 @@ export function createSarifOutputForIac(
     driver: {
       name: 'Snyk IaC',
       fullName: 'Snyk Infrastructure as Code',
+      version: getVersion(),
       informationUri:
         'https://docs.snyk.io/products/snyk-infrastructure-as-code',
       rules: extractReportingDescriptor(issues),


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds the current version of the CLI to the SARIF output under the driver field.
This is a direct continuation of the following PR: https://github.com/snyk/snyk/pull/2524

#### How should this be manually tested?
1. Run a test with the `--sarif` flag
2. under `runs[].tool.driver.version` you'll found the newly added driver version

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/301?modal=detail&selectedIssue=CFG-1313

#### Additional questions
What's the meaning of life? :)