### PR TITLE
[CFG-1300] add `iac drift gen-driftignore` command

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@ test/smoke/spec/snyk_basic_spec.sh @snyk/hammer
 test/smoke/.iac-data/ @snyk/group-infrastructure-as-code
 test/jest/unit/lib/formatters/iac-output.spec.ts @snyk/group-infrastructure-as-code
 test/jest/unit/iac/ @snyk/group-infrastructure-as-code
-test/jest/lib/iac/ @snyk/group-infrastructure-as-code
+test/jest/unit/lib/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/iac/ @snyk/group-infrastructure-as-code
 test/jest/acceptance/snyk-apps @snyk-moose
 src/lib/errors/invalid-iac-file.ts @snyk/group-infrastructure-as-code

--- a/test/jest/acceptance/iac/dift.spec.ts
+++ b/test/jest/acceptance/iac/dift.spec.ts
@@ -72,3 +72,53 @@ describe('iac drift scan', () => {
     ).toBe(true);
   });
 });
+
+describe('iac drift gen-driftignore', () => {
+  let run: (
+    cmd: string,
+    env: Record<string, string>,
+  ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
+  let teardown: () => void;
+
+  beforeAll(async () => {
+    ({ run, teardown } = await startMockServer());
+  });
+
+  afterAll(async () => teardown());
+
+  it('gen-driftignore fail without the right entitlement', async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `snyk iac drift gen-driftignore --org=no-iac-drift-entitlements`,
+      {},
+    );
+
+    expect(stdout).toMatch(
+      'Command "drift" is currently not supported for this org. To enable it, please contact snyk support.',
+    );
+    expect(stderr).toMatch('');
+    expect(exitCode).toBe(2);
+  });
+
+  if (os.platform() === 'win32') {
+    return; // skip following tests
+  }
+
+  it('gen-driftignore successfully executed from SNYK_DRIFTCTL_PATH env var when org has the entitlement', async () => {
+    const { stdout, stderr, exitCode } = await run(
+      `snyk iac drift gen-driftignore --input=something.json --output=stdout --exclude-changed --exclude-missing --exclude-unmanaged`,
+      {
+        SNYK_DRIFTCTL_PATH: path.join(
+          getFixturePath('iac'),
+          'drift',
+          'args-echo',
+        ),
+      },
+    );
+
+    expect(stdout).toMatch(
+      'gen-driftignore --input something.json --output stdout --exclude-changed --exclude-missing --exclude-unmanaged',
+    );
+    expect(stderr).toMatch('');
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -1,6 +1,9 @@
-const mockFs = require('mock-fs');
+import * as mockFs from 'mock-fs';
 
-import { parseArgs } from '../../../../../src/lib/iac/drift';
+import {
+  DriftctlGenDriftIgnoreOptions,
+  parseArgs,
+} from '../../../../../src/lib/iac/drift';
 import envPaths from 'env-paths';
 
 const paths = envPaths('snyk');
@@ -11,7 +14,7 @@ describe('driftctl integration', () => {
     mockFs.restore();
   });
 
-  it('default arguments are correct', () => {
+  it('scan: default arguments are correct', () => {
     const args = parseArgs(['scan'], {});
     expect(args).toEqual([
       'scan',
@@ -22,7 +25,12 @@ describe('driftctl integration', () => {
     ]);
   });
 
-  it('passing options generate correct arguments', () => {
+  it('gen-driftignore: default arguments are correct', () => {
+    const args = parseArgs(['gen-driftignore'], {});
+    expect(args).toEqual(['gen-driftignore']);
+  });
+
+  it('scan: passing options generate correct arguments', () => {
     const args = parseArgs(['scan'], {
       'config-dir': 'confdir',
       'tf-lockfile': 'tflockfile',
@@ -66,6 +74,27 @@ describe('driftctl integration', () => {
       'from',
       '--to',
       'to',
+    ]);
+  });
+
+  it('gen-driftignore: passing options generate correct arguments', () => {
+    const args = parseArgs(['gen-driftignore'], {
+      'exclude-changed': true,
+      'exclude-missing': true,
+      'exclude-unmanaged': true,
+      input: 'analysis.json',
+      output: '/dev/stdout',
+      org: 'testing-org', // Ensure that this should not be translated to args
+    } as DriftctlGenDriftIgnoreOptions);
+    expect(args).toEqual([
+      'gen-driftignore',
+      '--input',
+      'analysis.json',
+      '--output',
+      '/dev/stdout',
+      '--exclude-changed',
+      '--exclude-missing',
+      '--exclude-unmanaged',
     ]);
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?

This PR is a follow-up of #2634 and add a new subcommand `gen-driftignore` based on 

#### Where should the reviewer start?

Everything is in `src/lib/iac/drift.ts`

#### How should this be manually tested?

You can use the following file as input

`snyk iac drift gen-driftignore --input=driftctl.json --output=/dev/stdout`

```json
{
  "summary": {
    "total_resources": 2,
    "total_changed": 0,
    "total_unmanaged": 2,
    "total_missing": 0,
    "total_managed": 0
  },
  "managed": null,
  "unmanaged": [
    {
      "id": "AKIA5QYBVVD26LL6K7LW",
      "type": "aws_iam_access_key"
    },
    {
      "id": "AKIA5QYBVVD2RGR7VCH4",
      "type": "aws_iam_access_key"
    }
  ],
  "differences": null,
  "coverage": 0,
  "alerts": {},
  "provider_name": "aws",
  "provider_version": "3.19.0"
}
```

#### Any background context you want to provide?

https://docs.driftctl.com/0.20.0/usage/cmd/gen-driftignore-usage

#### What are the relevant tickets?

https://snyksec.atlassian.net/browse/CFG-1300

#### Screenshots

![image](https://user-images.githubusercontent.com/6154987/154672529-c67b8738-7e8f-45e4-8db4-a7ed6e7830b1.png)