### PR TITLE
feat: Add TF Variable support for nested directories [CFG-1483]

### DIFF
--- a/src/cli/commands/test/iac-local-execution/file-loader.ts
+++ b/src/cli/commands/test/iac-local-execution/file-loader.ts
@@ -14,6 +14,21 @@ import { getErrorStringCode } from './error-utils';
 
 const DEFAULT_ENCODING = 'utf-8';
 
+export async function loadContentForFiles(
+  filePaths: string[],
+): Promise<IacFileData[]> {
+  const loadedFiles = await Promise.all(
+    filePaths.map(async (filePath) => {
+      try {
+        return await tryLoadFileData(filePath);
+      } catch (e) {
+        throw new FailedToLoadFileError(filePath);
+      }
+    }),
+  );
+  return loadedFiles.filter((file) => file.fileContent !== '');
+}
+
 export async function loadFiles(
   pathToScan: string,
   options: IaCTestFlags = {},
@@ -27,16 +42,7 @@ export async function loadFiles(
   if (filePaths.length === 0) {
     throw new NoFilesToScanError();
   }
-
-  const loadedFiles: IacFileData[] = await Promise.all(
-    filePaths.map(async (filePath) => {
-      try {
-        return await tryLoadFileData(filePath);
-      } catch (e) {
-        throw new FailedToLoadFileError(filePath);
-      }
-    }),
-  );
+  const loadedFiles = await loadContentForFiles(filePaths);
 
   return loadedFiles.filter((file) => file.fileContent !== '');
 }

--- a/src/cli/commands/test/iac-local-execution/handle-terraform-files-utils.ts
+++ b/src/cli/commands/test/iac-local-execution/handle-terraform-files-utils.ts
@@ -1,0 +1,68 @@
+import * as fs from 'fs';
+import { join } from 'path';
+import { readdirSync } from 'fs';
+import * as path from 'path';
+import { VALID_TERRAFORM_FILE_TYPES } from './types';
+
+/**
+ * makeFileAndDirectoryGenerator is a generator function that helps walking the directory and file structure of this pathToScan
+ * @param root
+ * @param maxDepth? - An optional `maxDepth` argument can be provided to limit how deep in the file tree the search will go.
+ * @returns {Generator<object>} - a generator which yields an object with directories or paths for the path to scan
+ */
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export function* makeFileAndDirectoryGenerator(root = '.', maxDepth?: number) {
+  function* generatorHelper(pathToScan, currentDepth) {
+    {
+      yield { directory: pathToScan };
+    }
+    if (maxDepth !== currentDepth) {
+      for (const dirent of readdirSync(pathToScan, { withFileTypes: true })) {
+        if (
+          dirent.isDirectory() &&
+          fs.readdirSync(join(pathToScan, dirent.name)).length !== 0
+        ) {
+          yield* generatorHelper(
+            join(pathToScan, dirent.name),
+            currentDepth + 1,
+          );
+        } else if (dirent.isFile()) {
+          yield {
+            file: {
+              dir: pathToScan,
+              fileName: join(pathToScan, dirent.name),
+            },
+          };
+        }
+      }
+    }
+  }
+  yield* generatorHelper(root, 1);
+}
+
+export const getExtensionForPath = (pathToScan: string) =>
+  path.extname(pathToScan).toLowerCase();
+
+export const shouldBeParsed = (pathToScan: string): boolean =>
+  VALID_TERRAFORM_FILE_TYPES.includes(getExtensionForPath(pathToScan));
+
+export const isSingleFile = (pathToScan: string): boolean =>
+  !!getExtensionForPath(pathToScan);
+
+/**
+ * Checks if a file should be ignored from loading or not according to the filetype.
+ * We ignore the same files that Terraform ignores.
+ * https://github.com/hashicorp/terraform/blob/dc63fda44b67300d5161dabcd803426d0d2f468e/internal/configs/parser_config_dir.go#L137-L143
+ * @param {string}  pathToScan - The filepath to check
+ * @returns {boolean} if the filepath should be ignored or not
+ */
+export function isIgnoredFile(pathToScan: string): boolean {
+  // we normalise the path in case the user tries to scan a single file with a relative path
+  // e.g. './my-folder/terraform.tf'
+  const normalisedPath = path.normalize(pathToScan);
+  return (
+    normalisedPath.startsWith('.') || // Unix-like hidden files
+    normalisedPath.startsWith('~') || // vim
+    (normalisedPath.startsWith('#') && normalisedPath.endsWith('#')) // emacs
+  );
+}

--- a/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
+++ b/src/cli/commands/test/iac-local-execution/handle-terraform-files.ts
@@ -1,0 +1,139 @@
+import * as fs from 'fs';
+import { loadContentForFiles, NoFilesToScanError } from './file-loader';
+import * as path from 'path';
+import { parseTerraformFiles } from './file-parser';
+import { IacFileParsed, IacFileParseFailure } from './types';
+import {
+  isIgnoredFile,
+  isSingleFile,
+  shouldBeParsed,
+  makeFileAndDirectoryGenerator,
+} from './handle-terraform-files-utils';
+
+/**
+ * This function handles everything from filtering out Terraform files  directory by directory,
+ * loading them, sending them to the parser and getting the parsing results back.
+ * Then it concatenates and returns the new parsing results with the existing parsing results.
+ * @param pathToScan - the path to scan provided by the user
+ * @param parsedFiles - an array that holds all the existing parsedFiles
+ * @param failedFiles - an array that holds all the existing failedFiles
+ * @param maxDepth? - an optional maxDepth of directories if provided by the detection-depth flag
+ * @returns { allParsedFiles, allFailedFiles} - all the parsing results so far
+ */
+export async function loadAndParseTerraformFiles(
+  pathToScan: string,
+  parsedFiles: IacFileParsed[],
+  failedFiles: IacFileParseFailure[],
+  maxDepth?: number,
+): Promise<{
+  allParsedFiles: Array<IacFileParsed>;
+  allFailedFiles: Array<IacFileParseFailure>;
+}> {
+  let allParsedFiles: IacFileParsed[] = parsedFiles,
+    allFailedFiles: IacFileParseFailure[] = failedFiles;
+  const allDirectories = getAllDirectoriesForPath(pathToScan, maxDepth);
+  // we load and parse files directory by directory
+  // this is because we need all files in the same directory to share the same variable context
+  for (const currentDirectory of allDirectories) {
+    const filePathsInDirectory = getFilesForDirectory(
+      pathToScan,
+      currentDirectory,
+    );
+    if (filePathsInDirectory.length === 0) continue; // skip directories that have 0 files but have other directories
+    try {
+      const tfFilesToParse = await loadContentForFiles(filePathsInDirectory);
+      const {
+        parsedFiles: parsedTfFiles,
+        failedFiles: failedTfFiles,
+      } = parseTerraformFiles(tfFilesToParse);
+      allParsedFiles = allParsedFiles.concat(parsedTfFiles);
+      allFailedFiles = allFailedFiles.concat(failedTfFiles);
+    } catch (err) {
+      if (allParsedFiles.length !== 0 && err instanceof NoFilesToScanError) {
+        // ignore this error since we might only have .tf files in the folder and we have separated them
+      } else {
+        throw err;
+      }
+    }
+  }
+  return { allParsedFiles, allFailedFiles };
+}
+
+/**
+ * Gets all nested directories for the path that we ran a scan.
+ * @param pathToScan - the path to scan provided by the user
+ * @param maxDepth? - An optional `maxDepth` argument can be provided to limit how deep in the file tree the search will go.
+ * @returns {string[]} An array with all the non-empty nested directories in this path
+ */
+export function getAllDirectoriesForPath(
+  pathToScan: string,
+  maxDepth?: number,
+): string[] {
+  // if it is a single file (it has an extension)
+  if (isSingleFile(pathToScan)) {
+    if (!shouldBeParsed(pathToScan) || isIgnoredFile(pathToScan)) {
+      throw new NoFilesToScanError();
+    }
+    return [path.resolve(pathToScan)]; // we return the current path if it is a single file
+  }
+  // if the path we scanned itself is an empty directory, finish the scan here
+  if (fs.readdirSync(pathToScan).length === 0) {
+    throw new NoFilesToScanError();
+  }
+  return [...getAllDirectoriesForPathGenerator(pathToScan, maxDepth)];
+}
+
+/**
+ * Gets all the directories included in this path
+ * @param pathToScan - the path to scan provided by the user
+ * @param maxDepth? - An optional `maxDepth` argument can be provided to limit how deep in the file tree the search will go.
+ * @returns {Generator<string>} - a generator which yields the filepaths for the path to scan
+ */
+function* getAllDirectoriesForPathGenerator(
+  pathToScan: string,
+  maxDepth?: number,
+): Generator<string> {
+  for (const filePath of makeFileAndDirectoryGenerator(pathToScan, maxDepth)) {
+    if (filePath.directory) yield filePath.directory;
+  }
+}
+
+/**
+ * Gets all file paths for the specific directory
+ * @param pathToScan - the path to scan provided by the user
+ * @param currentDirectory - the directory which we want to return files for
+ * @returns {string[]} An array with all the Terraform filePaths for this directory
+ */
+export function getFilesForDirectory(
+  pathToScan: string,
+  currentDirectory: string,
+): string[] {
+  if (isSingleFile(pathToScan)) {
+    return [pathToScan];
+  } else {
+    return [...getTerraformFilesInDirectoryGenerator(currentDirectory)];
+  }
+}
+
+/**
+ * Iterates through the makeFileAndDirectoryGenerator function and gets all the Terraform files in the specified directory
+ * @param pathToScan - the pathToScan to scan provided by the user
+ * @returns {Generator<string>} - a generator which holds all the filepaths
+ */
+export function* getTerraformFilesInDirectoryGenerator(
+  pathToScan: string,
+): Generator<string> {
+  for (const filePath of makeFileAndDirectoryGenerator(pathToScan)) {
+    if (filePath.file && filePath.file.dir !== pathToScan) {
+      // we want to get files that belong just to the current walking directory, not the ones in nested directories
+      continue;
+    }
+    if (
+      filePath.file &&
+      shouldBeParsed(filePath.file.fileName) &&
+      !isIgnoredFile(filePath.file.fileName)
+    ) {
+      yield filePath.file.fileName;
+    }
+  }
+}

--- a/src/cli/commands/test/iac-local-execution/types.ts
+++ b/src/cli/commands/test/iac-local-execution/types.ts
@@ -28,6 +28,7 @@ export enum ValidFileType {
   TFVARS = 'tfvars',
 }
 export const VALID_FILE_TYPES = Object.values(ValidFileType);
+export const VALID_TERRAFORM_FILE_TYPES: string[] = ['.tf', '.tfvars'];
 
 export interface IacFileParsed extends IacFileData {
   jsonContent: Record<string, unknown> | TerraformScanInput;

--- a/src/lib/iac/iac-parser.ts
+++ b/src/lib/iac/iac-parser.ts
@@ -20,8 +20,13 @@ const debug = debugLib('snyk-detect');
 const requiredK8SObjectFields = ['apiVersion', 'kind', 'metadata'];
 
 export function getFileType(filePath: string): string {
-  const filePathSplit = filePath.split('.');
-  return filePathSplit[filePathSplit.length - 1].toLowerCase();
+  try {
+    const index = filePath.lastIndexOf('.'); // it will be -1 if it doesn't contain a dot
+    if (index !== -1) return filePath.slice(index + 1).toLowerCase();
+  } catch (e) {
+    // ignore errors if we can't extract the filetype
+  }
+  return '';
 }
 
 function parseFileContent(fileContent: string, filePath: string): any {

--- a/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
+++ b/test/jest/acceptance/iac/test-terraform-var-deref.spec.ts
@@ -43,119 +43,181 @@ describe('Terraform Language Support', () => {
   });
 
   describe('with feature flag', () => {
-    it('dereferences variables in the provided directory only', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/var_deref`,
-      );
-      expect(exitCode).toBe(1);
+    // TODO: can be merged with the existing test-terraform.spec.ts when the flag is removed
+    describe('files', () => {
+      it('finds issues in Terraform file', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support iac/terraform/sg_open_ssh.tf`,
+        );
+        expect(exitCode).toBe(1);
 
-      expect(stdout).toContain('Testing sg_open_ssh.tf...');
-      expect(stdout).toContain('Infrastructure as code issues:');
-      expect(stdout).toContain('✗ Security Group allows open ingress');
-      expect(stdout).toContain(
-        ' input > resource > aws_security_group[allow_ssh] > ingress',
-      );
-      expect(stdout).toContain(
-        ' input > resource > aws_security_group[allow_ssh_terraform_tfvars] > ingress',
-      );
-      expect(stdout).toContain(
-        ' input > resource > aws_security_group[allow_ssh_a_auto_tfvars] > ingress',
-      );
-      expect(stdout).toContain(
-        ' input > resource > aws_security_group[allow_ssh_b_auto_tfvars] > ingress',
-      );
-
-      expect(stdout).not.toContain(
-        'Testing nested-var_deref/sg_open_ssh.tf...',
-      );
+        expect(stdout).toContain(
+          `Testing ${path
+            .join('iac', 'terraform', 'sg_open_ssh.tf')
+            .replace(new RegExp('\\' + path.sep, 'g'), '/')}`,
+        );
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('✗ Security Group allows open ingress');
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh] > ingress',
+        );
+      });
+      it('finds no issues in empty Terraform file', async () => {
+        const { exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/empty_file.tf`,
+        );
+        expect(exitCode).toBe(0);
+      });
     });
 
-    it('still scans other files but not terraform files nested in a directory', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac`,
-      );
-      expect(exitCode).toBe(1);
+    describe('directories', () => {
+      it('dereferences variables in nested directories', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/var_deref`,
+        );
+        expect(exitCode).toBe(1);
 
-      expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('Testing sg_open_ssh.tf...');
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('✗ Security Group allows open ingress');
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh] > ingress',
+        );
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh_terraform_tfvars] > ingress',
+        );
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh_a_auto_tfvars] > ingress',
+        );
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh_b_auto_tfvars] > ingress',
+        );
 
-      expect(stdout).toContain(
-        `Testing ${path.join('kubernetes', 'pod-privileged.yaml')}`,
-      );
-      expect(stdout).toContain(
-        `Tested ${path.join(
-          'kubernetes',
-          'pod-privileged.yaml',
-        )} for known issues`,
-      );
+        expect(stdout).toContain(
+          `Testing ${path.join('nested_var_deref', 'sg_open_ssh.tf')}...`,
+        );
+      });
 
-      expect(stdout).not.toContain(
-        `Testing ${path.join('terraform', 'var_deref', 'sg_open_ssh.tf')}`,
-      );
-      expect(stdout).not.toContain(
-        `Tested ${path.join(
-          'terraform',
-          'var_deref',
-          'sg_open_ssh.tf',
-        )} for known issues`,
-      );
+      //TODO: add another test that checks a folder with edge cases
+
+      it('scans a mix of IaC files in nested directories', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac`,
+        );
+        expect(exitCode).toBe(1);
+
+        expect(stdout).toContain('Infrastructure as code issues:');
+
+        expect(stdout).toContain(
+          `Testing ${path.join('kubernetes', 'pod-privileged.yaml')}`,
+        );
+        expect(stdout).toContain(
+          `Tested ${path.join(
+            'kubernetes',
+            'pod-privileged.yaml',
+          )} for known issues`,
+        );
+
+        expect(stdout).toContain(
+          `Testing ${path.join('terraform', 'var_deref', 'sg_open_ssh.tf')}`,
+        );
+        expect(stdout).toContain(
+          `Tested ${path.join(
+            'terraform',
+            'var_deref',
+            'sg_open_ssh.tf',
+          )} for known issues, found`,
+        );
+      });
     });
 
-    it('is backwards compatible without variable dereferencing', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf`,
-      );
-      expect(exitCode).toBe(1);
+    describe('other functions', () => {
+      it('is backwards compatible without variable dereferencing', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support iac/terraform/sg_open_ssh.tf`,
+        );
+        expect(exitCode).toBe(1);
 
-      expect(stdout).toContain('Testing ./iac/terraform/sg_open_ssh.tf');
-      expect(stdout).toContain('Infrastructure as code issues:');
-      expect(stdout).toContain('✗ Security Group allows open ingress');
-      expect(stdout).toContain(
-        ' input > resource > aws_security_group[allow_ssh] > ingress',
-      );
-    });
+        expect(stdout).toContain(
+          `Testing ${path
+            .join('iac', 'terraform', 'sg_open_ssh.tf')
+            .replace(new RegExp('\\' + path.sep, 'g'), '/')}`,
+        );
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('✗ Security Group allows open ingress');
+        expect(stdout).toContain(
+          ' input > resource > aws_security_group[allow_ssh] > ingress',
+        );
+      });
 
