### PR TITLE
feat: propagate org name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@open-policy-agent/opa-wasm": "^1.6.0",
         "@snyk/cli-interface": "2.11.0",
         "@snyk/cloud-config-parser": "^1.13.1",
-        "@snyk/code-client": "^4.6.1",
+        "@snyk/code-client": "^4.7.0",
         "@snyk/dep-graph": "^1.27.1",
         "@snyk/docker-registry-v2-client": "^2.6.1",
         "@snyk/fix": "file:packages/snyk-fix",
@@ -1950,9 +1950,9 @@
       }
     },
     "node_modules/@snyk/code-client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.6.1.tgz",
-      "integrity": "sha512-U1Qu0EftOhcrmA1Mf6qtZw0ZRd6yzDiP7vFhed8Ajd0phL+SfxbhmDKRWnz8w8mXnxtzBEYzpoaxgGidZ6ptMA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.7.0.tgz",
+      "integrity": "sha512-QiChY2TTbZgoZ190ELhHIFz1oSvvNjbhl/5YxErEd96rD6VcCREW2R0mZRtRPuRpheDXELKdwRDwmqVcDdTPwg==",
       "dependencies": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",
@@ -21483,9 +21483,9 @@
       }
     },
     "@snyk/code-client": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.6.1.tgz",
-      "integrity": "sha512-U1Qu0EftOhcrmA1Mf6qtZw0ZRd6yzDiP7vFhed8Ajd0phL+SfxbhmDKRWnz8w8mXnxtzBEYzpoaxgGidZ6ptMA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@snyk/code-client/-/code-client-4.7.0.tgz",
+      "integrity": "sha512-QiChY2TTbZgoZ190ELhHIFz1oSvvNjbhl/5YxErEd96rD6VcCREW2R0mZRtRPuRpheDXELKdwRDwmqVcDdTPwg==",
       "requires": {
         "@deepcode/dcignore": "^1.0.4",
         "@snyk/fast-glob": "^3.2.6-patch",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@open-policy-agent/opa-wasm": "^1.6.0",
     "@snyk/cli-interface": "2.11.0",
     "@snyk/cloud-config-parser": "^1.13.1",
-    "@snyk/code-client": "^4.6.1",
+    "@snyk/code-client": "^4.7.0",
     "@snyk/dep-graph": "^1.27.1",
     "@snyk/docker-registry-v2-client": "^2.6.1",
     "@snyk/fix": "file:packages/snyk-fix",

--- a/src/lib/plugins/sast/analysis.ts
+++ b/src/lib/plugins/sast/analysis.ts
@@ -80,8 +80,14 @@ async function getCodeAnalysis(
     analysisContext: {
       initiator: 'CLI',
       flow: source,
-      orgDisplayName: config.org,
+      orgDisplayName: sastSettings.org,
       projectName: config.PROJECT_NAME,
+      org: {
+        name: sastSettings.org || 'unknown',
+        displayName: 'unknown',
+        publicId: 'unknown',
+        flags: {},
+      },
     },
   });
 

--- a/test/jest/unit/snyk-code/snyk-code-test.spec.ts
+++ b/test/jest/unit/snyk-code/snyk-code-test.spec.ts
@@ -369,6 +369,50 @@ describe('Test snyk code', () => {
     });
   });
 
+  it('should pass org returned by settings to analysis context', async () => {
+    const options: ArgsOptions = {
+      path: '',
+      traverseNodeModules: false,
+      showVulnPaths: 'none',
+      code: true,
+      _: [],
+      _doubleDashArgs: [],
+      org: 'anyOrg',
+    };
+
+    analyzeFoldersMock.mockResolvedValue(sampleAnalyzeFoldersResponse);
+    isSastEnabledForOrgSpy.mockResolvedValueOnce({
+      sastEnabled: true,
+      localCodeEngine: {
+        enabled: false,
+      },
+      org: 'defaultOrg',
+    });
+    trackUsageSpy.mockResolvedValue({});
+
+    try {
+      await snykTest('some/path', options);
+    } catch (error) {
+      expect(analyzeFoldersMock).toHaveBeenCalledWith({
+        analysisContext: {
+          flow: 'snyk-cli',
+          initiator: 'CLI',
+          orgDisplayName: 'defaultOrg',
+          projectName: undefined,
+          org: {
+            displayName: 'unknown',
+            flags: {},
+            name: 'defaultOrg',
+            publicId: 'unknown',
+          },
+        },
+        analysisOptions: expect.any(Object),
+        connection: expect.any(Object),
+        fileOptions: expect.any(Object),
+      });
+    }
+  });
+
   it.each([
     ['sarif', { sarif: true }],
     ['json', { json: true }],
@@ -592,6 +636,7 @@ describe('Test snyk code', () => {
       analysisContext: {
         flow: 'snyk-cli',
         initiator: 'CLI',
+        org: expect.anything(),
       },
     };
 
@@ -683,6 +728,7 @@ describe('Test snyk code', () => {
         analysisContext: {
           flow: 'snyk-cli',
           initiator: 'CLI',
+          org: expect.anything(),
         },
       };
 


### PR DESCRIPTION
#### What does this PR do?

The change propagates org name returned from `sast-settings`. This will be
either a default org or org provided in the CLI options (and verified to
exist)

#### Where should the reviewer start?

-

#### How should this be manually tested?

-

#### Any background context you want to provide?

We want to add more observability into our `snyk code test` flow. This will allow us to see what are specific orgs experiencing when using the command. 

#### What are the relevant tickets?
-

#### Screenshots
-

#### Additional questions
-