### PR TITLE
fix: proper exit codes for the unmanaged flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.15.2",
+        "snyk-cpp-plugin": "2.15.3",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -22233,9 +22233,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
-      "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.3.tgz",
+      "integrity": "sha512-7FyvPlzqxpZKZtzmSYZKCxA8THmJEnhZAH9Ko6o29iQW+GQBJyzrU4yEtfafDVEm+2wqfqrxnw5LyJWM6NwFYg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",
@@ -44235,7 +44235,7 @@
         "sinon": "^4.0.0",
         "snyk": "file:",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.15.2",
+        "snyk-cpp-plugin": "2.15.3",
         "snyk-docker-plugin": "^4.33.0",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -61888,9 +61888,9 @@
           }
         },
         "snyk-cpp-plugin": {
-          "version": "2.15.2",
-          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
-          "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
+          "version": "2.15.3",
+          "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.3.tgz",
+          "integrity": "sha512-7FyvPlzqxpZKZtzmSYZKCxA8THmJEnhZAH9Ko6o29iQW+GQBJyzrU4yEtfafDVEm+2wqfqrxnw5LyJWM6NwFYg==",
           "requires": {
             "@snyk/dep-graph": "^1.19.3",
             "chalk": "^4.1.0",
@@ -65185,9 +65185,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.2.tgz",
-      "integrity": "sha512-rbFcrrMD8lmE4EURASmq3pFnyLEZv3JXfqgHXuWRzZikQ3UanHw4du92bNsd5L7R+WISwSD58EX1jGPWuryDPw==",
+      "version": "2.15.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.15.3.tgz",
+      "integrity": "sha512-7FyvPlzqxpZKZtzmSYZKCxA8THmJEnhZAH9Ko6o29iQW+GQBJyzrU4yEtfafDVEm+2wqfqrxnw5LyJWM6NwFYg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.15.2",
+    "snyk-cpp-plugin": "2.15.3",
     "snyk-docker-plugin": "^4.33.0",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Align the exit codes of the `snyk unmanaged test` command to mirror the other ecosystems.

Currently, the supported exit codes for the unmanaged flows are:
&nbsp;&nbsp;&nbsp;&nbsp; 0: success, no vulns found
&nbsp;&nbsp;&nbsp;&nbsp; 1: action_needed, vulns found
&nbsp;&nbsp;&nbsp;&nbsp;  2: failure, try to re-run command
&nbsp;&nbsp;&nbsp;&nbsp;  3: failure, no supported projects detected

The above logic is available in the updated version of the c++ plugin.

#### Where should the reviewer start?

This is just a version bump for the c++ plugin.