-    it('filters out issues when using severity threshold', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --severity-threshold=high`,
-      );
+      it('filters out issues when using severity threshold', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support iac/terraform/sg_open_ssh.tf --severity-threshold=high`,
+        );
 
-      expect(exitCode).toBe(0);
-      expect(stdout).toContain('Infrastructure as code issues:');
-      expect(stdout).toContain(
-        'Tested ./iac/terraform/sg_open_ssh.tf for known issues, found 0 issues',
-      );
-    });
+        expect(exitCode).toBe(0);
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain(
+          `Tested ${path
+            .join('iac', 'terraform', 'sg_open_ssh.tf')
+            .replace(
+              new RegExp('\\' + path.sep, 'g'),
+              '/',
+            )} for known issues, found 0 issues`,
+        );
+      });
 
-    it('outputs an error for files with invalid HCL2', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh_invalid_hcl2.tf`,
-      );
+      it('filters out issues when using detection depth', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/ --detection-depth=2`,
+        );
 
-      expect(exitCode).toBe(2);
-      expect(stdout).toContain('We were unable to parse the Terraform file');
-    });
+        expect(exitCode).toBe(1);
+        expect(stdout).toContain('Infrastructure as code issues:');
+        expect(stdout).toContain('Testing sg_open_ssh.tf...');
+        expect(stdout).toContain(
+          `Testing ${path.join('var_deref', 'sg_open_ssh.tf')}...`,
+        );
+        expect(stdout).not.toContain(
+          `Testing ${path.join(
+            'nested_var_deref',
+            'var_deref',
+            'sg_open_ssh.tf',
+          )}...`,
+        );
+      });
 
