### PR TITLE
GH Action for syncing help files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,3 +56,4 @@ src/cli/commands/log4shell-hashes.ts @snyk/tundra
 src/cli/commands/log4shell.ts @snyk/tundra
 test/fixtures/unmanaged-log4j-fixture @snyk/tundra
 test/jest/acceptance/snyk-log4shell/log4shell-detection.spec.ts @snyk/tundra
+/.github @snyk/hammer

--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -25,17 +25,18 @@ jobs:
           if [[ $(git -C ./cli status --porcelain) ]]; then
             echo "Documentation changes detected"
             cd ./cli
+            npx prettier --write ./help/cli-commands
             git --no-pager diff --name-only
             git add .
             git commit -m "docs: synchronizing help from snyk/user-docs"
             git push --force --set-upstream origin docs/automatic-gitbook-update
-            if [[ ! $(gh pr view docs/automatic-gitbook-update) ]]; then
+            if [[ ! $(gh pr view docs/automatic-gitbook-update 2>&1 | grep -q "no open pull requests";) ]]; then
               echo "Creating PR"
               gh pr create --title="Synchronizing CLI help from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
             fi
-            echo "PR exists, pushed changes to it"
+            echo "PR exists, pushed changes to it."
           else
-            echo "No documentation changes detected, exiting"
+            echo "No documentation changes detected, exiting."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -1,13 +1,15 @@
-name: Copy CLI help from snyk/user-docs
+name: Synchronize Help
 
 on:
   workflow_dispatch:
   schedule:
     - cron: '0 12 * * 1-5' # Mon-Fri at 12
+  push:
+    branches: [chore/docs-action]
 
 jobs:
   build:
-    name: Copy CLI help from snyk/user-docs
+    name: synchronize-help
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -25,7 +27,7 @@ jobs:
             cd ./cli
             git --no-pager diff --name-only
             git add .
-            git commit -m "docs: synchronized help from snyk/user-docs"
+            git commit -m "docs: synchronizing help from snyk/user-docs"
             git push --force --set-upstream origin docs/automatic-gitbook-update
             gh pr create --title="Synchronizing CLI help from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
           else

