### PR TITLE
[CFG-1510] allow multiple from params to snyk iac drift

### DIFF
--- a/help/cli-commands/iac-describe.md
+++ b/help/cli-commands/iac-describe.md
@@ -196,34 +196,32 @@ the `/tmp` folder.
 Currently, driftctl only supports reading IaC from a Terraform state. We are investigating to support the Terraform code
 as well, as a state does not represent an intention.
 
-Multiple states can be read by passing `--from` flags. You can also use glob patterns to match multiple state files at
+Multiple states can be read by passing `--from` a coma separated list. You can also use glob patterns to match multiple state files at
 once.
 
 Examples:
 
 I want to read a local state and a state stored in an S3 bucket:
-`$ snyk iac describe \ --from tfstate+s3://statebucketdriftctl/terraform.tfstate \ --from tfstate://terraform_toto.tfstate`
+`$ snyk iac describe --from="tfstate+s3://statebucketdriftctl/terraform.tfstate,tfstate://terraform_toto.tfstate"`
 
 You can also read all files under a given prefix for S3
-`$ snyk iac describe --from tfstate+s3://statebucketdriftctl/states`
+`$ snyk iac describe --from=tfstate+s3://statebucketdriftctl/states`
 
 #### Supported IaC sources
 
 - Terraform state
-- Local: `--from tfstate://terraform.tfstate`
-- S3: `--from tfstate+s3://my-bucket/path/to/state.tfstate`
-- GCS: `--from tfstate+gs://my-bucket/path/to/state.tfstate`
-- HTTPS: `--from tfstate+https://my-url/state.tfstate`
-- Terraform Cloud / Terraform Enterprise: `--from tfstate+tfcloud://WORKSPACE_ID`
-- Azure blob storage: `--from tfstate+azurerm://container-name/path/to/state.tfstate`
-
-More details about sources configuration can be found on the [driftctl documentation](https://docs.driftctl.com/) website.
+- Local: `--from=tfstate://terraform.tfstate`
+- S3: `--from=tfstate+s3://my-bucket/path/to/state.tfstate`
+- GCS: `--from=tfstate+gs://my-bucket/path/to/state.tfstate`
+- HTTPS: `--from=tfstate+https://my-url/state.tfstate`
+- Terraform Cloud / Terraform Enterprise: `--from=tfstate+tfcloud://WORKSPACE_ID`
+- Azure blob storage: `--from=tfstate+azurerm://container-name/path/to/state.tfstate`
 
 You can use any unsupported backend by using `terraform` to pipe your state in a file and then use this file with
 driftctl:
 
 `$ terraform state pull > state.tfstate`
-`$ snyk iac describe --from tfstate://state.tfstate`
+`$ snyk iac describe --from=tfstate://state.tfstate`
 
 ## Examples for the iac describe command
 

--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -70,12 +70,12 @@ interface DriftCTLOptions {
   driftignore?: string;
   'tf-lockfile'?: string;
   'config-dir'?: string;
-  from?: string; // TODO We only handle one from at a time due to snyk cli arg parsing
   json?: boolean;
   'json-file-output'?: string;
   html?: boolean;
   'html-file-output'?: string;
   service?: string;
+  from?: string; // snyk cli args parsing does not support variadic args so this will be coma separated values
 }
 
 export function parseArgs(
@@ -217,8 +217,11 @@ export const parseDescribeFlags = (options: DriftCTLOptions): string[] => {
   args.push(configDir);
 
   if (options.from) {
-    args.push('--from');
-    args.push(options.from);
+    const froms = options.from.split(',');
+    for (const f of froms) {
+      args.push('--from');
+      args.push(f);
+    }
   }
 
   let to = 'aws+tf';

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -87,6 +87,23 @@ describe('driftctl integration', () => {
     ]);
   });
 
+  it('describe: from arguments is a coma separated list', () => {
+    const args = parseDescribeFlags({ from: 'path1,path2,path3' });
+    expect(args).toEqual([
+      'scan',
+      '--config-dir',
+      paths.cache,
+      '--from',
+      'path1',
+      '--from',
+      'path2',
+      '--from',
+      'path3',
+      '--to',
+      'aws+tf',
+    ]);
+  });
+
   it('gen-driftignore: passing options generate correct arguments', () => {
     const args = parseArgs(['gen-driftignore'], {
       'exclude-changed': true,


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
driftctl support variadic --from to input multiple state source. We decided to go with coma separated value in snyk cli in order to not change too much how the arg parsing is working.

#### What are the relevant tickets?
https://github.com/snyk/snyk/pull/2812

