### PR TITLE
feat: IaC CLI Share Results [CFG-1532]

### DIFF
--- a/packages/snyk-fix/src/types.ts
+++ b/packages/snyk-fix/src/types.ts
@@ -13,12 +13,16 @@ export interface ContainerTarget {
   image: string;
 }
 
+interface UnknownTarget {
+  name: string; // Should be equal to the project name
+}
+
 export interface ScanResult {
   readonly identity: Identity;
   readonly facts: Facts[];
   readonly name?: string;
   readonly policy?: string;
-  readonly target?: GitTarget | ContainerTarget;
+  readonly target?: GitTarget | ContainerTarget | UnknownTarget;
 }
 
 export interface Identity {

--- a/src/cli/commands/test/iac-local-execution/file-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/file-utils.ts
@@ -7,6 +7,7 @@ import {
   LOCAL_POLICY_ENGINE_DIR,
 } from './local-cache';
 import { CUSTOM_RULES_TARBALL } from './oci-pull';
+import { isLocalFolder } from '../../../../lib/detect';
 
 function hashData(s: string): string {
   const hashedData = crypto
@@ -67,4 +68,36 @@ export function computeCustomRulesBundleChecksum(): string | undefined {
   } catch (err) {
     return;
   }
+}
+
+export function computePaths(
+  filePath: string,
+  pathArg = '.',
+): { targetFilePath: string; projectName: string; targetFile: string } {
+  const targetFilePath = path.resolve(filePath, '.');
+
+  // the absolute path is needed to compute the full project path
+  const cmdPath = path.resolve(pathArg);
+
+  let projectPath: string;
+  let targetFile: string;
+  if (!isLocalFolder(cmdPath)) {
+    // if the provided path points to a file, then the project starts at the parent folder of that file
+    // and the target file was provided as the path argument
+    projectPath = path.dirname(cmdPath);
+    targetFile = path.isAbsolute(pathArg)
+      ? path.relative(process.cwd(), pathArg)
+      : pathArg;
+  } else {
+    // otherwise, the project starts at the provided path
+    // and the target file must be the relative path from the project path to the path of the scanned file
+    projectPath = cmdPath;
+    targetFile = path.relative(projectPath, targetFilePath);
+  }
+
+  return {
+    targetFilePath,
+    projectName: path.basename(projectPath),
+    targetFile,
+  };
 }

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -31,6 +31,7 @@ import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
 import { initRules } from './rules';
 import { NoFilesToScanError } from './file-loader';
 import { parseTerraformFiles } from './file-parser';
+import { formatAndShareResults } from './share-results';
 
 // this method executes the local processing engine and then formats the results to adapt with the CLI output.
 // this flow is the default GA flow for IAC scanning.
@@ -126,10 +127,21 @@ export async function test(
       scannedFiles,
       iacOrgSettings.customPolicies,
     );
+
+    let projectPublicIds: Record<string, string> = {};
+    if (options.report) {
+      projectPublicIds = await formatAndShareResults(
+        resultsWithCustomSeverities,
+        options,
+        orgPublicId,
+      );
+    }
+
     const formattedResults = formatScanResults(
       resultsWithCustomSeverities,
       options,
       iacOrgSettings.meta,
+      projectPublicIds,
     );
 
     const { filteredIssues, ignoreCount } = filterIgnoredIssues(

--- a/src/cli/commands/test/iac-local-execution/share-results-formatter.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results-formatter.ts
@@ -1,0 +1,47 @@
+import { computePaths } from './file-utils';
+import {
+  IacFileScanResult,
+  IacShareResultsFormat,
+  IaCTestFlags,
+} from './types';
+
+export function formatShareResults(
+  scanResults: IacFileScanResult[],
+  options: IaCTestFlags,
+): IacShareResultsFormat[] {
+  const resultsGroupedByFilePath = groupByFilePath(scanResults);
+
+  return resultsGroupedByFilePath.map((result) => {
+    const { projectName, targetFile } = computePaths(
+      result.filePath,
+      options.path,
+    );
+
+    return {
+      projectName,
+      targetFile,
+      filePath: result.filePath,
+      fileType: result.fileType,
+      projectType: result.projectType,
+      violatedPolicies: result.violatedPolicies,
+    };
+  });
+}
+
+function groupByFilePath(scanResults: IacFileScanResult[]) {
+  const groupedByFilePath = scanResults.reduce((memo, scanResult) => {
+    scanResult.violatedPolicies.forEach((violatedPolicy) => {
+      violatedPolicy.docId = scanResult.docId;
+    });
+    if (memo[scanResult.filePath]) {
+      memo[scanResult.filePath].violatedPolicies.push(
+        ...scanResult.violatedPolicies,
+      );
+    } else {
+      memo[scanResult.filePath] = scanResult;
+    }
+    return memo;
+  }, {} as Record<string, IacFileScanResult>);
+
+  return Object.values(groupedByFilePath);
+}

--- a/src/cli/commands/test/iac-local-execution/share-results.ts
+++ b/src/cli/commands/test/iac-local-execution/share-results.ts
@@ -1,0 +1,22 @@
+import { isFeatureFlagSupportedForOrg } from '../../../../lib/feature-flags';
+import { shareResults } from '../../../../lib/iac/cli-share-results';
+import { FeatureFlagError } from './assert-iac-options-flag';
+import { formatShareResults } from './share-results-formatter';
+
+export async function formatAndShareResults(
+  results,
+  options,
+  orgPublicId,
+): Promise<Record<string, string>> {
+  const isCliReportEnabled = await isFeatureFlagSupportedForOrg(
+    'iacCliShareResults',
+    orgPublicId,
+  );
+  if (!isCliReportEnabled.ok) {
+    throw new FeatureFlagError('report', 'iacCliShareResults');
+  }
+
+  const formattedResults = formatShareResults(results, options);
+
+  return await shareResults(formattedResults);
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -1,4 +1,8 @@
-import { IacProjectType, IacProjectTypes } from '../../../../lib/iac/constants';
+import {
+  IacFileTypes,
+  IacProjectType,
+  IacProjectTypes,
+} from '../../../../lib/iac/constants';
 import { SEVERITY } from '../../../../lib/snyk-test/common';
 import {
   AnnotatedIssue,
@@ -49,6 +53,15 @@ export type ParsingResults = {
 };
 
 export interface IacFileScanResult extends IacFileParsed {
+  violatedPolicies: PolicyMetadata[];
+}
+
+export interface IacShareResultsFormat {
+  projectName: string;
+  targetFile: string;
+  filePath: string;
+  fileType: IacFileTypes;
+  projectType: IacProjectType;
   violatedPolicies: PolicyMetadata[];
 }
 
@@ -149,6 +162,7 @@ export interface PolicyMetadata {
   remediation?: Partial<
     Record<'terraform' | 'cloudformation' | 'arm' | 'kubernetes', string>
   >;
+  docId?: number;
 }
 
 // Collection of all options supported by `iac test` command.
@@ -163,6 +177,7 @@ export type IaCTestFlags = Pick<
   | 'severityThreshold'
   | 'json'
   | 'sarif'
+  | 'report'
 
   // PolicyOptions
   | 'ignore-policy'
@@ -304,6 +319,7 @@ export enum IaCErrorCodes {
   FlagError = 1090,
   FlagValueError = 1091,
   UnsupportedEntitlementFlagError = 1092,
+  FeatureFlagError = 1093,
 
   // oci-pull errors
   FailedToExecuteCustomRulesError = 1100,

--- a/src/cli/commands/test/index.ts
+++ b/src/cli/commands/test/index.ts
@@ -43,6 +43,8 @@ import {
   containsSpotlightVulnIds,
   notificationForSpotlightVulns,
 } from '../../../lib/spotlight-vuln-notification';
+import config from '../../../lib/config';
+import { isIacShareResultsOptions } from './iac-local-execution/assert-iac-options-flag';
 
 const debug = Debug('snyk-test');
 const SEPARATOR = '\n-------------------------------------------------------\n';
@@ -108,6 +110,8 @@ export default async function test(
         // this path is an experimental feature feature for IaC which does issue scanning locally without sending files to our Backend servers.
         // once ready for GA, it is aimed to deprecate our remote-processing model, so IaC file scanning in the CLI is done locally.
         const { results, failures } = await iacTest(path, testOpts);
+        testOpts.org = results[0]?.org;
+        testOpts.projectName = results[0]?.projectName;
         res = results;
         iacScanFailures = failures;
       } else {
@@ -292,6 +296,13 @@ export default async function test(
     );
     response += spotlightVulnsMsg;
 
+    if (isIacShareResultsOptions(options)) {
+      response +=
+        chalk.bold.white(
+          `Your test results are available at: ${config.ROOT}/org/${resultOptions[0].org}/projects under the name ${resultOptions[0].projectName}`,
+        ) + EOL;
+    }
+
     const error = new Error(response) as any;
     // take the code of the first problem to go through error
     // translation
@@ -309,6 +320,13 @@ export default async function test(
   response += getProtectUpgradeWarningForPaths(
     packageJsonPathsWithSnykDepForProtect,
   );
+
+  if (isIacShareResultsOptions(options)) {
+    response +=
+      chalk.bold.white(
+        `Your test results are available at: ${config.ROOT}/org/${resultOptions[0].org}/projects under the name ${resultOptions[0].projectName}`,
+      ) + EOL;
+  }
 
   return TestCommandResult.createHumanReadableTestCommandResult(
     response,

--- a/src/lib/ecosystems/types.ts
+++ b/src/lib/ecosystems/types.ts
@@ -5,6 +5,8 @@ import { Options, ProjectAttributes, Tag } from '../types';
 
 export type Ecosystem = 'cpp' | 'docker' | 'code';
 
+export type FindingType = 'iacIssue';
+
 export interface PluginResponse {
   scanResults: ScanResult[];
 }
@@ -18,12 +20,17 @@ export interface ContainerTarget {
   image: string;
 }
 
+export interface UnknownTarget {
+  name: string; // Should be equal to the project name
+}
+
 export interface ScanResult {
   identity: Identity;
   facts: Facts[];
+  findings?: Finding[];
   name?: string;
   policy?: string;
-  target?: GitTarget | ContainerTarget;
+  target?: GitTarget | ContainerTarget | UnknownTarget;
   analytics?: Analytics[];
 }
 
@@ -40,6 +47,11 @@ export interface Identity {
 
 export interface Facts {
   type: string;
+  data: any;
+}
+
+export interface Finding {
+  type: FindingType;
   data: any;
 }
 

--- a/src/lib/iac/cli-share-results.ts
+++ b/src/lib/iac/cli-share-results.ts
@@ -1,0 +1,28 @@
+import config from '../config';
+import { makeRequest } from '../request';
+import { getAuthHeader } from '../api-token';
+import { IacShareResultsFormat } from '../../cli/commands/test/iac-local-execution/types';
+import { convertIacResultToScanResult } from './envelope-formatters';
+import { AuthFailedError } from '../errors/authentication-failed-error';
+
+export async function shareResults(
+  results: IacShareResultsFormat[],
+): Promise<Record<string, string>> {
+  const scanResults = results.map(convertIacResultToScanResult);
+
+  const { res, body } = await makeRequest({
+    method: 'POST',
+    url: `${config.API}/iac-cli-share-results`,
+    json: true,
+    headers: {
+      authorization: getAuthHeader(),
+    },
+    body: scanResults,
+  });
+
+  if (res.statusCode === 401) {
+    throw AuthFailedError();
+  }
+
+  return body;
+}

--- a/src/lib/iac/envelope-formatters.ts
+++ b/src/lib/iac/envelope-formatters.ts
@@ -1,0 +1,25 @@
+import {
+  IacShareResultsFormat,
+  PolicyMetadata,
+} from '../../cli/commands/test/iac-local-execution/types';
+import { ScanResult } from '../ecosystems/types';
+
+export function convertIacResultToScanResult(
+  iacResult: IacShareResultsFormat,
+): ScanResult {
+  return {
+    identity: {
+      type: iacResult.projectType,
+      targetFile: iacResult.targetFile,
+    },
+    facts: [],
+    findings: iacResult.violatedPolicies.map((policy: PolicyMetadata) => {
+      return {
+        data: { metadata: policy, docId: policy.docId },
+        type: 'iacIssue',
+      };
+    }),
+    name: iacResult.projectName,
+    target: { name: iacResult.projectName },
+  };
+}

--- a/src/lib/polling/types.ts
+++ b/src/lib/polling/types.ts
@@ -6,6 +6,7 @@ import {
 import {
   GitTarget,
   ContainerTarget,
+  UnknownTarget,
   MonitorDependenciesResponse,
 } from '../ecosystems/types';
 
@@ -48,5 +49,5 @@ export interface ResolutionMeta {
   identity: {
     type: string;
   };
-  target?: GitTarget | ContainerTarget;
+  target?: GitTarget | ContainerTarget | UnknownTarget;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -93,6 +93,7 @@ export interface Options {
   supportUnmanagedVulnDB?: boolean;
   'no-markdown'?: boolean;
   'max-depth'?: number;
+  report?: boolean;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -12,7 +12,7 @@ const featureFlagDefaults = (): Map<string, boolean> => {
   ]);
 };
 
-type FakeServer = {
+export type FakeServer = {
   getRequests: () => express.Request[];
   popRequest: () => express.Request;
   popRequests: (num: number) => express.Request[];

--- a/test/jest/acceptance/iac/cli-share-results.spec.ts
+++ b/test/jest/acceptance/iac/cli-share-results.spec.ts
@@ -1,0 +1,90 @@
+import { FakeServer } from '../../../acceptance/fake-server';
+import { startMockServer } from './helpers';
+
+jest.setTimeout(50000);
+
+describe('CLI Share Results', () => {
+  let server: FakeServer;
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const result = await startMockServer();
+    server = result.server;
+    run = result.run;
+    teardown = result.teardown;
+  });
+
+  afterEach(() => {
+    server.restore();
+  });
+
+  afterAll(async () => teardown());
+
+  describe('feature flag is not enabled', () => {
+    beforeAll(() => {
+      server.setFeatureFlag('iacCliShareResults', false);
+    });
+
+    it('the output includes an error', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --report`,
+      );
+      expect(exitCode).toBe(2);
+
+      expect(stdout).toMatch(
+        'Flag "--report" is only supported if feature flag "iacCliShareResults" is enabled. To enable it, please contact Snyk support.',
+      );
+    });
+  });
+
+  describe('feature flag is enabled', () => {
+    beforeAll(() => {
+      server.setFeatureFlag('iacCliShareResults', true);
+    });
+
+    it('the output of a regular scan includes a link to the projects page', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --report`,
+      );
+      expect(exitCode).toBe(1);
+
+      expect(stdout).toContain(
+        `Your test results are available at: http://localhost:${server.getPort()}/org/test-org/projects under the name arm`,
+      );
+    });
+
+    it('forwards value to iac-cli-share-results endpoint', async () => {
+      const { exitCode } = await run(
+        `snyk iac test ./iac/arm/rule_test.json --report`,
+      );
+
+      expect(exitCode).toEqual(1);
+
+      const testRequests = server
+        .getRequests()
+        .filter((request) => request.url?.includes('/iac-cli-share-results'));
+
+      expect(testRequests.length).toEqual(1);
+
+      expect(testRequests[0]).toMatchObject({
+        body: [
+          {
+            identity: {
+              type: 'armconfig',
+              targetFile: './iac/arm/rule_test.json',
+            },
+            facts: [],
+            findings: expect.arrayContaining([]),
+            name: 'arm',
+            target: {
+              name: 'arm',
+            },
+          },
+        ],
+      });
+    });
+  });
+});

--- a/test/jest/acceptance/iac/helpers.ts
+++ b/test/jest/acceptance/iac/helpers.ts
@@ -31,6 +31,7 @@ export async function startMockServer() {
   };
 
   return {
+    server,
     run: async (
       cmd: string,
       overrides?: Record<string, string>,

--- a/test/jest/unit/iac/cli-share-results.fixtures.ts
+++ b/test/jest/unit/iac/cli-share-results.fixtures.ts
@@ -1,0 +1,163 @@
+import {
+  IacShareResultsFormat,
+  PolicyMetadata,
+} from '../../../../src/cli/commands/test/iac-local-execution/types';
+import { IacProjectType } from '../../../../src/lib/iac/constants';
+import { SEVERITY } from '../../../../src/lib/snyk-test/common';
+
+const policyStub: PolicyMetadata = {
+  id: '1',
+  description: '',
+  impact:
+    'Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).',
+  issue: 'Container is running in privileged mode',
+  msg: 'input.spec.containers[whatever].securityContext.privileged',
+  publicId: 'SNYK-CC-K8S-1',
+  references: [
+    'CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers',
+    'https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged',
+    'https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/',
+  ],
+  resolve:
+    'Remove `securityContext.privileged` attribute, or set value to `false`',
+  severity: 'medium' as SEVERITY,
+  subType: 'Deployment',
+  title: 'Container is running in privileged mode',
+  type: 'k8s',
+  docId: 0,
+};
+
+const anotherPolicyStub: PolicyMetadata = {
+  ...policyStub,
+  severity: 'high' as SEVERITY,
+  id: '2',
+  publicId: 'SNYK-CC-K8S-2',
+  docId: 1,
+};
+
+export function generateScanResults(): IacShareResultsFormat[] {
+  return [
+    {
+      projectName: 'projectA',
+      targetFile: 'file.yaml',
+      filePath: '/some/path/to/file.yaml',
+      fileType: 'yaml',
+      projectType: IacProjectType.K8S,
+      violatedPolicies: [{ ...policyStub }, { ...anotherPolicyStub }],
+    },
+    {
+      projectName: 'projectB',
+      targetFile: 'file.yaml',
+      filePath: '/some/path/to/file.yaml',
+      fileType: 'yaml',
+      projectType: IacProjectType.K8S,
+      violatedPolicies: [{ ...policyStub }],
+    },
+  ];
+}
+
+export const expectedEnvelopeFormatterResults = [
+  {
+    identity: {
+      type: 'k8sconfig',
+      targetFile: 'file.yaml',
+    },
+    facts: [],
+    findings: [
+      {
+        data: {
+          metadata: {
+            id: '1',
+            description: '',
+            impact:
+              'Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).',
+            issue: 'Container is running in privileged mode',
+            msg: 'input.spec.containers[whatever].securityContext.privileged',
+            publicId: 'SNYK-CC-K8S-1',
+            references: [
+              'CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers',
+              'https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged',
+              'https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/',
+            ],
+            resolve:
+              'Remove `securityContext.privileged` attribute, or set value to `false`',
+            severity: 'medium',
+            subType: 'Deployment',
+            title: 'Container is running in privileged mode',
+            type: 'k8s',
+            docId: 0,
+          },
+          docId: 0,
+        },
+        type: 'iacIssue',
+      },
+      {
+        data: {
+          metadata: {
+            id: '2',
+            description: '',
+            impact:
+              'Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).',
+            issue: 'Container is running in privileged mode',
+            msg: 'input.spec.containers[whatever].securityContext.privileged',
+            publicId: 'SNYK-CC-K8S-2',
+            references: [
+              'CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers',
+              'https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged',
+              'https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/',
+            ],
+            resolve:
+              'Remove `securityContext.privileged` attribute, or set value to `false`',
+            severity: 'high',
+            subType: 'Deployment',
+            title: 'Container is running in privileged mode',
+            type: 'k8s',
+            docId: 1,
+          },
+          docId: 1,
+        },
+        type: 'iacIssue',
+      },
+    ],
+    name: 'projectA',
+    target: { name: 'projectA' },
+  },
+  {
+    identity: {
+      type: 'k8sconfig',
+      targetFile: 'file.yaml',
+    },
+    facts: [],
+    findings: [
+      {
+        data: {
+          metadata: {
+            id: '1',
+            description: '',
+            impact:
+              'Compromised container could potentially modify the underlying host’s kernel by loading unauthorized modules (i.e. drivers).',
+            issue: 'Container is running in privileged mode',
+            msg: 'input.spec.containers[whatever].securityContext.privileged',
+            publicId: 'SNYK-CC-K8S-1',
+            references: [
+              'CIS Kubernetes Benchmark 1.6.0 - 5.2.1 Minimize the admission of privileged containers',
+              'https://kubernetes.io/docs/concepts/policy/pod-security-policy/#privileged',
+              'https://kubernetes.io/blog/2016/08/security-best-practices-kubernetes-deployment/',
+            ],
+            resolve:
+              'Remove `securityContext.privileged` attribute, or set value to `false`',
+            severity: 'medium',
+            subType: 'Deployment',
+            title: 'Container is running in privileged mode',
+            type: 'k8s',
+            docId: 0,
+          },
+          docId: 0,
+        },
+        type: 'iacIssue',
+      },
+    ],
+    name: 'projectB',
+    target: { name: 'projectB' },
+  },
+];

--- a/test/jest/unit/iac/cli-share-results.spec.ts
+++ b/test/jest/unit/iac/cli-share-results.spec.ts
@@ -1,0 +1,59 @@
+import { shareResults } from '../../../../src/lib/iac/cli-share-results';
+import {
+  expectedEnvelopeFormatterResults,
+  generateScanResults,
+} from './cli-share-results.fixtures';
+import * as request from '../../../../src/lib/request';
+import * as envelopeFormatters from '../../../../src/lib/iac/envelope-formatters';
+import { IacShareResultsFormat } from '../../../../src/cli/commands/test/iac-local-execution/types';
+
+describe('CLI Share Results', () => {
+  let scanResults: IacShareResultsFormat[];
+  let requestSpy, envelopeFormattersSpy;
+
+  beforeAll(async () => {
+    scanResults = generateScanResults();
+    requestSpy = await jest.spyOn(request, 'makeRequest');
+    envelopeFormattersSpy = await jest.spyOn(
+      envelopeFormatters,
+      'convertIacResultToScanResult',
+    );
+  });
+
+  beforeEach(async () => {
+    await shareResults(scanResults);
+  });
+
+  afterEach(() => {
+    requestSpy.mockClear();
+    envelopeFormattersSpy.mockClear();
+  });
+
+  it("converts the results to Envelops's ScanResult interface", () => {
+    expect(envelopeFormattersSpy.mock.calls.length).toBe(2);
+
+    const [firstCall, secondCall] = envelopeFormattersSpy.mock.calls;
+    expect(firstCall[0]).toEqual(scanResults[0]);
+    expect(secondCall[0]).toEqual(scanResults[1]);
+
+    const [
+      firstCallResult,
+      secondCallResult,
+    ] = envelopeFormattersSpy.mock.results;
+    expect(firstCallResult.value).toEqual(expectedEnvelopeFormatterResults[0]);
+    expect(secondCallResult.value).toEqual(expectedEnvelopeFormatterResults[1]);
+  });
+
+  it('forwards value to iac-cli-share-results endpoint', () => {
+    expect(requestSpy.mock.calls.length).toBe(1);
+
+    expect(requestSpy.mock.calls[0][0]).toMatchObject({
+      method: 'POST',
+      url: expect.stringContaining('/iac-cli-share-results'),
+      json: true,
+      headers: expect.objectContaining({
+        authorization: expect.stringContaining('token'),
+      }),
+    });
+  });
+});

--- a/test/jest/unit/iac/results-formatter.fixtures.ts
+++ b/test/jest/unit/iac/results-formatter.fixtures.ts
@@ -30,14 +30,14 @@ export const policyStub: PolicyMetadata = {
   type: 'k8s',
 };
 
-const anotherPolicyStub: PolicyMetadata = {
+export const anotherPolicyStub: PolicyMetadata = {
   ...policyStub,
   severity: 'high' as SEVERITY,
   id: '2',
   publicId: 'SNYK-CC-K8S-2',
 };
 
-const yetAnotherPolicyStub: PolicyMetadata = {
+export const yetAnotherPolicyStub: PolicyMetadata = {
   ...anotherPolicyStub,
   id: '3',
   publicId: 'SNYK-CC-K8S-3',
@@ -155,7 +155,7 @@ function generateFormattedResults(options) {
     meta: {
       ...meta,
       policy: '',
-      projectId: '',
+      projectId: undefined,
     },
     org: meta.org,
     policy: '',

--- a/test/jest/unit/iac/results-formatter.spec.ts
+++ b/test/jest/unit/iac/results-formatter.spec.ts
@@ -82,6 +82,7 @@ describe('formatScanResults', () => {
         generateScanResults(optionsObject.generateOptions),
         optionsObject.formatOptions,
         meta,
+        {},
       );
 
       expect(formattedResults.length).toEqual(1);
@@ -106,6 +107,7 @@ describe('parser failures should return -1 for lineNumber', () => {
       generateScanResults(),
       { severityThreshold: SEVERITY.HIGH },
       meta,
+      {},
     );
 
     expect(formattedResults.length).toEqual(1);
@@ -122,6 +124,7 @@ describe('parser failures should return -1 for lineNumber', () => {
       generateScanResults(),
       { severityThreshold: SEVERITY.HIGH },
       meta,
+      {},
     );
 
     expect(formattedResults.length).toEqual(1);

--- a/test/jest/unit/iac/share-results-formatters.fixtures.ts
+++ b/test/jest/unit/iac/share-results-formatters.fixtures.ts
@@ -1,0 +1,20 @@
+import {
+  anotherPolicyStub,
+  policyStub,
+  yetAnotherPolicyStub,
+} from './results-formatter.fixtures';
+
+export const expectedFormattedResultsForShareResults = [
+  {
+    projectName: 'snyk',
+    targetFile: 'dont-care.yaml',
+    filePath: 'dont-care.yaml',
+    fileType: 'yaml',
+    projectType: 'k8sconfig',
+    violatedPolicies: [
+      { ...policyStub, docId: 0 },
+      { ...anotherPolicyStub, docId: 0 },
+      { ...yetAnotherPolicyStub, docId: 1 },
+    ],
+  },
+];

--- a/test/jest/unit/iac/share-results-formatters.spec.ts
+++ b/test/jest/unit/iac/share-results-formatters.spec.ts
@@ -1,0 +1,15 @@
+import { formatShareResults } from '../../../../src/cli/commands/test/iac-local-execution/share-results-formatter';
+import { generateScanResults } from './results-formatter.fixtures';
+import { expectedFormattedResultsForShareResults } from './share-results-formatters.fixtures';
+
+describe('formatShareResults', () => {
+  it('returns the formatted results', () => {
+    const IacShareResultsFormatResults = formatShareResults(
+      generateScanResults(),
+      {},
+    );
+    expect(IacShareResultsFormatResults).toStrictEqual(
+      expectedFormattedResultsForShareResults,
+    );
+  });
+});


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds the ability to send IaC scan results to the Snyk platform (or in other words, IaC's implementation of the `monitor` feature).
The new feature is enabled by adding the flag `--report` to the currently available `snyk iac test` command.

#### Where should the reviewer start?
https://github.com/snyk/snyk/pull/2702/files#diff-3c191734c1a12b3652b05f2a05c377ec9ccf30a5510e8b668c104b1c8349e19aR80

#### How should this be manually tested?
1. Locally run the following registry [branch](https://github.com/snyk/registry/pull/26028).
2. Enable the FF named `iacCliShareResults`
3. In the CLI test any IaC file / directory with the command `snyk-dev iac test {path_to_the_file} --report`
4. Check that the projects were created successfully in the Snyk platform.

#### Any background context you want to provide?
[Feature plan
](https://www.notion.so/snyk/Share-test-results-from-IaC-CLI-6e8287fcc7534a4f8d628d1f8f4187ba)

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1532

#### Screenshots
![image](https://user-images.githubusercontent.com/71096571/154078269-0a6117ad-65e8-4d87-982b-8c5359e8d19e.png)
(the last line was added as part of the feature)