--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -1,0 +1,35 @@
+name: Copy CLI help from snyk/user-docs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 12 * * 1-5' # Mon-Fri at 12
+
+jobs:
+  build:
+    name: Copy CLI help from snyk/user-docs
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh auth setup-git
+          git config --global user.email "noreply@snyk.io"
+          git config --global user.name "$GITHUB_ACTOR"
+          gh repo clone snyk/snyk cli -- --depth=1 --quiet
+          gh repo clone snyk/user-docs docs -- --depth=1 --quiet
+          git -C ./cli checkout -b docs/automatic-gitbook-update
+
+          cp ./docs/docs/features/snyk-cli/commands/*.md ./cli/help/cli-commands/
+
+          if [[ $(git -C ./cli status --porcelain) ]]; then
+            echo "Documentation changes detected, opening a PR"
+            cd ./cli
+            git --no-pager diff --name-only
+            git add .
+            git commit -m "docs: synchronized help from snyk/user-docs"
+            git push --force --set-upstream origin docs/automatic-gitbook-update
+            gh pr create --title="Synchronizing CLI help from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
+          else
+            echo "No documentation changes detected, exiting"
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-cli-help-to-user-docs.yml
+++ b/.github/workflows/sync-cli-help-to-user-docs.yml
@@ -23,13 +23,17 @@ jobs:
           cp ./docs/docs/features/snyk-cli/commands/*.md ./cli/help/cli-commands/
 
           if [[ $(git -C ./cli status --porcelain) ]]; then
-            echo "Documentation changes detected, opening a PR"
+            echo "Documentation changes detected"
             cd ./cli
             git --no-pager diff --name-only
             git add .
             git commit -m "docs: synchronizing help from snyk/user-docs"
             git push --force --set-upstream origin docs/automatic-gitbook-update
-            gh pr create --title="Synchronizing CLI help from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
+            if [[ ! $(gh pr view docs/automatic-gitbook-update) ]]; then
+              echo "Creating PR"
+              gh pr create --title="Synchronizing CLI help from user-docs" --body="Automatic PR controlled by GitHub Action" --head docs/automatic-gitbook-update
+            fi
+            echo "PR exists, pushed changes to it"
           else
             echo "No documentation changes detected, exiting"
           fi

--- a/help/README.md
+++ b/help/README.md
@@ -1,21 +1,7 @@
 # CLI Help files
 
-[Snyk CLI help files are in the `help/cli-commands` folder.](./cli-commands)
+Snyk CLI Help files are managed by GitBook connected to the [snyk/user-docs](https://github.com/snyk/user-docs) repository.
 
-## Updating or adding help documents
+It's recommended to make all CLI Help changes there. Changes from GitBook are automatically [synced to the Snyk CLI repository with a GitHub Action into a PR that needs to be approved and merged](https://github.com/snyk/snyk/actions/workflows/sync-cli-help-to-user-docs.yml). This Action could also be manually triggered.
 
-All commands are documented in a Markdown format. They are automatically pushed to the [Snyk User Documentation site](https://docs.snyk.io).
-
-Don't use HTML tags. These markdown files are the source for the `--help` command output in the Snyk CLI.
-
-Contact **Team Hammer** or open an issue in this repository when in doubt.
-
-### CLI options
-
-```markdown
-### `--severity-threshold=low|medium|high|critical`
-
-Only report vulnerabilities of provided level or higher.
-```
-
-CLI flag should be a heading and in backticks. See already documented commands and flags for more examples.
+If you need to make changes tied to a specific PR, you can absolutely make them in this repository first, merge the changes and then move them over to the GitBook. CLI help files are a standard Markdown.

--- a/help/README.md
+++ b/help/README.md
@@ -2,6 +2,8 @@
 
 Snyk CLI Help files are managed by GitBook connected to the [snyk/user-docs](https://github.com/snyk/user-docs) repository.
 
-It's recommended to make all CLI Help changes there. Changes from GitBook are automatically [synced to the Snyk CLI repository with a GitHub Action into a PR that needs to be approved and merged](https://github.com/snyk/snyk/actions/workflows/sync-cli-help-to-user-docs.yml). This Action could also be manually triggered.
+It's recommended to make all CLI Help changes there. Changes from GitBook are automatically [synced to the Snyk CLI repository with a GitHub Action](https://github.com/snyk/snyk/actions/workflows/sync-cli-help-to-user-docs.yml). The Action creates a PR that needs to be approved and merged. This Action could also be manually triggered.
 
-If you need to make changes tied to a specific PR, you can absolutely make them in this repository first, merge the changes and then move them over to the GitBook. CLI help files are a standard Markdown.
+If you need to make changes tied to a specific PR, you can make them in this repository first, merge the changes and then move them over to the GitBook.
+
+CLI help files are a standard Markdown.

--- a/src/cli/commands/help/markdown-renderer.ts
+++ b/src/cli/commands/help/markdown-renderer.ts
@@ -79,7 +79,7 @@ const renderer = {
       reflowText(text, getIdealTextWidth())
         .split('\n')
         .map((s) => getLeftTextPadding() + chalk.reset() + s)
-        .join('\n') + '\n'
+        .join('\n') + '\n\n'
     );
   },
   codespan(text) {
@@ -103,7 +103,7 @@ const renderer = {
         coloring = chalk.bold;
         break;
     }
-    return `\n${'  '.repeat(level === 1 ? 0 : currentHeader - 2)}${coloring(
+    return `${'  '.repeat(level === 1 ? 0 : currentHeader - 2)}${coloring(
       text,
     )}\n`;
   },

--- a/src/cli/commands/help/reflow-text.ts
+++ b/src/cli/commands/help/reflow-text.ts
@@ -37,7 +37,7 @@ function textLength(str: string): number {
 // characters between \n's is less than or equal to "width".
 export function reflowText(text: string, width: number): string {
   const HARD_RETURN = '\r|\n';
-  const HARD_RETURN_GFM_RE = new RegExp(HARD_RETURN + '|<br />');
+  const HARD_RETURN_GFM_RE = new RegExp(HARD_RETURN + '|<br ?/?>');
 
   const splitRe = HARD_RETURN_GFM_RE;
   const sections = text.split(splitRe);


### PR DESCRIPTION
Automatic action to sync CLI Help from snyk/user-docs repository

Example of such automatic PR: https://github.com/snyk/snyk/pull/2592 (also updated the renderer to handle the non-XHTML newline break `<br />` vs. `<br>`)

This update handles line breaks better:
<img width="1124" alt="Screen Shot 2022-01-18 at 16 40 00" src="https://user-images.githubusercontent.com/1788727/149969101-c78f6c5e-6e83-4d45-9309-b1935e5ce026.png">