-    it('outputs the expected text when running with --sarif flag', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --sarif`,
-      );
+      it('outputs an error for files with invalid HCL2', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh_invalid_hcl2.tf`,
+        );
 
-      expect(exitCode).toBe(1);
-      expect(isValidJSONString(stdout)).toBe(true);
-      expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
-      expect(stdout).toContain('"ruleId": "SNYK-CC-TF-1",');
-    });
+        expect(exitCode).toBe(2);
+        expect(stdout).toContain('We were unable to parse the Terraform file');
+      });
 
-    it('outputs the expected text when running with --json flag', async () => {
-      const { stdout, exitCode } = await run(
-        `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --json`,
-      );
+      it('outputs the expected text when running with --sarif flag', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --sarif`,
+        );
 
-      expect(exitCode).toBe(1);
-      expect(isValidJSONString(stdout)).toBe(true);
-      expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
-      expect(stdout).toContain('"packageManager": "terraformconfig",');
-      expect(stdout).toContain('"projectType": "terraformconfig",');
+        expect(exitCode).toBe(1);
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+        expect(stdout).toContain('"ruleId": "SNYK-CC-TF-1",');
+      });
+
+      it('outputs the expected text when running with --json flag', async () => {
+        const { stdout, exitCode } = await run(
+          `snyk iac test --org=tf-lang-support ./iac/terraform/sg_open_ssh.tf --json`,
+        );
+
+        expect(exitCode).toBe(1);
+        expect(isValidJSONString(stdout)).toBe(true);
+        expect(stdout).toContain('"id": "SNYK-CC-TF-1",');
+        expect(stdout).toContain('"packageManager": "terraformconfig",');
+        expect(stdout).toContain('"projectType": "terraformconfig",');
+      });
     });
   });
 });

--- a/test/jest/unit/iac/file-parser.spec.ts
+++ b/test/jest/unit/iac/file-parser.spec.ts
@@ -174,6 +174,19 @@ describe('parseTerraformFiles', () => {
     expect(failedFiles.length).toEqual(0);
   });
 
+  it('parses empty Terraform files', () => {
+    const { parsedFiles, failedFiles } = parseTerraformFiles([
+      { ...terraformFileDataStub, fileContent: '' },
+    ]);
+    expect(parsedFiles.length).toEqual(1);
+    expect(parsedFiles[0]).toEqual({
+      ...expectedTerraformParsingResult,
+      fileContent: '',
+      jsonContent: {},
+    });
+    expect(failedFiles.length).toEqual(0);
+  });
+
   it('does not throw an error if a file parse failed in a directory scan', () => {
     const { parsedFiles, failedFiles } = parseTerraformFiles([
       invalidTerraformFileDataStub,

--- a/test/jest/unit/iac/handle-terraform-files-utils.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files-utils.spec.ts
@@ -1,0 +1,28 @@
+import {
+  getExtensionForPath,
+  shouldBeParsed,
+} from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files-utils';
+
+describe('handle-terraform-files-utils', () => {
+  describe('getExtensionForPath and shouldBeParsed', () => {
+    it.each([
+      ['dir/file1.tf', '.tf', true],
+      ['dir/file2.yaml', '.yaml', false],
+      ['dir/.', '', false],
+      ['dir/..', '', false],
+      ['dir/.DS_Store', '', false],
+      ['dir/#', '', false],
+      ['dir/#swap#', '', false],
+      ['dir/~', '', false],
+      ['dir/~something', '', false],
+      ['dir/file.tfvars', '.tfvars', true],
+      ['dir/file.auto.tfvars', '.tfvars', true],
+    ])(
+      'given %p filepath, returns %p as expectedExtension and %p for shouldBeParsed',
+      (filepath, expectedExtension, expectedResult) => {
+        expect(getExtensionForPath(filepath)).toBe(expectedExtension);
+        expect(shouldBeParsed(filepath)).toBe(expectedResult);
+      },
+    );
+  });
+});

--- a/test/jest/unit/iac/handle-terraform-files.spec.ts
+++ b/test/jest/unit/iac/handle-terraform-files.spec.ts
@@ -1,0 +1,207 @@
+const mockFs = require('mock-fs');
+import {
+  getTerraformFilesInDirectoryGenerator,
+  getAllDirectoriesForPath,
+} from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
+import * as terraformFileHandler from '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files';
+import * as path from 'path';
+import { NoFilesToScanError } from '../../../../src/cli/commands/test/iac-local-execution/file-loader';
+import {
+  terraformFileStub,
+  level1Directory,
+  level2Directory,
+  level2FileStub,
+  level3Directory,
+  level3FileStub,
+  nonIacFileStub,
+} from './file-loader.fixtures';
+
+describe('getAllDirectoriesForPath', () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+    mockFs.restore();
+  });
+
+  describe('single file path', () => {
+    it('with a single .tf file', () => {
+      mockFs({ [terraformFileStub.filePath]: 'content' });
+      const directories = getAllDirectoriesForPath(terraformFileStub.filePath);
+      expect(directories).toEqual([terraformFileStub.filePath]);
+    });
+
+    describe('with a single .tfvars file', () => {
+      const fullPath = path.join(path.resolve('.'), 'file.tfvars');
+      it('returns an array with a single file', () => {
+        mockFs({ [fullPath]: 'some variables' });
+        const filePaths = getAllDirectoriesForPath('file.tfvars');
+        expect(filePaths).toEqual([fullPath]);
+      });
+
+      it('can handle single dot relative paths successfully', () => {
+        mockFs({ [fullPath]: 'some variables' });
+        const filePaths = getAllDirectoriesForPath('./file.tfvars');
+        expect(filePaths).toEqual([fullPath]);
+      });
+    });
+  });
+
+  describe('errors', () => {
+    it('throws an error if a single file scan and the file is not IaC', () => {
+      mockFs({ [nonIacFileStub.filePath]: 'content' });
+      expect(() => {
+        getAllDirectoriesForPath(nonIacFileStub.filePath);
+      }).toThrow(NoFilesToScanError);
+    });
+
+    it('throws an error when an error occurs when loading files', () => {
+      jest
+        .spyOn(terraformFileHandler, 'getAllDirectoriesForPath')
+        .mockImplementation(() => {
+          throw new Error('error occurred during fs operations');
+        });
+      expect(getAllDirectoriesForPath).toThrow(
+        Error('error occurred during fs operations'),
+      );
+    });
+  });
+
+  describe('directory paths', () => {
+    beforeEach(() => {
+      jest.restoreAllMocks();
+    });
+    describe('with just IaC files and 0 nested directories', () => {
+      it('returns itself', () => {
+        mockFs({
+          dir: {
+            ['file1.tf']: 'content',
+            ['file2.tf']: 'content',
+            ['file3.tfvars']: 'content',
+          },
+        });
+
+        const filePaths = getAllDirectoriesForPath('dir');
+        expect(filePaths).toEqual(['dir']);
+      });
+    });
+  });
+
+  describe('with multiple directories', () => {
+    it('returns the non empty directories', () => {
+      mockFs({
+        dir: {
+          ['file.tf']: 'content',
+          'nested-dir': {
+            ['file.tf']: 'something',
+            ['.']: 'something',
+          },
+          'empty-dir': {},
+        },
+        ['file.tfvars']: 'content',
+        'empty-dir-2': {},
+      });
+
+      const filePaths = getAllDirectoriesForPath('dir');
+      expect(filePaths).toEqual(['dir', 'dir/nested-dir']);
+    });
+
+    describe('with nested files inside multiple-level directories', () => {
+      beforeEach(() => {
+        mockFs({
+          [level1Directory]: {
+            [path.basename(level2Directory)]: {
+              [path.basename(
+                level2FileStub.filePath,
+              )]: level2FileStub.fileContent,
+              [path.basename(level3Directory)]: {
+                [path.basename(
+                  level3FileStub.filePath,
+                )]: level3FileStub.fileContent,
+              },
+            },
+          },
+        });
+      });
+
+      describe('with 1 directory', () => {
+        it('throws an error as there are no files at that level', () => {
+          mockFs({
+            'empty-dir': {},
+          });
+          expect(() => {
+            getAllDirectoriesForPath('empty-dir');
+          }).toThrow(NoFilesToScanError);
+        });
+
+        describe('with 2 directories', () => {
+          it('returns the files at level 2', () => {
+            const directoryFilePaths = getAllDirectoriesForPath(
+              level1Directory,
+            );
+            const level2Dir = path.join(
+              level1Directory,
+              path.basename(level2Directory),
+            );
+            expect(directoryFilePaths).toEqual([
+              level1Directory,
+              level2Dir,
+              path.join(level2Dir, path.basename(level3Directory)),
+            ]);
+          });
+        });
+
+        describe('with detection depth 1', () => {
+          it('returns the files at level 1', () => {
+            const directoryFilePaths = getAllDirectoriesForPath(
+              level1Directory,
+              1,
+            );
+            expect(directoryFilePaths).toEqual([level1Directory]);
+          });
+        });
+      });
+    });
+  });
+
+  describe('getTerraformFilesInDirectoryGenerator', () => {
+    it('ignores specific filetypes', () => {
+      mockFs({
+        dir: {
+          ['file1.tf']: 'content',
+          ['file2.yaml']: 'content',
+          ['.']: 'content',
+          ['..']: 'content',
+          ['.DS_Store']: 'content',
+          ['#']: 'content',
+          ['#swap#']: 'content',
+          ['~']: 'content',
+          ['~something']: 'content',
+          ['file.tfvars']: 'content',
+          ['file.auto.tfvars']: 'content',
+        },
+      });
+
+      const filePaths = [...getTerraformFilesInDirectoryGenerator('dir')];
+      expect(filePaths).toEqual([
+        'dir/file.auto.tfvars',
+        'dir/file.tfvars',
+        'dir/file1.tf',
+      ]);
+    });
+
+    it('gets filepaths for the specific directory only', () => {
+      mockFs({
+        dir: {
+          ['file1.tf']: 'content',
+          ['file.tfvars']: 'content',
+          nestedDir: {
+            ['file-nested.tf']: 'content',
+            ['file-nested.tfvars']: 'content',
+          },
+        },
+      });
+
+      const filePaths = [...getTerraformFilesInDirectoryGenerator('dir')];
+      expect(filePaths).toEqual(['dir/file.tfvars', 'dir/file1.tf']);
+    });
+  });
+});

--- a/test/jest/unit/iac/index.spec.ts
+++ b/test/jest/unit/iac/index.spec.ts
@@ -5,6 +5,7 @@ jest.mock('../../../../src/lib/feature-flags', () => ({
   isFeatureFlagSupportedForOrg: isFeatureFlagSupportedForOrgStub,
 }));
 const parseFilesStub = jest.fn();
+const loadAndParseFilesStub = jest.fn();
 const parseTerraformFilesStub = jest.fn();
 jest.mock(
   '../../../../src/cli/commands/test/iac-local-execution/file-parser',
@@ -32,6 +33,16 @@ jest.mock(
   '../../../../src/cli/commands/test/iac-local-execution/org-settings/get-iac-org-settings.ts',
   () => ({
     getIacOrgSettings: getIacOrgSettingsStub,
+  }),
+);
+
+const loadAndParseTerraformFilesStub = jest.fn();
+const getDirectoriesForTFScanStub = jest.fn();
+jest.mock(
+  '../../../../src/cli/commands/test/iac-local-execution/handle-terraform-files.ts',
+  () => ({
+    loadAndParseTerraformFiles: loadAndParseTerraformFilesStub,
+    getDirectoriesForTFScan: getDirectoriesForTFScanStub,
   }),
 );
 
@@ -132,6 +143,10 @@ describe('test()', () => {
 
       it('attempts to pull the custom-rules bundle using the provided configurations', async () => {
         const opts: IaCTestFlags = {};
+        loadAndParseTerraformFilesStub.mockResolvedValue({
+          allParsedFiles: parsedFiles,
+          allFailedFiles: failedFiles,
+        });
 
         await test('./iac/terraform/sg_open_ssh.tf', opts);
 
@@ -166,6 +181,13 @@ describe('test()', () => {
 
       it('returns the unparsable files excluding content', async () => {
         const opts: IaCTestFlags = {};
+        loadAndParseFilesStub.mockReturnValue(() => {
+          return {
+            allParsedFiles: parsedFiles,
+            allFailedFiles: failedFiles,
+          };
+        });
+
         const { failures } = await test('./storage/', opts);
 
         expect(failures).toEqual([


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR introduces TF variable dereferencing support in nested directories. Imagine this project structure:
```
.
├── arm-test.tf
├── dev
│   └── my-local-module
│       ├── terraform.tfvars
│       └── test-file.tf
├── file-with-input-var.tf
├── pre-prod
│   └── my-local-module
│       ├── terraform.tfvars
│       └── test-file.tf
├── prod
│   └── my-local-module
│       ├── terraform.tfvars
│       └── test-file.tf
├── empty-directory
├── staging
│   └── my-local-module
│       ├── terraform.tfvars
│       └── test-file.tf
├── terraform.tfvars
└── test-file.tf
└── empty-file.tf

9 directories, 13 files
```

We have several directories and files. So far, we supported running a scan and dereferencing variables only on the current working directory. This PR extends it to nested directories as well.
If we start iterating through the directories one by one, we will find more files and more nested directories.

The way we send terraform files to the parser in order to get parsed, and dereferenced is by sending all files in the same directory, as this is considered a root module directory by Terraform.
On this particular case, we would expect to send all files in each directory all together, so that they will share the variable context when each one of them will get dereferenced. We expect to see issues:

- /dev/my-local-module/test-file.tf - for any variables in the test-file.tf file in that folder
- /pre-prod/my-local-module/test-file.tf - for any variables in the test-file.tf file in that folder
- /prod/my-local-module/test-file.tf - for any variables in the test-file.tf file in that folder
- /staging/my-local-module/test-file.tf - for any variables in the test-file.tf file in that folder

 in the top directory (.), all the files are also sharing the same variable context, so:
- arm-test.tf, if there are defaults inside that or any of the other files in `.`
- test-file.tf if there are defaults inside that or any of the other files in `.`
- file-with-input-var.tf if there are defaults inside that or any of the other files in `.`


TODO - refactoring

#### Where should the reviewer start?

The flow is the following:
* get all directories for the specific pathToScan 
  * if the pathToScan is a single file, check that it is valid  (.tf., .tfvars) and return the path itself
* for each of the directories returned in the array, return all the filepaths of the files in it.
   * send all the files in the directory to the parser
   * get the parsedFiles and failedFiles
* scan and find issues for these files 

It works for all the existing flags, plus detection depth as well.

#### How should this be manually tested?
This has been tested for all these scenarios in unit and acceptance tests, also manually, please play around yourselves and try to create scenarios like these:

- top level directory
- empty top level directory
- single IaC file
- single TF, TFVARS file
- single file with empty content
- non IaC file
- directory with 0 files and 0 directories (empty)
- directory with 0 files and N directories
- directory with 0 files and another nested empty directory
- terraform workspace with a lot of tf generated files
- directory with mix of IaC files (yaml, json,tf)
- directory with mix of IaC and non IaC files
- scanning by providing a relative path (e.g. `./dir` or `../dir`)
- scanning by current path `.`
- scanning with --json, --sarif, --severity-threshold
- scanning with --detection-depth (PENDING)

#### Any background context you want to provide?


#### What are the relevant tickets?
[CFG-1483]

#### Screenshots
For this tree structure: 
![image](https://user-images.githubusercontent.com/6989529/156221706-96994c0c-1ff1-4793-87d4-393984ebb250.png)

You can see the traversing and parsing, directory by directory:
![image](https://user-images.githubusercontent.com/6989529/156222174-98f476e4-c782-4ce0-adb8-501bda447206.png)
![image](https://user-images.githubusercontent.com/6989529/156222232-5314bbe0-bfd3-47d4-98d3-368cd1d8e32c.png)
![image](https://user-images.githubusercontent.com/6989529/156222307-6d2a6b1b-ceac-42fb-a924-d612963619fb.png)



This shows that we send the files of each directory together at parser, so that we can get the shared variable context for the specific directory.
 
#### Additional questions


[CFG-1483]: https://snyksec.atlassian.net/browse/CFG-1483?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