### PR TITLE
[CFG-1484] Add a static help message for snyk iac drift scan

### DIFF
--- a/help/cli-commands/iac-drift.md
+++ b/help/cli-commands/iac-drift.md
@@ -1,0 +1,209 @@
+# snyk iac drift -- find differences between Cloud and Infrastructure as Code
+
+The `snyk iac drift scan` command detect, track and alert on infrastructure drift. It runs driftctl in the background.
+
+For more information see the [driftctl documentation](https://docs.driftctl.com/).
+
+## Exit codes
+
+Possible exit codes and their meaning:
+
+**0**: success, no drift found<br />
+**1**: action_needed, drifts found or failure<br />
+
+## Configure the Snyk CLI
+
+You can use environment variables to configure the Snyk CLI and also set variables to configure the Snyk CLI to connect with the Snyk API. See [Configure the Snyk CLI](https://docs.snyk.io/features/snyk-cli/configure-the-snyk-cli).
+
+## Debug
+
+Use the `-d` option to output the debug logs.
+
+## Options
+
+NOTE: Although driftctl is used in the background, the Snyk CLI brings its own options to run drift detection.
+
+### `--quiet`
+
+This flag prevents stdout to be use for anything but the scan result.
+
+### `--filter`
+
+Filter rules allow you to build complex expression to include and exclude a set of resources in your workflow. Powered by expression language JMESPath you could build a complex include and exclude expression.
+
+See [documentation for more details](https://docs.driftctl.com/0.19.0/usage/filtering/rules).
+
+### `--output`
+
+driftctl supports multiple kinds of output formats and by default uses the standard output (console).
+
+Environment: `DCTL_OUTPUT`
+
+See [documentation for more details](https://docs.driftctl.com/0.19.0/usage/cmd/scan-usage#--output).
+
+### `--to`
+
+driftctl supports multiple providers. By default it will scan against AWS, but you can change this using `--to`.
+
+#### Usage
+
+Environment: `DCTL_TO`
+
+`$ snyk iac drift scan --to PROVIDER+TYPE`
+
+Examples:
+
+`$ snyk iac drift scan --to aws+tf`
+`$ DCTL_TO=github+tf snyk iac drift scan`
+
+#### Supported Providers
+
+driftctl supports these providers:
+
+- `github+tf`
+- `aws+tf`
+- `gcp+tf`
+- `azure+tf`
+
+### `--headers`
+
+Use a specific HTTP header(s) for the HTTP backend.
+
+Example:
+
+`$ GITLAB_TOKEN=<access_token> \ snyk iac drift scan \ --from tfstate+https://gitlab.com/api/v4/projects/<project_id>/terraform/state/<path_to_state> \ --headers "Authorization=Bearer ${GITLAB_TOKEN}"`
+
+### `--tfc-token`
+
+Specify an API token to authenticate to the Terraform Cloud or Enterprise API.
+
+### `--tfc-endpoint`
+
+You can also read the current state for a given workspace from Terraform Enterprise by passing the tfc-endpoint value that's specific to your Org's Terraform Enterprise installation.
+
+You can obtain your workspace id from the General Settings of the workspace.
+
+Don't forget to provide your Terraform Enterprise API token.
+
+Example:
+
+`$ snyk iac drift scan --from tfstate+tfcloud://$WORKSPACE_ID --tfc-token $TFC_TOKEN --tfc-endpoint 'https://tfe.example.com/api/v2'`
+
+### `--tf-provider-version`
+
+You can specify a terraform provider version to use. If none, driftctl uses defaults like below:
+
+- aws@3.19.0
+- github@4.4.0
+
+#### Usage
+
+I use terraform provider 3.43.0 so I can use this provider with driftctl to avoid scan errors. driftctl will scan with an AWS terraform provider v3.43.0
+`$ DCTL_TF_PROVIDER_VERSION=3.43.0 snyk iac drift scan`
+
+Same parameter is used for every cloud provider.
+driftctl will scan with a GitHub terraform provider v4.10.1.
+`$ DCTL_TF_PROVIDER_VERSION=4.10.1 snyk iac drift scan --to github+tf`
+
+### `--strict`
+
+When running driftctl against an AWS account, you may experience unnecessary noises with resources that don't belong to you. It can be the case if you have an organization account in which you will by default have a service-linked role associated to your account (e.g. AWSServiceRoleForOrganizations). For now, driftctl ignores those service-linked resources by default.
+
+If you still want to include those resources in the report anyway, you can enable the strict mode.
+
+For now, resources include:
+
+- Service-linked AWS IAM roles, including their policies and policy attachments
+
+#### Usage
+
+`$ snyk iac drift scan --strict`
+
+### `--deep`
+
+#### Warning
+
+This flag is **EXPERIMENTAL**. Enabling deep mode while using a Terraform state as IaC source can lead to unexpected behaviors: false positive drifts, undetected drifts.
+
+Deep mode enables resources details retrieval. It was the original driftctl behavior.
+
+- In **deep** mode we compare resources details to expected ones (like a terraform plan).
+- In **non-deep** mode (the default one) we only enumerate resources and display which ones are out of IaC scope.
+
+Since it overlaps the new `terraform plan` behavior (as of Terraform 0.15 it shows diffs between your state and the remote) we moved the original behavior under the `--deep` **experimental** flag.
+
+#### Info
+
+If you use a version of driftctl prior to 0.13, the deep mode was the default behavior. If you want to keep the old behavior in a newer version you have to enable the deep mode flag.
+
+#### Usage
+
+`$ snyk iac drift scan --deep`
+
+### `--driftignore`
+
+The default name for a driftignore file is `.driftignore`. If for some reason you want to use a custom filename, you can do so using the `--driftignore` flag. This is especially useful when you have multiple driftignore files, where each of them represents a particular use case.
+
+NOTE: You can use only one driftignore file at once.
+
+#### Usage
+
+Apply ignore directives from the /path/to/driftignore file
+
+`$ snyk iac drift scan --driftignore /path/to/driftignore`
+
+### `--tf-lockfile`
+
+By default, driftctl tries to read a Terraform lock file (.terraform.lock.hcl) in the current directory, so driftctl can automatically detect which provider to use, according to the --to flag. You can specify a custom path for that file using the --tf-lockfile flag. If parsing the lockfile fails for some reason, errors will be logged and scan will continue.
+
+#### Note
+
+When using both --tf-lockfile and --tf-provider-version flags together, --tf-provider-version will simply take precedence overall.
+
+#### Example
+
+`$ snyk iac drift scan --to aws+tf --tf-lockfile path/to/.terraform.lock.hcl`
+
+### `--config-dir`
+
+You can change the directory path that driftctl uses for configuration. By default, it is the `$HOME` directory.
+
+This can be useful, for example, if you want to invoke driftctl in an AWS Lambda function where you can only use the `/tmp` folder.
+
+#### Usage
+
+`$ snyk iac drift scan --config-dir path_to_driftctl_config_dir`
+`$ DCTL_CONFIG_DIR=path_to_driftctl_config_dir snyk iac drift scan`
+
+### `--from`
+
+Currently, driftctl only supports reading IaC from a Terraform state.
+We are investigating to support the Terraform code as well, as a state does not represent an intention.
+
+Multiple states can be read by passing `--from` flags. You can also use glob patterns to match multiple state files at once.
+
+Examples:
+
+I want to read a local state and a state stored in an S3 bucket:
+`$ snyk iac drift scan \ --from tfstate+s3://statebucketdriftctl/terraform.tfstate \ --from tfstate://terraform_toto.tfstate`
+
+You can also read all files under a given prefix for S3
+`$ snyk iac drift scan --from tfstate+s3://statebucketdriftctl/states`
+
+#### Supported IaC sources
+
+- Terraform state
+- Local: `--from tfstate://terraform.tfstate`
+- S3: `--from tfstate+s3://my-bucket/path/to/state.tfstate`
+- GCS: `--from tfstate+gs://my-bucket/path/to/state.tfstate`
+- HTTPS: `--from tfstate+https://my-url/state.tfstate`
+- Terraform Cloud / Terraform Enterprise: `--from tfstate+tfcloud://WORKSPACE_ID`
+
+You can use any unsupported backend by using `terraform` to pipe your state in a file and then use this file with driftctl:
+
+`$ terraform state pull > state.tfstate`
+`$ snyk iac drift scan --from tfstate://state.tfstate`
+
+## Examples for the iac drift scan command
+
+[For more information see [Synk CLI for Infrastructure as Code](https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code).

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -70,12 +70,14 @@ export interface ArgsOptions {
   // (see the snyk-mvn-plugin or snyk-gradle-plugin)
   _doubleDashArgs: string[];
   _: MethodArgs;
+  rawArgv: string[];
   [key: string]: boolean | string | number | MethodArgs | string[]; // The two last types are for compatibility only
 }
 
 export function args(rawArgv: string[]): Args {
   const argv = {
     _: [] as string[],
+    rawArgv,
   } as ArgsOptions;
 
   for (let arg of rawArgv.slice(2)) {

--- a/src/cli/commands/help/index.ts
+++ b/src/cli/commands/help/index.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { renderMarkdown } from './markdown-renderer';
+import { ArgsOptions, MethodArgs } from '../../args';
 
 const DEFAULT_HELP = 'README';
 
@@ -9,28 +10,72 @@ function readHelpFile(filename: string): string {
   return renderMarkdown(file);
 }
 
-export default async function help(item?: string | boolean): Promise<string> {
-  if (!item || item === true || typeof item !== 'string' || item === 'help') {
-    item = DEFAULT_HELP;
+// This function is a workaround to get the absolute path
+// of the project for both CLI and unit tests.
+export function getProjectAbsolutePath(): string {
+  const filepath = path.dirname(__filename);
+  if (filepath.indexOf('dist') > -1) {
+    return path.join(filepath, '../../');
+  }
+  // Jest tests aren't transpiled, so the current filepath
+  // is the TS file, not the transpiled JS file.
+  return path.join(filepath, '../../../../');
+}
+
+export function getHelpFilePath(argv: string[]): string {
+  let item: string = DEFAULT_HELP;
+  while (argv.length) {
+    if (argv[0] === 'help') {
+      argv.shift();
+    }
+    const docFile = argv.join('-');
+    argv.pop();
+    const filename = path.resolve(
+      getProjectAbsolutePath(),
+      'help/cli-commands',
+      `${docFile}.md`,
+    );
+    if (!fs.existsSync(filename)) {
+      continue;
+    }
+    item = docFile;
+    break;
   }
 
   // cleanse the filename to only contain letters
   // aka: /\W/g but figured this was easier to read
   item = item.replace(/[^a-z0-9-]/gi, '');
 
-  try {
-    const filename = path.resolve(
-      __dirname,
-      '../../help/cli-commands', // this is a relative path from the webpack dist directory
-      item === DEFAULT_HELP ? `${DEFAULT_HELP}.md` : `${item}.md`,
-    );
-    return readHelpFile(filename);
-  } catch (error) {
-    const filename = path.resolve(
-      __dirname,
-      '../../help/cli-commands',
-      `${DEFAULT_HELP}.md`,
-    );
-    return readHelpFile(filename);
+  return path.resolve(
+    getProjectAbsolutePath(),
+    'help/cli-commands',
+    `${item}.md`,
+  );
+}
+
+export default async function help(...args: MethodArgs): Promise<string> {
+  let rawArgv: string[] | MethodArgs = args;
+  if (args.length > 1) {
+    rawArgv = (args.pop() as ArgsOptions).rawArgv;
   }
+  const formattedArgv = getSubcommandWithoutFlags(rawArgv as string[]);
+  return readHelpFile(getHelpFilePath(formattedArgv));
+}
+
+export function getSubcommandWithoutFlags(argv: string[]): string[] {
+  const formattedArgv: string[] = [];
+  if (!argv) {
+    return formattedArgv;
+  }
+  for (const arg of argv) {
+    if (
+      arg.indexOf('-') === 0 ||
+      arg.indexOf('/') > -1 ||
+      arg.indexOf('.') > -1
+    ) {
+      continue;
+    }
+    formattedArgv.push(arg);
+  }
+  return formattedArgv;
 }

--- a/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
+++ b/src/cli/commands/test/iac-local-execution/assert-iac-options-flag.ts
@@ -106,10 +106,15 @@ export function assertIaCOptionsFlags(argv: string[]) {
   // We process the process.argv so we don't get default values.
   const parsed = args(argv);
   for (const key of Object.keys(parsed.options)) {
-    // The _ property is a special case that contains non
+    // The _ and rawArgv properties are special cases that contain non
     // flag strings passed to the command line (usually files)
     // and `iac` is the command provided.
-    if (key !== '_' && key !== 'iac' && !allowed.has(key)) {
+    if (
+      key !== '_' &&
+      key !== 'iac' &&
+      key !== 'rawArgv' &&
+      !allowed.has(key)
+    ) {
       throw new FlagError(key, '');
     }
   }

--- a/test/jest/unit/analytics-sources.spec.ts
+++ b/test/jest/unit/analytics-sources.spec.ts
@@ -18,6 +18,7 @@ const emptyArgs = [];
 const defaultArgsParams = {
   _: [],
   _doubleDashArgs: [],
+  rawArgv: [],
 };
 
 beforeEach(() => {

--- a/test/jest/unit/cli/commands/help/help.spec.ts
+++ b/test/jest/unit/cli/commands/help/help.spec.ts
@@ -1,0 +1,96 @@
+import * as help from '../../../../../../src/cli/commands/help';
+
+describe('getHelpFilePath', () => {
+  test('should find iac.md', () => {
+    expect(help.getHelpFilePath(['help', 'iac'])).toContain(
+      '/help/cli-commands/iac.md',
+    );
+    expect(help.getHelpFilePath(['iac'])).toContain(
+      '/help/cli-commands/iac.md',
+    );
+  });
+
+  test('should find README.md', () => {
+    expect(help.getHelpFilePath(['wrongcommand', '--help'])).toContain(
+      'help/cli-commands/README.md',
+    );
+    expect(help.getHelpFilePath(['wrongcommand'])).toContain(
+      'help/cli-commands/README.md',
+    );
+    expect(help.getHelpFilePath(['help', 'wrongcommand'])).toContain(
+      'help/cli-commands/README.md',
+    );
+  });
+
+  test('should find container.md', () => {
+    expect(help.getHelpFilePath(['container', 'test'])).toContain(
+      'help/cli-commands/container.md',
+    );
+    expect(help.getHelpFilePath(['container'])).toContain(
+      'help/cli-commands/container.md',
+    );
+    expect(help.getHelpFilePath(['help', 'container'])).toContain(
+      'help/cli-commands/container.md',
+    );
+  });
+
+  test('should find iac-drift.md', () => {
+    expect(help.getHelpFilePath(['iac', 'drift'])).toContain(
+      'help/cli-commands/iac-drift.md',
+    );
+    expect(help.getHelpFilePath(['iac', 'drift', 'scan'])).toContain(
+      'help/cli-commands/iac-drift.md',
+    );
+  });
+});
+
+describe('getSubcommandWithoutFlags', () => {
+  test('should filter out CLI flags', () => {
+    expect(
+      help.getSubcommandWithoutFlags([
+        '/usr/local/bin/node',
+        '/home/test/index.js',
+        'iac',
+        'drift',
+        '--help',
+      ]),
+    ).toEqual(['iac', 'drift']);
+  });
+
+  test('should return empty array', () => {
+    expect(
+      help.getSubcommandWithoutFlags([
+        '/usr/local/bin/node',
+        '/home/test/index.js',
+      ]),
+    ).toEqual([]);
+  });
+
+  test('should return filter out absolute paths', () => {
+    expect(
+      help.getSubcommandWithoutFlags([
+        '/usr/local/bin/node',
+        '/home/test/index.js',
+        'iac',
+        'test',
+        '../plan.json',
+      ]),
+    ).toEqual(['iac', 'test']);
+    expect(
+      help.getSubcommandWithoutFlags([
+        '/usr/local/bin/node',
+        '/home/test/index.js',
+        'iac',
+        'test',
+        'plan.json',
+      ]),
+    ).toEqual(['iac', 'test']);
+    expect(
+      help.getSubcommandWithoutFlags([
+        '/usr/local/bin/node',
+        '/home/test/index.js',
+        'iac',
+      ]),
+    ).toEqual(['iac']);
+  });
+});

--- a/test/jest/unit/lib/commands/fix/fix.spec.ts
+++ b/test/jest/unit/lib/commands/fix/fix.spec.ts
@@ -76,6 +76,7 @@ describe('snyk fix (functional tests)', () => {
         quiet: true,
         _doubleDashArgs: [],
         _: [],
+        rawArgv: [],
       });
       expect(snykFixSpy).toHaveBeenCalledTimes(1);
       expect(snykFixSpy.mock.calls[0][1]).toEqual({
@@ -124,6 +125,7 @@ describe('snyk fix (functional tests)', () => {
         dryRun: true, // prevents write to disc
         _doubleDashArgs: [],
         _: [],
+        rawArgv: [],
       });
       expect(snykFixSpy).toHaveBeenCalledTimes(1);
       expect(snykFixSpy.mock.calls[0][1]).toEqual({
@@ -180,6 +182,7 @@ describe('snyk fix (functional tests)', () => {
         quiet: true,
         _doubleDashArgs: [],
         _: [],
+        rawArgv: [],
       });
       expect(snykFixSpy).toHaveBeenCalledTimes(1);
       expect(snykFixSpy.mock.calls[0][1]).toEqual({
@@ -239,6 +242,7 @@ describe('snyk fix (functional tests)', () => {
         quiet: true,
         _doubleDashArgs: [],
         _: [],
+        rawArgv: [],
       });
       expect(snykFixSpy.mock.calls[0][1]).toEqual({
         dryRun: true,
@@ -333,6 +337,7 @@ describe('snyk fix (functional tests)', () => {
           quiet: true,
           _doubleDashArgs: [],
           _: [],
+          rawArgv: [],
         });
       } catch (e) {
         res = e.message;
@@ -403,6 +408,7 @@ describe('snyk fix (functional tests)', () => {
           quiet: true,
           _doubleDashArgs: [],
           _: [],
+          rawArgv: [],
         });
       } catch (error) {
         res = error;
@@ -458,6 +464,7 @@ describe('snyk fix (functional tests)', () => {
         quiet: true,
         _doubleDashArgs: [],
         _: [],
+        rawArgv: [],
       });
       expect(snykFixSpy).toHaveBeenCalledTimes(1);
       expect(snykFixSpy.mock.calls[0][1]).toEqual({

--- a/test/jest/unit/lib/util.spec.ts
+++ b/test/jest/unit/lib/util.spec.ts
@@ -10,6 +10,7 @@ describe('Sanitize args', () => {
       username: 'fakeuser',
       password: 'fakepass',
       file: 'Dockerfile',
+      rawArgv: [],
     };
 
     const resultWithFlag = obfuscateArgs(
@@ -30,6 +31,7 @@ describe('Sanitize args', () => {
       org: 'demo-org',
       username: 'fakeuser',
       file: 'Dockerfile',
+      rawArgv: [],
     };
 
     const resultWithFlag = obfuscateArgs(
@@ -53,6 +55,7 @@ describe('Sanitize args', () => {
         password: 'fakepass',
         debug: true,
         docker: true,
+        rawArgv: [],
       },
     ];
 

--- a/test/jest/unit/python/snyk-test-pyproject.spec.ts
+++ b/test/jest/unit/python/snyk-test-pyproject.spec.ts
@@ -67,6 +67,7 @@ describe('snyk test for python project', () => {
           json: true,
           _: [],
           _doubleDashArgs: [],
+          rawArgv: [],
         });
 
         expect(mockedLoadPlugin).toHaveBeenCalledTimes(1);
@@ -147,6 +148,7 @@ describe('snyk test for python project', () => {
           json: true,
           _: [],
           _doubleDashArgs: [],
+          rawArgv: [],
         });
 
         expect(mockedLoadPlugin).toHaveBeenCalledTimes(1);
@@ -237,6 +239,7 @@ describe('snyk test for python project', () => {
           json: true,
           _: [],
           _doubleDashArgs: [],
+          rawArgv: [],
         });
 
         expect(mockedLoadPlugin).toHaveBeenCalledTimes(2);

--- a/test/jest/unit/query-strings.spec.ts
+++ b/test/jest/unit/query-strings.spec.ts
@@ -40,6 +40,7 @@ describe('getQueryParamsAsString', () => {
       {
         ...args,
         _: [],
+        rawArgv: [],
         _doubleDashArgs: [],
       },
     ];

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -156,6 +156,7 @@ describe('Test snyk code', () => {
       code: true,
       _: [],
       _doubleDashArgs: [],
+      rawArgv: [],
     };
 
     analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
@@ -208,6 +209,7 @@ describe('Test snyk code', () => {
         code: true,
         _: [],
         _doubleDashArgs: [],
+        rawArgv: [],
       });
     } catch (error) {
       expect(error).toEqual(expected);
@@ -223,7 +225,12 @@ describe('Test snyk code', () => {
     });
 
     await expect(
-      snykTest('some/path', { code: true, _: [], _doubleDashArgs: [] }),
+      snykTest('some/path', {
+        code: true,
+        _: [],
+        _doubleDashArgs: [],
+        rawArgv: [],
+      }),
     ).rejects.toHaveProperty(
       'userMessage',
       'Snyk Code is not supported for org: enable in Settings > Snyk Code',
@@ -237,7 +244,12 @@ describe('Test snyk code', () => {
     });
 
     await expect(
-      snykTest('some/path', { code: true, _: [], _doubleDashArgs: [] }),
+      snykTest('some/path', {
+        code: true,
+        _: [],
+        _doubleDashArgs: [],
+        rawArgv: [],
+      }),
     ).rejects.toHaveProperty('userMessage', 'error from api: org not found');
   });
 
@@ -254,7 +266,12 @@ describe('Test snyk code', () => {
     });
 
     await expect(
-      snykTest('some/path', { code: true, _: [], _doubleDashArgs: [] }),
+      snykTest('some/path', {
+        code: true,
+        _: [],
+        _doubleDashArgs: [],
+        rawArgv: [],
+      }),
     ).rejects.toHaveProperty('userMessage', 'Test limit reached!');
   });
 
@@ -267,6 +284,7 @@ describe('Test snyk code', () => {
       _: [],
       _doubleDashArgs: [],
       'sarif-file-output': 'test.json',
+      rawArgv: [],
     };
 
     analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
@@ -346,6 +364,7 @@ describe('Test snyk code', () => {
       sarif: true,
       _: [],
       _doubleDashArgs: [],
+      rawArgv: [],
     };
 
     analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
@@ -387,6 +406,7 @@ describe('Test snyk code', () => {
       _: [],
       _doubleDashArgs: [],
       'no-markdown': true,
+      rawArgv: [],
     };
 
     analyzeFoldersMock.mockResolvedValue(sampleSarif);


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

Following #2634. This PR refactor the help command behavior and adds a help page for the `snyk iac drift scan` command.

The actual help command's logic only support 1 level of subcommand and force us to put the help content in the mode's documentation (here, *iac*). Following this behavior means having a huge documentation page for IaC. With this change, the help command handler receive all the arguments given by user and lookup for the most relevant documentation available. It browse each top-level command to find the help page and always fallback to the closest documentation available. This doesn't bring breaking change, but it suggest we have to follow a specific file structure for CLI documentation.

```
# This will search for iac-drift.md, then iac.md, then README.md
$ snyk iac drift --help

# This will search for iac.md, then README.md
$ snyk help iac
```

#### Where should the reviewer start?

Start looking at `test/jest/unit/cli/commands/help/help.spec.ts` to see what it does and ensure there's no regression. Then look at `src/cli/commands/help/index.ts` where refactoring happened. The raw arguments are simply passed by the args function in `src/cli/args.ts`.

Before going deeper in the review (tests, grammar, ...), please first review the overall approach. Keep in mind that this PR **shouldn't** bring breaking changes to the actual help command behavior.

Also, [read this comment](https://github.com/snyk/snyk/pull/2735/files/0bd79c746b04251e4eeeedb509c43ed4c0904e59#r810450907).

#### How should this be manually tested?

Simply run locally and trigger the help command.

```
$ ./bin/snyk help iac drift
$ ./bin/snyk iac drift scan -h
```

#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CFG-1484
- https://github.com/snyk/snyk/pull/2634

#### Screenshots

![image](https://user-images.githubusercontent.com/16480203/154217923-38da2aae-eb8a-4b01-935a-3054c955375a.png)

