### PR TITLE
[CFG-1600] adapt `iac drift` exits codes to snyk cli

### DIFF
--- a/help/cli-commands/iac-describe.md
+++ b/help/cli-commands/iac-describe.md
@@ -9,7 +9,8 @@ For more information see the [driftctl documentation](https://docs.driftctl.com/
 Possible exit codes and their meaning:
 
 **0**: success, no drift found<br />
-**1**: action_needed, drifts found or failure<br />
+**1**: drifts or unmanaged resources found<br />
+**2**: failure<br />
 
 ## Configure the Snyk CLI
 

--- a/src/cli/commands/drift.ts
+++ b/src/cli/commands/drift.ts
@@ -1,9 +1,9 @@
 import { MethodArgs } from '../args';
 import { processCommandArgs } from './process-command-args';
-import { driftctl, parseArgs } from '../../lib/iac/drift';
 import { UnsupportedEntitlementCommandError } from './test/iac-local-execution/assert-iac-options-flag';
 import { getIacOrgSettings } from './test/iac-local-execution/measurable-methods';
 import config from '../../lib/config';
+import { driftctl, parseArgs } from '../../lib/iac/drift';
 
 const legacyError = require('../../lib/errors/legacy-errors');
 

--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -12,11 +12,19 @@ import {
   createIgnorePattern,
   verifyServiceMappingExists,
 } from './service-mappings';
+import { EXIT_CODES } from '../../cli/exit-codes';
 
 const cachePath = config.CACHE_PATH ?? envPaths('snyk').cache;
 const debug = debugLib('drift');
 
 export const driftctlVersion = 'v0.21.0';
+
+export const DCTL_EXIT_CODES = {
+  EXIT_IN_SYNC: 0,
+  EXIT_NOT_IN_SYNC: 1,
+  EXIT_ERROR: 2,
+};
+
 const driftctlChecksums = {
   'driftctl_windows_386.exe':
     'f7affbe0ba270b0339d0398befc686bd747a1694a4db0890ce73a2b1921521d4',
@@ -240,12 +248,28 @@ export const parseDescribeFlags = (options: DriftCTLOptions): string[] => {
   return args;
 };
 
+export function translateExitCode(exitCode: number) {
+  switch (exitCode) {
+    case DCTL_EXIT_CODES.EXIT_IN_SYNC:
+      return 0;
+    case DCTL_EXIT_CODES.EXIT_NOT_IN_SYNC:
+      return EXIT_CODES.VULNS_FOUND;
+    case DCTL_EXIT_CODES.EXIT_ERROR:
+      return EXIT_CODES.ERROR;
+    default:
+      debug('driftctl returned %d', exitCode);
+      return EXIT_CODES.ERROR;
+  }
+}
+
 export async function driftctl(args: string[]): Promise<number> {
   debug('running driftctl %s ', args.join(' '));
 
   const path = await findOrDownload();
 
-  return await launch(path, args);
+  const exitCode = await launch(path, args);
+
+  return translateExitCode(exitCode);
 }
 
 async function launch(path: string, args: string[]): Promise<number> {

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -1,11 +1,14 @@
 import * as mockFs from 'mock-fs';
 
 import {
+  DCTL_EXIT_CODES,
   DriftctlGenDriftIgnoreOptions,
   parseArgs,
   parseDescribeFlags,
+  translateExitCode,
 } from '../../../../../src/lib/iac/drift';
 import envPaths from 'env-paths';
+import { EXIT_CODES } from '../../../../../src/cli/exit-codes';
 
 const paths = envPaths('snyk');
 
@@ -106,5 +109,16 @@ describe('driftctl integration', () => {
       '--exclude-missing',
       '--exclude-unmanaged',
     ]);
+  });
+
+  it('run driftctl: exit code is translated', () => {
+    expect(translateExitCode(DCTL_EXIT_CODES.EXIT_IN_SYNC)).toEqual(0);
+    expect(translateExitCode(DCTL_EXIT_CODES.EXIT_NOT_IN_SYNC)).toEqual(
+      EXIT_CODES.VULNS_FOUND,
+    );
+    expect(translateExitCode(DCTL_EXIT_CODES.EXIT_ERROR)).toEqual(
+      EXIT_CODES.ERROR,
+    );
+    expect(translateExitCode(42)).toEqual(EXIT_CODES.ERROR);
   });
 });


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

This PR make sure that driftctl return code are translated into snyk cli idiomatic codes. 

#### What are the relevant tickets?
https://snyksec.atlassian.net/jira/software/c/projects/CFG/boards/328?modal=detail&selectedIssue=CFG-1600
