### PR TITLE
smoke: add node 10 check to smoke tests

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -182,7 +182,7 @@ jobs:
         run: |
           which snyk
           snyk version
-          shellspec -f d
+          shellspec -f d --skip-message quiet
 
       - name: Run shellspec tests - Windows
         if: ${{ matrix.os == 'windows' }}

--- a/test/smoke/run-shellspec-win.sh
+++ b/test/smoke/run-shellspec-win.sh
@@ -1,3 +1,3 @@
 echo "run-shellscript-win.sh"
 
-/c/Users/runneradmin/.local/bin/shellspec -f d
+/c/Users/runneradmin/.local/bin/shellspec -f d --skip-message quiet

--- a/test/smoke/spec/snyk_code_spec.sh
+++ b/test/smoke/spec/snyk_code_spec.sh
@@ -5,6 +5,7 @@ Describe "Snyk Code test command"
   After snyk_logout
 
   Describe "snyk code test"
+    Skip if "skip for node 10" check_if_node10
     run_test_in_subfolder() {
       cd ../fixtures/sast/shallow_sast_webgoat || return
       snyk code test . --org=snyk-cli-smoke-test-with-snykcode
@@ -20,6 +21,7 @@ Describe "Snyk Code test command"
   End
 
   Describe "code test with SARIF output"
+    Skip if "skip for node 10" check_if_node10 
     It "outputs a valid SARIF with vulns"
       When run snyk code test ../fixtures/sast/shallow_sast_webgoat --sarif --org=snyk-cli-smoke-test-with-snykcode
       The status should be failure # issues found

--- a/test/smoke/spec/snyk_monitor_spec.sh
+++ b/test/smoke/spec/snyk_monitor_spec.sh
@@ -5,6 +5,7 @@ Describe "Snyk monitor command"
   After snyk_logout
 
   Describe "monitor npm project"
+    Skip if "skip for node 10" check_if_node10
     run_monitor_in_subfolder() {
       cd ../fixtures/basic-npm || return
       snyk monitor

--- a/test/smoke/spec/snyk_test_spec.sh
+++ b/test/smoke/spec/snyk_test_spec.sh
@@ -56,6 +56,7 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project in the same folder"
+      Skip if "skip for node 10" check_if_node10
       When run run_test_in_subfolder
       The status should equal 1
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
@@ -63,6 +64,7 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project when pointing to a folder"
+      Skip if "skip for node 10" check_if_node10
       When run snyk test ../fixtures/basic-npm
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"
@@ -70,6 +72,7 @@ Describe "Snyk test command"
     End
 
     It "finds vulns in a project when pointing to a file"
+      Skip if "skip for node 10" check_if_node10
       When run snyk test --file=../fixtures/basic-npm/package.json
       The status should be failure # issues found
       The output should include "https://snyk.io/vuln/npm:minimatch:20160620"

--- a/test/smoke/spec/spec_helper.sh
+++ b/test/smoke/spec/spec_helper.sh
@@ -68,4 +68,11 @@ spec_helper_configure() {
   snyk() {
     eval "${SNYK_COMMAND:=$ORIGINAL_SNYK_EXECUTABLE}" "$@"
   }
+
+  check_if_node10() {
+    if command -v node > /dev/null 2>&1; then
+      if node --version | grep -Eq '^v10.*'; then echo 1
+      fi
+    fi
+  }
 }


### PR DESCRIPTION
Fix failing smoke tests caused by the new deprecation message of node 10.
