### PR TITLE
refactor: don’t recommend running snyk wizard

### DIFF
--- a/src/lib/errors/policy-not-found-error.ts
+++ b/src/lib/errors/policy-not-found-error.ts
@@ -3,8 +3,7 @@ import { CustomError } from './custom-error';
 export class PolicyNotFoundError extends CustomError {
   private static ERROR_CODE = 404;
   private static ERROR_STRING_CODE = 'MISSING_DOTFILE';
-  private static ERROR_MESSAGE =
-    'Could not load policy. Try running `snyk wizard` to define a Snyk protect policy';
+  private static ERROR_MESSAGE = 'Policy file not found.';
 
   constructor() {
     super(PolicyNotFoundError.ERROR_MESSAGE);


### PR DESCRIPTION
Don't recommend running `snyk wizard` when a policy file cannot be found.