### PR TITLE
feat: added a new option: --no-markdown for sarif output

### DIFF
--- a/help/cli-commands/code.md
+++ b/help/cli-commands/code.md
@@ -53,6 +53,10 @@ Print results in JSON format.
 
 Return results in SARIF format.
 
+## `--no-markdown`
+
+Should be used when using `--sarif`. Will remove the `markdown` field from the `result.message` object. Might help if parsing `arguments` is not working properly.
+
 ### `--severity-threshold=low|medium|high|critical`
 
 Report only vulnerabilities at the specified level or higher. Note that the Snyk Code configuration issues do not currently use the `critical` severity level.

--- a/help/cli-commands/code.md
+++ b/help/cli-commands/code.md
@@ -55,7 +55,7 @@ Return results in SARIF format.
 
 ## `--no-markdown`
 
-Should be used when using `--sarif`. Will remove the `markdown` field from the `result.message` object. Might help if parsing `arguments` is not working properly.
+Removes the `markdown` field from the `result.message` object. Should be used when using `--sarif`.
 
 ### `--severity-threshold=low|medium|high|critical`
 

--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -11,7 +11,6 @@ import { EcosystemPlugin } from '../../ecosystems/types';
 import { FailedToRunTestError, NoSupportedSastFiles } from '../../errors';
 import { jsonStringifyLargeObject } from '../../json';
 import * as analytics from '../../analytics';
-const omit = require('lodash.omit');
 
 const debug = debugLib('snyk-code-test');
 

--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -11,6 +11,7 @@ import { EcosystemPlugin } from '../../ecosystems/types';
 import { FailedToRunTestError, NoSupportedSastFiles } from '../../errors';
 import { jsonStringifyLargeObject } from '../../json';
 import * as analytics from '../../analytics';
+const omit = require('lodash.omit');
 
 const debug = debugLib('snyk-code-test');
 
@@ -40,9 +41,13 @@ export const codePlugin: EcosystemPlugin = {
       }
       const numOfIssues = sarifTypedResult!.runs?.[0].results?.length || 0;
       analytics.add('sast-issues-found', numOfIssues);
-
       if (options.sarif || options.json) {
         if (numOfIssues > 0) {
+          if (options['no-markdown']) {
+            sarifTypedResult.runs?.[0].results?.forEach((result) => {
+              result.message = omit(result.message, ['markdown']);
+            });
+          }
           hasIssues(jsonStringifyLargeObject(sarifTypedResult));
         }
         return { readableResult: jsonStringifyLargeObject(sarifTypedResult) };

--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -44,8 +44,8 @@ export const codePlugin: EcosystemPlugin = {
       if (options.sarif || options.json) {
         if (numOfIssues > 0) {
           if (options['no-markdown']) {
-            sarifTypedResult.runs?.[0].results?.forEach((result) => {
-              result.message = omit(result.message, ['markdown']);
+            sarifTypedResult.runs?.[0].results?.forEach(({ message }) => {
+              delete message.markdown;
             });
           }
           hasIssues(jsonStringifyLargeObject(sarifTypedResult));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,7 @@ export interface Options {
   'target-reference'?: string;
   'exclude-base-image-vulns'?: boolean;
   supportUnmanagedVulnDB?: boolean;
+  'no-markdown'?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -331,6 +331,45 @@ describe('Test snyk code', () => {
     }
   });
 
+  it('succeed testing with correct exit code - with sarif output and no markdown', async () => {
+    const sampleSarif = loadJson(
+      path.join(
+        __dirname,
+        '/../../../fixtures/sast/sample-analyze-folders-response.json',
+      ),
+    );
+    const options: ArgsOptions = {
+      path: '',
+      traverseNodeModules: false,
+      showVulnPaths: 'none',
+      code: true,
+      sarif: true,
+      _: [],
+      _doubleDashArgs: [],
+      'no-markdown': true,
+    };
+
+    analyzeFoldersMock.mockResolvedValue(sampleSarif);
+    isSastEnabledForOrgSpy.mockResolvedValueOnce({
+      sastEnabled: true,
+      localCodeEngine: {
+        enabled: false,
+      },
+    });
+    trackUsageSpy.mockResolvedValue({});
+
+    try {
+      await snykTest('some/path', options);
+    } catch (error) {
+      const errMessage = error.message.trim();
+      expect(error.code).toBe('VULNS');
+      const output = JSON.parse(errMessage);
+      expect(Object.keys(output.runs[0].results[0].message)).not.toContain(
+        'markdown',
+      );
+    }
+  });
+
   it('succeed testing with correct exit code - and analytics added', async () => {
     const analyticSend = jest.spyOn(analytics, 'add');
 


### PR DESCRIPTION
#### What does this PR do?
Adding a new flag to options, `--no-markdown`, which removes the `markdown` property from `result.message` when using `sarif` output.

#### How should this be manually tested?
`snyk code test --sarif --no-markdown`

#### Any background context you want to provide?
Slack discussion: https://snyk.slack.com/archives/C01U14WSN73/p1642928960104800

#### What are the relevant tickets?
This is a result of a support ticket: https://snyk.zendesk.com/agent/tickets/18450
