### PR TITLE
feat: add org name to snyk code test [NEBULA-195]

### DIFF
--- a/src/lib/plugins/sast/index.ts
+++ b/src/lib/plugins/sast/index.ts
@@ -45,7 +45,11 @@ export const codePlugin: EcosystemPlugin = {
       }
       const numOfIssues = sarifTypedResult!.runs?.[0].results?.length || 0;
       analytics.add('sast-issues-found', numOfIssues);
-      const meta = getMeta(options, path);
+      let newOrg = options.org;
+      if (!newOrg && sastSettings.org) {
+        newOrg = sastSettings.org;
+      }
+      const meta = getMeta({ ...options, org: newOrg }, path);
       const prefix = getPrefix(path);
       let readableResult = getCodeDisplayedOutput(
         sarifTypedResult!,

--- a/src/lib/plugins/sast/types.ts
+++ b/src/lib/plugins/sast/types.ts
@@ -12,6 +12,7 @@ export interface SastSettings {
   error?: string;
   userMessage?: string;
   localCodeEngine: LocalCodeEngine;
+  org?: string;
 }
 
 export interface TrackUsageResponse {

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -298,6 +298,77 @@ describe('Test snyk code', () => {
     }
   });
 
+  describe('Default org test in CLI output', () => {
+    beforeAll(() => {
+      userConfig.set('org', 'defaultOrg');
+    });
+
+    afterAll(() => {
+      userConfig.set('org', undefined);
+    });
+
+    it('should show the default org in the output when org is not provided', async () => {
+      const options: ArgsOptions = {
+        path: '',
+        traverseNodeModules: false,
+        showVulnPaths: 'none',
+        code: true,
+        _: [],
+        _doubleDashArgs: [],
+      };
+
+      analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
+      isSastEnabledForOrgSpy.mockResolvedValueOnce({
+        sastEnabled: true,
+        localCodeEngine: {
+          enabled: false,
+        },
+        org: 'defaultOrg',
+      });
+      trackUsageSpy.mockResolvedValue({});
+
+      try {
+        await snykTest('some/path', options);
+      } catch (error) {
+        const errMessage = stripAscii(stripAnsi(error.message.trim()));
+
+        expect(error.code).toBe('VULNS');
+        expect(errMessage).toMatch(/Organization:\s+defaultOrg/);
+      }
+    });
+
+    it('should show the provided org in the output when org is provided', async () => {
+      const options: ArgsOptions = {
+        path: '',
+        traverseNodeModules: false,
+        showVulnPaths: 'none',
+        code: true,
+        _: [],
+        _doubleDashArgs: [],
+        org: 'otherOrg',
+      };
+
+      analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
+      isSastEnabledForOrgSpy.mockResolvedValueOnce({
+        sastEnabled: true,
+        localCodeEngine: {
+          enabled: false,
+        },
+        org: 'defaultOrg',
+      });
+      trackUsageSpy.mockResolvedValue({});
+
+      try {
+        await snykTest('some/path', options);
+      } catch (error) {
+        const errMessage = stripAscii(stripAnsi(error.message.trim()));
+
+        expect(error.code).toBe('VULNS');
+        expect(errMessage).toMatch(/Organization:\s+otherOrg/);
+      }
+    });
+  });
+
   it.each([
     ['sarif', { sarif: true }],
     ['json', { json: true }],


### PR DESCRIPTION
### What does this PR do?

When running `snyk code test`, the organization would appear as `undefined`.
This was solved by passing the `org` from the `SastSettings` API endpoint (which is the default `org` when not specified by the flag or config) and displaying it in the CLI.

### Notes for the reviewer

Check the [PR](https://github.com/snyk/registry/pull/26282) on the registry side as well for the API changes.

### How should this be manually tested?

Run `snyk code test` in a repository and check the printed `Organization` line. It should not be undefined.

Notes:
- Undefined organizations will assume the default organization.
- Specify an `org` by using the flag `--org=org.name` or by setting the `org` in the config by running `snyk config set org=org.name`
- Check if an org is in the config by running `snyk config get org`
- To remove an assigned org in the config, run `snyk config unset org`

### More information

- [Slack thread](https://snyk.slack.com/archives/C01DGQ3AT09/p1635359391196500)
- [Jira ticket NEBULA-195](https://snyksec.atlassian.net/browse/NEBULA-195)

### Screenshots

_Note: The default `org` for this example was `patricia.vale`. The config had no org specified and no flags were used._

**When running `snyk code test`...**

Before:
<img width="326" alt="image" src="https://user-images.githubusercontent.com/97087926/154458957-198b345a-e8c3-43e1-b7c1-32f4358cb83c.png">

After:
<img width="322" alt="image" src="https://user-images.githubusercontent.com/97087926/154458978-8194ad67-71bc-464d-bb00-6fd3487622ad.png">