### PR TITLE
feat: TF Language Support - dereference variables in CWD while parsing [CFG-1496]

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,7 @@ test-output
 test-results
 test/**/workspaces
 .iac-data
+src/cli/commands/test/iac-local-execution/parsers/hcl-to-json/parser.js
+src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/parser.js
+release-scripts/hcl-to-json-parser-generator/src/hcltojson/test.js
+release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson/test.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,7 @@ test/**/workspaces
 .iac-data
 
 src/cli/commands/test/iac-local-execution/parsers/hcl-to-json/parser.js
+src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/parser.js
 
 # Has empty lines for templating convenience
 .github/PULL_REQUEST_TEMPLATE.md

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/snyk/snyk-iac-parsers v0.1.0
+	github.com/snyk/snyk-iac-parsers v0.2.0
+	github.com/tmccombs/hcl2json v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 )

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
@@ -109,6 +109,7 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/hcl/v2 v2.6.0/go.mod h1:bQTN5mpo+jewjJgh8jr0JUguIi7qPHUF6yIfAEN3jqY=
+github.com/hashicorp/hcl/v2 v2.9.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/hcl/v2 v2.11.1 h1:yTyWcXcm9XB0TEkyU/JCRU6rYy4K+mgLtzn2wlrJbcc=
 github.com/hashicorp/hcl/v2 v2.11.1/go.mod h1:FwWsfWEjyV/CMj8s/gqAuiviY72rJ1/oayI9WftqcKg=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
@@ -191,6 +192,8 @@ github.com/snyk/snyk-iac-parsers v0.0.7-0.20220207170447-0dca49a02401 h1:PrNu6S/
 github.com/snyk/snyk-iac-parsers v0.0.7-0.20220207170447-0dca49a02401/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/snyk/snyk-iac-parsers v0.1.0 h1:+VHQorhJ0iro0EwCJR2kNFYpkQ6EsfWSVi3xYFXPyBc=
 github.com/snyk/snyk-iac-parsers v0.1.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
+github.com/snyk/snyk-iac-parsers v0.2.0 h1:bc48Ra3U3spo5wl6XogFoT4N7VlkxCGBM3Cq0rjd0C8=
+github.com/snyk/snyk-iac-parsers v0.2.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -211,6 +214,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmccombs/hcl2json v0.3.1 h1:Pf+Lb9OpZ5lkQuIC0BB5txdCQskZ2ud/l8sz/Nkjf3A=
 github.com/tmccombs/hcl2json v0.3.1/go.mod h1:ljY0/prd2IFUF3cagQjV3cpPEEQKzqyGqnKI7m5DBVY=
+github.com/tmccombs/hcl2json v0.3.3 h1:+DLNYqpWE0CsOQiEZu+OZm5ZBImake3wtITYxQ8uLFQ=
+github.com/tmccombs/hcl2json v0.3.3/go.mod h1:Y2chtz2x9bAeRTvSibVRVgbLJhLJXKlUeIvjeVdnm4w=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
@@ -219,6 +224,7 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.6.1/go.mod h1:VDR4+I79ubFBGm1uJac1226K5yANQFHeauxPBoP54+o=
 github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
+github.com/zclconf/go-cty v1.8.1/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty v1.10.0 h1:mp9ZXQeIcN8kAwuqorjH+Q+njbJKjLrvB2yIh4q7U+0=
 github.com/zclconf/go-cty v1.10.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/sg_open_ssh_defaults.tf
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/sg_open_ssh_defaults.tf
@@ -3,3 +3,8 @@ resource "aws_security_group" "allow_ssh" {
   description = "Allow SSH inbound from anywhere"
   cidr_blocks = var.dummy
 }
+
+variable "dummy" {
+  type = "string"
+  default = "dummy_value"
+}

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/test.js
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/test.js
@@ -24,6 +24,12 @@ const expectedParsedJSON =
   '\t\t\t\t"name": "allow_ssh"\n' +
   '\t\t\t}\n' +
   '\t\t}\n' +
+  '\t},\n' +
+  '\t"variable": {\n' +
+  '\t\t"dummy": {\n' +
+  '\t\t\t"default": "dummy_value",\n' +
+  '\t\t\t"type": "string"\n' +
+  '\t\t}\n' +
   '\t}\n' +
   '}';
 

