### PR TITLE
fix: IaC analytics

### DIFF
--- a/src/lib/analytics/index.ts
+++ b/src/lib/analytics/index.ts
@@ -109,15 +109,36 @@ export function add(key: string, value: unknown): void {
   }
 
   if (metadata[key]) {
-    if (typeof value === 'number' && typeof metadata[key] === 'number') {
-      metadata[key] += value;
-    } else {
-      if (!Array.isArray(metadata[key])) {
-        metadata[key] = [metadata[key]];
-      }
-      Array.isArray(value)
-        ? metadata[key].push(...value)
-        : metadata[key].push(value);
+    switch (key) {
+      case 'iac-metrics':
+        break;
+      case 'iac-type':
+        if (typeof value === 'object') {
+          for (const type in value) {
+            if (metadata[key][type]) {
+              for (const metric in value[type]) {
+                metadata[key][type][metric] &&
+                typeof value[type][metric] === 'number'
+                  ? (metadata[key][type][metric] += value[type][metric])
+                  : (metadata[key][type][metric] = value[type][metric]);
+              }
+            } else {
+              metadata[key][type] = value[type];
+            }
+          }
+        }
+        break;
+      default:
+        if (typeof value === 'number' && typeof metadata[key] === 'number') {
+          metadata[key] += value;
+        } else {
+          if (!Array.isArray(metadata[key])) {
+            metadata[key] = [metadata[key]];
+          }
+          Array.isArray(value)
+            ? metadata[key].push(...value)
+            : metadata[key].push(value);
+        }
     }
   } else {
     metadata[key] = value;


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
Today a user can test multiple files/directories by using the command snyk iac test {path1} {path2}.

When doing so we are saving the `iac-type` and `iac-metric` analytics incorrectly, for example:
```
"iac-type": [
      {
        "cloudformationconfig": {
          "count": 1,
          "low": 1,
          "medium": 9
        }
      },
      {
        "terraformconfig": {
          "count": 1,
          "medium": 15,
          "high": 10,
          "low": 20
        }
      },
      {
        "terraformconfig": {
          "count": 1,
          "low": 5
        },
        "cloudformationconfig": {
          "count": 1,
          "low": 2,
          "medium": 1
        }
      }
    ],
```
We should save it as a single object that aggregates the values of all the items in the array.

#### How should this be manually tested?
Run a test with multiple args and use the -d flag to check the metadata field at the bottom.

#### Any background context you want to provide?
This PR is a continuation of the work done in https://github.com/snyk/snyk/pull/2620.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1446

#### Screenshots
Before
![image](https://user-images.githubusercontent.com/71096571/151981015-b6d8c82b-f816-4862-bc5d-4b73ef3d4796.png)
After
![image](https://user-images.githubusercontent.com/71096571/151981068-bbf9a950-efbf-4695-829b-185cb168cf26.png)

