### PR TITLE
feat: add debug logs for tf vars [CFG-1582]

### DIFF
--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/snyk/snyk-iac-parsers v0.3.0
+	github.com/snyk/snyk-iac-parsers v0.4.0
 	github.com/tmccombs/hcl2json v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 )

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
@@ -194,8 +194,8 @@ github.com/snyk/snyk-iac-parsers v0.1.0 h1:+VHQorhJ0iro0EwCJR2kNFYpkQ6EsfWSVi3xY
 github.com/snyk/snyk-iac-parsers v0.1.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/snyk/snyk-iac-parsers v0.2.0 h1:bc48Ra3U3spo5wl6XogFoT4N7VlkxCGBM3Cq0rjd0C8=
 github.com/snyk/snyk-iac-parsers v0.2.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
-github.com/snyk/snyk-iac-parsers v0.3.0 h1:WusEK8AT1TiFbkTPVtfJohyGwtQNWBHVeruLVAA2ueI=
-github.com/snyk/snyk-iac-parsers v0.3.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
+github.com/snyk/snyk-iac-parsers v0.4.0 h1:qTuxHULxDlpk0j5zhfG4L/66ags4BpfW2suz6JPvqgg=
+github.com/snyk/snyk-iac-parsers v0.4.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/index.ts
+++ b/src/cli/commands/test/iac-local-execution/parsers/hcl-to-json-v2/index.ts
@@ -8,6 +8,7 @@ type MapOfFiles = Record<FilePath, FileContent>;
 type ParsedResults = {
   parsedFiles: MapOfFiles;
   failedFiles: MapOfFiles;
+  debugLogs: MapOfFiles;
 };
 
 interface HclToJsonArtifact {


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR adds debug logs, which show up when the command is run with a `--debug` option. This will help customers debug why their files fail.

Needs https://github.com/snyk/snyk-iac-parsers/pull/10 first so we can update the version of `snyk/snyk-iac-parsers` and generate a new release.

#### How should this be manually tested?
1. `npm run build`
2. Run `snyk iac test ./test/fixtures/iac/terraform/sg_open_ssh_invalid_hcl2.tf -d` and see no debug logs
3. Enable the `iacTerraformVarSupport` feature flag
4. Run `snyk iac test ./test/fixtures/iac/terraform/sg_open_ssh_invalid_hcl2.tf -d` and see no debug logs (see screenshots)
5. Run `snyk-dev iac test ./test/fixtures/iac/terraform/sg_open_ssh_invalid_hcl2.tf -d` and see the new debug logs (see screenshots)

#### What are the relevant tickets?
[CFG-1582](https://snyksec.atlassian.net/browse/CFG-1582)

#### Screenshots
- before
![Screenshot 2022-02-17 at 14 52 37](https://user-images.githubusercontent.com/81559517/154673060-3b0f2234-33af-4242-ad7f-beb6d5fe4dd1.png)
![Screenshot 2022-02-18 at 20 02 07](https://user-images.githubusercontent.com/81559517/154753476-9203419a-d0ab-422d-9be5-abf437ce1a15.png)

- after
![Screenshot 2022-02-17 at 14 50 14](https://user-images.githubusercontent.com/81559517/154673075-ee683e24-23c9-4410-ba5a-279dafb3a820.png)
![Screenshot 2022-02-18 at 20 01 26](https://user-images.githubusercontent.com/81559517/154753381-5d49f0a1-0e5b-481f-97e0-efc44a84b20f.png)

