### PR TITLE
Allow documenting sub-commands in --help

### DIFF
--- a/help/cli-commands/iac-drift.md
+++ b/help/cli-commands/iac-drift.md
@@ -1,0 +1,3 @@
+# snyk iac drift -- find differences between Cloud and Infrastructure as Code
+
+The `snyk iac drift scan` command detect, track and alert on infrastructure drift. It runs driftctl in the background.

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -128,8 +128,12 @@ export function args(rawArgv: string[]): Args {
   const cli = require('./commands');
 
   // the first argument is the command we'll execute, everything else will be
-  // an argument to our command, like `snyk help protect`
-  let command = argv._.shift() as string; // can actually be undefined
+  // an argument to our command, like `snyk test package2test`
+  let command = '';
+  // since we are handling documentation for subcommands now, we should keep all the arguments
+  if (!argv.help) {
+    command = argv._.shift() as string; // can actually be undefined
+  }
 
   // snyk [mode?] [command] [paths?] [options-double-dash]
   command = displayModeHelp(command, argv);

--- a/src/cli/commands/help/index.ts
+++ b/src/cli/commands/help/index.ts
@@ -1,36 +1,27 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { MethodArgs } from '../../args';
 import { renderMarkdown } from './markdown-renderer';
 
-const DEFAULT_HELP = 'README';
-
-function readHelpFile(filename: string): string {
-  const file = fs.readFileSync(filename, 'utf8');
-  return renderMarkdown(file);
+export function findHelpFile(
+  helpArgs: string[],
+  helpFolderPath = '../../help/cli-commands', // this is a relative path from the webpack dist directory,
+): string {
+  while (helpArgs.length > 0) {
+    // cleanse the filename to only contain letters
+    // aka: /\W/g but figured this was easier to read
+    const file = `${helpArgs.join('-').replace(/[^a-z0-9-]/gi, '')}.md`;
+    const testHelpAbsolutePath = path.resolve(__dirname, helpFolderPath, file);
+    if (fs.existsSync(testHelpAbsolutePath)) {
+      return testHelpAbsolutePath;
+    }
+    helpArgs = helpArgs.slice(0, -1);
+  }
+  return path.resolve(__dirname, helpFolderPath, `README.md`); // Default help file
 }
 
-export default async function help(item?: string | boolean): Promise<string> {
-  if (!item || item === true || typeof item !== 'string' || item === 'help') {
-    item = DEFAULT_HELP;
-  }
-
-  // cleanse the filename to only contain letters
-  // aka: /\W/g but figured this was easier to read
-  item = item.replace(/[^a-z0-9-]/gi, '');
-
-  try {
-    const filename = path.resolve(
-      __dirname,
-      '../../help/cli-commands', // this is a relative path from the webpack dist directory
-      item === DEFAULT_HELP ? `${DEFAULT_HELP}.md` : `${item}.md`,
-    );
-    return readHelpFile(filename);
-  } catch (error) {
-    const filename = path.resolve(
-      __dirname,
-      '../../help/cli-commands',
-      `${DEFAULT_HELP}.md`,
-    );
-    return readHelpFile(filename);
-  }
+export default async function help(...args: MethodArgs): Promise<string> {
+  const helpArgs = args.filter((arg): arg is string => typeof arg === 'string');
+  const helpFileAbsolutePath = findHelpFile(helpArgs);
+  return renderMarkdown(fs.readFileSync(helpFileAbsolutePath, 'utf8'));
 }

--- a/test/jest/unit/cli/commands/help/help.spec.ts
+++ b/test/jest/unit/cli/commands/help/help.spec.ts
@@ -1,0 +1,33 @@
+import * as help from '../../../../../../src/cli/commands/help';
+
+describe('findHelpFile', () => {
+  it('returns default help README path with no arguments', () => {
+    expect(help.findHelpFile([], '../../../../help/cli-commands')).toContain(
+      'README.md',
+    );
+  });
+
+  it('returns default help README path with non-existing command', () => {
+    expect(
+      help.findHelpFile(['rainmaker'], '../../../../help/cli-commands'),
+    ).toContain('README.md');
+  });
+
+  it('returns correct help markdown path with a `test` command', () => {
+    expect(
+      help.findHelpFile(['test'], '../../../../help/cli-commands'),
+    ).toContain('test.md');
+  });
+
+  it('returns correct help markdown path with a `container` command and a non-documented subcommand', () => {
+    expect(
+      help.findHelpFile(['container', 'test'], '../../../../help/cli-commands'),
+    ).toContain('container.md');
+  });
+
+  it('returns correct help markdown path for a documented subcommand with `iac drift`', () => {
+    expect(
+      help.findHelpFile(['iac', 'drift'], '../../../../help/cli-commands'),
+    ).toContain('iac-drift.md');
+  });
+});

--- a/test/smoke/spec/snyk_basic_spec.sh
+++ b/test/smoke/spec/snyk_basic_spec.sh
@@ -80,6 +80,14 @@ Describe "Snyk CLI basics"
       The stderr should equal ""
     End
 
+    It "prints help info for documented subcommands"
+      When run snyk --help iac drift
+      The output should include "snyk iac drift"
+      The status should be success
+      # TODO: unusable with our current docker issues
+      The stderr should equal ""
+    End
+
     Describe "prints help info without ascii escape sequences"
       It "has NO_COLOR set"
         snyk_help_no_color() {


### PR DESCRIPTION
Follow up to #2735

Refactored the `snyk help` command to allow documenting subcommands like `snyk iac drift`