### PR TITLE
fix: max-depth argument for unmanaged flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.16.1",
+        "snyk-cpp-plugin": "2.16.3",
         "snyk-docker-plugin": "^4.34.5",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -2935,9 +2935,9 @@
       "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg=="
     },
     "node_modules/@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -16387,18 +16387,20 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.1.tgz",
-      "integrity": "sha512-qSD0Ndn0z0Kbkh6T6E5IWnj1KviTbFrEy7cU7M8dm5ijKR6m097XCwu1J92rgla3ZoMXjOU0NY4C5X30si2oRg==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.3.tgz",
+      "integrity": "sha512-R6oxd7nDAEYjU2DHFV4FXeLQS8LLjz/SaWnA4AKxL8MNQi4UlL0GgiFGJ1H98EyCz8NVUzR98HsNd/y1u7DHSg==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
+        "@types/uuid": "^8.3.4",
         "adm-zip": "^0.5.9",
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
         "hosted-git-info": "^3.0.7",
         "p-map": "^4.0.0",
         "tar": "^6.1.11",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=10"
@@ -22410,9 +22412,9 @@
       "integrity": "sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg=="
     },
     "@types/uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg=="
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw=="
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -32782,18 +32784,20 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.1.tgz",
-      "integrity": "sha512-qSD0Ndn0z0Kbkh6T6E5IWnj1KviTbFrEy7cU7M8dm5ijKR6m097XCwu1J92rgla3ZoMXjOU0NY4C5X30si2oRg==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.3.tgz",
+      "integrity": "sha512-R6oxd7nDAEYjU2DHFV4FXeLQS8LLjz/SaWnA4AKxL8MNQi4UlL0GgiFGJ1H98EyCz8NVUzR98HsNd/y1u7DHSg==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
+        "@types/uuid": "^8.3.4",
         "adm-zip": "^0.5.9",
         "chalk": "^4.1.0",
         "debug": "^4.1.1",
         "hosted-git-info": "^3.0.7",
         "p-map": "^4.0.0",
         "tar": "^6.1.11",
-        "tslib": "^2.0.0"
+        "tslib": "^2.0.0",
+        "uuid": "^8.3.2"
       },
       "dependencies": {
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.16.1",
+    "snyk-cpp-plugin": "2.16.3",
     "snyk-docker-plugin": "^4.34.5",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -92,6 +92,7 @@ export interface Options {
   'exclude-base-image-vulns'?: boolean;
   supportUnmanagedVulnDB?: boolean;
   'no-markdown'?: boolean;
+  'max-depth'?: number;
 }
 
 // TODO(kyegupov): catch accessing ['undefined-properties'] via noImplicitAny
@@ -117,6 +118,7 @@ export interface MonitorOptions {
   reachableVulnsTimeout?: number;
   initScript?: string;
   yarnWorkspaces?: boolean;
+  'max-depth'?: number;
 }
 
 export interface MonitorMeta {


### PR DESCRIPTION
Define the `--max-depth` arg used by the unmanaged flows.

- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

For the unmanaged cpp flows we need the `--max-depth` arg for knowing how many levels we go deep while unarchiving tarballs.

The PR includes also a bump for the cpp plugin to enable the above flag.