### PR TITLE
feat: added option --sarif-file-output for snyk code test [NEBULA-157]

### DIFF
--- a/help/cli-commands/code.md
+++ b/help/cli-commands/code.md
@@ -53,6 +53,12 @@ Print results in JSON format.
 
 Return results in SARIF format.
 
+### `--sarif-file-output=<OUTPUT_FILE_PATH>`
+
+Save test output in SARIF format directly to the <OUTPUT_FILE_PATH> file, regardless of whether or not you use the `--sarif` option.
+
+This is especially useful if you want to display the human-readable test output using stdout and at the same time save the SARIF format output to a file.
+
 ## `--no-markdown`
 
 Removes the `markdown` field from the `result.message` object. Should be used when using `--sarif`.

--- a/src/lib/ecosystems/test.ts
+++ b/src/lib/ecosystems/test.ts
@@ -22,8 +22,15 @@ export async function testEcosystem(
   // TODO: this is an intermediate step before consolidating ecosystem plugins
   // to accept flows that act differently in the testDependencies step
   if (plugin.test) {
-    const { readableResult: res } = await plugin.test(paths, options);
-    return TestCommandResult.createHumanReadableTestCommandResult(res, '');
+    const { readableResult: res, sarifResult: sarifRes } = await plugin.test(
+      paths,
+      options,
+    );
+    return TestCommandResult.createHumanReadableTestCommandResult(
+      res,
+      '',
+      sarifRes,
+    );
   }
   const scanResultsByPath: { [dir: string]: ScanResult[] } = {};
   for (const path of paths) {

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -106,7 +106,7 @@ export interface EcosystemPlugin {
   test?: (
     paths: string[],
     options: Options,
-  ) => Promise<{ readableResult: string }>;
+  ) => Promise<{ readableResult: string; sarifResult?: string }>;
 }
 
 export interface EcosystemMonitorError {


### PR DESCRIPTION
### What this does

This PR adds support to the `--sarif-file-output` flag in `snyk code test`.
The commands `snyk test` and `snyk iac test` support this flag, while `snyk code test` only supports `--sarif` but not writing to a file directly.

### Notes for the reviewer

Run `snyk code test --sarif-file-output` in a repository to generate a file with the sarif result. This can be used simultaneously with other flags like `--sarif` and `--no-markdown`.

### More information

- [Jira ticket NEBULA-157](https://snyksec.atlassian.net/browse/NEBULA-157)
- [Zendesk ticket 15314](https://snyk.zendesk.com/agent/tickets/15314)
- [Zendesk ticket 15028](https://snyk.zendesk.com/agent/tickets/15028)