### PR TITLE
feat: Improve npm7+ error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.3",
-        "snyk-nodejs-lockfile-parser": "1.37.2",
+        "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -22502,6 +22502,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/snyk-docker-plugin/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "node_modules/snyk-docker-plugin/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/snyk-docker-plugin/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -22547,6 +22563,34 @@
       },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/snyk-docker-plugin/node_modules/snyk-nodejs-lockfile-parser": {
+      "version": "1.37.2",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+      "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+      "dependencies": {
+        "@snyk/dep-graph": "^1.28.0",
+        "@snyk/graphlib": "2.1.9-patch.3",
+        "@yarnpkg/core": "^2.4.0",
+        "@yarnpkg/lockfile": "^1.1.0",
+        "event-loop-spinner": "^2.0.0",
+        "js-yaml": "^4.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatmap": "^4.5.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.set": "^4.3.2",
+        "lodash.topairs": "^4.3.0",
+        "semver": "^7.3.5",
+        "snyk-config": "^4.0.0-rc.2",
+        "tslib": "^1.9.3",
+        "uuid": "^8.3.0"
+      },
+      "bin": {
+        "parse-nodejs-lockfile": "bin/index.js"
       },
       "engines": {
         "node": ">=10"
@@ -22825,9 +22869,9 @@
       "integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
     },
     "node_modules/snyk-nodejs-lockfile-parser": {
-      "version": "1.37.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
-      "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.38.0.tgz",
+      "integrity": "sha512-m/SM6SW70SYSYmda0wdyGqIESwKMLoiOOH4tSZpY9rYzVDHBQxWfVQ5k8L03V1TOeaFeBDl+lPc8iiY13ETwOg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -22838,7 +22882,6 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.set": "^4.3.2",
         "lodash.topairs": "^4.3.0",
         "semver": "^7.3.5",
         "snyk-config": "^4.0.0-rc.2",
@@ -44501,7 +44544,7 @@
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
         "snyk-mvn-plugin": "2.26.3",
-        "snyk-nodejs-lockfile-parser": "1.37.2",
+        "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
         "snyk-policy": "^1.22.1",
@@ -62346,6 +62389,19 @@
             "uuid": "^8.2.0"
           },
           "dependencies": {
+            "argparse": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+              "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+            },
+            "js-yaml": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+              "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+              "requires": {
+                "argparse": "^2.0.1"
+              }
+            },
             "lru-cache": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -62373,6 +62429,28 @@
               "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
               "requires": {
                 "lru-cache": "^6.0.0"
+              }
+            },
+            "snyk-nodejs-lockfile-parser": {
+              "version": "1.37.2",
+              "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+              "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+              "requires": {
+                "@snyk/dep-graph": "^1.28.0",
+                "@snyk/graphlib": "2.1.9-patch.3",
+                "@yarnpkg/core": "^2.4.0",
+                "@yarnpkg/lockfile": "^1.1.0",
+                "event-loop-spinner": "^2.0.0",
+                "js-yaml": "^4.1.0",
+                "lodash.clonedeep": "^4.5.0",
+                "lodash.flatmap": "^4.5.0",
+                "lodash.isempty": "^4.4.0",
+                "lodash.set": "^4.3.2",
+                "lodash.topairs": "^4.3.0",
+                "semver": "^7.3.5",
+                "snyk-config": "^4.0.0-rc.2",
+                "tslib": "^1.9.3",
+                "uuid": "^8.3.0"
               }
             },
             "tmp": {
@@ -62606,9 +62684,9 @@
           }
         },
         "snyk-nodejs-lockfile-parser": {
-          "version": "1.37.2",
-          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
-          "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+          "version": "1.38.0",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.38.0.tgz",
+          "integrity": "sha512-m/SM6SW70SYSYmda0wdyGqIESwKMLoiOOH4tSZpY9rYzVDHBQxWfVQ5k8L03V1TOeaFeBDl+lPc8iiY13ETwOg==",
           "requires": {
             "@snyk/dep-graph": "^1.28.0",
             "@snyk/graphlib": "2.1.9-patch.3",
@@ -62619,7 +62697,6 @@
             "lodash.clonedeep": "^4.5.0",
             "lodash.flatmap": "^4.5.0",
             "lodash.isempty": "^4.4.0",
-            "lodash.set": "^4.3.2",
             "lodash.topairs": "^4.3.0",
             "semver": "^7.3.5",
             "snyk-config": "^4.0.0-rc.2",
@@ -65700,6 +65777,19 @@
         "uuid": "^8.2.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
         "lru-cache": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -65727,6 +65817,28 @@
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "requires": {
             "lru-cache": "^6.0.0"
+          }
+        },
+        "snyk-nodejs-lockfile-parser": {
+          "version": "1.37.2",
+          "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
+          "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+          "requires": {
+            "@snyk/dep-graph": "^1.28.0",
+            "@snyk/graphlib": "2.1.9-patch.3",
+            "@yarnpkg/core": "^2.4.0",
+            "@yarnpkg/lockfile": "^1.1.0",
+            "event-loop-spinner": "^2.0.0",
+            "js-yaml": "^4.1.0",
+            "lodash.clonedeep": "^4.5.0",
+            "lodash.flatmap": "^4.5.0",
+            "lodash.isempty": "^4.4.0",
+            "lodash.set": "^4.3.2",
+            "lodash.topairs": "^4.3.0",
+            "semver": "^7.3.5",
+            "snyk-config": "^4.0.0-rc.2",
+            "tslib": "^1.9.3",
+            "uuid": "^8.3.0"
           }
         },
         "tmp": {
@@ -65960,9 +66072,9 @@
       }
     },
     "snyk-nodejs-lockfile-parser": {
-      "version": "1.37.2",
-      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.37.2.tgz",
-      "integrity": "sha512-AOQ73l5xZWeIvK/wJY++QMLqrbuIr1VGAi5eaXdTkodpZ2kO6AlhtvM6F3KjdUOsDbT8mM96tKqNrBl1vTHE5Q==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/snyk-nodejs-lockfile-parser/-/snyk-nodejs-lockfile-parser-1.38.0.tgz",
+      "integrity": "sha512-m/SM6SW70SYSYmda0wdyGqIESwKMLoiOOH4tSZpY9rYzVDHBQxWfVQ5k8L03V1TOeaFeBDl+lPc8iiY13ETwOg==",
       "requires": {
         "@snyk/dep-graph": "^1.28.0",
         "@snyk/graphlib": "2.1.9-patch.3",
@@ -65973,7 +66085,6 @@
         "lodash.clonedeep": "^4.5.0",
         "lodash.flatmap": "^4.5.0",
         "lodash.isempty": "^4.4.0",
-        "lodash.set": "^4.3.2",
         "lodash.topairs": "^4.3.0",
         "semver": "^7.3.5",
         "snyk-config": "^4.0.0-rc.2",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
     "snyk-mvn-plugin": "2.26.3",
-    "snyk-nodejs-lockfile-parser": "1.37.2",
+    "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",
     "snyk-policy": "^1.22.1",


### PR DESCRIPTION
This patch bumps the `nodejs-lockfile-parser` to `1.38.0`, improving the error message shown when a dependency is missing from the lockfile

https://github.com/snyk/nodejs-lockfile-parser/releases/tag/v1.38.0
