### PR TITLE
test: fix terraform plan tests

### DIFF
--- a/test/jest/acceptance/iac/test-terraform-plan.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-plan.spec.ts
@@ -40,7 +40,7 @@ describe('Terraform plan scanning', () => {
     expect(exitCode).toBe(1);
     expect(stdout).toContain('Infrastructure as code issues:');
     expect(stdout).toContain(
-      'Tested ./iac/terraform-plan/tf-plan-create.json for known issues, found 3 issues',
+      'Tested ./iac/terraform-plan/tf-plan-create.json for known issues',
     );
   });
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This test started failing because it finds less issues. I think it must be related to https://github.com/snyk/cloud-config-opa-policies/pull/720 but it's hard to tell.

See the test failure [here](https://app.circleci.com/pipelines/github/snyk/snyk/10037/workflows/6ad6d181-4509-4b4a-aeac-01306e874151/jobs/77740)