### PR TITLE
fix: add support for --API to iac test command [CFG-1513]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -155,6 +155,10 @@ export type IaCTestFlags = Pick<
   | 'policy-path'
 > & {
   // Supported flags not yet covered by Options or TestOptions
+  api?: string;
+  // for some reason container/oss ONLY support uppercase flag
+  // so this is included here for consistency.
+  API?: string;
   'json-file-output'?: string;
   'sarif-file-output'?: string;
   v?: boolean;

--- a/test/jest/unit/iac-unit-tests/assert-iac-options-flag.spec.ts
+++ b/test/jest/unit/iac-unit-tests/assert-iac-options-flag.spec.ts
@@ -9,6 +9,7 @@ describe('assertIaCOptionsFlags()', () => {
 
   it('accepts all command line flags accepted by the iac command', () => {
     const options = [
+      '--API',
       '--debug',
       '--insecure',
       '--detection-depth',
@@ -35,6 +36,13 @@ describe('assertIaCOptionsFlags()', () => {
   });
 
   it('throws an error if an unexpected flag is present', () => {
+    const options = ['--project-name'];
+    expect(() =>
+      assertIaCOptionsFlags([...command, ...options, ...files]),
+    ).toThrow();
+  });
+
+  it('throws an error if the --api flag is present', () => {
     const options = ['--project-name'];
     expect(() =>
       assertIaCOptionsFlags([...command, ...options, ...files]),


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Adds support for the `--API` flag to the `snyk iac test` command.

#### Where should the reviewer start?

Start in assert-iac-options-flag.ts and verify the types.ts file. We just needed to add the flag to the safelist of commands supported by the `snyk iac test` flow.

We also have to be careful _not_ to support the lowercase `--api` flag because due to our unique arg parsing and config objects we parse the command line arguments both in `args.ts` _and_ in the snyk-config library. Meaning that command line flags will also end up in the `config` object and we need to be careful to avoid conflicts here.

The flag `--api=foo` will override the `config.api` value which is the auth token saved in the Snyk config file under the `api` key NOT the endpoint. But `--API=foo` will set the `config.API` value which is the _endpoint_ saved in the Snyk config file under the `endpoint` key. What a world we live in.

#### How should this be manually tested?

./bin/snyk iac test --API=<your api> test/fixtures/iac/kubernetes/pod-privileged-multi.yaml


#### What are the relevant tickets?

[CFG-1513]


[CFG-1513]: https://snyksec.atlassian.net/browse/CFG-1513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