### PR TITLE
chore: improve iac analytics [CFG-1386]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/analytics.ts
+++ b/src/cli/commands/test/iac-local-execution/analytics.ts
@@ -5,7 +5,11 @@ import { computeCustomRulesBundleChecksum } from './file-utils';
 
 export function addIacAnalytics(
   formattedResults: FormattedResult[],
-  ignoredIssuesCount: number,
+  opts: {
+    ignoredIssuesCount: number;
+    isLocalCustomRules: boolean;
+    isRemoteCustomRules: boolean;
+  },
 ): void {
   let totalIssuesCount = 0;
   const customRulesIdsFoundInIssues: { [customRuleId: string]: true } = {};
@@ -41,10 +45,13 @@ export function addIacAnalytics(
 
   analytics.add('packageManager', Array.from(new Set(packageManagers)));
   analytics.add('iac-issues-count', totalIssuesCount);
-  analytics.add('iac-ignored-issues-count', ignoredIssuesCount);
+  analytics.add('iac-ignored-issues-count', opts.ignoredIssuesCount);
   analytics.add('iac-type', projectTypeAnalytics);
   analytics.add('iac-metrics', performanceAnalyticsObject);
-  analytics.add('iac-test-count', formattedResults.length);
+  analytics.add('iac-test-count', formattedResults.length); // TODO: remove this once we all analytics use iac-files-count
+  analytics.add('iac-files-count', formattedResults.length);
+  analytics.add('iac-local-custom-rules', opts.isLocalCustomRules);
+  analytics.add('iac-remote-custom-rules', opts.isRemoteCustomRules);
   analytics.add('iac-custom-rules-issues-count', issuesFromCustomRulesCount);
   analytics.add(
     'iac-custom-rules-issues-percentage',

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -144,7 +144,11 @@ export async function test(
       // run their tests by squashing the error.
     }
 
-    addIacAnalytics(filteredIssues, ignoreCount);
+    addIacAnalytics(filteredIssues, {
+      ignoredIssuesCount: ignoreCount,
+      isLocalCustomRules: !!customRulesPath,
+      isRemoteCustomRules: isOCIRegistryURLProvided,
+    });
 
     // TODO: add support for proper typing of old TestResult interface.
     return {


### PR DESCRIPTION
#### What does this PR do?
This PR improves the Snyk IaC CLI analytics by sending 3 new values:
- `iac-files-count`: will eventually replace `iac-test-count` (hence the TODO), since it actually tells us how many files were scanned
- `iac-local-custom-rules': will eventually be used in Looker by BI, since we learned this is preferred to reading the JSON in the `args` analytics which contains the `--rules `flag
- `iac-remote-custom-rules`: will be eventually be used in Looker by BI, instead of `iac-custom-rules-checksum`
At the moment these won't be used in Looker since our customers would need to update their CLI versions

#### How should this be manually tested?
1. Run `npm run build`
2. Run `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml -d` - without custom rules
3. Run `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml -d --rules=bundle.tar.gz` - with a local custom rules bundle generated by [snyk-iac-rules](https://github.com/snyk/snyk-iac-rules)
4. Go to `https://app.snyk.io/org/<org name>/manage/cloud-config` and enable custom rules and configure the registry URL with a custom rules bundle pushed by [snyk-iac-rules](https://github.com/snyk/snyk-iac-rules)
5. Run `snyk-dev config set oci-registry-username=<username>` and `snyk-dev config set oci-registry-password=<password>`
4. Run `snyk-dev iac test ./test/fixtures/iac/kubernetes/pod-privileged.yaml -d` - with a remote custom rules bundle

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1386

#### Screenshots
- Without custom rules
![Screenshot 2022-01-21 at 15 23 40](https://user-images.githubusercontent.com/81559517/150553517-c2f89821-12a2-4dd4-9cf9-a966ba86d09f.png)

- With local custom rules
![Screenshot 2022-01-21 at 15 24 19](https://user-images.githubusercontent.com/81559517/150553492-d8f2a3db-8615-4a3a-8058-dce03dc9e45d.png)
- With remote custom rules
![Screenshot 2022-01-21 at 15 25 59](https://user-images.githubusercontent.com/81559517/150553468-5afaa503-1169-4e6c-b594-b9a7595b7298.png)

