### PR TITLE
test: fix test failing on node@10 warning messages

### DIFF
--- a/test/jest/acceptance/snyk-protect/deduped-package-patch.spec.ts
+++ b/test/jest/acceptance/snyk-protect/deduped-package-patch.spec.ts
@@ -7,12 +7,18 @@ jest.setTimeout(1000 * 60);
 describe('deduped-package-patch test', () => {
   it('npm deduped packages are found and patched correctly', async () => {
     const project = await createProjectFromFixture('deduped-dep');
+    const previousSemver = await project.read('node_modules/semver/semver.js');
+
     expect(await runSnykCLI('protect', { cwd: project.path() })).toEqual(
       expect.objectContaining<RunCommandResult>({
         code: 0,
         stdout: expect.stringContaining('Successfully applied Snyk patches'),
-        stderr: expect.not.stringMatching(/snyk/gi), // We don't expect an error from snyk
+        stderr: expect.not.stringMatching(/error/gi), // We don't expect an error
       }),
+    );
+
+    expect(await project.read('node_modules/semver/semver.js')).not.toEqual(
+      previousSemver,
     );
   });
 });


### PR DESCRIPTION
Node 10 support is being deprecated so API alerts have been added server-side to show a warning message in CLI.

https://app.circleci.com/pipelines/github/snyk/snyk/9244/workflows/c1dafc02-fe38-4b11-b7ba-bf88b0042784/jobs/71252

This isn't relevant to these tests so I've updated the assertions.

We should mock the response but this is blocking pipelines and it would require re-writing the entire test. There are other tests with the same issue so it'd be easier to migrate them together.