### PR TITLE
feat: bump snyk sbt plugin for warning on sbt-dep-graph plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,7 @@
         "snyk-python-plugin": "1.22.2",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.12.0",
+        "snyk-sbt-plugin": "2.13.0",
         "snyk-try-require": "^2.0.2",
         "strip-ansi": "^5.2.0",
         "tar": "^6.1.2",
@@ -23208,9 +23208,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/snyk-sbt-plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.12.0.tgz",
-      "integrity": "sha512-dJhRpO4nLGYKCTKigrx/vu4JfswyXNssH1oVU1922AENgoQw56pAhNZv5N7ozhDkk7mFV1ghcPCpub+/DPde7w==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.13.0.tgz",
+      "integrity": "sha512-pluHrBQb7grxKD/N/pWRFvkJ+vC6w3pm0X6X3oBRWP7J4LxsJlEQ/CsgvC6z48OT8nQyKeHcbjlKydHw4lD5Mw==",
       "dependencies": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",
@@ -44564,7 +44564,7 @@
         "snyk-python-plugin": "1.22.2",
         "snyk-resolve": "1.1.0",
         "snyk-resolve-deps": "4.7.3",
-        "snyk-sbt-plugin": "2.12.0",
+        "snyk-sbt-plugin": "2.13.0",
         "snyk-try-require": "^2.0.2",
         "strip-ansi": "^5.2.0",
         "tap": "^12.6.1",
@@ -62991,9 +62991,9 @@
           }
         },
         "snyk-sbt-plugin": {
-          "version": "2.12.0",
-          "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.12.0.tgz",
-          "integrity": "sha512-dJhRpO4nLGYKCTKigrx/vu4JfswyXNssH1oVU1922AENgoQw56pAhNZv5N7ozhDkk7mFV1ghcPCpub+/DPde7w==",
+          "version": "2.13.0",
+          "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.13.0.tgz",
+          "integrity": "sha512-pluHrBQb7grxKD/N/pWRFvkJ+vC6w3pm0X6X3oBRWP7J4LxsJlEQ/CsgvC6z48OT8nQyKeHcbjlKydHw4lD5Mw==",
           "requires": {
             "debug": "^4.1.1",
             "semver": "^6.1.2",
@@ -66373,9 +66373,9 @@
       }
     },
     "snyk-sbt-plugin": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.12.0.tgz",
-      "integrity": "sha512-dJhRpO4nLGYKCTKigrx/vu4JfswyXNssH1oVU1922AENgoQw56pAhNZv5N7ozhDkk7mFV1ghcPCpub+/DPde7w==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/snyk-sbt-plugin/-/snyk-sbt-plugin-2.13.0.tgz",
+      "integrity": "sha512-pluHrBQb7grxKD/N/pWRFvkJ+vC6w3pm0X6X3oBRWP7J4LxsJlEQ/CsgvC6z48OT8nQyKeHcbjlKydHw4lD5Mw==",
       "requires": {
         "debug": "^4.1.1",
         "semver": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "snyk-python-plugin": "1.22.2",
     "snyk-resolve": "1.1.0",
     "snyk-resolve-deps": "4.7.3",
-    "snyk-sbt-plugin": "2.12.0",
+    "snyk-sbt-plugin": "2.13.0",
     "snyk-try-require": "^2.0.2",
     "strip-ansi": "^5.2.0",
     "tar": "^6.1.2",


### PR DESCRIPTION

#### What does this PR do?
Bumping our SBT plugin to pick up new additional warning we've added to inform users regarding the new 
sbt-dependency-graph annotation.

See https://github.com/snyk/snyk-sbt-plugin/pull/104

