### PR TITLE
[CFG-1639] Add default --no-version-check flag to driftctl

### DIFF
--- a/src/lib/iac/drift.ts
+++ b/src/lib/iac/drift.ts
@@ -50,6 +50,7 @@ const driftctlChecksums = {
 
 const dctlBaseUrl = 'https://github.com/snyk/driftctl/releases/download/';
 const driftctlPath = path.join(cachePath, 'driftctl_' + driftctlVersion);
+const driftctlDefaultOptions = ['--no-version-check'];
 
 export interface DriftctlGenDriftIgnoreOptions {
   input?: string;
@@ -85,7 +86,7 @@ interface DriftCTLOptions {
 export const parseGenDriftIgnoreFlags = (
   options: DriftctlGenDriftIgnoreOptions,
 ): string[] => {
-  const args: string[] = ['gen-driftignore'];
+  const args: string[] = ['gen-driftignore', ...driftctlDefaultOptions];
 
   if (options.input) {
     args.push('--input');
@@ -113,7 +114,7 @@ export const parseGenDriftIgnoreFlags = (
 };
 
 export const parseDescribeFlags = (options: DriftCTLOptions): string[] => {
-  const args: string[] = ['scan'];
+  const args: string[] = ['scan', ...driftctlDefaultOptions];
 
   if (options.quiet) {
     args.push('--quiet');

--- a/test/jest/acceptance/iac/describe.spec.ts
+++ b/test/jest/acceptance/iac/describe.spec.ts
@@ -60,7 +60,9 @@ describe('iac describe', () => {
       ),
     });
 
-    expect(stdout).toMatch('scan --config-dir ' + paths.cache + ' --to aws+tf');
+    expect(stdout).toMatch(
+      'scan --no-version-check --config-dir ' + paths.cache + ' --to aws+tf',
+    );
     expect(stderr).toMatch('');
     expect(exitCode).toBe(0);
   });
@@ -72,7 +74,9 @@ describe('iac describe', () => {
       SNYK_CACHE_PATH: cachedir,
     });
 
-    expect(stdout).toMatch('scan --config-dir ' + cachedir + ' --to aws+tf');
+    expect(stdout).toMatch(
+      'scan --no-version-check --config-dir ' + cachedir + ' --to aws+tf',
+    );
     expect(stderr).toMatch('');
     expect(exitCode).toBe(0);
     expect(

--- a/test/jest/acceptance/iac/gen-driftignore.spec.ts
+++ b/test/jest/acceptance/iac/gen-driftignore.spec.ts
@@ -48,7 +48,7 @@ describe('iac gen-driftignore', () => {
     );
 
     expect(stdout).toMatch(
-      'gen-driftignore --input something.json --output stdout --exclude-changed --exclude-missing --exclude-unmanaged',
+      'gen-driftignore --no-version-check --input something.json --output stdout --exclude-changed --exclude-missing --exclude-unmanaged',
     );
     expect(stderr).toMatch('');
     expect(exitCode).toBe(0);

--- a/test/jest/unit/lib/iac/drift.spec.ts
+++ b/test/jest/unit/lib/iac/drift.spec.ts
@@ -22,6 +22,7 @@ describe('driftctl integration', () => {
     const args = parseDescribeFlags({});
     expect(args).toEqual([
       'scan',
+      '--no-version-check',
       '--config-dir',
       paths.cache,
       '--to',
@@ -31,7 +32,7 @@ describe('driftctl integration', () => {
 
   it('gen-driftignore: default arguments are correct', () => {
     const args = parseGenDriftIgnoreFlags({});
-    expect(args).toEqual(['gen-driftignore']);
+    expect(args).toEqual(['gen-driftignore', '--no-version-check']);
   });
 
   it('describe: passing options generate correct arguments', () => {
@@ -58,6 +59,7 @@ describe('driftctl integration', () => {
     });
     expect(args).toEqual([
       'scan',
+      '--no-version-check',
       '--quiet',
       '--filter',
       'filter',
@@ -98,6 +100,7 @@ describe('driftctl integration', () => {
     const args = parseDescribeFlags({ from: 'path1,path2,path3' });
     expect(args).toEqual([
       'scan',
+      '--no-version-check',
       '--config-dir',
       paths.cache,
       '--from',
@@ -122,6 +125,7 @@ describe('driftctl integration', () => {
     } as DriftctlGenDriftIgnoreOptions);
     expect(args).toEqual([
       'gen-driftignore',
+      '--no-version-check',
       '--input',
       'analysis.json',
       '--output',


### PR DESCRIPTION
- [x] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?

Driftctl update checking should be turned off when running driftctl from Snyk CLI. This PR adds `--no-version-check` option to driftctl by default so it doesn't perform this check anymore. This is a global flag in driftctl so I added it for both scan and gen-driftignore commands.


#### How should this be manually tested?

```
$ SNYK_API=http://localhost:8000/api/v1 ./bin/snyk iac describe --service=aws_s3
```


#### What are the relevant tickets?

- https://snyksec.atlassian.net/browse/CFG-1639
- https://docs.driftctl.com/0.22.0/usage/flags/version-check

#### Screenshots

![image](https://user-images.githubusercontent.com/16480203/156367766-3d4eb4eb-b3e7-4833-8238-9b8755c28e70.png)

