### PR TITLE
feat: dereference variables from terraform.tfvars and *.auto.tfvars [CFG-1502]

### DIFF
--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/snyk/snyk-iac-parsers v0.2.0
+	github.com/snyk/snyk-iac-parsers v0.3.0
 	github.com/tmccombs/hcl2json v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 )

--- a/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
+++ b/release-scripts/hcl-to-json-parser-generator-v2/src/hcltojson-v2/go.sum
@@ -194,6 +194,8 @@ github.com/snyk/snyk-iac-parsers v0.1.0 h1:+VHQorhJ0iro0EwCJR2kNFYpkQ6EsfWSVi3xY
 github.com/snyk/snyk-iac-parsers v0.1.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/snyk/snyk-iac-parsers v0.2.0 h1:bc48Ra3U3spo5wl6XogFoT4N7VlkxCGBM3Cq0rjd0C8=
 github.com/snyk/snyk-iac-parsers v0.2.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
+github.com/snyk/snyk-iac-parsers v0.3.0 h1:WusEK8AT1TiFbkTPVtfJohyGwtQNWBHVeruLVAA2ueI=
+github.com/snyk/snyk-iac-parsers v0.3.0/go.mod h1:vmR6e9WfglVPO2Y82lW49Sb5jiGb13FXGwJGNtVRBcw=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/src/cli/commands/test/iac-local-execution/index.ts
+++ b/src/cli/commands/test/iac-local-execution/index.ts
@@ -62,7 +62,9 @@ export async function test(
     // if TF vars enabled, valid files are all except terraform files
     const validFileTypes = isTFVarSupportEnabled
       ? VALID_FILE_TYPES.filter(
-          (fileType) => fileType !== ValidFileType.Terraform,
+          (fileType) =>
+            fileType !== ValidFileType.Terraform &&
+            fileType !== ValidFileType.TFVARS,
         )
       : undefined;
 
@@ -85,7 +87,6 @@ export async function test(
     // we may have loaded and parsed all but terraform files in the previous step
     // so now we check if we need to do a second load and parse which dereferences TF vars
     if (validFileTypes && !validFileTypes.includes(ValidFileType.Terraform)) {
-      // TODO: read and send .tfvars to parser
       // TODO: iterate through nested directories
       try {
         const tfFilesToParse = await loadFiles(
@@ -94,12 +95,13 @@ export async function test(
             ...options,
             detectionDepth: 1,
           },
-          [ValidFileType.Terraform],
+          [ValidFileType.Terraform, ValidFileType.TFVARS],
         );
         const {
           parsedFiles: parsedTfFiles,
           failedFiles: failedTfFiles,
         } = parseTerraformFiles(tfFilesToParse);
+
         parsedFiles = parsedFiles.concat(parsedTfFiles);
         failedFiles = failedFiles.concat(failedTfFiles);
       } catch (err) {

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -21,6 +21,7 @@ export enum ValidFileType {
   JSON = 'json',
   YAML = 'yaml',
   YML = 'yml',
+  TFVARS = 'tfvars',
 }
 export const VALID_FILE_TYPES = Object.values(ValidFileType);
 

--- a/test/fixtures/iac/terraform/var_deref/a.auto.tfvars
+++ b/test/fixtures/iac/terraform/var_deref/a.auto.tfvars
@@ -1,0 +1,4 @@
+remote_user_addr_a_auto_tfvars = ["0.0.0.0/0"]
+
+remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
+

--- a/test/fixtures/iac/terraform/var_deref/b.auto.tfvars
+++ b/test/fixtures/iac/terraform/var_deref/b.auto.tfvars
@@ -1,0 +1,1 @@
+remote_user_addr_b_auto_tfvars = ["0.0.0.0/0"]

--- a/test/fixtures/iac/terraform/var_deref/sg_open_ssh.tf
+++ b/test/fixtures/iac/terraform/var_deref/sg_open_ssh.tf
@@ -10,3 +10,42 @@ resource "aws_security_group" "allow_ssh" {
     cidr_blocks = var.remote_user_addr
   }
 }
+
+resource "aws_security_group" "allow_ssh_terraform_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_terraform_tfvars
+  }
+}
+
+resource "aws_security_group" "allow_ssh_a_auto_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_a_auto_tfvars
+  }
+}
+
+resource "aws_security_group" "allow_ssh_b_auto_tfvars" {
+  name        = "allow_ssh"
+  description = "Allow SSH inbound from anywhere"
+  vpc_id      = "${aws_vpc.main.id}"
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = var.remote_user_addr_b_auto_tfvars
+  }
+}

--- a/test/fixtures/iac/terraform/var_deref/terraform.tfvars
+++ b/test/fixtures/iac/terraform/var_deref/terraform.tfvars
@@ -1,0 +1,6 @@
+remote_user_addr_terraform_tfvars = ["0.0.0.0/0"]
+
+remote_user_addr_a_auto_tfvars = ["1.2.3.4/32"]
+
+remote_user_addr_b_auto_tfvars = ["1.2.3.4/32"]
+

--- a/test/fixtures/iac/terraform/var_deref/variables.tf
+++ b/test/fixtures/iac/terraform/var_deref/variables.tf
@@ -2,3 +2,18 @@ variable "remote_user_addr" {
   type = list(string)
   default = ["0.0.0.0/0", "1.2.3.4/32"]
 }
