### PR TITLE
fix: support C++-dependencies with unknown version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "rimraf": "^2.6.3",
         "semver": "^6.0.0",
         "snyk-config": "4.0.0",
-        "snyk-cpp-plugin": "2.16.3",
+        "snyk-cpp-plugin": "^2.16.5",
         "snyk-docker-plugin": "^4.34.5",
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
@@ -16396,9 +16396,9 @@
       }
     },
     "node_modules/snyk-cpp-plugin": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.3.tgz",
-      "integrity": "sha512-R6oxd7nDAEYjU2DHFV4FXeLQS8LLjz/SaWnA4AKxL8MNQi4UlL0GgiFGJ1H98EyCz8NVUzR98HsNd/y1u7DHSg==",
+      "version": "2.16.5",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.5.tgz",
+      "integrity": "sha512-QWcFcQFnf6RZkkNZjqciRjosVMoHQDSqxQp9RdMvKyukevlI6/YkSMJcx7/aa30oLZjH+nAQMquSTvKsMverMA==",
       "dependencies": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/uuid": "^8.3.4",
@@ -32798,9 +32798,9 @@
       }
     },
     "snyk-cpp-plugin": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.3.tgz",
-      "integrity": "sha512-R6oxd7nDAEYjU2DHFV4FXeLQS8LLjz/SaWnA4AKxL8MNQi4UlL0GgiFGJ1H98EyCz8NVUzR98HsNd/y1u7DHSg==",
+      "version": "2.16.5",
+      "resolved": "https://registry.npmjs.org/snyk-cpp-plugin/-/snyk-cpp-plugin-2.16.5.tgz",
+      "integrity": "sha512-QWcFcQFnf6RZkkNZjqciRjosVMoHQDSqxQp9RdMvKyukevlI6/YkSMJcx7/aa30oLZjH+nAQMquSTvKsMverMA==",
       "requires": {
         "@snyk/dep-graph": "^1.19.3",
         "@types/uuid": "^8.3.4",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "rimraf": "^2.6.3",
     "semver": "^6.0.0",
     "snyk-config": "4.0.0",
-    "snyk-cpp-plugin": "2.16.3",
+    "snyk-cpp-plugin": "^2.16.5",
     "snyk-docker-plugin": "^4.34.5",
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",


### PR DESCRIPTION
Updates the CPP-plugin to version [v2.16.5](https://github.com/snyk/snyk-cpp-plugin/releases/tag/v2.16.5), to include following fixes:

- Add support for larger projects to prevent recursion problems
- Adds support for dependencies with omitted version number:
  - Use dependency ID with empty string as version.
  - Use "unknown" in the standard output, if version has been omitted.

- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules

#### How should this be manually tested?

Use `snyk unmanaged test` to verify that some specific projects now works without failures due to number of files.
