### PR TITLE
fix: don't override debug namespace

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -34,6 +34,7 @@ alias.p = 'prune-repeated-subdependencies';
 const DEBUG_DEFAULT_NAMESPACES = [
   'snyk-test',
   'snyk',
+  'snyk-code',
   'snyk:find-files',
   'snyk:run-test',
   'snyk:prune',

--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -12,7 +12,6 @@ import { FailedToRunTestError, NoSupportedSastFiles } from '../../errors';
 import { jsonStringifyLargeObject } from '../../json';
 import * as analytics from '../../analytics';
 
-debugLib.enable('snyk-code');
 const debug = debugLib('snyk-code');
 
 export const codePlugin: EcosystemPlugin = {


### PR DESCRIPTION
`debugLib.enable` was overriding the debug namespaces defined by the CLI.

https://github.com/snyk/snyk/blob/49b07498ed5c95d8cbb0841553e4b5eab616b360/src/cli/args.ts#L111-L121

This silenced debug output _after_ the SAST plugin.

Since this is a command specific _and_ global behavior, it's somewhat tricky to test properly. Debug module might need some more love.
Follow up to https://github.com/snyk/snyk/pull/2692