+
+variable "remote_user_addr_terraform_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}
+
+variable "remote_user_addr_a_auto_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}
+
+variable "remote_user_addr_b_auto_tfvars" {
+  type = list(string)
+  default = ["1.2.3.4/32"]
+}

--- a/test/jest/acceptance/iac/test-directory.spec.ts
+++ b/test/jest/acceptance/iac/test-directory.spec.ts
@@ -47,7 +47,7 @@ describe('Directory scan', () => {
     expect(stdout).toContain('Failed to parse YAML file');
     expect(stdout).toContain('Failed to parse JSON file');
     expect(stdout).toContain(
-      '21 projects, 15 contained issues. Failed to test 5 projects.',
+      '21 projects, 15 contained issues. Failed to test 8 projects.',
     );
   });
 

--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -30,6 +30,15 @@ describe('Terraform Language Support', () => {
       expect(stdout).not.toContain(
         ' input > resource > aws_security_group[allow_ssh] > ingress',
       );
+      expect(stdout).not.toContain(
+        ' input > resource > aws_security_group[allow_ssh_terraform_tfvars] > ingress',
+      );
+      expect(stdout).not.toContain(
+        ' input > resource > aws_security_group[allow_ssh_a_auto_tfvars] > ingress',
+      );
+      expect(stdout).not.toContain(
+        ' input > resource > aws_security_group[allow_ssh_b_auto_tfvars] > ingress',
+      );
     });
   });
 
@@ -45,6 +54,15 @@ describe('Terraform Language Support', () => {
       expect(stdout).toContain('✗ Security Group allows open ingress');
       expect(stdout).toContain(
         ' input > resource > aws_security_group[allow_ssh] > ingress',
+      );
+      expect(stdout).toContain(
+        ' input > resource > aws_security_group[allow_ssh_terraform_tfvars] > ingress',
+      );
+      expect(stdout).toContain(
+        ' input > resource > aws_security_group[allow_ssh_a_auto_tfvars] > ingress',
+      );
+      expect(stdout).toContain(
+        ' input > resource > aws_security_group[allow_ssh_b_auto_tfvars] > ingress',
       );
 
       expect(stdout).not.toContain(
@@ -67,7 +85,7 @@ describe('Terraform Language Support', () => {
         `Tested ${path.join(
           'kubernetes',
           'pod-privileged.yaml',
-        )} for known issues, found 9 issues`,
+        )} for known issues`,
       );
 
       expect(stdout).not.toContain(
@@ -78,7 +96,7 @@ describe('Terraform Language Support', () => {
           'terraform',
           'var_deref',
           'sg_open_ssh.tf',
-        )} for known issues, found 0 issues`,
+        )} for known issues`,
       );
     });
 

--- a/test/jest/unit/iac/file-parser.terraform.fixtures.ts
+++ b/test/jest/unit/iac/file-parser.terraform.fixtures.ts
@@ -34,12 +34,12 @@ const terraformPlanJson = JSON.parse(terraformPlanFileContent.toString());
 export const terraformPlanMissingFieldsJson = { ...terraformPlanJson };
 export const terraformFileDataStub: IacFileData = {
   fileContent: terraformFileContent,
-  filePath: 'dont-care',
+  filePath: 'dont-care.tf',
   fileType: 'tf',
 };
 export const terraformPlanDataStub: IacFileData = {
   fileContent: terraformPlanFileContent.toString(),
-  filePath: 'dont-care',
+  filePath: 'dont-care.tf',
   fileType: 'json',
 };
 export const expectedTerraformParsingResult: IacFileParsed = {
@@ -85,7 +85,7 @@ resource "aws_security_group" "allow_ssh" {
 }`;
 export const invalidTerraformFileDataStub: IacFileData = {
   fileContent: invalidTerraformFileContent,
-  filePath: 'dont-care-invalid',
+  filePath: 'dont-care-invalid.tf',
   fileType: 'tf',
 };
 


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### What does this PR do?
This PR enables support for dereferencing variables defined in`terraform.tfvars` and `*.auto.tfvars` . It does not aim to support `terraform.tfvars.json` and `*.auto.tfvars.json` files, or files provided via the `-var` and `-var-file`flags. Tfvars files are explained [here](https://www.terraform.io/language/values/variables#variable-definitions-tfvars-files).

It requires https://github.com/snyk/snyk-iac-parsers/pull/12 to be merged first in order to generate a new release of the parser.

#### Where should the reviewer start?
There are only two code changes required in `src/cli/commands/test/iac-local-execution/index.ts`, to start reading `.tfvars` files. The rest of the changes in this PR are tests, making sure we are able to read and dereference variables from both `terraform.tfvars` and `*.auto.tfvars` files, with the right priority.

#### How should this be manually tested?
1. `npm run build`
2. Enable the `iacTerraformVarSupport` feature flag
3. Run `snyk iac test ./test/fixtures/iac/terraform/var_deref` and see only one issue
5. Run `snyk-dev iac test ./test/fixtures/iac/terraform/var_deref` and see four issues

#### What are the relevant tickets?
Jira ticket: https://snyksec.atlassian.net/browse/CFG-1502

#### Screenshots
- before
![Screenshot 2022-02-21 at 18 15 20](https://user-images.githubusercontent.com/81559517/155008281-5cb8fd5b-d8d5-4d60-b83c-bc08c6c3173a.png)


- after
![Screenshot 2022-02-18 at 19 53 11](https://user-images.githubusercontent.com/81559517/154752412-ffbb0090-76a1-4e4d-bbcc-5ca40cd00d9f.png)
