### PR TITLE
fix: maven root project scan exclude aggregate projects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "snyk-go-plugin": "1.18.0",
         "snyk-gradle-plugin": "3.17.0",
         "snyk-module": "3.1.0",
-        "snyk-mvn-plugin": "2.26.3",
+        "snyk-mvn-plugin": "2.26.4",
         "snyk-nodejs-lockfile-parser": "1.38.0",
         "snyk-nuget-plugin": "1.23.4",
         "snyk-php-plugin": "1.9.2",
@@ -16888,9 +16888,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/snyk-mvn-plugin": {
-      "version": "2.26.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.3.tgz",
-      "integrity": "sha512-XWEwEe+eHqjsi3HYrY+CtShFluh+U152l3eqb1ICzNOPnUVZ5AZoUuSob5OEjVbvJ7gOys14QKG/JCteUVxGYQ==",
+      "version": "2.26.4",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.4.tgz",
+      "integrity": "sha512-fKh5tA0Plu1hZejbxMGVxmqn5eiZLk31Wy/pEbPca58/8JypzqLcN2KCxnP0SZPIuy3LRiR6stJEXycGqpi/0Q==",
       "dependencies": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",
@@ -33182,9 +33182,9 @@
       }
     },
     "snyk-mvn-plugin": {
-      "version": "2.26.3",
-      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.3.tgz",
-      "integrity": "sha512-XWEwEe+eHqjsi3HYrY+CtShFluh+U152l3eqb1ICzNOPnUVZ5AZoUuSob5OEjVbvJ7gOys14QKG/JCteUVxGYQ==",
+      "version": "2.26.4",
+      "resolved": "https://registry.npmjs.org/snyk-mvn-plugin/-/snyk-mvn-plugin-2.26.4.tgz",
+      "integrity": "sha512-fKh5tA0Plu1hZejbxMGVxmqn5eiZLk31Wy/pEbPca58/8JypzqLcN2KCxnP0SZPIuy3LRiR6stJEXycGqpi/0Q==",
       "requires": {
         "@snyk/cli-interface": "2.11.0",
         "@snyk/dep-graph": "^1.23.1",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "snyk-go-plugin": "1.18.0",
     "snyk-gradle-plugin": "3.17.0",
     "snyk-module": "3.1.0",
-    "snyk-mvn-plugin": "2.26.3",
+    "snyk-mvn-plugin": "2.26.4",
     "snyk-nodejs-lockfile-parser": "1.38.0",
     "snyk-nuget-plugin": "1.23.4",
     "snyk-php-plugin": "1.9.2",

--- a/test/tap/cli-monitor.acceptance.test.ts
+++ b/test/tap/cli-monitor.acceptance.test.ts
@@ -700,15 +700,12 @@ if (!isWindows) {
     );
     t.match(req.url, '/monitor/maven', 'puts at correct url');
     t.equal(pkg.name, 'com.mycompany.app:maven-multi-app', 'specifies name');
-    t.ok(
-      pkg.dependencies['com.mycompany.app:simple-child'],
-      'specifies dependency',
+    // child projects are not included when scanning root project
+    t.notOk(
+      pkg.dependencies?.['com.mycompany.app:simple-child'],
+      'does not include modules',
     );
     t.notOk(pkg.from, 'no "from" array on root');
-    t.notOk(
-      pkg.dependencies['com.mycompany.app:simple-child'].from,
-      'no "from" array on dep',
-    );
   });
 
   test('`monitor maven-multi-app with --project-business-criticality`', async (t) => {


### PR DESCRIPTION




- [X] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/CONTRIBUTING.md) rules

#### What does this PR do?
Snyk CLI treats each project (pom.xml) file as a project. Previously we have been including aggregate (modules) projects underneath the root project. Now (using '--all-projects') Snyk scans all maven projects at once and creates Snyk projects for each and there is no need to nest aggregate projects under the root.

#### What are the relevant tickets?
See https://github.com/snyk/snyk-mvn-plugin/pull/114
