### PR TITLE
feat: modify analytics [CFG-1446]

### DIFF
--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -98,7 +98,7 @@ async function postAnalytics(
 }
 
 /**
- * Adds a key-value pair to the analytics data `metadata` field. This doesn't send the analytis, just stages it for
+ * Adds a key-value pair to the analytics data `metadata` field. This doesn't send the analytics, just stages it for
  * sending later (via the {@link addDataAndSend} function).
  * @param key
  * @param value
@@ -107,11 +107,18 @@ export function add(key: string, value: unknown): void {
   if (typeof value === 'string') {
     value = stripAnsi(value);
   }
+
   if (metadata[key]) {
-    if (!Array.isArray(metadata[key])) {
-      metadata[key] = [metadata[key]];
+    if (typeof value === 'number' && typeof metadata[key] === 'number') {
+      metadata[key] += value;
+    } else {
+      if (!Array.isArray(metadata[key])) {
+        metadata[key] = [metadata[key]];
+      }
+      Array.isArray(value)
+        ? metadata[key].push(...value)
+        : metadata[key].push(value);
     }
-    metadata[key].push(value);
   } else {
     metadata[key] = value;
   }

--- a/test/jest/unit/lib/analytics/index.spec.ts
+++ b/test/jest/unit/lib/analytics/index.spec.ts
@@ -36,4 +36,27 @@ describe('analytics module', () => {
 
     await expect(result).resolves.toBeUndefined();
   });
+
+  it('adds a value to the current analytics metadata', async () => {
+    const requestSpy = jest.spyOn(request, 'makeRequest');
+    requestSpy.mockResolvedValue();
+
+    analytics.add('k2', 2);
+    analytics.add('k3', { test: 'test' });
+    analytics.add('k1', 'v2');
+    analytics.add('k1', ['v3', 'v4']);
+    analytics.add('k1', 5);
+    analytics.add('k2', 4);
+    analytics.add('k3', { test: 'test' });
+
+    await analytics.addDataAndSend({
+      args: argsFrom({}),
+    });
+
+    expect(requestSpy.mock.calls[0][0].body.data).toHaveProperty('metadata', {
+      k1: ['v1', 'v2', 'v3', 'v4', 5], //v1 was added in the 1st test
+      k2: 6,
+      k3: [{ test: 'test' }, { test: 'test' }],
+    });
+  });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Today a user can test multiple files/directories by using the command `snyk {product} test {path1} {path2}`.

When doing so we are saving some of the analytics incorrectly, some examples:
`"iac-test-count": [1,2],` (should be a numeric value and not an array)
`"packageManager": ["cloudformationconfig",["terraformconfig","cloudformationconfig"]],` (shouldn't be a nested array)
Those are some IaC examples but the problem is shared across all products.

Objects should probably be handled in [registry](https://github.com/snyk/registry/blob/cdc684900ca34379eedb823e5fe0c0deff4b39d1/src/lib/analytics/cli.ts#L200) by each team separately.

#### How should this be manually tested?
Run a test with multiple args and use the `-d` flag to check the metadata field at the bottom.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1446

#### Screenshots
Before:
![image](https://user-images.githubusercontent.com/71096571/150688719-fc09aa0d-7442-4f1b-b8bf-5c30cfa78cff.png)

After:
![image](https://user-images.githubusercontent.com/71096571/150688740-49b0ba61-eb28-4256-ba7f-84e991a4810f.png)