--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -17,9 +17,11 @@ const DEFAULT_ENCODING = 'utf-8';
 export async function loadFiles(
   pathToScan: string,
   options: IaCTestFlags = {},
+  validFileTypes?: string[],
 ): Promise<IacFileData[]> {
   const filePaths = getFilePathsFromDirectory(pathToScan, {
     maxDepth: options.detectionDepth,
+    validFileTypes,
   });
 
   if (filePaths.length === 0) {
@@ -39,13 +41,19 @@ export async function loadFiles(
   return loadedFiles.filter((file) => file.fileContent !== '');
 }
 
-function hasValidFileType(filePath: string): boolean {
-  return VALID_FILE_TYPES.includes(getFileType(filePath));
+function hasValidFileType(
+  filePath: string,
+  validFileTypes: string[] = VALID_FILE_TYPES,
+): boolean {
+  return validFileTypes.includes(getFileType(filePath));
 }
 
 function getFilePathsFromDirectory(
   pathToScan: string,
-  options: { maxDepth?: number } = {},
+  options: {
+    maxDepth?: number;
+    validFileTypes?: string[];
+  } = {},
 ): string[] {
   const resFilePaths: string[] = [];
 
@@ -56,13 +64,13 @@ function getFilePathsFromDirectory(
     });
 
     for (const filePath of dirIterator) {
-      if (hasValidFileType(filePath)) {
+      if (hasValidFileType(filePath, options.validFileTypes)) {
         resFilePaths.push(filePath);
       }
     }
   } else {
     // File
-    if (hasValidFileType(pathToScan)) {
+    if (hasValidFileType(pathToScan, options.validFileTypes)) {
       resFilePaths.push(pathToScan);
     }
   }

--- a/src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/index.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/index.ts
@@ -1,0 +1,19 @@
+// This artifact was generated using GopherJS and https://github.com/snyk/snyk-iac-parsers
+
+const gopherJsArtifact: HclToJsonArtifact = require('./parser');
+
+type FilePath = string;
+type FileContent = string;
+type MapOfFiles = Record<FilePath, FileContent>;
+type ParsedResults = {
+  parsedFiles: MapOfFiles;
+  failedFiles: MapOfFiles;
+};
+
+interface HclToJsonArtifact {
+  parseModule: (MapOfFiles) => ParsedResults;
+}
+
+export default function hclToJsonV2(files: MapOfFiles): ParsedResults {
+  return gopherJsArtifact.parseModule(files);
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -15,7 +15,14 @@ import {
 export interface IacFileData extends IacFileInDirectory {
   fileContent: string;
 }
-export const VALID_FILE_TYPES = ['tf', 'json', 'yaml', 'yml'];
+
+export enum ValidFileType {
+  Terraform = 'tf',
+  JSON = 'json',
+  YAML = 'yaml',
+  YML = 'yml',
+}
+export const VALID_FILE_TYPES = Object.values(ValidFileType);
 
 export interface IacFileParsed extends IacFileData {
   jsonContent: Record<string, unknown> | TerraformScanInput;

--- a/test/acceptance/fake-server.ts
+++ b/test/acceptance/fake-server.ts
@@ -6,7 +6,10 @@ import * as path from 'path';
 import { getFixturePath } from '../jest/util/getFixturePath';
 
 const featureFlagDefaults = (): Map<string, boolean> => {
-  return new Map([['cliFailFast', false]]);
+  return new Map([
+    ['cliFailFast', false],
+    ['iacTerraformVarSupport', false],
+  ]);
 };
 
 type FakeServer = {
@@ -357,6 +360,13 @@ export const fakeServer = (basePath: string, snykToken: string): FakeServer => {
       res.send({
         ok: false,
         userMessage: `Org ${org} doesn't have '${flag}' feature enabled'`,
+      });
+      return;
+    }
+
+    if (org === 'tf-lang-support') {
+      res.send({
+        ok: true,
       });
       return;
     }

--- a/test/fixtures/iac/terraform/var_deref/nested_var_deref/sg_open_ssh.tf
+++ b/test/fixtures/iac/terraform/var_deref/nested_var_deref/sg_open_ssh.tf
@@ -1,0 +1,8 @@
+resource "aws_security_group_rule" "egress" {
+  type              = "egress"
+  from_port         = 0
+  to_port           = 65535
+  protocol          = "all"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.allow.id
+}

--- a/test/fixtures/iac/terraform/var_deref/nested_var_deref/variables.tf
+++ b/test/fixtures/iac/terraform/var_deref/nested_var_deref/variables.tf
@@ -1,0 +1,4 @@
+variable "remote_user_addr" {
+  type = string
+  default = "0.0.0.0/0"
+}

--- a/test/fixtures/iac/terraform/var_deref/sg_open_ss.tf
+++ b/test/fixtures/iac/terraform/var_deref/sg_open_ss.tf
@@ -1,0 +1,12 @@
+resource "aws_security_group" "allow_ssh" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr
+  }
+}

--- a/test/fixtures/iac/terraform/var_deref/variables.tf
+++ b/test/fixtures/iac/terraform/var_deref/variables.tf
@@ -1,0 +1,4 @@
+variable "remote_user_addr" {
+  type = list(string)
+  default = ["0.0.0.0/0", "1.2.3.4/32"]
+}

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -47,7 +47,7 @@ describe('Directory scan', () => {
     expect(stdout).toContain('Failed to parse YAML file');
     expect(stdout).toContain('Failed to parse JSON file');
     expect(stdout).toContain(
-      'Tested 17 projects, 14 contained issues. Failed to test 5 projects.',
+      '21 projects, 15 contained issues. Failed to test 5 projects.',
     );
   });
 

--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -1,0 +1,129 @@
+import { startMockServer, isValidJSONString } from './helpers';
+
+jest.setTimeout(50000);
+
+describe('Terraform Language Support', () => {
+  let run: (
+    cmd: string,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    const result = await startMockServer();
+    run = result.run;
+    teardown = result.teardown;
+  });
+
+  afterAll(async () => teardown());
+
+  describe('without feature flag', () => {
+    it('does not dereference variables', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test ./iac/terraform/var_deref`,
+      );
+      expect(exitCode).toBe(1);
+
+      expect(stdout).toContain('Testing sg_open_ss.tf...');
+      expect(stdout).toContain('Infrastructure as code issues:');
+      expect(stdout).not.toContain('✗ Security Group allows open ingress');
+      expect(stdout).not.toContain(
+        ' input > resource > aws_security_group[allow_ssh] > ingress',
+      );
+    });
+  });
+
+  describe('with feature flag', () => {
+    it('dereferences variables in the provided directory only', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/var_deref`,
+      );
+      expect(exitCode).toBe(1);
+
+      expect(stdout).toContain('Testing sg_open_ss.tf...');
+      expect(stdout).toContain('Infrastructure as code issues:');
+      expect(stdout).toContain('✗ Security Group allows open ingress');
+      expect(stdout).toContain(
+        ' input > resource > aws_security_group[allow_ssh] > ingress',
+      );
+
+      expect(stdout).not.toContain('Testing nested-var_deref/sg_open_ss.tf...');
+    });
+
+    it('still scans other files but not terraform files nested in a directory', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac`,
+      );
+      expect(exitCode).toBe(1);
+
+      expect(stdout).toContain('Infrastructure as code issues:');
+
+      expect(stdout).toContain('Testing kubernetes/pod-privileged.yaml');
+      expect(stdout).toContain(
+        'Tested kubernetes/pod-privileged.yaml for known issues, found 9 issues',
+      );
+
+      expect(stdout).not.toContain('Testing terraform/var_deref/sg_open_ss.tf');
+      expect(stdout).not.toContain(
+        'Tested terraform/var_deref/sg_open_ss.tf for known issues, found 0 issues',
+      );
+    });
+
+    it('is backwards compatible without variable dereferencing', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf`,
+      );
+      expect(exitCode).toBe(1);
+
+      expect(stdout).toContain('Testing ./iac/terraform/sg_open_ssh.tf');
+      expect(stdout).toContain('Infrastructure as code issues:');
+      expect(stdout).toContain('✗ Security Group allows open ingress');
+      expect(stdout).toContain(
+        ' input > resource > aws_security_group[allow_ssh] > ingress',
+      );
+    });
+
+    it('filters out issues when using severity threshold', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --severity-threshold=high`,
+      );
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain('Infrastructure as code issues:');
+      expect(stdout).toContain(
+        'Tested ./iac/terraform/sg_open_ssh.tf for known issues, found 0 issues',
+      );
+    });
+
+    it('outputs an error for files with invalid HCL2', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh_invalid_hcl2.tf`,
+      );
+
+      expect(exitCode).toBe(2);
+      expect(stdout).toContain('We were unable to parse the Terraform file');
+    });
+
+    it('outputs the expected text when running with --sarif flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --sarif`,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+      expect(stdout).toContain('"ruleId": "SNYK-CC-TF-1",');
+    });
+
+    it('outputs the expected text when running with --json flag', async () => {
+      const { stdout, exitCode } = await run(
+        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --json`,
+      );
+
+      expect(exitCode).toBe(1);
+      expect(isValidJSONString(stdout)).toBe(true);
+      expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+      expect(stdout).toContain('"packageManager": "terraformconfig",');
+      expect(stdout).toContain('"projectType": "terraformconfig",');
+    });
+  });
+});

--- a/test/jest/unit/iac/file-parser.spec.ts
+++ b/test/jest/unit/iac/file-parser.spec.ts
@@ -1,6 +1,7 @@
 import {
   UnsupportedFileTypeError,
   parseFiles,
+  parseTerraformFiles,
 } from '../../../../src/cli/commands/test/iac-local-execution/file-parser';
 import { NoFilesToScanError } from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
 import {
@@ -160,5 +161,32 @@ describe('parseFiles', () => {
     expect(() => tryParsingTerraformFile(invalidTerraformFileDataStub)).toThrow(
       FailedToParseTerraformFileError,
     );
+  });
+});
+
+describe('parseTerraformFiles', () => {
+  it('parses multiple Terraform files as expected', () => {
+    const { parsedFiles, failedFiles } = parseTerraformFiles([
+      terraformFileDataStub,
+    ]);
+    expect(parsedFiles.length).toEqual(1);
+    expect(parsedFiles[0]).toEqual(expectedTerraformParsingResult);
+    expect(failedFiles.length).toEqual(0);
+  });
+
+  it('does not throw an error if a file parse failed in a directory scan', () => {
+    const { parsedFiles, failedFiles } = parseTerraformFiles([
+      invalidTerraformFileDataStub,
+      terraformFileDataStub,
+    ]);
+    expect(parsedFiles.length).toEqual(1);
+    expect(parsedFiles[0]).toEqual(expectedTerraformParsingResult);
+    expect(failedFiles.length).toEqual(1);
+  });
+
+  it('throws an error if a file parse failed in a file scan', () => {
+    expect(() => {
+      parseTerraformFiles([invalidTerraformFileDataStub]);
+    }).toThrow(FailedToParseTerraformFileError);
   });
 });

--- a/test/jest/unit/iac/file-parser.terraform.fixtures.ts
+++ b/test/jest/unit/iac/file-parser.terraform.fixtures.ts
@@ -85,7 +85,7 @@ resource "aws_security_group" "allow_ssh" {
 }`;
 export const invalidTerraformFileDataStub: IacFileData = {
   fileContent: invalidTerraformFileContent,
-  filePath: 'dont-care',
+  filePath: 'dont-care-invalid',
   fileType: 'tf',
 };
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR introduces a new parsing flow for Terraform files, which supports dereferencing variables. This flow is behind the `iacTerraformVarSupport` feature flag and currently only supports scanning Terraform files in the current directory.

Scanning nested directories is out of scope for this PR.

#### Where should the reviewer start?
The changes are split in commits:
1. the changes in `release-scripts]/` are to update the version of the `snyk/snyk-iac-parsers` library to the latest, https://github.com/snyk/snyk-iac-parsers/releases/tag/v0.2.0
2. the acceptance tests verify backwards compatibility, optional flag support, and dereferencing
3. the `parseTerraformFiles` function will take in the Terraform files, send them to the `snyk-iac-parsers` library, and modify them into the desired output
4. the main flow is split into two phases, depending on whether the `iacTerraformVarSupport` feature flag is enabled or not
    - in `src/cli/commands/test/iac-local-execution/file-loader.ts` we modify the directory reader to take in an optional `validFileTypes`, which specifies what kind of files are valid
    - this will be used to separate Terraform files from all other files when the `iacTerraformVarSupport` feature flag is enabled, thus allowing us to parse Terraform files separately with our `parseTerraformFiles` function

#### How should this be manually tested?
1. `npm run build`
2. Clone https://github.com/snyk-labs/infrastructure-as-code-goof
3. Run `snykiac test variables/`
4. Run `snyk-dev iac test variables/` and see that there are extra misconfigurations

#### Any background context you want to provide?
This PR is the first in a line of PRs to enhance Terraform Language Support, as part of [this](https://www.notion.so/snyk/Terraform-Language-Support-Variables-Modules-2d245e26560248d8840e9cbda1baf91e) feature. We have delivered a new Terraform parser in https://github.com/snyk/snyk-iac-parsers, which supports extracting variables and dereferencing them inline wherever they're references. The files referencing these variables get converted into JSON, which is used to run our Rego rules (internal or custom) and discover misconfigurations.

#### What are the relevant tickets?
https://snyksec.atlassian.net/browse/CFG-1498

#### Screenshots
Before:
![Screenshot 2022-02-14 at 12 14 49](https://user-images.githubusercontent.com/81559517/153908512-909124cf-0ef6-4f4d-93c7-aa3bb802fb5f.png)

After:
![Screenshot 2022-02-14 at 12 15 06](https://user-images.githubusercontent.com/81559517/153908525-5a1bb113-b4de-4959-ac8a-6c960f778bfe.png)
