### PR TITLE
fix: ignore symlinks for unmanaged scanning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.15.0",
+        "snyk-cpp-plugin": "2.15.2",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22233,9 +22233,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
-      "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
+      "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -44235,7 +44235,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.15.0",
+        "snyk-cpp-plugin": "2.15.2",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -61888,9 +61888,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.15.0",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
-          "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
+          "version": "2.15.2",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
+          "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -65185,9 +65185,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.0.tgz",
-      "integrity": "sha512-VYz6BWpVRJzxdsLKrjVXecc2MqJnc2AWkH1LOjQYXbozAVnE6x7vpbxZiJ39wvuurCqD4ntYQU4EnmlSjhFmdg==",
+      "version": "2.15.2",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
+      "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.15.0",
+    "snyk-cpp-plugin": "2.15.2",
     "snyk-docker-plugin": "^4.33.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
Changed the parsing logic to ignore the symlinks while doing unmanaged scanning.

Bumped the cpp-plugin plugin to bring the changes into the CLI.