### PR TITLE
chore(ci): move windows nodejs to choco config

### DIFF
--- a/.circleci/chocolatey.config
+++ b/.circleci/chocolatey.config
@@ -4,4 +4,5 @@
     <package id="gradle" version="6.8.3" />
     <package id="sbt" version="1.5.5" />
     <package id="awscli" version="2.4.12" />
+    <package id="nodejs" version="16.13.2" />
 </packages>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,11 @@ commands:
                   - << parameters.npm_cache_directory >>
   install_sdks_windows:
     steps:
+      - run:
+          name: Removing pre-installed NodeJS
+          command: |
+            $current_node_version = node --version
+            nvm uninstall $current_node_version
       - restore_cache:
           name: Restoring Chocolatey cache
           keys:
@@ -119,19 +124,6 @@ commands:
           key: sdkman-archive-cache-v3-{{ arch }}-{{ checksum ".circleci/install-sdks-linux.sh" }}
           paths:
             - ~/.sdkman/archives
-  install_node_windows:
-    parameters:
-      node_version:
-        type: string
-    steps:
-      - run:
-          name: Removing pre-installed NodeJS
-          command: |
-            $current_node_version = node --version
-            nvm uninstall $current_node_version
-      - run:
-          name: Installing NodeJS
-          command: choco install nodejs --version=<< parameters.node_version >> --no-progress
   install_shellspec_dependencies:
     steps:
       - run:
@@ -248,8 +240,6 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - install_node_windows:
-          node_version: << parameters.node_version >>
       - install_sdks_windows
       - setup_npm:
           node_version: << parameters.node_version >>


### PR DESCRIPTION
So that it can benefit from caching.

The previous config was parameterised using `parameters.node_version` but this is actually more like a global constant since we don't pass in any parameters and it falls back to defaults.

Progresses #2599