### PR TITLE
fix: broken help tests

### DIFF
--- a/test/smoke/spec/snyk_basic_spec.sh
+++ b/test/smoke/spec/snyk_basic_spec.sh
@@ -50,7 +50,7 @@ Describe "Snyk CLI basics"
 
     It "prints specific help info for container"
       When run snyk -h container
-      The output should include "test container images for vulnerabilities"
+      The output should include "tests container images for vulnerabilities"
       The status should be success
       # TODO: unusable with our current docker issues
       The stderr should equal ""
@@ -58,7 +58,7 @@ Describe "Snyk CLI basics"
 
     It "prints specific help info for iac"
       When run snyk iac -help
-      The output should include "find security issues in Infrastructure as Code files"
+      The output should include "finds security issues in Infrastructure as Code files"
       The status should be success
       # TODO: unusable with our current docker issues
       The stderr should equal ""
@@ -66,7 +66,7 @@ Describe "Snyk CLI basics"
 
     It "prints specific help info when called with flag and equals sign"
       When run snyk --help=iac
-      The output should include "find security issues in Infrastructure as Code files"
+      The output should include "finds security issues in Infrastructure as Code files"
       The status should be success
       # TODO: unusable with our current docker issues
       The stderr should equal ""
@@ -74,7 +74,7 @@ Describe "Snyk CLI basics"
 
     It "prints help info for argument with mode"
       When run snyk --help container test
-      The output should include "test container images for vulnerabilities"
+      The output should include "tests container images for vulnerabilities"
       The status should be success
       # TODO: unusable with our current docker issues
       The stderr should equal ""


### PR DESCRIPTION
A change in our help docs caused some tests to break
[Slack thread](https://snyk.slack.com/archives/C0127HWU0E7/p1645098442016399)